### PR TITLE
Removed "Order allow,deny"

### DIFF
--- a/INSTALL/matecat-vhost.conf.sample
+++ b/INSTALL/matecat-vhost.conf.sample
@@ -7,7 +7,6 @@
         <Directory @@@path@@@/>
             Options All
             AllowOverride All
-            Order allow,deny
 
            <IfVersion < 2.4>
                    Order allow,deny


### PR DESCRIPTION
Order allow,deny was repeated, it must be only in the <if> clause for the virtualhost or it will forbid the access to the root directory