### PR TITLE
Engine error reporting during translation.

### DIFF
--- a/lib/Controller/getContributionController.php
+++ b/lib/Controller/getContributionController.php
@@ -225,6 +225,8 @@ class getContributionController extends ajaxController {
             $mt_result = $mt->get( $config );
 
             if ( isset( $mt_result['error']['code'] ) ) {
+                $mt_result['error']['created_by_type'] = 'MT';
+                $this->result[ 'errors' ][] = $mt_result['error'];
                 $mt_result = false;
             }
 
@@ -333,7 +335,6 @@ class getContributionController extends ajaxController {
         }
 
         $this->result[ 'data' ][ 'matches' ] = $matches;
-
     }
 
     private function setSuggestionReport( $matches ) {

--- a/lib/Utils/Engines/AbstractEngine.php
+++ b/lib/Utils/Engines/AbstractEngine.php
@@ -135,16 +135,14 @@ abstract class Engines_AbstractEngine {
         if ( $mh->hasError( $resourceHash ) ) {
             $curl_error = $mh->getError( $resourceHash );
             Log::doLog( 'Curl Error: (http status ' . $curl_error[ 'http_code' ] .') '. $curl_error[ 'errno' ] . " - " . $curl_error[ 'error' ] . " " . var_export( parse_url( $url ), true ) );
+            $responseRawValue = $mh->getSingleContent( $resourceHash );
             $rawValue = array(
                     'error' => array(
                             'code'    => -$curl_error[ 'errno' ],
-                            'message' => " {$curl_error[ 'error' ]}. Server Not Available (http status " . $curl_error[ 'http_code' ] .")"
+                            'message' => " {$curl_error[ 'error' ]}. Server Not Available (http status " . $curl_error[ 'http_code' ] .")",
+                            'response' => $responseRawValue // Some useful info might still be contained in the response body
                     )
             ); //return negative number
-            $responseRawValue = $mh->getSingleContent( $resourceHash ); // Although an error was returned some useful info might still be contained in the response body
-            if(!empty($responseRawValue)) {
-                $rawValue['result'] = $responseRawValue;
-            }
         } else {
             $rawValue = $mh->getSingleContent( $resourceHash );
         }

--- a/lib/Utils/Engines/AbstractEngine.php
+++ b/lib/Utils/Engines/AbstractEngine.php
@@ -141,6 +141,10 @@ abstract class Engines_AbstractEngine {
                             'message' => " {$curl_error[ 'error' ]}. Server Not Available (http status " . $curl_error[ 'http_code' ] .")"
                     )
             ); //return negative number
+            $responseRawValue = $mh->getSingleContent( $resourceHash ); // Although an error was returned some useful info might still be contained in the response body
+            if(!empty($responseRawValue)) {
+                $rawValue['result'] = $responseRawValue;
+            }
         } else {
             $rawValue = $mh->getSingleContent( $resourceHash );
         }

--- a/lib/Utils/Engines/LetsMT.php
+++ b/lib/Utils/Engines/LetsMT.php
@@ -147,11 +147,18 @@ class Engines_LetsMT extends Engines_AbstractEngine implements Engines_EngineInt
                 }
             }
         } else {
-            $decoded = $rawValue;
-            // in case of an invalid user id http status 401 is returned.
-            // display a more user friendly message
-            if (strpos($decoded['error'], 'http status 401') !== false) {
-                $decoded['error']['message'] = 'Invalid Client ID.';
+            $parsed = json_decode( $rawValue['result'], true );
+            if (!empty($parsed['ErrorMessage'])) {
+                $message = sprintf("%s (%s)", $parsed['ErrorMessage'], $parsed['ErrorCode']);
+                $code = int_val($parsed['ErrorCode']);
+                $decoded = array(
+                    'error' => array(
+                            'code'    $code,
+                            'message' => $message
+                    )
+            }
+            else{
+                $decoded = array( 'error' => $rawValue['error']);
             }
         }
 

--- a/lib/Utils/Engines/LetsMT.php
+++ b/lib/Utils/Engines/LetsMT.php
@@ -149,7 +149,7 @@ class Engines_LetsMT extends Engines_AbstractEngine implements Engines_EngineInt
             $parsed = json_decode( $rawValue['result'], true );
             if (!empty($parsed['ErrorMessage'])) {
                 $mt_code = intval($parsed['ErrorCode']);
-                $code = $mt_code == 21 ? '-1002' : '-1001'; // if engine is waking up render message as a warning (code -1002) else as error (code -1001).
+                $code = $mt_code == 21 ? '-2002' : '-2001'; // if engine is waking up render message as a warning (code -2002) else as error (code -2001).
                 $message = sprintf("(%s) %s", $parsed['ErrorCode'], $parsed['ErrorMessage']);
                 $decoded = array(
                     'error' => array(

--- a/lib/Utils/Engines/LetsMT.php
+++ b/lib/Utils/Engines/LetsMT.php
@@ -149,12 +149,15 @@ class Engines_LetsMT extends Engines_AbstractEngine implements Engines_EngineInt
         } else {
             $parsed = json_decode( $rawValue['result'], true );
             if (!empty($parsed['ErrorMessage'])) {
-                $message = sprintf("%s (%s)", $parsed['ErrorMessage'], $parsed['ErrorCode']);
-                $code = intval($parsed['ErrorCode']);
+                $mt_code = intval($parsed['ErrorCode']);
+                $code = $mt_code == 21 ? '-1002' : '-1001'; // if engine is waking up render message as a warning (code -1002) else as error (code -1001).
+                $msg_type = $mt_code == 21 ? 'Warning' : 'Error';
+                $message = sprintf("%s (%s): %s", $msg_type, $parsed['ErrorCode'], $parsed['ErrorMessage']);
                 $decoded = array(
                     'error' => array(
                             'code' => $code,
-                            'message' => $message
+                            'message' => $message,
+                            'created_by' => "MT-" . $this->getName()
                     )
                 );
             }

--- a/lib/Utils/Engines/LetsMT.php
+++ b/lib/Utils/Engines/LetsMT.php
@@ -150,15 +150,19 @@ class Engines_LetsMT extends Engines_AbstractEngine implements Engines_EngineInt
             $parsed = json_decode( $rawValue['result'], true );
             if (!empty($parsed['ErrorMessage'])) {
                 $message = sprintf("%s (%s)", $parsed['ErrorMessage'], $parsed['ErrorCode']);
-                $code = int_val($parsed['ErrorCode']);
+                $code = intval($parsed['ErrorCode']);
                 $decoded = array(
                     'error' => array(
-                            'code'    $code,
+                            'code' => $code,
                             'message' => $message
                     )
+                );
             }
             else{
                 $decoded = array( 'error' => $rawValue['error']);
+                if (strpos($decoded['error'], 'Server Not Available (http status 401)') !== false) {
+-                   $decoded['error']['message'] = 'Invalid Client ID.';
+                }
             }
         }
 

--- a/lib/Utils/Engines/LetsMT.php
+++ b/lib/Utils/Engines/LetsMT.php
@@ -162,7 +162,7 @@ class Engines_LetsMT extends Engines_AbstractEngine implements Engines_EngineInt
             else{
                 $decoded = array( 'error' => $rawValue['error']);
                 if (strpos($decoded['error'], 'Server Not Available (http status 401)') !== false) {
--                   $decoded['error']['message'] = 'Invalid Client ID.';
+                   $decoded['error']['message'] = 'Invalid Client ID.';
                 }
             }
         }

--- a/lib/Utils/Engines/LetsMT.php
+++ b/lib/Utils/Engines/LetsMT.php
@@ -146,7 +146,11 @@ class Engines_LetsMT extends Engines_AbstractEngine implements Engines_EngineInt
                 }
             }
         } else {
-            $parsed = json_decode( $rawValue['result'], true );
+            // get the response body for the error message
+            $parsed = array();
+            if (!empty($rawValue['error'])){
+                $parsed = json_decode( $rawValue['error']['response'], true );
+            }
             if (!empty($parsed['ErrorMessage'])) {
                 $mt_code = intval($parsed['ErrorCode']);
                 $code = $mt_code == 21 ? '-2002' : '-2001'; // if engine is waking up render message as a warning (code -2002) else as error (code -2001).
@@ -159,6 +163,7 @@ class Engines_LetsMT extends Engines_AbstractEngine implements Engines_EngineInt
                     )
                 );
             }
+            // no response body for the error message
             else{
                 $decoded = array( 'error' => $rawValue['error']);
                 if (strpos($decoded['error'], 'Server Not Available (http status 401)') !== false) {

--- a/lib/Utils/Engines/LetsMT.php
+++ b/lib/Utils/Engines/LetsMT.php
@@ -151,8 +151,7 @@ class Engines_LetsMT extends Engines_AbstractEngine implements Engines_EngineInt
             if (!empty($parsed['ErrorMessage'])) {
                 $mt_code = intval($parsed['ErrorCode']);
                 $code = $mt_code == 21 ? '-1002' : '-1001'; // if engine is waking up render message as a warning (code -1002) else as error (code -1001).
-                $msg_type = $mt_code == 21 ? 'Warning' : 'Error';
-                $message = sprintf("%s (%s): %s", $msg_type, $parsed['ErrorCode'], $parsed['ErrorMessage']);
+                $message = sprintf("(%s) %s", $parsed['ErrorCode'], $parsed['ErrorMessage']);
                 $decoded = array(
                     'error' => array(
                             'code' => $code,

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2162,6 +2162,20 @@ textarea, input, .editarea, .search-editarea, select  {
 .addline-suggestion{display:none;float:left;height:50px;background:#fff}
 .add-ul{background:#efefef !important}
 
+/*engine errror messages*/
+.engine-errrors summary {
+    text-align: left;
+    padding-left: 20px;
+    cursor: pointer;
+}
+
+.engine-errrors summary:focus {
+    outline: 0;
+}
+
+.engine-errrors .error {
+    color: red;
+}
 
 /*status*/
 .status-container .status{width:11px;display:block;position:absolute;height:100%;padding:0;background:#dddedf;right:0;border-left:1px solid #ccc;	margin:0px 0px 0px 0 !Important;z-index:99;border-bottom:1px solid #ccc	}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -2177,6 +2177,37 @@ textarea, input, .editarea, .search-editarea, select  {
     color: red;
 }
 
+.engine-error {
+    padding-left: 40px!important;
+}
+
+.error-img {
+    background: #c5351c url(../img/warning.png) no-repeat center;
+    background-size: 12px;
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    border-radius: 5px;
+    margin-left: -20px;
+    top: 2px;
+    position: relative;
+    float: left;
+}
+
+.warning-img {
+    background: #FF9900 url(../img/warning.png) no-repeat center;
+    background-size: 12px;
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    border-radius: 5px;
+    margin-left: -20px;
+    top: 2px;
+    position: relative;
+    float: left;
+}
+
+
 /*status*/
 .status-container .status{width:11px;display:block;position:absolute;height:100%;padding:0;background:#dddedf;right:0;border-left:1px solid #ccc;	margin:0px 0px 0px 0 !Important;z-index:99;border-bottom:1px solid #ccc	}
 section.readonly .status-container a.status:hover,

--- a/public/js/cat.js
+++ b/public/js/cat.js
@@ -6382,17 +6382,20 @@ $.extend(UI, {
                 var percentClass = "";
                 var messageClass = "";
                 var imgClass = "";
+                var  messageTypeText = '';
                 if(this.code == '-1001') {
                     console.log('ERROR -1001');
                     percentClass = "per-red";
                     messageClass = 'error';
                     imgClass = 'error-img';
+                    messageTypeText = 'Error: ';
                 }
                 else if (this.code == '-1002') {
                     console.log('WARNING -1002');
                     percentClass = "per-orange";
                     messageClass = 'warning';
                     imgClass = 'warning-img';
+                    messageTypeText = 'Warning: ';
                 }
                 else {
                     return;
@@ -6404,7 +6407,7 @@ $.extend(UI, {
                 var cb = this.created_by;
 
                 $('.tab.sub-editor.matches .engine-errors', segment).append('<ul class="engine-error-item graysmall"><li class="engine-error">' +
-                        '<div class="' + imgClass + '"></div><span class="engine-error-message ' + messageClass + '">' + this.message +
+                        '<div class="' + imgClass + '"></div><span class="engine-error-message ' + messageClass + '">' + messageTypeText + this.message +
                         '</span></li><ul class="graysmall-details"><li class="percent ' + percentClass + '">' + percentText +
                         '</li><li>' + suggestion_info + '</li><li class="graydesc">Source: <span class="bold">' + cb + '</span></li></ul></ul>');
             });

--- a/public/js/cat.js
+++ b/public/js/cat.js
@@ -6381,15 +6381,18 @@ $.extend(UI, {
             $.each(errors, function(){
                 var percentClass = "";
                 var messageClass = "";
+                var imgClass = "";
                 if(this.code == '-1001') {
                     console.log('ERROR -1001');
                     percentClass = "per-red";
-                    messageClass = 'error'
+                    messageClass = 'error';
+                    imgClass = 'error-img';
                 }
                 else if (this.code == '-1002') {
                     console.log('WARNING -1002');
                     percentClass = "per-orange";
-                    messageClass = 'warning'
+                    messageClass = 'warning';
+                    imgClass = 'warning-img';
                 }
                 else {
                     return;
@@ -6401,7 +6404,7 @@ $.extend(UI, {
                 var cb = this.created_by;
 
                 $('.tab.sub-editor.matches .engine-errors', segment).append('<ul class="engine-error-item graysmall"><li class="engine-error">' +
-                        '<span class="engine-error-message ' + messageClass + '">' + this.message +
+                        '<div class="' + imgClass + '"></div><span class="engine-error-message ' + messageClass + '">' + this.message +
                         '</span></li><ul class="graysmall-details"><li class="percent ' + percentClass + '">' + percentText +
                         '</li><li>' + suggestion_info + '</li><li class="graydesc">Source: <span class="bold">' + cb + '</span></li></ul></ul>');
             });

--- a/public/js/cat.js
+++ b/public/js/cat.js
@@ -440,6 +440,7 @@ console.log('changeStatus');
 					'</ul>' +
 					'<div class="tab sub-editor matches" ' + ((config.isReview)? 'style="display: none"' : '') + ' id="segment-' + this.currentSegmentId + '-matches">' +
 					'	<div class="overflow"></div>' +
+                                        '       <details class="engine-errrors"><summary>Errors</summary></details>' +
 					'</div>' +
 					'<div class="tab sub-editor concordances" id="segment-' + this.currentSegmentId + '-concordances">' +
 					'	<div class="overflow">' +
@@ -3221,13 +3222,13 @@ console.log('changeStatus');
 			if (this.code == '-1000') {
 				console.log('ERROR -1000');
 				console.log('operation: ', operation);
-                UI.blockUIForNoConnection();
-//				UI.failedConnection(0, 'no');
+                                UI.blockUIForNoConnection();
+        //				UI.failedConnection(0, 'no');
 			}
-            if (this.code == '-101') {
-                console.log('ERROR -101');
-                UI.blockUIForNoConnection();
-            }
+                        if (this.code == '-101') {
+                            console.log('ERROR -101');
+                            UI.blockUIForNoConnection();
+                        }
 		});
 	},
 	reloadPage: function() {
@@ -6245,6 +6246,7 @@ $.extend(UI, {
 		} else {
 			$(".sbm > .matches", segment).hide();
 		}
+                this.renderContributionErrors(d.errors, segment);
 
     },
 	renderContributions: function(d, segment) {
@@ -6373,6 +6375,37 @@ $.extend(UI, {
             }
 		}
 	},
+        renderContributionErrors: function(errors, segment) {
+            $('.tab.sub-editor.matches details', segment).children(':not(summary)').remove();
+            $('.tab.sub-editor.matches details', segment).hide();
+            $.each(errors, function(){
+                var percentClass = "";
+                var messageClass = "";
+                if(this.code == '-1001') {
+                    console.log('ERROR -1001');
+                    percentClass = "per-red";
+                    messageClass = 'error'
+                }
+                else if (this.code == '-1002') {
+                    console.log('WARNING -1002');
+                    percentClass = "per-orange";
+                    messageClass = 'warning'
+                }
+                else {
+                    return;
+                }
+                debugger;
+                $('.tab.sub-editor.matches details', segment).show();
+                var percentText = this.created_by_type;
+                var suggestion_info = '';
+                var cb = this.created_by;
+
+                $('.tab.sub-editor.matches details', segment).append('<ul class="engine-error-item graysmall"><li class="engine-error">' +
+                        '<span class="engine-error-message ' + messageClass + '">' + this.message +
+                        '</span></li><ul class="graysmall-details"><li class="percent ' + percentClass + '">' + percentText +
+                        '</li><li>' + suggestion_info + '</li><li class="graydesc">Source: <span class="bold">' + cb + '</span></li></ul></ul>');
+            });
+        },
 	setContribution: function(segment_id, status, byStatus) {
 //        console.log('setContribution');
         this.addToSetContributionTail('setContribution', segment_id, status, byStatus);

--- a/public/js/cat.js
+++ b/public/js/cat.js
@@ -440,7 +440,7 @@ console.log('changeStatus');
 					'</ul>' +
 					'<div class="tab sub-editor matches" ' + ((config.isReview)? 'style="display: none"' : '') + ' id="segment-' + this.currentSegmentId + '-matches">' +
 					'	<div class="overflow"></div>' +
-                                        '       <details class="engine-errrors"><summary>Errors</summary></details>' +
+                                        '       <div class="engine-errors"></div>' +
 					'</div>' +
 					'<div class="tab sub-editor concordances" id="segment-' + this.currentSegmentId + '-concordances">' +
 					'	<div class="overflow">' +
@@ -6376,8 +6376,8 @@ $.extend(UI, {
 		}
 	},
         renderContributionErrors: function(errors, segment) {
-            $('.tab.sub-editor.matches details', segment).children(':not(summary)').remove();
-            $('.tab.sub-editor.matches details', segment).hide();
+            $('.tab.sub-editor.matches .engine-errors', segment).empty();
+            $('.tab.sub-editor.matches .engine-errors', segment).hide();
             $.each(errors, function(){
                 var percentClass = "";
                 var messageClass = "";
@@ -6395,12 +6395,12 @@ $.extend(UI, {
                     return;
                 }
                 debugger;
-                $('.tab.sub-editor.matches details', segment).show();
+                $('.tab.sub-editor.matches .engine-errors', segment).show();
                 var percentText = this.created_by_type;
                 var suggestion_info = '';
                 var cb = this.created_by;
 
-                $('.tab.sub-editor.matches details', segment).append('<ul class="engine-error-item graysmall"><li class="engine-error">' +
+                $('.tab.sub-editor.matches .engine-errors', segment).append('<ul class="engine-error-item graysmall"><li class="engine-error">' +
                         '<span class="engine-error-message ' + messageClass + '">' + this.message +
                         '</span></li><ul class="graysmall-details"><li class="percent ' + percentClass + '">' + percentText +
                         '</li><li>' + suggestion_info + '</li><li class="graydesc">Source: <span class="bold">' + cb + '</span></li></ul></ul>');

--- a/public/js/cat.js
+++ b/public/js/cat.js
@@ -6400,7 +6400,6 @@ $.extend(UI, {
                 else {
                     return;
                 }
-                debugger;
                 $('.tab.sub-editor.matches .engine-errors', segment).show();
                 var percentText = this.created_by_type;
                 var suggestion_info = '';

--- a/public/js/cat_source/ui.contribution.js
+++ b/public/js/cat_source/ui.contribution.js
@@ -175,6 +175,7 @@ $.extend(UI, {
 		} else {
 			$(".sbm > .matches", segment).hide();
 		}
+                this.renderContributionErrors(d.errors, segment);
 
     },
 	renderContributions: function(d, segment) {
@@ -303,6 +304,42 @@ $.extend(UI, {
             }
 		}
 	},
+        renderContributionErrors: function(errors, segment) {
+            $('.tab.sub-editor.matches .engine-errors', segment).empty();
+            $('.tab.sub-editor.matches .engine-errors', segment).hide();
+            $.each(errors, function(){
+                var percentClass = "";
+                var messageClass = "";
+                var imgClass = "";
+                var  messageTypeText = '';
+                if(this.code == '-1001') {
+                    console.log('ERROR -1001');
+                    percentClass = "per-red";
+                    messageClass = 'error';
+                    imgClass = 'error-img';
+                    messageTypeText = 'Error: ';
+                }
+                else if (this.code == '-1002') {
+                    console.log('WARNING -1002');
+                    percentClass = "per-orange";
+                    messageClass = 'warning';
+                    imgClass = 'warning-img';
+                    messageTypeText = 'Warning: ';
+                }
+                else {
+                    return;
+                }
+                $('.tab.sub-editor.matches .engine-errors', segment).show();
+                var percentText = this.created_by_type;
+                var suggestion_info = '';
+                var cb = this.created_by;
+
+                $('.tab.sub-editor.matches .engine-errors', segment).append('<ul class="engine-error-item graysmall"><li class="engine-error">' +
+                        '<div class="' + imgClass + '"></div><span class="engine-error-message ' + messageClass + '">' + messageTypeText + this.message +
+                        '</span></li><ul class="graysmall-details"><li class="percent ' + percentClass + '">' + percentText +
+                        '</li><li>' + suggestion_info + '</li><li class="graydesc">Source: <span class="bold">' + cb + '</span></li></ul></ul>');
+            });
+        },
 	setContribution: function(segment_id, status, byStatus) {
 //        console.log('setContribution');
         this.addToSetContributionTail('setContribution', segment_id, status, byStatus);

--- a/public/js/cat_source/ui.contribution.js
+++ b/public/js/cat_source/ui.contribution.js
@@ -312,15 +312,15 @@ $.extend(UI, {
                 var messageClass = "";
                 var imgClass = "";
                 var  messageTypeText = '';
-                if(this.code == '-1001') {
-                    console.log('ERROR -1001');
+                if(this.code == '-2001') {
+                    console.log('ERROR -2001');
                     percentClass = "per-red";
                     messageClass = 'error';
                     imgClass = 'error-img';
                     messageTypeText = 'Error: ';
                 }
-                else if (this.code == '-1002') {
-                    console.log('WARNING -1002');
+                else if (this.code == '-2002') {
+                    console.log('WARNING -2002');
                     percentClass = "per-orange";
                     messageClass = 'warning';
                     imgClass = 'warning-img';

--- a/public/js/cat_source/ui.core.js
+++ b/public/js/cat_source/ui.core.js
@@ -440,6 +440,7 @@ console.log('changeStatus');
 					'</ul>' +
 					'<div class="tab sub-editor matches" ' + ((config.isReview)? 'style="display: none"' : '') + ' id="segment-' + this.currentSegmentId + '-matches">' +
 					'	<div class="overflow"></div>' +
+                                        '       <div class="engine-errors"></div>' +
 					'</div>' +
 					'<div class="tab sub-editor concordances" id="segment-' + this.currentSegmentId + '-concordances">' +
 					'	<div class="overflow">' +


### PR DESCRIPTION
Closes #12, closes #10
This adds on top of #13 some error reporting functionality in the document translation view.

Firstly we make [the rest of the response](https://github.com/matecat/MateCat/commit/4a739a5f39d34256e6a63f26b8110ee60c09b7be#diff-d9e66f5a209f37f869b77d6faede18dfR144) available when an error is returned to a request. This allows us to [pass engine errors to the frontend](https://github.com/matecat/MateCat/commit/76f4c11f36700cc85bc95829c4b039787377cbba#diff-350226ecb327b1389944f5046f36c3b1R229) where [they are rendered](https://github.com/matecat/MateCat/commit/76f4c11f36700cc85bc95829c4b039787377cbba#diff-0016513769a46f73f3b1104e87eb4237R6378) bellow the list of translation suggestions if the error message has either the code `-1001` or `-1002`.