### PR TITLE
fix UI.Segment instance being passed twice

### DIFF
--- a/public/js/cat_source/review_improved.translate_extensions.js
+++ b/public/js/cat_source/review_improved.translate_extensions.js
@@ -12,7 +12,14 @@ if ( ReviewImproved.enabled() && !config.isReview)
             return false;
         },
         cleanupLegacyButtons : function( segment ) {
-            var segObj = new UI.Segment(segment);
+            var segObj ;
+
+            if ( segment instanceof UI.Segment ) {
+                segObj = segment ;
+            } else {
+                segObj = new UI.Segment(segment);
+            }
+            
             var buttonsOb = $('#segment-' + segObj.id + '-buttons');
             buttonsOb.empty();
             $('p.warnings', segObj.el).empty();


### PR DESCRIPTION
This fixes a bug with review improved when segment is provided as UI.Segment instance already. 