### PR TITLE
Speech2text enabled logic improved and fixed globally

### DIFF
--- a/public/js/cat_source/db.js
+++ b/public/js/cat_source/db.js
@@ -63,4 +63,16 @@ if ( true ) // < TODO: investigate: chrome raises weird excetpion if this is mis
         }
     }
 
+    var putSegmentsInStore = function(data) {
+        $.each(data.files, function() {
+            $.each( this.segments, function() {
+                MateCat.db.upsert( 'segments', 'sid', _.clone( this ) );
+            });
+        });
+    }
+
+    $(document).on('segments:load', function(e, data) {
+        putSegmentsInStore( data );
+    });
+
 })(jQuery, window);

--- a/public/js/cat_source/review_improved.common_events.js
+++ b/public/js/cat_source/review_improved.common_events.js
@@ -20,21 +20,10 @@ if ( ReviewImproved.enabled() ) {
         });
     });
 
-    var putSegmentsInStore = function(data) {
-        $.each(data.files, function() {
-            $.each( this.segments, function() {
-                MateCat.db.upsert( 'segments', 'sid', _.clone( this ) );
-            });
-        });
-    }
-
     $(document).on('ready', function() {
         ReviewImproved.mountPanelComponent();
     });
 
-    $(document).on('segments:load', function(e, data) {
-        putSegmentsInStore( data );
-    });
 
     $(document).on('segment-filter:filter-data:load', function() {
         ReviewImproved.closePanel();

--- a/public/js/cat_source/speech2text.js
+++ b/public/js/cat_source/speech2text.js
@@ -1,11 +1,11 @@
 Speech2Text = {
-    isSupported: function () {
+    enabled: function () {
         return !!('webkitSpeechRecognition' in window);
 
     }
 };
 
-if ( Speech2Text.isSupported() ) {
+if ( Speech2Text.enabled() ) {
     (function ($, Speech2Text, undefined) {
         $.extend(Speech2Text, {
             recognition: null,

--- a/public/js/cat_source/templates/translate/_text_area_container.hbs
+++ b/public/js/cat_source/templates/translate/_text_area_container.hbs
@@ -9,6 +9,8 @@
                         data-sid="{{segment.sid}}"
                         >{{#if segment.translation }}{{{ decoded_translation }}}{{/if}}
   </div>
+
+  {{#if s2t_enabled}}
   <div class="micSpeech" title="Activate voice input" data-segment-id="{{originalId}}">
         <div class="micBg"></div>
         <div class="micBg2">
@@ -20,6 +22,7 @@
           </svg>
         </div>
   </div>
+  {{/if}}
   <div class="toolbar">
     {{{tagLockCustomizable}}}
     {{#if tagModesEnabled }}

--- a/public/js/cat_source/ui.core.js
+++ b/public/js/cat_source/ui.core.js
@@ -682,11 +682,11 @@ UI = {
             current_segment : UI.currentSegment
         });
 
-            if( !this.opening && UI.currentSegmentId == segment.data('splitOriginalId') ) {
-                Speech2Text.disableContinuousRecognizing();
-            }
+        if( !this.opening && UI.currentSegmentId == segment.data('splitOriginalId') ) {
+            Speech2Text.enabled() && Speech2Text.disableContinuousRecognizing();
+        }
 
-            Speech2Text.disableMicrophone( segment );
+        Speech2Text.enabled() && Speech2Text.disableMicrophone( segment );
 	},
 	detectAdjacentSegment: function(segment, direction, times) { // currently unused
 		if (!times)
@@ -960,8 +960,6 @@ UI = {
 			},
 			success: function(d) {
                 $(document).trigger('segments:load', d.data);
-
-                Speech2Text.putSegmentsInStore( d.data );
 
                 if ($.cookie('tmpanel-open') == '1') UI.openLanguageResourcesPanel();
 				UI.getSegments_success(d, options);

--- a/public/js/cat_source/ui.opensegment.js
+++ b/public/js/cat_source/ui.opensegment.js
@@ -142,7 +142,7 @@
                 segment: segment
             });
 
-            Speech2Text.enableMicrophone(segment.el);
+            Speech2Text.enabled() && Speech2Text.enableMicrophone(segment.el);
         }
     });
 })(jQuery, UI);

--- a/public/js/cat_source/ui.segment.js
+++ b/public/js/cat_source/ui.segment.js
@@ -62,8 +62,7 @@
                 segment.segment || '', 
                 true, segment.sid, 'source');
 
-            // If Enabled Speech2Text add micActive class
-            ( !_.isUndefined(Speech2Text) && Speech2Text.isSupported() ) ? editarea_classes.push( 'micActive' ): false;
+            Speech2Text.enabled() && editarea_classes.push( 'micActive' ) ; 
 
             return  {
                 t                       : t,
@@ -86,7 +85,8 @@
                 decoded_translation     : decoded_translation  ,
                 status_change_title     : status_change_title ,
                 segment_edit_sec        : segment_edit_sec,
-                segment_edit_min        : segment_edit_min
+                segment_edit_min        : segment_edit_min, 
+                s2t_enabled             : Speech2Text.enabled() 
             };
 
         },


### PR DESCRIPTION
prepend a call to `Speech2text.enabled()` as usually done in such cases in MateCat.
