### PR TITLE
fixes issue with link to comment in top balloon

### DIFF
--- a/public/js/cat_source/mbc.main.js
+++ b/public/js/cat_source/mbc.main.js
@@ -357,8 +357,6 @@ if ( MBC.enabled() )
         }
 
         var renderSegmentBalloon = function ( el ) {
-            if ( !$( el ).is( ':visible' ) ) return;
-
             var segment = new UI.Segment( el );
             var comments = db.getCommentsBySegment( segment.absoluteId );
             if ( comments.length > 0 ) {
@@ -374,17 +372,22 @@ if ( MBC.enabled() )
             var someMarginOnTop = 100;
             var headerMenu = $( '.header-menu' ).height();
 
-            $( "html,body" ).animate( {
+            var animation = $( "html,body" ).animate( {
                 scrollTop: section.offset().top - headerMenu - someMarginOnTop
             }, 500 );
+            
+            return animation ;
         }
 
         var openSegmentComment = function ( el ) {
-            $( 'article' ).addClass( 'mbc-commenting-opened' );
-            $( 'body' ).addClass( 'side-tools-opened' );
+            popLastCommentHash(); 
             hackSnapEngage( true );
-            renderSegmentBalloon( el );
-            scrollSegment( el );
+
+            scrollSegment( el ).promise().done( function() {
+                $( 'article' ).addClass( 'mbc-commenting-opened' );
+                $( 'body' ).addClass( 'side-tools-opened' );
+                renderSegmentBalloon( el );
+            }); 
         }
 
         var openSegmentCommentNoScroll = function ( el ) {


### PR DESCRIPTION
Not sure what was causing the error, but this new implementation works. It also fixes another issue with `popLastCommentHash` not being called on segment open. 