### PR TITLE
adds condition on getWarning to ignore DRAFT status

### DIFF
--- a/lib/Model/queries.php
+++ b/lib/Model/queries.php
@@ -573,14 +573,16 @@ function getFirstSegmentOfFilesInJob( $jid ) {
 function getWarning( $jid, $jpassword ) {
     $db  = Database::obtain();
     $jid = $db->escape( $jid );
+    $status_new = Constants_TranslationStatus::STATUS_NEW ;
 
     $query = "SELECT id_segment, serialized_errors_list
 		FROM segment_translations
 		JOIN jobs ON jobs.id = id_job AND id_segment BETWEEN jobs.job_first_segment AND jobs.job_last_segment
 		WHERE jobs.id = $jid
 		AND jobs.password = '$jpassword'
-		-- following is a condition on bitbask to filter by severity ERROR 
-		AND warning&1 = 1 ";
+		AND segment_translations.status != '$status_new' 
+		-- following is a condition on bitmask to filter by severity ERROR
+		AND warning & 1 = 1 ";
 
     $results = $db->fetch_array( $query );
 


### PR DESCRIPTION
Fix a problem that can happen sometimes when DRAFT segment_translations contain a translation coming from TM that contains something that MateCat detects as a warning. 

