### PR TITLE
rebutted segments must be considered as translated

### DIFF
--- a/lib/Model/WordCount/Counter.php
+++ b/lib/Model/WordCount/Counter.php
@@ -309,11 +309,8 @@ class WordCount_Counter {
      * @return string
      */
     private function methodNameForStatusCall( $name ) {
-        if ( strtoupper($name) == Constants_TranslationStatus::STATUS_FIXED ) {
-            return 'TranslatedWords';
-        }
-        if ( strtoupper($name) == Constants_TranslationStatus::STATUS_REBUTTED ) {
-            return 'RejectedWords';
+        if ( in_array( strtoupper($name), Constants_TranslationStatus::$POST_REVISION_STATUSES  ) ) {
+            return 'TranslatedWords' ;
         }
         return ucfirst( strtolower( $name ) ) . 'Words';
 


### PR DESCRIPTION
Without this change it is impossible on translate page to click
the button mark as complete, because a condition imposes that no
rejected segments must be on the job.