### PR TITLE
Fixed problems with 'closest' function on no-jquery objects. 

### DIFF
--- a/public/js/cat_source/mbc.main.js
+++ b/public/js/cat_source/mbc.main.js
@@ -649,7 +649,7 @@ if ( MBC.enabled() )
          * of the page.
          */
         $(document).on('click', function(e) {
-            if (e.target.closest('section') == null) {
+            if ($(e.target).closest('section') == null) {
                 closeBalloon();
             }
         });

--- a/public/js/cat_source/review_improved.common_events.js
+++ b/public/js/cat_source/review_improved.common_events.js
@@ -77,11 +77,11 @@ if ( ReviewImproved.enabled() ) {
     });
 
     $(document).on('click', function( e ) {
-        if (e.target.closest('body') == null ) {
+        if ($(e.target).closest('body') == null ) {
             // it's a detatched element, likely the APPROVE button.
             return ;
         }
-        if (e.target.closest('header, .modal, section, #review-side-panel') == null) {
+        if ($(e.target).closest('header, .modal, section, #review-side-panel') == null) {
             ReviewImproved.closePanel( );
         }
     });

--- a/public/js/cat_source/ui.core.js
+++ b/public/js/cat_source/ui.core.js
@@ -104,13 +104,14 @@ UI = {
         this.currentSegmentTranslation = segment.find( UI.targetContainerSelector() ).text();
     },
 	cacheObjects: function( editarea_or_segment ) {
+        var segment;
         if ( editarea_or_segment instanceof UI.Segment ) {
-            var segment = editarea_or_segment ;
+            segment = editarea_or_segment ;
             this.editarea = segment.el.find( '.editarea' );
         }
         else {
-            this.editarea = $(".editarea", editarea_or_segment.closest('section'));
-            var segment = new UI.Segment( editarea_or_segment.closest('section') );
+            this.editarea = $(".editarea", $(editarea_or_segment).closest('section'));
+            segment = new UI.Segment( $(editarea_or_segment).closest('section') );
         }
 
 		this.lastOpenedSegment = this.currentSegment; // this.currentSegment

--- a/public/js/cat_source/ui.events.js
+++ b/public/js/cat_source/ui.events.js
@@ -1047,7 +1047,7 @@ $.extend(UI, {
 				UI.currentSegment.removeClass( 'hasTagsToggle' );
 			}
 
-			if ( UI.hasMissingTargetTags( e.target.closest('section') ) ) {
+			if ( UI.hasMissingTargetTags( $(e.target).closest('section') ) ) {
 				UI.currentSegment.addClass( 'hasTagsAutofill' );
 			} else {
 				UI.currentSegment.removeClass( 'hasTagsAutofill' );

--- a/public/js/cat_source/ui.opensegment.js
+++ b/public/js/cat_source/ui.opensegment.js
@@ -2,14 +2,14 @@
 
     $.extend(UI, {
         openSegment: function(editarea_or_segment, operation) {
-
+            var editarea, segment;
             if ( editarea_or_segment instanceof UI.Segment ) {
-                var editarea = $('.editarea', editarea_or_segment.el);
-                var segment = editarea_or_segment ;
+                editarea = $('.editarea', editarea_or_segment.el);
+                segment = editarea_or_segment ;
             }
             else {
-                var editarea = editarea_or_segment ;
-                var segment = new UI.Segment( editarea_or_segment.closest('section') );
+                editarea = $(editarea_or_segment) ;
+                segment = new UI.Segment( editarea.closest('section') );
             }
 
             if ( Review.enabled() && !Review.evalOpenableSegment( segment.el ) ) {


### PR DESCRIPTION
Fixed problems with 'closest' function on no-jquery objects. The function was working only on Safari Version > 8'

https://developer.mozilla.org/it/docs/Web/API/Element/closest