### PR TITLE
Rework getLocalizedName function for lang validaiton

### DIFF
--- a/inc/Bootstrap.php
+++ b/inc/Bootstrap.php
@@ -350,8 +350,9 @@ class Bootstrap {
      */
     public static function areMandatoryKeysPresent()  {
         $merged_config = array_merge(self::$CONFIG, self::$CONFIG[ INIT::$ENV ] );
+
         foreach ( INIT::$MANDATORY_KEYS as $key ) {
-            if (! array_key_exists($key, $merged_config ) || empty( $merged_config[$key] ) ) {
+            if ( !array_key_exists($key, $merged_config) || $merged_config[ $key ] === null ) {
                 return false;
             }
         }

--- a/lib/Controller/API/NewController.php
+++ b/lib/Controller/API/NewController.php
@@ -641,7 +641,7 @@ class NewController extends ajaxController {
         }
 
         try {
-            $this->lang_handler->getLocalizedName( $this->source_lang ) ;
+            $this->lang_handler->getLocalizedNameRFC( $this->source_lang ) ;
 
         } catch ( Exception $e ) {
             $this->api_output['message'] = $e->getMessage();
@@ -661,7 +661,7 @@ class NewController extends ajaxController {
 
         try {
             foreach ( $targets as $target ) {
-               $this->lang_handler->getLocalizedName( $target );
+               $this->lang_handler->getLocalizedNameRFC( $target );
             }
         } catch ( Exception $e ) {
             $this->api_output['message'] = $e->getMessage();

--- a/lib/Controller/createProjectController.php
+++ b/lib/Controller/createProjectController.php
@@ -336,7 +336,7 @@ class createProjectController extends ajaxController {
 
         try {
             foreach ( $targets as $target ) {
-                $this->lang_handler->getLocalizedName( $target );
+                $this->lang_handler->getLocalizedNameRFC( $target );
             }
         } catch ( Exception $e ) {
             $this->result[ 'errors' ][]    = array( "code" => -4, "message" => $e->getMessage() );
@@ -351,7 +351,7 @@ class createProjectController extends ajaxController {
         }
 
         try {
-            $this->lang_handler->getLocalizedName( $this->source_language ) ;
+            $this->lang_handler->getLocalizedNameRFC( $this->source_language ) ;
 
         } catch ( Exception $e ) {
             $this->result[ 'errors' ][]    = array( "code" => -3, "message" => $e->getMessage() );

--- a/lib/Model/ProjectOptionsSanitizer.php
+++ b/lib/Model/ProjectOptionsSanitizer.php
@@ -62,7 +62,7 @@ class ProjectOptionsSanitizer {
 
     private function sanitizeSegmentationRule() {
         $rules = array( 'patent' );
-        if ( array_search( $this->options[ 'segmentation_rule' ], $rules ) !== false ) {
+        if ( array_search( @$this->options[ 'segmentation_rule' ], $rules ) !== false ) {
             $this->sanitized[ 'segmentation_rule' ] = $this->options[ 'segmentation_rule' ];
         }
     }

--- a/lib/Utils/Langs/Languages.php
+++ b/lib/Utils/Langs/Languages.php
@@ -194,10 +194,26 @@ class Langs_Languages {
      * @return mixed
      */
     public function getLocalizedName( $code, $lang = 'en' ) {
+        if ( strlen( $code ) < 5 ) {
+            $code = self::$map_iso2rfc[ $code ];
+        }
+        return self::$map_rfc2obj[ $code ][ 'localized' ][ $lang ];
+    }
+
+    /**
+     *
+     * Be strict when and only find localized name with an RFC expected input
+     * 
+     * @param        $code
+     * @param string $lang
+     *
+     * @return mixed
+     * @throws Exception
+     */
+    public function getLocalizedNameRFC( $code, $lang = 'en') {
         if ( !array_key_exists( $code, self::$map_rfc2obj ) ) {
             throw new Lang_InvalidLanguageException('Invalid language code: ' . $code ) ;
         }
-
         return self::$map_rfc2obj[ $code ][ 'localized' ][ $lang ];
     }
 

--- a/lib/Utils/Langs/Languages.php
+++ b/lib/Utils/Langs/Languages.php
@@ -4,6 +4,9 @@
    this class manages supported languages in the CAT tool
  */
 
+
+class Lang_InvalidLanguageException extends Exception {} ;
+
 class Langs_Languages {
 
     private static $instance; //singleton instance
@@ -192,7 +195,7 @@ class Langs_Languages {
      */
     public function getLocalizedName( $code, $lang = 'en' ) {
         if ( !array_key_exists( $code, self::$map_rfc2obj ) ) {
-            throw new Exception('Invalid language code: ' . $code ) ;
+            throw new Lang_InvalidLanguageException('Invalid language code: ' . $code ) ;
         }
 
         return self::$map_rfc2obj[ $code ][ 'localized' ][ $lang ];

--- a/test/integration/CreateProjectController/defaultProjectOptionTest.php
+++ b/test/integration/CreateProjectController/defaultProjectOptionTest.php
@@ -118,14 +118,14 @@ class createProjectControllerTest extends IntegrationTest {
         prepare_file_in_upload_folder( $file, $upload_session );
 
         do_file_conversion(array(
-                'source_lang' => 'mm-MY',
+                'source_lang' => 'my-MM',
                 'target_lang' => 'ja-JP,be-BY',
                 'file_name' => 'amex-test.docx.xlf',
                 'upload_session' => $upload_session
         ));
 
         $response = createProjectWithUIParams( array(
-                'source_language' => 'mm-MY',
+                'source_language' => 'my-MM',
                 'target_language' => 'ja-JP,be-BY', 
                 'pretranslate_100' => 1,
                 'job_subject' => 'general',
@@ -256,14 +256,14 @@ class createProjectControllerTest extends IntegrationTest {
         prepare_file_in_upload_folder( $file, $upload_session );
 
         do_file_conversion(array(
-                'source_lang' => 'mm-MY',
+                'source_lang' => 'my-MM',
                 'target_lang' => 'ja-JP,be-BY',
                 'file_name' => 'amex-test.docx.xlf',
                 'upload_session' => $upload_session
         ));
 
         $response = createProjectWithUIParams( array(
-                'source_language' => 'mm-MY',
+                'source_language' => 'my-MM',
                 'target_language' => 'ja-JP,be-BY',
                 'pretranslate_100' => 1,
                 'job_subject' => 'general',


### PR DESCRIPTION
This fixes a case that was observed in development environment: for unknown reasons some the cookies we use to store the source and target langs for history happen to be full lowercase ( e.g. it-it). This breaks the page due to the validation we recently introduced. 

This also refactors a little the `doAction` method in controller.