### PR TITLE
Fix glossary QA checks and quality report 

### DIFF
--- a/lib/Model/GlossaryModel.php
+++ b/lib/Model/GlossaryModel.php
@@ -38,6 +38,11 @@ class GlossaryModel {
         $this->role = TmKeyManagement_Filter::ROLE_REVISOR ;
     }
 
+    private function __matchWithWordBoundary( $what, $where ) {
+        $quoted = preg_quote( $what );
+        return preg_match_all("/\\b$quoted\\b/u", $where ) ;
+    }
+
     /**
      * Only returns matches that are not present in translation.
      *
@@ -50,12 +55,10 @@ class GlossaryModel {
         $unmatched = array() ;
 
         foreach($allMatches as $match) {
-            $quoted = preg_quote( $match['raw_translation'] );
-            $found = preg_match_all("/\\b$quoted\\b/", $translation ) ;
-
-            // TODO: consider to change this in favour of a comparison with
-            // $match['usage_count']. 
-            if ( $found == 0 ) {
+            if (
+                    $this->__matchWithWordBoundary( $match['raw_segment'], $segment ) > 0 &&
+                    $this->__matchWithWordBoundary( $match['raw_translation'], $translation ) === 0
+            ) {
                 $unmatched[] = $match ;
             }
         }

--- a/lib/Plugins/Features/QaCheckGlossary/Worker/GlossaryWorker.php
+++ b/lib/Plugins/Features/QaCheckGlossary/Worker/GlossaryWorker.php
@@ -74,12 +74,26 @@ class GlossaryWorker extends AbstractWorker {
                     'id_segment' => $id_segment,
                     'scope'      => QaCheckGlossary::GLOSSARY_SCOPE,
                     'severity'   => WarningModel::WARNING,
-                    'data'       => json_encode( $entry )
+                    'data'       => json_encode( $this->_formatWarningData( $entry ) )
             ) );
 
             $warningModel->addWarning( $warning );
         }
         $warningModel->save();
+    }
+
+    /**
+     * This function controls what we write in  data field, to avoid to pass the raw TM response to clients.
+     *
+     * @param $warning
+     *
+     * @return array
+     */
+    protected function _formatWarningData( $warning ) {
+        return array(
+                'raw_segment'        => $warning['raw_segment'],
+                'raw_translation'    => $warning['raw_translation']
+        );
     }
 
     protected function _checkForReQueueEnd( QueueElement $queueElement ){

--- a/lib/Plugins/Features/ReviewImproved/Model/QualityReportModel.php
+++ b/lib/Plugins/Features/ReviewImproved/Model/QualityReportModel.php
@@ -154,7 +154,7 @@ class QualityReportModel {
                 $this->structureNestSegment( $record );
             }
 
-            if ( $current_issue_id != $record[ 'issue_id' ] ) {
+            if ( $current_issue_id != $record[ 'issue_id' ] && $record['issue_id'] !== null ) {
                 $this->structureNestIssue( $record );
             }
 


### PR DESCRIPTION
Two issues are resolved here: 

1) fix case when quality report includes segments with no issues ( for example when there is just a QA check to notify ). 
2) only save in segment warnings the terms that have exact match. Prior to this change all terms proposed by the TM where saved to segment_warnings.