### PR TITLE
CurlFile support for PHP >= 5.5

### DIFF
--- a/lib/Utils/Filters.php
+++ b/lib/Utils/Filters.php
@@ -122,7 +122,7 @@ class Filters {
         $filename = "$basename.$extension";
 
         $data = array(
-            'documentContent' => "@$filePath",
+            'documentContent' => Utils::curlFile($filePath),
             'sourceLocale' => Langs_Languages::getInstance()->getLangRegionCode( $sourceLang ),
             'targetLocale' => Langs_Languages::getInstance()->getLangRegionCode( $targetLang ),
             'segmentation' => $segmentation,
@@ -153,7 +153,7 @@ class Filters {
             $tmpFiles[$id] = $tmpXliffFile;
             file_put_contents($tmpXliffFile, $xliffData[ 'document_content' ]);
 
-            $dataGroups[$id] = array('xliffContent' => "@$tmpXliffFile");
+            $dataGroups[$id] = array('xliffContent' => Utils::curlFile($tmpXliffFile));
         }
 
         $responses = self::sendToFilters($dataGroups, self::XLIFF_TO_TARGET_ENDPOINT);

--- a/lib/Utils/Utils.php
+++ b/lib/Utils/Utils.php
@@ -41,6 +41,16 @@ class Utils {
 		return is_array($array) AND (bool) count(array_filter(array_keys($array), 'is_string'));
 	}
 
+	public static function curlFile($filePath)
+	{
+		$curlFile =  "@$filePath";		
+		// CURLfile is available with PHP 5.5 and higher versions
+		if( version_compare(PHP_VERSION, '5.5.0') >= 0 ){ 
+		    $curlFile = new CURLFile($filePath);
+		}
+		return $curlFile;
+	}
+
 	public static function curl_post($url, &$d, $opt = array()) {
 		if (!self::is_assoc($d)) {
 			throw new Exception("The input data to " . __FUNCTION__ . "must be an associative array", -1);


### PR DESCRIPTION
I added a new function to Utils to be used any time Matecat wants to upload a file with Curl.
I think this commit fixes the issue #309. I'm unsure if there are other places where Matecat uploads files.

PS: Utils needs to unify it's cases: I used camelCase, but some other functions use underscore cases.