### PR TITLE
adds config to disable error email sending

### DIFF
--- a/inc/INIT.php
+++ b/inc/INIT.php
@@ -363,6 +363,8 @@ class INIT {
      */
     public static $TASK_RUNNER_CONFIG = null;
 
+    public static $SEND_ERR_MAIL_REPORT = true ;
+
     /**
      * Initialize the Class Instance
      */

--- a/lib/Utils/Utils.php
+++ b/lib/Utils/Utils.php
@@ -128,7 +128,7 @@ class Utils {
 
 	public static function sendErrMailReport( $htmlContent, $subject = null ){
 
-        if ( EnvWrap::isTest() ) {
+        if ( !INIT::$SEND_ERR_MAIL_REPORT ) {
           return true ;
         }
 


### PR DESCRIPTION
Error email delivery can be disabled by a line in config.ini.
Enabled by default, can be disabled for development and test
environment.