### PR TITLE
fix issue with TRACKING_CODES_VIEW_PATH

### DIFF
--- a/inc/Bootstrap.php
+++ b/inc/Bootstrap.php
@@ -51,12 +51,13 @@ class Bootstrap {
         INIT::$OAUTH_CONFIG = $OAUTH_CONFIG[ 'OAUTH_CONFIG' ];
         INIT::obtain();
 
-
+        // Overridable defaults
         INIT::$ROOT                           = self::$_ROOT; // Accessible by Apache/PHP
         INIT::$BASEURL                        = "/"; // Accessible by the browser
         INIT::$TIME_TO_EDIT_ENABLED           = false;
         INIT::$DEFAULT_NUM_RESULTS_FROM_TM    = 3;
         INIT::$THRESHOLD_MATCH_TM_NOT_TO_SHOW = 50;
+        INIT::$TRACKING_CODES_VIEW_PATH       = INIT::$ROOT . "/lib/View";
 
         //get the environment configuration
         self::initConfig();


### PR DESCRIPTION
tracking codes path should default to the TEMPLATE_ROOT.
Otherwise it works by chance, but does not work for plugins that reside in deep nested path. 

In other words "" is considered relative to the local path, so external_sources.html is not found. 