### PR TITLE
RI: fix multitarget projects postCreate callback

### DIFF
--- a/lib/Plugins/Features/ReviewImproved.php
+++ b/lib/Plugins/Features/ReviewImproved.php
@@ -129,8 +129,9 @@ class ReviewImproved extends BaseFeature {
             $this->setQaModelFromJsonFile( $projectStructure );
         }
 
-        $id_job = $projectStructure['array_jobs']['job_list'][0];
-        $this->createQaChunkReviewRecord( $id_job, $projectStructure );
+        foreach( $projectStructure['array_jobs']['job_list'] as $id_job ) {
+            $this->createQaChunkReviewRecord( $id_job, $projectStructure );
+        }
     }
 
     /**
@@ -139,7 +140,7 @@ class ReviewImproved extends BaseFeature {
      * Deletes the previously created record and creates the new records matching the new chunks.
      */
     public function postJobSplitted(\ArrayObject $projectStructure) {
-        $id_job = $projectStructure['array_jobs']['job_list'][0] ;
+        $id_job = $projectStructure['job_to_split'];
         $old_reviews = ChunkReviewDao::findByIdJob( $id_job );
         $first_password = $old_reviews[0]->review_password ;
 

--- a/test/integration/Features/ReviewImproved/CreateRecordInQaJobReviewsTest.php
+++ b/test/integration/Features/ReviewImproved/CreateRecordInQaJobReviewsTest.php
@@ -34,6 +34,31 @@ class CreateRecordInQaJobReviewsTest extends IntegrationTest {
         $this->assertNotEmpty( $reviews );
     }
 
+
+    function tests_qa_job_review_record_for_multiple_targets() {
+        // Create a project with multilanguage target
+
+        $project = integrationCreateTestProject( array(
+            'headers' => $this->test_data->headers,
+            'files' => array(
+                test_file_path('zip-with-model-json.zip')
+            ),
+            'params' => array(
+                'target_lang' => 'it-IT,pt-BR'
+            )
+        ));
+
+        // $project = $this->createProject();
+        $project = Projects_ProjectDao::findById( $project->id_project );
+
+        $this->assertNotNull( $project->id );
+        $reviews = ChunkReviewDao::findByProjectId( $project->id ) ;
+        $this->assertCount(2, $reviews) ;
+        $jobs = $project->getJobs();
+        $this->assertNotNull( ChunkReviewDao::findByIdJob( $jobs[0]->id ) );
+        $this->assertNotNull( ChunkReviewDao::findByIdJob( $jobs[1]->id ) );
+    }
+
     function tests_update_chunk_review_records_on_split() {
         $project = $this->createProject();
         $project = Projects_ProjectDao::findById( $project->id_project );


### PR DESCRIPTION
Fixes a problem with ReviewImproved enabled projects with multi target language. 
Record in `qa_chunk_reviews` was only created for first job. 
Fixed postJobSplitted callback as well which may have been affected by the same problem. 

