### PR TITLE
lexiQA: Enable Suggestions

### DIFF
--- a/public/js/cat_source/lxq.main.js
+++ b/public/js/cat_source/lxq.main.js
@@ -158,78 +158,15 @@ LXQ.init  = function () {
             s5: {t: 'currency mismatch',
                 s: 'currency mismatch'},
             default: {t:'not found in source',
-            	      s: 'missing from target' }                 									 
+            	      s: 'missing from target' }
         };
-        
+
         var modulesNoHighlight = ['b1g','g1g','g2g','g3g'];
         var tpls = LXQ.const.tpls;
 
         var initConstants = function () {
             tpls = LXQ.const.tpls;
         };
-
-        // var renderHistoryWithErrors = function () {
-        //     var root = $(tpls.historyHasErrors);
-        //
-        //     // console.log('### warnings: ');
-        //     // console.dir(LXQ.lexiqaData.lexiqaWarnings);
-        //     LXQ.lexiqaData.segments.sort(function(a,b) {
-        //         if (parseInt(a)>parseInt(b))
-        //             return 1;
-        //         else if (parseInt(a)<parseInt(b))
-        //             return -1;
-        //         else
-        //         //for splitted segments 111-1 111-2 etc.
-        //             if (a>b)
-        //                 return 1;
-        //             else if (a<b)
-        //                 return -1
-        //             else
-        //                 return 0;
-        //     });
-        //     // for (var j = 0; j < LXQ.lexiqaData.segments.length; j++) {
-        //     //     var warnings = getVisibleWarningsCountForSegment(LXQ.lexiqaData.segments[j]);
-        //     //     var ignores = getIgnoredWarningsCountForSegment(LXQ.lexiqaData.segments[j]);
-        //     //     if (ignores!==0 || warnings!==0) {
-        //     //         var segmentWarningsRow = $(tpls.segmentWarningsRow);
-        //     //         segmentWarningsRow.find('.lxq-history-balloon-segment-number').text(LXQ.lexiqaData.segments[j]);
-        //     //         segmentWarningsRow.find('.lxq-history-balloon-segment-link').attr('href', '#' + LXQ.lexiqaData.segments[j]);
-        //     //         segmentWarningsRow.find('.lxq-history-balloon-total').text(warnings);
-        //     //         segmentWarningsRow.find('.lxq-history-balloon-ignored').text(ignores);
-        //
-        //     //         root.append(segmentWarningsRow);
-        //     //     }
-        //     //     else {
-        //     //         console.log('renderHistoryWithErrors: not adding segment: '+ LXQ.lexiqaData.segments[j]);
-        //     //     }
-        //     // }
-        //
-        //     // $('.lxq-history-balloon-has-comment').remove();
-        //     // $('.lxq-history-balloon-has-no-comments').hide();
-        //
-        //     // $('.lxq-history-balloon-outer').append(root);
-        // };
-
-        // var renderHistoryWithNoComments = function () {
-        //     $('.lxq-history-balloon-has-comment').remove();
-        //     $('.lxq-history-balloon-has-no-comments').show();
-        //     //$('.lxq-comment-highlight-history').removeClass('lxq-visible');
-        // };
-        // var updateHistoryWithLoadedSegments = function () {
-        //     if (LXQ.lexiqaData.segments.length == 0) {
-        //         $('#lexiqabox')
-        //             .addClass('lxq-history-balloon-icon-has-no-comments')
-        //             .removeClass('lxq-history-balloon-icon-has-comment');
-        //         renderHistoryWithNoComments();
-        //     }
-        //     else {
-        //         $('#lexiqabox')
-        //             .removeClass('lxq-history-balloon-icon-has-no-comments')
-        //             .addClass('lxq-history-balloon-icon-has-comment');
-        //         // renderHistoryWithErrors();
-        //     }
-        // };
-        
         var refreshElements = function () {
             //initCommentLinks();
             //renderCommentIconLinks();
@@ -264,54 +201,6 @@ LXQ.init  = function () {
 
         });
 
-
-        // $(document).on('lxq:ready', function (ev) {
-        //     //console.log('---------- lxq:ready')
-        //     //$( '#lxq-history' ).remove();
-        //     $('.lxq-history-balloon-outer').remove();
-        //     //$( '.header-menu li#filterSwitch' ).before( $( tpls.historyIcon ) );
-        //     $('.header-menu').append($(tpls.historyOuter).append($(tpls.historyNoComments)));
-        //
-        //
-        //     refreshElements();
-        //
-        //     // open a comment if was asked by hash
-        //     // var lastAsked = popLastCommentHash();
-        //     // if ( lastAsked ) {
-        //     //     openSegmentComment( UI.Segment.findEl( lastAsked.segmentId ) );
-        //     // }
-        // });
-
-
-        // $(document).on('click', '#lexiqabox', function (ev) {
-        //     ev.preventDefault();
-        //     if ($('.searchbox').is(':visible')) {
-        //         UI.toggleSearch(ev);
-        //     }
-        //
-        //     var lexiqaPopupHeight = $('#lexiqa-popup').height() + 30;
-        //
-        //     $('#lexiqa-popup').toggleClass('lxq-visible').focus();
-        //
-        //     if ($('#lexiqa-popup').hasClass('lxq-visible')) {
-        //         $('#outer').css('margin-top', lexiqaPopupHeight);
-        //         //go the first segment with errors...
-        //         var segid = getFristSegmentWithWarning();
-        //         if (UI.segmentIsLoaded(segid) === true)
-        //             UI.gotoSegment(segid);
-        //         else {
-        //             config.last_opened_segment = segid;
-        //             window.location.hash = segid;
-        //             $('#outer').empty();
-        //             UI.render({
-        //                 firstLoad: false
-        //             });
-        //         }
-        //     } else {
-        //         $('#outer').css('margin-top', 20);
-        //     }
-        //     $('.mbc-history-balloon-outer').removeClass('mbc-visible');
-        // });
         var isNumeric = function (n) {
             return !isNaN(parseFloat(n)) && isFinite(n);
         }
@@ -995,7 +884,7 @@ LXQ.init  = function () {
             if (getVisibleWarningsCountForSegment(targetSeg)<=0) {
                 //remove the segment from database/reduce the number count
                 LXQ.lxqRemoveSegmentFromWarningList(targetSeg);
-            }  
+            }
             postIgnoreError(errorid);
         }
 
@@ -1022,7 +911,7 @@ LXQ.init  = function () {
                         glossary: [],
                         blacklist: []
                     }
-            }; 
+            };
             $.each(LXQ.lexiqaData.lexiqaWarnings[segmentId],function(key,qadata) {
                 if (!qadata.ignored)
                 if (qadata.insource) {
@@ -1107,7 +996,7 @@ LXQ.init  = function () {
             }
             else
                 segId = UI.getSegmentId(segment);
-                
+
             if (!LXQ.lexiqaData.lexiqaWarnings.hasOwnProperty(segId))
                 return 0;
             var count = 0;
@@ -1124,7 +1013,7 @@ LXQ.init  = function () {
             }
             else
                 segId = UI.getSegmentId(segment);
-                
+
             if (!LXQ.lexiqaData.lexiqaWarnings.hasOwnProperty(segId))
                 return 0;
             var count = 0;
@@ -1204,7 +1093,7 @@ LXQ.init  = function () {
             if (ind == -1) //this is the largest segmentid
                 ind = 0;
             return LXQ.lexiqaData.segments[ind];
-            
+
         }
         var getPreviousSegmentWithWarning = function () {
             //if there are no errors..
@@ -1229,7 +1118,7 @@ LXQ.init  = function () {
                 ind = LXQ.lexiqaData.segments.length - 1;
             return LXQ.lexiqaData.segments[ind];
         };
-        
+
         var initPopup = function () {
 
             $.ajax(

--- a/public/js/cat_source/lxq.templates.js
+++ b/public/js/cat_source/lxq.templates.js
@@ -17,23 +17,23 @@
         //     '       <div class="lxq-history-balloon-body lxq-clearfix"> ' +
         //     '            <div class="lxq-history-balloon-row lxq-clearfix"> ' +
         //     '                <span class="lxq-history-balloon-header-segment">Segment</span> ' +
-        //     '                <span class="lxq-history-balloon-header-total">Errors</span>' + 
-        //     '                <span class="lxq-history-balloon-header-ignored">Ignored</span>' + 
-        //     '            </div> ' +   
-        //     '' + //     
+        //     '                <span class="lxq-history-balloon-header-total">Errors</span>' +
+        //     '                <span class="lxq-history-balloon-header-ignored">Ignored</span>' +
+        //     '            </div> ' +
+        //     '' + //
         //     '       </div> ' +
-        //     '   </div> ' +    
-        //     ' ' + 
+        //     '   </div> ' +
+        //     ' ' +
         //     ' </div> ',
-          
+
         //   <img src="http://s29.postimg.org/zdbe56c9v/segment_arrow.png" alt="Go to segment" />
         segmentWarningsRow: '' +
             '            <div class="lxq-history-balloon-row lxq-clearfix"> ' +
             '                <span class="lxq-history-balloon-segment"><a href="#" class="lxq-history-balloon-segment-link"><span class="lxq-history-balloon-segment-number">231</span></a></span> ' +
-            '                <span class="lxq-history-balloon-total">3</span>' + 
+            '                <span class="lxq-history-balloon-total">3</span>' +
             '                <span class="lxq-history-balloon-ignored">2</span>' +
-            '           </div> ',  
-            
+            '           </div> ',
+
         historyNoComments : '' +
             ' <div class="lxq-history-balloon lxq-history-balloon-has-no-comments" style="display: block;">' +
             '    <div class="lxq-thread-wrap"> ' +
@@ -56,7 +56,10 @@
             '</div>',
         lxqTooltipSpellcheckBody: ''+
             '<div class="tooltip-error-container"> '+
-                '<a class="tooltip-error-category">xxxx</a> '                 
+                '<a class="tooltip-error-category">xxxx</a> </div>',
+        lxqTooltipSuggestionBody: ''+
+            '<div class="tooltip-error-container lxq-suggestion"> '+
+                '<a class="tooltip-error-category">xxxx</a> </div>',
 
     };
 

--- a/public/js/cat_source/ui.core.js
+++ b/public/js/cat_source/ui.core.js
@@ -2283,11 +2283,16 @@ UI = {
             APP.addNotification(notification);
 		}
 	},
-    currentSegmentLexiQA: function() {
-        var translation = $('.editarea', UI.currentSegment ).text().replace(/\uFEFF/g,'');
-        var id_segment = UI.getSegmentId(UI.currentSegment);
-        LXQ.doLexiQA(UI.currentSegment, translation, id_segment,false, function () {}) ;
-    },
+  segmentLexiQA: function(_segment) {
+      var segment = _segment;
+      //new API?
+      if (_segment.raw) {
+        segment = _segment.raw
+      }
+      var translation = $('.editarea', segment ).text().replace(/\uFEFF/g,'');
+      var id_segment = UI.getSegmentId(segment);
+      LXQ.doLexiQA(segment, translation, id_segment,false, function () {}) ;
+  },
 	currentSegmentQA: function() {
         console.warn(
             'currentSegmentQA is deprecated, use segmentQA and pass a segment as argument',
@@ -2346,25 +2351,26 @@ UI = {
 			success: function(d) {
 				if (segment.el.hasClass('waiting_for_check_result')) {
 
-                    // TODO: define d.total more explicitly
+          // TODO: define d.total more explicitly
 					if ( !d.total ) {
-						$('p.warnings', segment.el).empty();
-						$('span.locked.mismatch', segment.el).removeClass('mismatch');
-                        $('.editor .editarea .order-error').removeClass('order-error');
+  						$('p.warnings', segment.el).empty();
+  						$('span.locked.mismatch', segment.el).removeClass('mismatch');
+              $('.editor .editarea .order-error').removeClass('order-error');
 
 					}
-                    else {
-                        UI.fillCurrentSegmentWarnings(d.details, false); // update warnings
-                        UI.markTagMismatch(d.details);
-                        delete UI.checkSegmentsArray[d.token]; // delete the token from the tail
-                        segment.el.removeClass('waiting_for_check_result');
-                    }
+          else {
+              UI.fillCurrentSegmentWarnings(d.details, false); // update warnings
+              UI.markTagMismatch(d.details);
+              delete UI.checkSegmentsArray[d.token]; // delete the token from the tail
+              segment.el.removeClass('waiting_for_check_result');
+          }
 				}
 
-                $(document).trigger('getWarning:local:success', { resp : d, segment: segment }) ;
+        $(document).trigger('getWarning:local:success', { resp : d, segment: segment }) ;
+        if (LXQ.enabled()) UI.segmentLexiQA(segment);
 			}
 		}, 'local');
-        if (LXQ.enabled()) UI.currentSegmentLexiQA();
+
 	},
 
     translationIsToSave : function( segment ) {
@@ -3134,7 +3140,7 @@ UI = {
         var htmlToSave = this.editarea.html();
         this.undoStack.push(htmlToSave);
         // $('.undoCursorPlaceholder').remove();
-        
+
 	},
 	clearUndoStack: function() {
 		this.undoStack = [];


### PR DESCRIPTION
- Added code to show localization suggestions by lexiQA where available (currently dates) on warning tooltip, with the option to "click to replace with suggestion".
- Changed deprecated call currentSegmentQA to segmentQA
- moved lexiQA checks inside the success handler of segmentQA
- Removed commented out code