### PR TITLE
lexiQA PartnerId configurable - suggestions update

### DIFF
--- a/inc/INIT.php
+++ b/inc/INIT.php
@@ -118,9 +118,13 @@ class INIT {
      *
      */
     public static $LXQ_LICENSE = false;
-
     public static $LXQ_SERVER  = "https://backend.lexiqa.net";
-
+    /**
+     * Your partnerid will be provided along with your
+     * @see http://www.lexiqa.net
+     *
+     */
+    public static $LXQ_PARTNERID  = false;
     /**
      * Time zone string that should match the one set in the database.
      * @var string

--- a/inc/config.ini.sample
+++ b/inc/config.ini.sample
@@ -35,6 +35,9 @@ FILTERS_MASHAPE_KEY = Register to https://market.mashape.com/translated/matecat-
 ; THIS SHOULD BE YOUR LEXIQA LICENSE, Request your license key at
 ; @see http://www.lexiqa.net
 LXQ_LICENSE = false
+LXQ_PARTNERID = false
+
+
 
 ;----------------------------------------
 [staging]
@@ -63,6 +66,9 @@ FILTERS_MASHAPE_KEY = Register to https://market.mashape.com/translated/matecat-
 ; THIS SHOULD BE YOUR LEXIQA LICENSE, Request your license key at
 ; @see http://www.lexiqa.net
 LXQ_LICENSE = false
+LXQ_PARTNERID = false
+
+
 
 ;----------------------------------------
 [production]
@@ -91,3 +97,5 @@ FILTERS_MASHAPE_KEY = Register to https://market.mashape.com/translated/matecat-
 ; THIS SHOULD BE YOUR LEXIQA LICENSE, Request your license key at
 ; @see http://www.lexiqa.net
 LXQ_LICENSE = false
+LXQ_PARTNERID = false
+LXQ_PARTNERID = false

--- a/lib/Model/LexiQA/LexiQADecorator.php
+++ b/lib/Model/LexiQA/LexiQADecorator.php
@@ -60,6 +60,7 @@ class LexiQADecorator {
         if( INIT::$LXQ_LICENSE ){
             //LEXIQA license key
             $this->template->lxq_license = INIT::$LXQ_LICENSE;
+            $this->template->lxq_partnerid = INIT::$LXQ_PARTNERID;
             $this->template->lexiqa_languages = json_encode( ProjectOptionsSanitizer::$lexiQA_allowed_languages );
         }
 

--- a/lib/View/index.html
+++ b/lib/View/index.html
@@ -84,6 +84,7 @@
                  *
                 */
                 lxq_license: '${lxq_license | string:}',
+                lxq_partnerid: '${lxq_partnerid | string:}',
                 lxq_enabled:  ${lxq_enabled},
                 lexiqa_languages: ${lexiqa_languages | string:[]},
                 lexiqaServer: '${lexiqaServer | string:}',

--- a/public/js/cat_source/lxq.main.js
+++ b/public/js/cat_source/lxq.main.js
@@ -729,7 +729,7 @@ LXQ.init  = function () {
                         if (warningData.suggestions && warningData.suggestions.length && word && word.length) {
                           $.each(warningData.suggestions, function (i, suggest) {
                               var suggestRow = $(tpls.lxqTooltipSuggestionBody);
-                              suggestRow.find('.tooltip-error-category').text(suggest);
+                              suggestRow.find('.tooltip-error-category').text(suggest).css('cursor','pointer');;
                               suggestRow.data('word',word);
                               root.append(suggestRow);
                           });

--- a/public/js/cat_source/lxq.main.js
+++ b/public/js/cat_source/lxq.main.js
@@ -81,14 +81,14 @@ LXQ.init  = function () {
       $.lexiqaAuthenticator.init(
           {
               licenseKey: config.lxq_license,
-              partnerId: 'matecat',
+              partnerId: config.lxq_partnerid,
               lxqServer: config.lexiqaServer,
               projectId: config.id_job+'-'+config.password
           }
       );
     }
     return (function ($, config, window, LXQ, undefined) {
-        var partnerid = 'matecat';
+        var partnerid = config.lxq_partnerid;
         var colors = {
             numbers: '#D08053',
             punctuation: '#3AB45F',


### PR DESCRIPTION
1) We would like to have LXQ_PARTNERID as a a configuration option. It will be provided by lexiQA along with the license key.

2) Update to lexiQA Suggestions on tooltip: Cursor set to pointer in order to show that the item is clickable

