### PR TITLE
Enable LexiQA in teams branch

### DIFF
--- a/inc/INIT.php
+++ b/inc/INIT.php
@@ -119,8 +119,13 @@ class INIT {
      */
     public static $LXQ_LICENSE = false;
 
-    public static $LXQ_SERVER  = "http://localhost:8181";
-
+    public static $LXQ_SERVER  = "https://backend.lexiqa.net";
+    /**
+     * Your partnerid will be provided along with your license key
+     * @see http://www.lexiqa.net
+     *
+     */
+    public static $LXQ_PARTNERID  = false;
     /**
      * Time zone string that should match the one set in the database.
      * @var string

--- a/inc/INIT.php
+++ b/inc/INIT.php
@@ -119,7 +119,7 @@ class INIT {
      */
     public static $LXQ_LICENSE = false;
 
-    public static $LXQ_SERVER  = "https://backend.lexiqa.net";
+    public static $LXQ_SERVER  = "http://localhost:8181";
 
     /**
      * Time zone string that should match the one set in the database.

--- a/inc/config.ini.sample
+++ b/inc/config.ini.sample
@@ -35,6 +35,7 @@ FILTERS_MASHAPE_KEY = Register to https://market.mashape.com/translated/matecat-
 ; THIS SHOULD BE YOUR LEXIQA LICENSE, Request your license key at
 ; @see http://www.lexiqa.net
 LXQ_LICENSE = false
+LXQ_PARTNERID = false
 
 ;----------------------------------------
 [staging]
@@ -63,6 +64,7 @@ FILTERS_MASHAPE_KEY = Register to https://market.mashape.com/translated/matecat-
 ; THIS SHOULD BE YOUR LEXIQA LICENSE, Request your license key at
 ; @see http://www.lexiqa.net
 LXQ_LICENSE = false
+LXQ_PARTNERID = false
 
 ;----------------------------------------
 [production]
@@ -91,3 +93,4 @@ FILTERS_MASHAPE_KEY = Register to https://market.mashape.com/translated/matecat-
 ; THIS SHOULD BE YOUR LEXIQA LICENSE, Request your license key at
 ; @see http://www.lexiqa.net
 LXQ_LICENSE = false
+LXQ_PARTNERID = false

--- a/lib/Model/LexiQA/LexiQADecorator.php
+++ b/lib/Model/LexiQA/LexiQADecorator.php
@@ -61,6 +61,7 @@ class LexiQADecorator {
         if( INIT::$LXQ_LICENSE ){
             //LEXIQA license key
             $this->template->lxq_license = INIT::$LXQ_LICENSE;
+            $this->template->lxq_partnerid = INIT::$LXQ_PARTNERID;
             $this->template->lexiqa_languages = json_encode( ProjectOptionsSanitizer::$lexiQA_allowed_languages );
         }
 

--- a/lib/Model/LexiQA/LexiQADecorator.php
+++ b/lib/Model/LexiQA/LexiQADecorator.php
@@ -95,14 +95,14 @@ class LexiQADecorator {
             $this->lexiqa_enabled = false;
             return $this;
         }
-
-        if  (
-            in_array( Features::QACHECK_GLOSSARY, $featureSet->getCodes() ) ||
-            in_array( Features::QACHECK_BLACKLIST, $featureSet->getCodes() )
-        ) {
-                $this->deny_lexiqa = true;
-                $this->lexiqa_enabled = false;
-        }
+        $this->lexiqa_enabled = true;
+        // if  (
+        //     in_array( Features::QACHECK_GLOSSARY, $featureSet->getCodes() ) ||
+        //     in_array( Features::QACHECK_BLACKLIST, $featureSet->getCodes() )
+        // ) {
+        //         $this->deny_lexiqa = true;
+        //         $this->lexiqa_enabled = false;
+        // }
 
         return $this;
 

--- a/lib/Plugins/Features/QaCheckBlacklist/Decorator/CatDecorator.php
+++ b/lib/Plugins/Features/QaCheckBlacklist/Decorator/CatDecorator.php
@@ -16,6 +16,6 @@ class CatDecorator extends \AbstractDecorator {
      */
     public function decorate() {
         $this->template->qa_check_blacklist_enabled = true ;
-        $this->template->deny_lexiqa = true ;
+        //$this->template->deny_lexiqa = true ;
     }
 }

--- a/lib/Plugins/Features/QaCheckGlossary/Decorator/CatDecorator.php
+++ b/lib/Plugins/Features/QaCheckGlossary/Decorator/CatDecorator.php
@@ -19,6 +19,6 @@ class CatDecorator extends \AbstractDecorator {
      */
     public function decorate() {
         $this->template->qa_check_glossary_enabled = true ;
-        $this->template->deny_lexiqa = true ;
+        //$this->template->deny_lexiqa = true ;
     }
 }

--- a/lib/View/index.html
+++ b/lib/View/index.html
@@ -87,6 +87,7 @@
                 lxq_enabled:  ${lxq_enabled},
                 lexiqa_languages: ${lexiqa_languages | string:[]},
                 lexiqaServer: '${lexiqaServer | string:}',
+                lxq_partnerid: '${lxq_partnerid | string:}',
                 deny_lexiqa: ${deny_lexiqa | string:false},
 
                 qa_check_glossary_enabled : ${qa_check_glossary_enabled | string:false },

--- a/public/js/cat_source/lxq.main.js
+++ b/public/js/cat_source/lxq.main.js
@@ -77,8 +77,6 @@ var LXQ = {
 
 LXQ.init  = function () {
     LXQ.initialized = true;
-    //TODO: merge the rest of lxq partnerId stuff
-    config.lxq_partnerid = 'matecat';
     var globalReceived = false;
     if (config.lxq_license) {
       $.lexiqaAuthenticator.init(

--- a/public/js/cat_source/lxq.templates.js
+++ b/public/js/cat_source/lxq.templates.js
@@ -17,23 +17,23 @@
         //     '       <div class="lxq-history-balloon-body lxq-clearfix"> ' +
         //     '            <div class="lxq-history-balloon-row lxq-clearfix"> ' +
         //     '                <span class="lxq-history-balloon-header-segment">Segment</span> ' +
-        //     '                <span class="lxq-history-balloon-header-total">Errors</span>' + 
-        //     '                <span class="lxq-history-balloon-header-ignored">Ignored</span>' + 
-        //     '            </div> ' +   
-        //     '' + //     
+        //     '                <span class="lxq-history-balloon-header-total">Errors</span>' +
+        //     '                <span class="lxq-history-balloon-header-ignored">Ignored</span>' +
+        //     '            </div> ' +
+        //     '' + //
         //     '       </div> ' +
-        //     '   </div> ' +    
-        //     ' ' + 
+        //     '   </div> ' +
+        //     ' ' +
         //     ' </div> ',
-          
+
         //   <img src="http://s29.postimg.org/zdbe56c9v/segment_arrow.png" alt="Go to segment" />
         segmentWarningsRow: '' +
             '            <div class="lxq-history-balloon-row lxq-clearfix"> ' +
             '                <span class="lxq-history-balloon-segment"><a href="#" class="lxq-history-balloon-segment-link"><span class="lxq-history-balloon-segment-number">231</span></a></span> ' +
-            '                <span class="lxq-history-balloon-total">3</span>' + 
+            '                <span class="lxq-history-balloon-total">3</span>' +
             '                <span class="lxq-history-balloon-ignored">2</span>' +
-            '           </div> ',  
-            
+            '           </div> ',
+
         historyNoComments : '' +
             ' <div class="lxq-history-balloon lxq-history-balloon-has-no-comments" style="display: block;">' +
             '    <div class="lxq-thread-wrap"> ' +
@@ -56,7 +56,10 @@
             '</div>',
         lxqTooltipSpellcheckBody: ''+
             '<div class="tooltip-error-container"> '+
-                '<a class="tooltip-error-category">xxxx</a> '                 
+                '<a class="tooltip-error-category">xxxx</a> </div>',
+        lxqTooltipSuggestionBody: ''+
+            '<div class="tooltip-error-container lxq-suggestion"> '+
+                '<a class="tooltip-error-category">xxxx</a> </div>',
 
     };
 

--- a/public/js/cat_source/qa_check_blacklist.js
+++ b/public/js/cat_source/qa_check_blacklist.js
@@ -60,7 +60,8 @@ if (QaCheckBlacklist.enabled() )
             editarea[0].normalize() ;
 
             var newHTML = editarea.html() ;
-            newHTML = LXQ.cleanUpHighLighting(newHTML);
+            if (LXQ.enabled())
+              newHTML = LXQ.cleanUpHighLighting(newHTML);
             $(matched_words).each(function(index, value) {
                 value = escapeRegExp( value );
                 var re = new RegExp('\\b(' + value + ')\\b',"g");

--- a/public/js/cat_source/qa_check_blacklist.js
+++ b/public/js/cat_source/qa_check_blacklist.js
@@ -26,7 +26,24 @@ if (QaCheckBlacklist.enabled() )
         });
         $('.blacklistItem', editarea).data({ 'powertipjq' : $('<div class="blacklistTooltip">Blacklisted term</div>') });
     }
-
+    /*
+    * Can be called externaly (by LexiQA) to reload powerip
+    * and add the click handler - which have been removed after the HTML was replaced
+    */
+    function reloadPowertip(editarea) {
+        $('.blacklistItem', editarea).powerTip({
+            placement : 's'
+        });
+        $('.blacklistItem', editarea).data({ 'powertipjq' : $('<div class="blacklistTooltip">Blacklisted term</div>') });
+        $('.blacklistItem', editarea).on('click', blacklistItemClick);
+    }
+    /*
+    * Can be called externaly (by LexiQA) to destroy powtip and prevent
+    * memory leak when HTML is replaced
+    */
+    function destroyPowertip(editarea) {
+        $.powerTip.destroy($('.blacklistItem', editarea));
+    }
     /**
      *
      * @param editarea
@@ -43,7 +60,7 @@ if (QaCheckBlacklist.enabled() )
             editarea[0].normalize() ;
 
             var newHTML = editarea.html() ;
-
+            newHTML = LXQ.cleanUpHighLighting(newHTML);
             $(matched_words).each(function(index, value) {
                 value = escapeRegExp( value );
                 var re = new RegExp('\\b(' + value + ')\\b',"g");
@@ -89,6 +106,7 @@ if (QaCheckBlacklist.enabled() )
 
     $( window ).on( 'segmentsAdded', function ( e ) {
         globalReceived = false ;
+        console.log('[QACHECKBLACKLIST] got segmentsAdded');
         renderGlobalWarnings() ;
     });
 
@@ -98,11 +116,12 @@ if (QaCheckBlacklist.enabled() )
         }
 
         globalWarnings = data.resp.data.blacklist ;
-
+        console.log('[QACHECKBLACKLIST] got getWarning:GLOBAL:success');
         renderGlobalWarnings() ;
     });
 
     $(document).on('getWarning:local:success', function(e, data) {
+      console.log('[QACHECKBLACKLIST] got getWarning:local:success');
         if ( !data.resp.data.blacklist || data.segment.isReadonly() ) {
             // No blacklist data contained in response, skip it
             // or segment is readonly, skip
@@ -115,8 +134,9 @@ if (QaCheckBlacklist.enabled() )
         updateBlacklistItemsInSegment( editarea, matched_words );
     });
 
+    $.extend(QaCheckBlacklist, {
+        reloadPowertip : reloadPowertip,
+        destroyPowertip: destroyPowertip
+    });
+
 })(jQuery, UI );
-
-
-
-

--- a/public/js/cat_source/qa_check_glossary.js
+++ b/public/js/cat_source/qa_check_glossary.js
@@ -16,6 +16,7 @@ if ( QaCheckGlossary.enabled() )
      * so to provide a consistent feelint go the user.
      */
     $(document).on('getWarning:local:success', function( e, data ) {
+        console.log('[GLOSSARY] getWarning:local:success');
         startLocalUnusedGlossaryHighlight( data.segment );
     });
 
@@ -76,6 +77,22 @@ if ( QaCheckGlossary.enabled() )
 
         updateGlossaryUnusedMatches( segment, unusedMatches ) ;
     }
+    /*
+    * Can be called externaly (by LexiQA) to reload powerip
+    */
+    function redoBindEvents(container) {
+        $('.unusedGlossaryTerm', container).powerTip({
+            placement : 's'
+        });
+        $('.unusedGlossaryTerm', container).data({ 'powertipjq' : $('<div class="unusedGlossaryTip" style="padding: 4px;">Unused glossary term</div>') });
+    }
+    /*
+    * Can be called externaly (by LexiQA) to destroy powtip and prevent
+    * memory leak when HTML is replaced
+    */
+    function destroyPowertip(container) {
+        $.powerTip.destroy($('.blacklistItem', container));
+    }
 
     function bindEvents( container, unusedMatches ) {
 
@@ -130,7 +147,9 @@ if ( QaCheckGlossary.enabled() )
     }
 
     $.extend(QaCheckGlossary, {
-        removeUnusedGlossaryMarks : removeUnusedGlossaryMarks
+        removeUnusedGlossaryMarks : removeUnusedGlossaryMarks,
+        destroyPowertip: destroyPowertip,
+        redoBindEvents: redoBindEvents
     });
 
 })(jQuery, QaCheckGlossary);

--- a/public/js/cat_source/qa_check_glossary.js
+++ b/public/js/cat_source/qa_check_glossary.js
@@ -16,7 +16,6 @@ if ( QaCheckGlossary.enabled() )
      * so to provide a consistent feelint go the user.
      */
     $(document).on('getWarning:local:success', function( e, data ) {
-        console.log('[GLOSSARY] getWarning:local:success');
         startLocalUnusedGlossaryHighlight( data.segment );
     });
 

--- a/public/js/cat_source/qa_check_glossary.js
+++ b/public/js/cat_source/qa_check_glossary.js
@@ -116,7 +116,9 @@ if ( QaCheckGlossary.enabled() )
         removeUnusedGlossaryMarks( container ) ;
 
         var newHTML = container.html();
-
+        //clean up lexiqa highlighting - if enabled
+        if (LXQ.enabled())
+          newHTML = LXQ.cleanUpHighLighting(newHTML);
         $.each(unusedMatches, function( index ) {
             var value = this.raw_segment ;
             value = escapeRegExp( value );

--- a/support_scripts/grunt/Gruntfile.js
+++ b/support_scripts/grunt/Gruntfile.js
@@ -193,6 +193,8 @@ module.exports = function(grunt) {
                     basePath + 'cat_source/db.js',
                     basePath + 'cat_source/mbc.main.js',
                     basePath + 'cat_source/mbc.templates.js',
+                    //WARNING: lxq.main.js: this should always be below qa_check_glossary and
+                    //qa_check_blacklist, in order for its event handlers to be excecuted last
                     basePath + 'cat_source/lxq.main.js',
                     basePath + 'cat_source/lxq.templates.js',
                     basePath + 'cat_source/project_completion.*.js',
@@ -448,5 +450,3 @@ module.exports = function(grunt) {
         'sass'
     ]);
 };
-
-


### PR DESCRIPTION
**Merged LexiQA changes from developement:**
- Create config parameter lxq_partnerid and add it in initialization code
- Add code for LexiQA suggestions

**Enable LexiQA in teams**
- Bind lexiqa to "getWarning:local:success", "getWarning:global:success", "setTranslation:success", "segmentsAdded", in order to force excecution after Matecat's qa_check blacklist/glossary
- Added a destroy/reload powetip method in both qa_check_blacklist/glossary. Since LexiQA replaces the source/edit area HTML, any powertip & event handlers are lost and need to be recreated.
- In qa_check_glosasary/blacklist: If lexiQA is enabled, clean up its markup before adding their own
- Changed LexiQA highlighter to preserve (and give priority) to anything within <spans>s in the source/target HTML. If an overlap of an LexiQA warning with a Matecat QA check (or other markup) occures, the LexiQA warning is not highlighted.
- Removed  hardcoded "deny_lexiqa" in the relevant decorators

@freegenie 