### PR TITLE
fix job download URLs + add chunk status in API

### DIFF
--- a/lib/View/API/V2/Json/Chunk.php
+++ b/lib/View/API/V2/Json/Chunk.php
@@ -36,6 +36,7 @@ class Chunk {
         }
 
         return [
+            'status'             => $chunk->status_owner,
             'password'           => $chunk->password,
             'created_at'         => \Utils::api_timestamp($chunk->create_date),
             'open_threads_count' => (int) $chunk->getOpenThreadsCount(),

--- a/lib/View/API/V2/Json/ProjectUrls.php
+++ b/lib/View/API/V2/Json/ProjectUrls.php
@@ -40,7 +40,7 @@ class ProjectUrls {
                     'id' => $record['id_file'],
                     'name' => $record['filename'],
                     'original_download_url' => $this->downloadOriginalUrl( $record ),
-                    'translation_download_url' => $this->downloadTranslationUrl( $record ),
+                    'translation_download_url' => $this->downloadFileTranslationUrl( $record ),
                     'xliff_download_url' => $this->downloadXliffUrl( $record )
                 );
             }
@@ -93,11 +93,19 @@ class ProjectUrls {
         );
     }
 
+    private function downloadFileTranslationUrl($record ) {
+        return Routes::downloadTranslation(
+                $record['jid'],
+                $record['jpassword'],
+                $record['id_file']
+        );
+    }
+
     private function downloadTranslationUrl($record) {
         return Routes::downloadTranslation(
             $record['jid'],
             $record['jpassword'],
-            $record['id_file']
+            ''
         );
     }
 


### PR DESCRIPTION
To download the whole translation the id_file parameter must be null.