### PR TITLE
Fix Error when issue is hovered in sidepanel

### DIFF
--- a/lib/Plugins/Features/ReviewImproved/Decorator/CatDecorator.php
+++ b/lib/Plugins/Features/ReviewImproved/Decorator/CatDecorator.php
@@ -49,7 +49,7 @@ class CatDecorator extends \AbstractDecorator {
         }
 
         $this->template->overall_quality_class = $this->getOverallQualityClass();
-        $this->template->deny_lexiqa = $this->controller->isRevision() ;
+        $this->template->deny_lexiqa = false ; // TODO: remove this variable
 
     }
 

--- a/public/js/cat_source/lxq.main.js
+++ b/public/js/cat_source/lxq.main.js
@@ -98,7 +98,7 @@ LXQ.init  = function () {
         if (data.segment.raw) {
           segment = data.segment.raw
         }
-        var translation = $('.editarea', segment ).text().replace(/\uFEFF/g,'');
+        var translation = $(UI.targetContainerSelector(), segment ).text().replace(/\uFEFF/g,'');
         var id_segment = UI.getSegmentId(segment);
         LXQ.doLexiQA(segment, translation, id_segment,false, function () {}) ;
     });
@@ -116,7 +116,7 @@ LXQ.init  = function () {
     $(document).on('setTranslation:success', function(e, data) {
       console.log('[LEXIQA] got setTranslation:success');
         var segment = data.segment;
-        var translation = $('.editarea', segment ).text().replace(/\uFEFF/g,'');
+        var translation = $(UI.targetContainerSelector(), segment ).text().replace(/\uFEFF/g,'');
         LXQ.doLexiQA(segment,translation,UI.getSegmentId(segment),true,null);
     });
     /* invoked when more segments are loaded...*/
@@ -131,10 +131,10 @@ LXQ.init  = function () {
                       //clean up and redo powertip on any glossaries/blacklists
                       var _segment = UI.getSegmentById(segment.sid)
                       QaCheckGlossary.enabled() && QaCheckGlossary.destroyPowertip(_segment);
-                      QaCheckBlacklist.enabled() && QaCheckBlacklist.destroyPowertip($( ".editarea", _segment ));
+                      QaCheckBlacklist.enabled() && QaCheckBlacklist.destroyPowertip($( UI.targetContainerSelector(), _segment ));
                       LXQ.redoHighlighting(segment.sid,true);
                       LXQ.redoHighlighting(segment.sid,false);
-                      QaCheckBlacklist.enabled() && QaCheckBlacklist.reloadPowertip($( ".editarea", _segment ));
+                      QaCheckBlacklist.enabled() && QaCheckBlacklist.reloadPowertip($( UI.targetContainerSelector(), _segment ));
                       QaCheckGlossary.enabled() && QaCheckGlossary.redoBindEvents(_segment);
                   }
             });
@@ -712,7 +712,7 @@ LXQ.init  = function () {
         };
         var buildPowertipDataForSegment = function (segment) {
             var sourceHighlihts = $('.source', segment).find('lxqwarning#lexiqahighlight');
-            var targetHighlihts = $('.editarea', segment).find('lxqwarning#lexiqahighlight');
+            var targetHighlihts = $(UI.targetContainerSelector(), segment).find('lxqwarning#lexiqahighlight');
 
             $.each(sourceHighlihts, function(i, element) {
                var classlist = element.className.split(/\s+/);
@@ -917,7 +917,7 @@ LXQ.init  = function () {
         }
 
         var replaceWord  = function(word, suggest,target) {
-            if ($(target).closest('.editarea').attr('contenteditable')) {
+            if ($(target).closest(UI.targetContainerSelector()).attr('contenteditable')) {
                 if ($(target).text() === word) {
                     //there is no overlaping errors (like caps after punct...)
                 }
@@ -1013,11 +1013,11 @@ LXQ.init  = function () {
                 $(".source", segment).html(html);
             }
             else {
-                //html = UI.clearMarks($.trim($(".editarea", segment).html()));
-                html = $(".editarea", segment).html();
+                //html = UI.clearMarks($.trim($(UI.targetContainerSelector(), segment).html()));
+                html = $(UI.targetContainerSelector(), segment).html();
                 html = highLightText(html,highlights.target,(segment===UI.currentSegment ? true : false),
                     LXQ.shouldHighlighWarningsForSegment(segment),false,segment);
-                $(".editarea", segment).html(html);
+                $(UI.targetContainerSelector(), segment).html(html);
 
             }
             // $('.lxq-error-seg',segment).attr('numberoferrors',LXQ.getVisibleWarningsCountForSegment(segment));
@@ -1383,19 +1383,19 @@ LXQ.init  = function () {
                             //delete LXQ.lexiqaWarnings[id_segment];
                             LXQ.lexiqaData.lexiqaWarnings[id_segment] = newWarnings[id_segment];
                             QaCheckGlossary.enabled() && QaCheckGlossary.destroyPowertip(segment);
-                            QaCheckBlacklist.enabled() && QaCheckBlacklist.destroyPowertip($( ".editarea", segment ));
+                            QaCheckBlacklist.enabled() && QaCheckBlacklist.destroyPowertip($( UI.targetContainerSelector(), segment ));
                             source_val = LXQ.highLightText( source_val, highlights.source, isSegmentCompleted, true, true, segment );
                             if ( callback != null )
                                 saveSelection();
-                            var target_val = $( ".editarea", segment ).html();
+                            var target_val = $( UI.targetContainerSelector(), segment ).html();
                             target_val = LXQ.highLightText( target_val, highlights.target, isSegmentCompleted, true, false, segment );
 
-                            $( ".editarea", segment ).html( target_val );
+                            $( UI.targetContainerSelector(), segment ).html( target_val );
                             if ( callback != null )
                                 restoreSelection();
                             $( ".source", segment ).html( source_val );
                             LXQ.reloadPowertip( segment );
-                            QaCheckBlacklist.enabled() && QaCheckBlacklist.reloadPowertip($( ".editarea", segment ));
+                            QaCheckBlacklist.enabled() && QaCheckBlacklist.reloadPowertip($( UI.targetContainerSelector(), segment ));
                             QaCheckGlossary.enabled() && QaCheckGlossary.redoBindEvents(segment);
                             //only reload dropdown menu and link, if there was an error...
                             //if ( LXQ.enabled() ) LXQ.refreshElements();
@@ -1411,9 +1411,9 @@ LXQ.init  = function () {
                             source_val = LXQ.cleanUpHighLighting( source_val );
                             if ( callback != null )
                                 saveSelection();
-                            target_val = $( ".editarea", segment ).html();
+                            target_val = $( UI.targetContainerSelector(), segment ).html();
                             target_val = LXQ.cleanUpHighLighting( target_val );
-                            $( ".editarea", segment ).html( target_val );
+                            $( UI.targetContainerSelector(), segment ).html( target_val );
                             if ( callback != null )
                                 restoreSelection();
                             $( ".source", segment ).html( source_val );
@@ -1485,7 +1485,7 @@ LXQ.init  = function () {
                             };
                             LXQ.lexiqaData.lexiqaWarnings[element.segid] = {};
                             var seg = UI.getSegmentById( element.segid );
-                            var translation = $( ".editarea", seg ).text();
+                            var translation = $( UI.targetContainerSelector(), seg ).text();
                             results.results[element.segid].forEach( function ( qadata ) {
                                 LXQ.lexiqaData.lexiqaWarnings[element.segid][qadata.errorid] = qadata;
                                 if ( !qadata.ignored ) {
@@ -1515,14 +1515,14 @@ LXQ.init  = function () {
                             var source_val = $( ".source", seg ).html();
                             QaCheckGlossary.enabled() && QaCheckGlossary.destroyPowertip(seg);
                             source_val = LXQ.highLightText( source_val, highlights.source, true, LXQ.shouldHighlighWarningsForSegment( seg ), true, seg );
-                            QaCheckBlacklist.enabled() && QaCheckBlacklist.destroyPowertip($( ".editarea", seg ));
+                            QaCheckBlacklist.enabled() && QaCheckBlacklist.destroyPowertip($( UI.targetContainerSelector(), seg ));
                             var target_val = $(".targetarea", seg).html();
                             target_val = LXQ.highLightText( target_val, highlights.target, true, LXQ.shouldHighlighWarningsForSegment( seg ), false, seg );
                             $(".targetarea", seg).html(target_val);
                             $( ".source", seg ).html( source_val );
                             LXQ.buildPowertipDataForSegment( seg );
                             QaCheckGlossary.enabled() && QaCheckGlossary.redoBindEvents(seg);
-                            QaCheckBlacklist.enabled() && QaCheckBlacklist.reloadPowertip($( ".editarea", seg ));
+                            QaCheckBlacklist.enabled() && QaCheckBlacklist.reloadPowertip($( UI.targetContainerSelector(), seg ));
                         } );
                         if ( LXQ.enabled() ) {
                             LXQ.reloadPowertip();

--- a/public/js/cat_source/review_improved.review_events.js
+++ b/public/js/cat_source/review_improved.review_events.js
@@ -75,22 +75,38 @@ if ( ReviewImproved.enabled() && config.isReview ) {
     var textSelectedInsideSelectionArea = function( selection, container ) {
         // return $.inArray( selection.focusNode, container.contents() ) !==  -1 &&
         //     $.inArray( selection.anchorNode, container.contents() ) !== -1 &&
-        return container.contents().text().indexOf(selection.focusNode.wholeText)>=0 &&
-            container.contents().text().indexOf(selection.anchorNode.wholeText)>=0 &&
+        return container.contents().text().indexOf(selection.focusNode.textContent)>=0 &&
+            container.contents().text().indexOf(selection.anchorNode.textContent)>=0 &&
             selection.toString().length > 0 ;
     };
 
     function getSelectionData(selection, container) {
         var data = {};
-
         data.start_node = $.inArray( selection.anchorNode, container.contents() );
-        data.start_offset = selection.anchorOffset;
+        var nodes = container.contents();//array of nodes
+        if (data.start_node ===0)
+          data.start_offset =  selection.anchorOffset;
+        else {
+          data.start_offset = 0;
+          for (var i=0;i<data.start_node;i++) {
+            data.start_offset += nodes[i].textContent.length;
+          }
+          data.start_offset += selection.anchorOffset;
+          data.start_node = 0;
+        }
 
         data.end_node = $.inArray( selection.focusNode, container.contents() );
-        data.end_offset = selection.focusOffset;
-
+        if (data.end_node ===0)
+          data.end_offset =  selection.focusOffset;
+        else {
+          data.end_offset = 0;
+          for (var i=0;i<data.end_node;i++) {
+            data.end_offset += nodes[i].textContent.length;
+          }
+          data.end_offset += selection.focusOffset;
+          data.end_node = 0;
+        }
         data.selected_string = selection.toString() ;
-
         return data ;
     }
 

--- a/public/js/cat_source/review_improved.review_events.js
+++ b/public/js/cat_source/review_improved.review_events.js
@@ -35,7 +35,7 @@ if ( ReviewImproved.enabled() && config.isReview ) {
         var section = $(e.target).closest('section') ;
 
         if ( section.hasClass('muted') || section.hasClass('readonly') ) {
-            return ; 
+            return ;
         }
 
         if ( ! section.hasClass('opened') ) {
@@ -73,8 +73,10 @@ if ( ReviewImproved.enabled() && config.isReview ) {
     });
 
     var textSelectedInsideSelectionArea = function( selection, container ) {
-        return $.inArray( selection.focusNode, container.contents() ) !==  -1 &&
-            $.inArray( selection.anchorNode, container.contents() ) !== -1 &&
+        // return $.inArray( selection.focusNode, container.contents() ) !==  -1 &&
+        //     $.inArray( selection.anchorNode, container.contents() ) !== -1 &&
+        return container.contents().text().indexOf(selection.focusNode.wholeText)>=0 &&
+            container.contents().text().indexOf(selection.anchorNode.wholeText)>=0 &&
             selection.toString().length > 0 ;
     };
 
@@ -97,17 +99,19 @@ if ( ReviewImproved.enabled() && config.isReview ) {
         UI.gotoNextSegment();
     });
 
-    $(document).on('mouseup', 'section.opened .errorTaggingArea', function(e) {
+
+    $(document).on('mouseup', 'section.opened .errorTaggingArea', function (e) {
         var segment = new UI.Segment( $(e.target).closest('section'));
         var selection = document.getSelection();
         var container = $(e.target);
-
+        if (container.is('lxqwarning')) {
+          container = container.closest('.errorTaggingArea');
+        }
         if ( textSelectedInsideSelectionArea(selection, container ) )  {
             var selection = getSelectionData( selection, container ) ;
             RI.openPanel( { sid: segment.id,  selection : selection });
         }
     });
-
     function renderButtons(segment) {
         if (segment === undefined) {
             segment = UI.Segment.find( UI.currentSegmentId );

--- a/public/js/cat_source/review_improved.review_events.js
+++ b/public/js/cat_source/review_improved.review_events.js
@@ -83,6 +83,11 @@ if ( ReviewImproved.enabled() && config.isReview ) {
     function getSelectionData(selection, container) {
         var data = {};
         data.start_node = $.inArray( selection.anchorNode, container.contents() );
+        if (data.start_node<0) {
+          //this means that the selection is probably ending inside a lexiqa tag,
+          //or matecat tag/marking
+          data.start_node = $.inArray( $(selection.anchorNode).parent()[0], container.contents() );
+        }
         var nodes = container.contents();//array of nodes
         if (data.start_node ===0)
           data.start_offset =  selection.anchorOffset;
@@ -96,6 +101,11 @@ if ( ReviewImproved.enabled() && config.isReview ) {
         }
 
         data.end_node = $.inArray( selection.focusNode, container.contents() );
+        if (data.end_node<0) {
+          //this means that the selection is probably ending inside a lexiqa tag,
+          //or matecat tag/marking
+          data.end_node = $.inArray( $(selection.focusNode).parent()[0], container.contents() );
+        }
         if (data.end_node ===0)
           data.end_offset =  selection.focusOffset;
         else {

--- a/public/js/cat_source/review_improved.review_extension.js
+++ b/public/js/cat_source/review_improved.review_extension.js
@@ -137,10 +137,8 @@ if ( ReviewImproved.enabled() && config.isReview ) {
             return '.errorTaggingArea';
         },
 
-        getSegmentTarget : function() {
-            // read status from DOM? wrong approach, read from
-            // database instead
-            var segment = db.segments.by('sid', sid);
+        getSegmentTarget : function( seg ) {
+            var segment = db.segments.by('sid', UI.getSegmentId( seg ) );
             var translation =  segment.translation ;
 
             return translation ;


### PR DESCRIPTION
This patch fixes the issue when the selection starts, ends or contains a Matecat or lexiQA marked up tag.
It works by calculating the start/end offset of the selection on the base (clear from decorations) text and set both start/end node to 0. 
This needs to happen, because the text to be highlighted in the review side panel, does not contain any mark up, thus there are no nodes other than 0.