### PR TITLE
Added new languages

### DIFF
--- a/lib/Utils/Langs/supported_langs.json
+++ b/lib/Utils/Langs/supported_langs.json
@@ -1,14 +1,14 @@
 {
     "langs": [
-    {
-        "localized":[{
-            "en":"Afrikaans"
-        }],
+        {
+            "localized":[{
+                "en":"Afrikaans"
+            }],
             "isocode":"af",
             "enabled":true,
             "rtl":false,
             "rfc3066code":"af-ZA"
-    }
+        }
     ,
         {
             "localized":[{
@@ -25,7 +25,7 @@
                 "en":"Amharic"
             }],
             "isocode":"am",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
             "rfc3066code":"am-AM"
         }
@@ -89,7 +89,7 @@
             "enabled":true,
             "rtl":false,
             "rfc3066code":"az-AZ",
-                    "languageRegionCode":"az-Latn-AZ"
+            "languageRegionCode":"az-Latn-AZ"
         }
     ,
         {
@@ -120,6 +120,16 @@
             "enabled":false,
             "rtl":false,
             "rfc3066code":"rm-RO"
+        }
+    ,
+        {
+            "localized":[{
+                "en":"Bashkir"
+            }],
+            "isocode":"ba",
+            "enabled":true,
+            "rtl":false,
+            "rfc3066code":"ba-RU"
         }
     ,
         {
@@ -491,15 +501,15 @@
             "rfc3066code":"fr-FR"
         }
     ,
-          {
-                        "localized":[{
-                                "en":"French Canada"
-                        }],
-                        "isocode":"fr",
-                        "enabled":true,
-                        "rtl":false,
-                        "rfc3066code":"fr-CA"
-                }
+        {
+            "localized":[{
+                "en":"French Canada"
+            }],
+            "isocode":"fr",
+            "enabled":true,
+            "rtl":false,
+            "rfc3066code":"fr-CA"
+        }
     ,
         {
             "localized":[{
@@ -614,6 +624,16 @@
     ,
         {
             "localized":[{
+                "en":"Hill Mari"
+            }],
+            "isocode":"mrj",
+            "enabled":true,
+            "rtl":false,
+            "rfc3066code":"mrj-RU"
+        }
+    ,
+        {
+            "localized":[{
                 "en":"Hindi"
             }],
             "isocode":"hi",
@@ -708,10 +728,10 @@
             "localized":[{
                 "en":"Javanese"
             }],
-            "isocode":"jw",
-            "enabled":false,
+            "isocode":"jv",
+            "enabled":true,
             "rtl":true,
-            "rfc3066code":"jw-ID"
+            "rfc3066code":"jv-ID"
         }
     ,
         {
@@ -739,9 +759,9 @@
                 "en":"Kannada"
             }],
             "isocode":"kn",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
-            "rfc3066code":"ka-IN"
+            "rfc3066code":"kn-IN"
         }
     ,
         {
@@ -839,9 +859,9 @@
                 "en":"Lao"
             }],
             "isocode":"lo",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
-            "rfc3066code":"lo-LO"
+            "rfc3066code":"lo-LA"
         }
     ,
         {
@@ -849,7 +869,7 @@
                 "en":"Latin"
             }],
             "isocode":"la",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
             "rfc3066code":"la-XN"
         }
@@ -879,9 +899,9 @@
                 "en":"Luxembourgish"
             }],
             "isocode":"lb",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
-            "rfc3066code":"lb-LB"
+            "rfc3066code":"lb-LU"
         }
     ,
         {
@@ -956,6 +976,16 @@
     ,
         {
             "localized":[{
+                "en":"Mari"
+            }],
+            "isocode":"mhr",
+            "enabled":true,
+            "rtl":false,
+            "rfc3066code":"mhr-RU"
+        }
+    ,
+        {
+            "localized":[{
                 "en":"Maori"
             }],
             "isocode":"mi",
@@ -969,7 +999,7 @@
                 "en":"Marathi"
             }],
             "isocode":"mr",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
             "rfc3066code":"mr-IN"
         }
@@ -1130,10 +1160,10 @@
     ,
         {
             "localized":[{
-                "en":"Panjabi"
+                "en":"Punjabi"
             }],
             "isocode":"pa",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
             "rfc3066code":"pa-IN"
         }
@@ -1142,10 +1172,10 @@
             "localized":[{
                 "en":"Papiamentu"
             }],
-            "isocode":"x1",
-            "enabled":false,
+            "isocode":"pap",
+            "enabled":true,
             "rtl":false,
-            "rfc3066code":"pap-PAP"
+            "rfc3066code":"pap-CW"
         }
     ,
         {
@@ -1288,7 +1318,7 @@
                 "en":"Scots Gaelic"
             }],
             "isocode":"gd",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
             "rfc3066code":"gd-GB"
         }
@@ -1359,7 +1389,7 @@
                 "en":"Sinhala"
             }],
             "isocode":"si",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
             "rfc3066code":"si-LK"
         }
@@ -1449,6 +1479,16 @@
     ,
         {
             "localized":[{
+                "en":"Sundanese"
+            }],
+            "isocode":"su",
+            "enabled":true,
+            "rtl":false,
+            "rfc3066code":"su-ID"
+        }
+    ,
+        {
+            "localized":[{
                 "en":"Swahili"
             }],
             "isocode":"sw",
@@ -1505,7 +1545,7 @@
                 "en":"Tajik"
             }],
             "isocode":"tg",
-            "enabled":false,
+            "enabled":true,
             "rtl":false,
             "rfc3066code":"tg-TJ"
         }
@@ -1673,6 +1713,16 @@
     ,
         {
             "localized":[{
+                "en":"Udmurt"
+            }],
+            "isocode":"udm",
+            "enabled":true,
+            "rtl":false,
+            "rfc3066code":"udm-RU"
+        }
+    ,
+        {
+            "localized":[{
                 "en":"Ukrainian"
             }],
             "isocode":"uk",
@@ -1692,13 +1742,13 @@
         }
     ,
         {
-          "localized": [{
-              "en": "Urdu"
+            "localized": [{
+                "en": "Urdu"
             }],
-          "isocode": "ur",
-          "enabled": true,
-          "rtl": true,
-          "rfc3066code": "ur-PK"
+            "isocode": "ur",
+            "enabled": true,
+            "rtl": true,
+            "rfc3066code": "ur-PK"
         },
         {
             "localized":[{
@@ -1786,7 +1836,7 @@
                 "en":"Yiddish"
             }],
             "isocode":"yi",
-            "enabled":false,
+            "enabled":true,
             "rtl":true,
             "rfc3066code":"yi-YD"
         }


### PR DESCRIPTION
Added new languages supported by Yandex.Translate engine (https://github.com/matecat/MateCat/issues/762)

Added:
Bashkir (ba)
Hill Mari (mhr)
Mari (mrj)
Sundanese (su)
Udmurt (udm)

Enabled:
Amharic (am)
Javanese (jv)
Kannada (kn)
Lao (lo)
Latin (la)
Luxembourgish (lb)
Marathi (mr)
Punjabi (pa)
Papiamentu (pap)
Scots Gaelic (gd)
Sinhala (si)
Tajik (tg)
Yiddish (yi)