### PR TITLE
API to create projects in detatched mode

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -48,6 +48,9 @@ RewriteRule ^activityLog/([^/]*)/([^/]*)[/]?(download)?$ index.php?action=activi
 
 RewriteRule ^utils/xliff-to-target$ index.php?action=xliffToTargetView [L]
 RewriteRule ^api/docs$ lib/View/APIDoc.php [L]
+
+RewriteRule ^api/v1/new$ index.php?api=true&action=newDetatched [QSA,L]
+
 RewriteRule ^(api)[/]?([^/]*)?[/]?$ index.php?api=true&action=$2 [QSA,L]
 RewriteRule ^api/(.*)$ router.php [QSA,L]
 RewriteRule ^webhooks/(.*)$ router.php [QSA,L]

--- a/lib/Controller/API/NewController.php
+++ b/lib/Controller/API/NewController.php
@@ -62,7 +62,7 @@ class NewController extends ajaxController {
     private $private_tm_user = null;
     private $private_tm_pass = null;
 
-    private $new_keys = array();
+    protected $new_keys = array();
 
     private $owner = "";
     /**
@@ -88,6 +88,13 @@ class NewController extends ajaxController {
     protected $team;
 
     protected $id_team ;
+
+    protected $projectStructure ;
+
+    /**
+     * @var ProjectManager
+     */
+    protected $projectManager ;
 
     public function __construct() {
 
@@ -529,8 +536,8 @@ class NewController extends ajaxController {
 
         $arFiles = $newArFiles;
 
-        $projectManager   = new ProjectManager();
-        $projectStructure = $projectManager->getProjectStructure();
+        $this->projectManager   = new ProjectManager();
+        $projectStructure = $this->projectManager->getProjectStructure();
 
         $projectStructure[ 'sanitize_project_options' ] = false;
 
@@ -560,26 +567,27 @@ class NewController extends ajaxController {
             $projectStructure[ 'uid' ]           = $this->current_user->getUid();
             $projectStructure[ 'id_customer' ]   = $this->current_user->getEmail();
             $projectStructure[ 'owner' ]         = $this->current_user->getEmail();
-            $projectManager->setTeam( $this->team ) ;
+            $this->projectManager->setTeam( $this->team ) ;
         }
 
         FilesStorage::moveFileFromUploadSessionToQueuePath( $uploadFile->getDirUploadToken() );
 
         //reserve a project id from the sequence
         $projectStructure[ 'id_project' ] = Database::obtain()->nextSequence( Database::SEQ_ID_PROJECT )[ 0 ];
-        $projectStructure[ 'ppassword' ]  = $projectManager->generatePassword();
+        $projectStructure[ 'ppassword' ]  = $this->projectManager->generatePassword();
+
+        $this->projectStructure = $projectStructure ;
+
+        $this->projectManager->sanitizeProjectStructure();
 
         Queue::sendProject( $projectStructure );
 
-        $time = time();
-        do {
-            $this->result = Queue::getPublishedResults( $projectStructure['id_project'] ); //LOOP for 290 seconds **** UGLY **** Deprecate in API V2
-            if ( $this->result != null ){
-                break;
-            }
-            sleep(2);
-        } while( time() - $time <= 290 );
+        $this->_pollForCreationResult();
 
+        $this->_outputResult() ;
+    }
+
+    protected function _outputResult() {
         if( $this->result == null ){
             $this->api_output[ 'status' ]  = 504;
             $this->api_output[ 'message' ] = 'Project Creation Failure';
@@ -592,14 +600,28 @@ class NewController extends ajaxController {
 
         } else {
             //everything ok
-            $this->api_output[ 'status' ]       = 'OK';
-            $this->api_output[ 'message' ]      = 'Success';
-            $this->api_output[ 'id_project' ]   = $this->result[ 'id_project' ];
-            $this->api_output[ 'project_pass' ] = $this->result[ 'ppassword' ];
-            $this->api_output[ 'new_keys' ] = $this->new_keys;
-            $this->api_output[ 'analyze_url' ] = $this->result[ 'analyze_url' ];
+            $this->_outputForSuccess();
         }
+    }
 
+    protected function _outputForSuccess() {
+        $this->api_output[ 'status' ]       = 'OK';
+        $this->api_output[ 'message' ]      = 'Success';
+        $this->api_output[ 'id_project' ]   = $this->projectStructure[ 'id_project' ];
+        $this->api_output[ 'project_pass' ] = $this->projectStructure[ 'ppassword' ];
+        $this->api_output[ 'new_keys' ]     = $this->new_keys;
+        $this->api_output[ 'analyze_url' ]  = $this->projectManager->getAnalyzeURL();
+    }
+
+    protected function _pollForCreationResult() {
+        $time = time();
+        do {
+            $this->result = Queue::getPublishedResults( $this->projectStructure['id_project'] ); //LOOP for 290 seconds **** UGLY **** Deprecate in API V2
+            if ( $this->result != null ){
+                break;
+            }
+            sleep(2);
+        } while( time() - $time <= 290 );
     }
 
     private function validateSourceLang() {

--- a/lib/Controller/API/NewDetatchedController.php
+++ b/lib/Controller/API/NewDetatchedController.php
@@ -1,0 +1,12 @@
+<?php
+
+class NewDetatchedController extends NewController {
+
+    public function __construct() {
+        parent::__construct();
+    }
+
+    protected function _pollForCreationResult() {
+        $this->result['errors'] = $this->projectStructure[ 'result' ][ 'errors' ]->getArrayCopy();
+    }
+}

--- a/lib/Controller/AbstractControllers/viewController.php
+++ b/lib/Controller/AbstractControllers/viewController.php
@@ -382,6 +382,11 @@ abstract class viewController extends controller {
         return $is_revision_url;
     }
 
+    protected function render404() {
+        $this->makeTemplate('404.html');
+        $this->finalize();
+    }
+
     /**
      * Create an instance of skeleton PHPTAL template
      *

--- a/lib/Controller/analyzeController.php
+++ b/lib/Controller/analyzeController.php
@@ -92,7 +92,10 @@ class analyzeController extends viewController {
         }
 
         $this->features = new FeatureSet();
-        $this->features->loadForProject( $this->project );
+
+        if ( $this->project ) {
+            $this->features->loadForProject( $this->project );
+        }
 
     }
 
@@ -100,6 +103,11 @@ class analyzeController extends viewController {
         $this->features->run('beginDoAction', 'analyzeController', array(
                 'project' => $this->project
         ));
+
+        if ( !$this->project ) {
+            $this->render404() ;
+            return ;
+        }
 
         $this->model = new Analysis_AnalysisModel( $this->project, $this->chunk );
         $this->model->loadData();


### PR DESCRIPTION
This creates a new /api/v1/new endpoint taking the same input params as /api/new, which responds immediately after queueing the project for creation. 

Some refactoring was needed to get projectName and analyzeURL immediately, while it was before delegated to project creation step which happens in background. 

