### PR TITLE
lexiQA update

### DIFF
--- a/public/js/cat_source/es6/react/components/QAComponent.js
+++ b/public/js/cat_source/es6/react/components/QAComponent.js
@@ -331,7 +331,7 @@ class QAComponent extends React.Component {
                     </li>
                     <li className="lexiqa-popup-item">Full QA report
                         <a className="lexiqa-popup-icon lexiqa-report-icon icon-file" id="lexiqa-report-link" target="_blank" alt="Read the full QA report"
-                        href={config.lexiqaServer + '/errorreport?id='+LXQ.partnerid+'-' + config.id_job + '-' + config.password+'&type='+(config.isReview?'revise':'translate')}/>
+                        href={config.lexiqaServer + '/errorreport?id='+LXQ.partnerid+'-' + config.id_job +'&type='+(config.isReview?'revise':'translate')}/>
                     </li>
                 </ul>;
             }
@@ -368,4 +368,3 @@ class QAComponent extends React.Component {
 }
 
 export default QAComponent ;
-

--- a/public/js/cat_source/lxq.main.js
+++ b/public/js/cat_source/lxq.main.js
@@ -115,9 +115,11 @@ LXQ.init  = function () {
     /* invoked when segment is completed (translated clicked)*/
     $(document).on('setTranslation:success', function(e, data) {
       console.log('[LEXIQA] got setTranslation:success');
-        var segment = data.segment;
-        var translation = $(UI.targetContainerSelector(), segment ).text().replace(/\uFEFF/g,'');
-        LXQ.doLexiQA(segment,translation,UI.getSegmentId(segment),true,null);
+      if (LXQ.lexiqaData.lexiqaProjectStatus !== 'loaded')
+        return;
+      var segment = data.segment;
+      var translation = $(UI.targetContainerSelector(), segment ).text().replace(/\uFEFF/g,'');
+      LXQ.doLexiQA(segment,translation,UI.getSegmentId(segment),true,null);
     });
     $( window ).on( 'files:appended', function ( e , data) {
       globalReceived = false ;
@@ -1319,7 +1321,7 @@ LXQ.init  = function () {
 
 
         doLexiQA: function ( segment, translation, id_segment, isSegmentCompleted, callback ) {
-            if ( !LXQ.enabled() ) {
+            if ( !LXQ.enabled() || LXQ.lexiqaData.lexiqaProjectStatus !== 'loaded') {
                 if ( callback !== undefined && typeof callback === 'function' ) {
                     callback();
                 }

--- a/public/js/cat_source/lxq.main.js
+++ b/public/js/cat_source/lxq.main.js
@@ -1137,38 +1137,6 @@ LXQ.init  = function () {
                 return null;
 
         }
-        var notCheckedSegments; //store the unchecked segments at startup
-        var doQAallSegments = function () {
-            var segments = $('#outer').find('section');
-            var notChecked = [];
-            $.each(segments,function (keys,segment) {
-                var segId = UI.getSegmentId(segment);
-                if (LXQ.lexiqaData.segments.indexOf(segId) < 0) {
-                    // console.log('segment not in lexiqaDB: '+segId);
-                    notChecked.push(segId);
-                }
-            });
-            notCheckedSegments = notChecked;
-            checkNextUncheckedSegment();
-        }
-
-        var checkNextUncheckedSegment = function (previousSegment) {
-            if (previousSegment!==undefined && previousSegment!== null )
-                reloadPowertip(previousSegment);
-            if (!(notCheckedSegments.length >0))
-                return;
-            var segment = notCheckedSegments.pop();
-            if (segment === undefined)
-                return;
-            var seg =  UI.getSegmentById(segment);
-            if (UI.getSegmentTarget(seg).length > 0) {
-                // console.log('Requesting QA for: '+segment);
-                LXQ.doLexiQA(seg, UI.getSegmentTarget(seg),segment, true, checkNextUncheckedSegment);
-            }
-            else {
-                checkNextUncheckedSegment();
-            }
-        }
         var getFristSegmentWithWarning = function () {
              if (LXQ.lexiqaData.hasOwnProperty('segments') && LXQ.lexiqaData.segments.length > 0) {
                 return LXQ.lexiqaData.segments[0];
@@ -1247,39 +1215,6 @@ LXQ.init  = function () {
 
             $('#lexiqa-quide-link').attr('href', config.lexiqaServer + '/documentation.html');
             $('#lexiqa-report-link').attr('href', config.lexiqaServer + '/errorreport?id='+this.partnerid+'-' + config.id_job +'&type='+(config.isReview?'revise':'translate'));
-
-            // $('#lexiqa-prev-seg').on('click', function (e) {
-            //     e.preventDefault();
-            //     var segid = getPreviousSegmentWithWarning();
-            //     if (UI.segmentIsLoaded(segid) === true)
-            //         UI.gotoSegment(segid);
-            //     else {
-            //         config.last_opened_segment = segid;
-            //         //config.last_opened_segment = this.nextUntranslatedSegmentId;
-            //         window.location.hash = segid;
-            //         $('#outer').empty();
-            //         UI.render({
-            //             firstLoad: false
-            //         });
-            //     }
-            // });
-            // $('#lexiqa-next-seg').on('click', function (e) {
-            //     e.preventDefault();
-            //     //UI.gotoSegment(getNextSegmentWithWarning());
-            //     var segid = getNextSegmentWithWarning();
-            //     if (UI.segmentIsLoaded(segid) === true)
-            //         UI.gotoSegment(segid);
-            //     else {
-            //         //UI.reloadWarning();
-            //         config.last_opened_segment = segid;
-            //         //config.last_opened_segment = this.nextUntranslatedSegmentId;
-            //         window.location.hash = segid;
-            //         $('#outer').empty();
-            //         UI.render({
-            //             firstLoad: false
-            //         });
-            //     }
-            // });
         };
         // Interfaces
         $.extend(LXQ, {
@@ -1295,7 +1230,6 @@ LXQ.init  = function () {
             reloadPowertip : reloadPowertip,
             ignoreError: ignoreError,
             redoHighlighting:redoHighlighting,
-            doQAallSegments: doQAallSegments,
             getNextSegmentWithWarning: getNextSegmentWithWarning,
             getPreviousSegmentWithWarning:getPreviousSegmentWithWarning,
             initPopup: initPopup,
@@ -1321,7 +1255,7 @@ LXQ.init  = function () {
 
 
         doLexiQA: function ( segment, translation, id_segment, isSegmentCompleted, callback ) {
-            if ( !LXQ.enabled() || LXQ.lexiqaData.lexiqaProjectStatus !== 'loaded') {
+            if ( !LXQ.enabled()) {
                 if ( callback !== undefined && typeof callback === 'function' ) {
                     callback();
                 }
@@ -1656,11 +1590,6 @@ LXQ.init  = function () {
                         results.qaurl = "#";
                     }
 
-                    // if ( LXQ.enabled() ) {
-                    //     LXQ.doQAallSegments();
-                    //     //LXQ.refreshElements();
-                    // }
-                    //$('.lxq-history-balloon-header-link').attr('href', results.qaurl);
                     LXQ.lexiqaData.lexiqaFetching = false;
                     if (callback) callback();
                 }

--- a/public/js/cat_source/review_improved.js
+++ b/public/js/cat_source/review_improved.js
@@ -67,7 +67,7 @@ if ( ReviewImproved.enabled() )
             node.contents('.rangySelectionBoundary').remove();
             node[0].normalize();
 
-            var contents = node.contents() ; 
+            var contents = node.contents() ;
             range.setStart( contents[ issue.start_node ], issue.start_offset );
             range.setEnd( contents[ issue.end_node ], issue.end_offset );
 
@@ -206,7 +206,11 @@ if ( ReviewImproved.enabled() && config.isReview ) {
         var segment = UI.Segment.find( sid );
         // TODO: refactor this, the click to activate a
         // segment is not a good way to handle.
-        segment.el.find('.errorTaggingArea').click();
+        if (segment && segment.el) {
+          //dofoteinakis: the first time going into the review page (i.e. from igognito window)
+          //this is undefined.
+          segment.el.find('.errorTaggingArea').click();
+        }
     });
 
     $.extend(ReviewImproved, {
@@ -214,7 +218,7 @@ if ( ReviewImproved.enabled() && config.isReview ) {
             var path  = sprintf('/api/v2/jobs/%s/%s/segments/%s/translation-issues',
                   config.id_job, config.password, sid);
             var segment = UI.Segment.find( sid );
-            
+
             var deferreds = _.map( data_array, function( data ) {
                 return $.post( path, data )
                 .done(function( data ) {

--- a/public/js/cat_source/ui.core.js
+++ b/public/js/cat_source/ui.core.js
@@ -1395,24 +1395,12 @@ UI = {
 					$('#file-' + fid).append(newFile);
 				}
 			}
-            // if (LXQ.enabled())
-            // $.each(this.segments,function(i,seg) {
-            // if (!starting)
-            // if (LXQ.hasOwnProperty('lexiqaData') && LXQ.lexiqaData.hasOwnProperty('lexiqaWarnings') &&
-            //     LXQ.lexiqaData.lexiqaWarnings.hasOwnProperty(seg.sid)) {
-            //         console.log('in loadmore segments, segment: '+seg.sid+' already has qa info...');
-            //         //FOTDDD
-            //         LXQ.redoHighlighting(seg.sid,true);
-            //         LXQ.redoHighlighting(seg.sid,false);
-            //     }
-            // });
 		});
 
-        $(document).trigger('files:appended');
+        $(document).trigger('files:appended', {data: files});
 
 		if (starting) {
 			this.init();
-            // LXQ.getLexiqaWarnings();
 		}
 
 	},
@@ -1534,12 +1522,14 @@ UI = {
     },
 
     saveSegment: function(segment) {
-		this.setTranslation({
-            id_segment: this.getSegmentId(segment),
-            status: this.getStatusForAutoSave( segment ) ,
-            caller: 'autosave'
-        });
-		segment.addClass('saved');
+      if (segment) {
+  		this.setTranslation({
+              id_segment: this.getSegmentId(segment),
+              status: this.getStatusForAutoSave( segment ) ,
+              caller: 'autosave'
+          });
+  		segment.addClass('saved');
+    }
 	},
 
 	renderAndScrollToSegment: function(sid) {


### PR DESCRIPTION
Update includes:
- Use the new lexiQA API to create a project in lexiQA with the Matecat project TMX. This allows the creation of all segments at once and we avoid sending multiple requests when the page loads.
- Use only the matecat JobId as the project identifier. This allows to use the same QA data across jobs with changed password (avoids project recreation in lexiQA)
- Matecat fixes: Fixed an exception when translate (or review) loads and there is no initial segment selected

@freegenie This update requires a specific version of lexiQA, so it will not work in the production system. For this purpose you need to point the beta.matecat.com server to (https://)testbackend.lexiqa.net