### PR TITLE
LexiQA Update

### DIFF
--- a/public/js/cat_source/es6/react/components/QAComponent.js
+++ b/public/js/cat_source/es6/react/components/QAComponent.js
@@ -331,7 +331,7 @@ class QAComponent extends React.Component {
                     </li>
                     <li className="lexiqa-popup-item">Full QA report
                         <a className="lexiqa-popup-icon lexiqa-report-icon icon-file" id="lexiqa-report-link" target="_blank" alt="Read the full QA report"
-                        href={config.lexiqaServer + '/errorreport?id='+LXQ.partnerid+'-' + config.id_job + '-' + config.password+'&type='+(config.isReview?'revise':'translate')}/>
+                        href={config.lexiqaServer + '/errorreport?id='+LXQ.partnerid+'-' + config.id_job +'&type='+(config.isReview?'revise':'translate')}/>
                     </li>
                 </ul>;
             }
@@ -368,4 +368,3 @@ class QAComponent extends React.Component {
 }
 
 export default QAComponent ;
-

--- a/public/js/cat_source/lxq.main.js
+++ b/public/js/cat_source/lxq.main.js
@@ -83,7 +83,7 @@ LXQ.init  = function () {
               licenseKey: config.lxq_license,
               partnerId: config.lxq_partnerid,
               lxqServer: config.lexiqaServer,
-              projectId: config.id_job+'-'+config.password
+              projectId: config.id_job
           }
       );
     }
@@ -92,31 +92,55 @@ LXQ.init  = function () {
     */
     $(document).on('getWarning:local:success', function(e, data) {
       console.log('[LEXIQA] got getWarning:local:success');
-        var segment = data.segment;
-        //new API?
-        if (data.segment.raw) {
-          segment = data.segment.raw
-        }
-        var translation = $(UI.targetContainerSelector(), segment ).text().replace(/\uFEFF/g,'');
-        var id_segment = UI.getSegmentId(segment);
-        LXQ.doLexiQA(segment, translation, id_segment,false, function () {}) ;
+      if (LXQ.lexiqaData.lexiqaProjectStatus !== 'loaded')
+        return;
+      var segment = data.segment;
+      //new API?
+      if (data.segment.raw) {
+        segment = data.segment.raw
+      }
+      var translation = $(UI.targetContainerSelector(), segment ).text().replace(/\uFEFF/g,'');
+      var id_segment = UI.getSegmentId(segment);
+      LXQ.doLexiQA(segment, translation, id_segment,false, function () {}) ;
     });
     /* Invoked when page loads */
     $(document).on('getWarning:global:success', function(e, data) {
+      console.log('--- lexiqa global received!!!');
       if ( globalReceived ) {
           return ;
       }
-
-      LXQ.getLexiqaWarnings(function() {
-        globalReceived = true;
-      });
+      globalReceived = true;
+      LXQ.getLexiqaProjectStatus(LXQ.projectStatusCallback);
     });
     /* invoked when segment is completed (translated clicked)*/
     $(document).on('setTranslation:success', function(e, data) {
       console.log('[LEXIQA] got setTranslation:success');
-        var segment = data.segment;
-        var translation = $(UI.targetContainerSelector(), segment ).text().replace(/\uFEFF/g,'');
-        LXQ.doLexiQA(segment,translation,UI.getSegmentId(segment),true,null);
+      if (LXQ.lexiqaData.lexiqaProjectStatus !== 'loaded')
+        return;
+      var segment = data.segment;
+      var translation = $(UI.targetContainerSelector(), segment ).text().replace(/\uFEFF/g,'');
+      LXQ.doLexiQA(segment,translation,UI.getSegmentId(segment),true,null);
+    });
+    $( window ).on( 'files:appended', function ( e , data) {
+      globalReceived = false ;
+      console.log('[LEXIQA] got files:appended ');
+      $.each(data.data, function (id,file) {
+        if (file.segments && LXQ.hasOwnProperty('lexiqaData') && LXQ.lexiqaData.hasOwnProperty('lexiqaWarnings')) {
+          $.each(file.segments, function (i,segment) {
+                if (LXQ.lexiqaData.lexiqaWarnings.hasOwnProperty(segment.sid)) {
+                    console.log('in loadmore segments, segment: '+segment.sid+' already has qa info...');
+                    //clean up and redo powertip on any glossaries/blacklists
+                    var _segment = UI.getSegmentById(segment.sid)
+                    QaCheckGlossary.enabled() && QaCheckGlossary.destroyPowertip(_segment);
+                    QaCheckBlacklist.enabled() && QaCheckBlacklist.destroyPowertip($( UI.targetContainerSelector(), _segment ));
+                    LXQ.redoHighlighting(segment.sid,true);
+                    LXQ.redoHighlighting(segment.sid,false);
+                    QaCheckBlacklist.enabled() && QaCheckBlacklist.reloadPowertip($( UI.targetContainerSelector(), _segment ));
+                    QaCheckGlossary.enabled() && QaCheckGlossary.redoBindEvents(_segment);
+                }
+          });
+        }
+      });
     });
     /* invoked when more segments are loaded...*/
     $( window ).on( 'segmentsAdded', function ( e , data) {
@@ -810,7 +834,7 @@ LXQ.init  = function () {
                     closeDelay: 500
                 });
                 $('.tooltipa',segment).on('powerTipRender', function() {
-                    console.log('powerTipRender');
+                    //console.log('powerTipRender');
                     //var rows = $('#powerTip').find('tooltip-error-category');
                     var that = this;
                     if ($('#powerTip').find('.lxq-suggestion').length) {
@@ -1113,38 +1137,6 @@ LXQ.init  = function () {
                 return null;
 
         }
-        var notCheckedSegments; //store the unchecked segments at startup
-        var doQAallSegments = function () {
-            var segments = $('#outer').find('section');
-            var notChecked = [];
-            $.each(segments,function (keys,segment) {
-                var segId = UI.getSegmentId(segment);
-                if (LXQ.lexiqaData.segments.indexOf(segId) < 0) {
-                    // console.log('segment not in lexiqaDB: '+segId);
-                    notChecked.push(segId);
-                }
-            });
-            notCheckedSegments = notChecked;
-            checkNextUncheckedSegment();
-        }
-
-        var checkNextUncheckedSegment = function (previousSegment) {
-            if (previousSegment!==undefined && previousSegment!== null )
-                reloadPowertip(previousSegment);
-            if (!(notCheckedSegments.length >0))
-                return;
-            var segment = notCheckedSegments.pop();
-            if (segment === undefined)
-                return;
-            var seg =  UI.getSegmentById(segment);
-            if (UI.getSegmentTarget(seg).length > 0) {
-                // console.log('Requesting QA for: '+segment);
-                LXQ.doLexiQA(seg, UI.getSegmentTarget(seg),segment, true, checkNextUncheckedSegment);
-            }
-            else {
-                checkNextUncheckedSegment();
-            }
-        }
         var getFristSegmentWithWarning = function () {
              if (LXQ.lexiqaData.hasOwnProperty('segments') && LXQ.lexiqaData.segments.length > 0) {
                 return LXQ.lexiqaData.segments[0];
@@ -1222,40 +1214,7 @@ LXQ.init  = function () {
             });
 
             $('#lexiqa-quide-link').attr('href', config.lexiqaServer + '/documentation.html');
-            $('#lexiqa-report-link').attr('href', config.lexiqaServer + '/errorreport?id='+this.partnerid+'-' + config.id_job + '-' + config.password+'&type='+(config.isReview?'revise':'translate'));
-
-            // $('#lexiqa-prev-seg').on('click', function (e) {
-            //     e.preventDefault();
-            //     var segid = getPreviousSegmentWithWarning();
-            //     if (UI.segmentIsLoaded(segid) === true)
-            //         UI.gotoSegment(segid);
-            //     else {
-            //         config.last_opened_segment = segid;
-            //         //config.last_opened_segment = this.nextUntranslatedSegmentId;
-            //         window.location.hash = segid;
-            //         $('#outer').empty();
-            //         UI.render({
-            //             firstLoad: false
-            //         });
-            //     }
-            // });
-            // $('#lexiqa-next-seg').on('click', function (e) {
-            //     e.preventDefault();
-            //     //UI.gotoSegment(getNextSegmentWithWarning());
-            //     var segid = getNextSegmentWithWarning();
-            //     if (UI.segmentIsLoaded(segid) === true)
-            //         UI.gotoSegment(segid);
-            //     else {
-            //         //UI.reloadWarning();
-            //         config.last_opened_segment = segid;
-            //         //config.last_opened_segment = this.nextUntranslatedSegmentId;
-            //         window.location.hash = segid;
-            //         $('#outer').empty();
-            //         UI.render({
-            //             firstLoad: false
-            //         });
-            //     }
-            // });
+            $('#lexiqa-report-link').attr('href', config.lexiqaServer + '/errorreport?id='+this.partnerid+'-' + config.id_job +'&type='+(config.isReview?'revise':'translate'));
         };
         // Interfaces
         $.extend(LXQ, {
@@ -1271,13 +1230,12 @@ LXQ.init  = function () {
             reloadPowertip : reloadPowertip,
             ignoreError: ignoreError,
             redoHighlighting:redoHighlighting,
-            doQAallSegments: doQAallSegments,
             getNextSegmentWithWarning: getNextSegmentWithWarning,
             getPreviousSegmentWithWarning:getPreviousSegmentWithWarning,
             initPopup: initPopup,
             hidePopUp: hidePopUp,
             partnerid: partnerid,
-            projectid: config.id_job+'-'+config.password,
+            projectid: config.id_job,
             getWarningForModule: getWarningForModule,
             replaceWord: replaceWord
         });
@@ -1297,7 +1255,7 @@ LXQ.init  = function () {
 
 
         doLexiQA: function ( segment, translation, id_segment, isSegmentCompleted, callback ) {
-            if ( !LXQ.enabled() ) {
+            if ( !LXQ.enabled()) {
                 if ( callback !== undefined && typeof callback === 'function' ) {
                     callback();
                 }
@@ -1377,7 +1335,12 @@ LXQ.init  = function () {
                                         highlights.source[qadata.category].push( qadata );
                                     }
                                     else {
+                                      try {
                                         highlights.target[qadata.category].push( qadata );
+                                      }
+                                      catch (e) {
+                                        console.log('ex');
+                                      }
                                     }
                                 }
                             } );
@@ -1436,6 +1399,96 @@ LXQ.init  = function () {
         lxqRemoveSegmentFromWarningList: function ( id_segment ) {
             LXQ.removeSegmentWarning(id_segment);
         },
+        createProject: function () {
+          $.ajax({
+            type: 'POST',
+            url: config.lexiqaServer + '/matecat/'+LXQ.lexiqaData.lexiqaProjectId+'/create?token='+$.lexiqaAuthenticator.getToken(),
+            data: {
+              matecatUrl: window.location.href,
+              sourceLocale: config.source_rfc,
+              targetLocale: config.target_rfc
+            },
+            cache: false,
+            success: function (result, textStatus, jqXHR) {
+              if (jqXHR.status === 202) {
+                console.log('lexiqa project pending');
+                LXQ.lexiqaData.lexiqaProjectStatus = 'pending';
+              }
+              else {
+                console.log('lexiqa project should not see this');
+              }
+            },
+            error: function (jqXHR, textStatus) {
+                console.log('project creation failed',LXQ.lexiqaData.lexiqaProjectId,', with status:',jqXHR.status);
+                LXQ.lexiqaData.lexiqaProjectStatus = 'failed';
+            }
+          });
+        },
+        projectStatusCallback: function (callback) {
+          if (LXQ.lexiqaData.lexiqaProjectStatus === 'failed') {
+            console.log('lexiqa project failed, do nothing');
+          }
+          else if (LXQ.lexiqaData.lexiqaProjectStatus === 'pending') {
+            console.log('lexiqa project pedning, check back in 2sec');
+            setTimeout(function() {
+              LXQ.getLexiqaProjectStatus(LXQ.projectStatusCallback);
+            }, 2000);
+          }
+          else if (LXQ.lexiqaData.lexiqaProjectStatus === 'notfound') {
+            console.log('lexiqa project not found, lets create');
+            LXQ.createProject();
+            setTimeout(function() {
+              LXQ.getLexiqaProjectStatus(LXQ.projectStatusCallback);
+            }, 3000);
+          }
+          else {
+            console.log('lexiqa project found/created, load the erors');
+            if (LXQ.lexiqaData.lexiqaProjectStatus !== 'loaded')
+              LXQ.getLexiqaWarnings(function() {
+                  console.log('lexiqa Warnings loaded');
+                  LXQ.lexiqaData.lexiqaProjectStatus = 'loaded';
+              });
+          }
+        },
+        getLexiqaProjectStatus: function (callback) {
+          if ( !LXQ.enabled() ) {
+            if (callback) callback();
+            return;
+          }
+          if (LXQ.lexiqaData.lexiqaProjectStatus === 'loaded') {
+            if (callback) callback();
+            return;
+          }
+          LXQ.lexiqaData.lexiqaFetching = true;
+          LXQ.lexiqaData.lexiqaProjectId = LXQ.partnerid + '-' + config.id_job;
+          LXQ.lexiqaData.lexiqaProjectStatus = 'pending';
+          $.ajax({
+            type: 'GET',
+            url: config.lexiqaServer + '/matecat/'+LXQ.lexiqaData.lexiqaProjectId+'/status?token='+$.lexiqaAuthenticator.getToken(),
+            cache: false,
+            success: function (result, textStatus, jqXHR) {
+              if (jqXHR.status === 202) {
+                console.log('lexiqa project pending');
+              }
+              else {
+                console.log('lexiqa project created');
+                LXQ.lexiqaData.lexiqaProjectStatus = 'created';
+              }
+              callback();
+            },
+            error: function (jqXHR, textStatus) {
+              if (jqXHR.status === 404) {
+                console.log('lexiqa project not found',LXQ.lexiqaData.lexiqaProjectId,',lets create it');
+                LXQ.lexiqaData.lexiqaProjectStatus = 'notfound';
+              }
+              else {
+                console.log('project creation failed',LXQ.lexiqaData.lexiqaProjectId,',stop');
+                LXQ.lexiqaData.lexiqaProjectStatus = 'failed';
+              }
+              callback();
+            }
+          });
+        },
         getLexiqaWarnings: function (callback) {
             if ( !LXQ.enabled() ) {
               if (callback) callback();
@@ -1446,14 +1499,14 @@ LXQ.init  = function () {
             $.ajax( {
                 type: "GET",
                 url: config.lexiqaServer + "/matecaterrors",
-                data: {id: LXQ.partnerid + '-' + config.id_job + '-' + config.password},
+                data: {id: LXQ.partnerid + '-' + config.id_job},
                 cache: false,
                 success: function ( results ) {
                     var errorCnt = 0, ind;
                     if ( results.errors != 0 ) {
                         //only do something if there are errors in lexiqa server
                         LXQ.lexiqaData.lexiqaWarnings = {};
-
+                        LXQ.lexiqaData.segments = [];
                         results.segments.forEach( function ( element ) {
                             if ( element.errornum === 0 ) {
                                 return;
@@ -1537,11 +1590,6 @@ LXQ.init  = function () {
                         results.qaurl = "#";
                     }
 
-                    if ( LXQ.enabled() ) {
-                        LXQ.doQAallSegments();
-                        //LXQ.refreshElements();
-                    }
-                    //$('.lxq-history-balloon-header-link').attr('href', results.qaurl);
                     LXQ.lexiqaData.lexiqaFetching = false;
                     if (callback) callback();
                 }

--- a/public/js/cat_source/review_improved.js
+++ b/public/js/cat_source/review_improved.js
@@ -67,7 +67,7 @@ if ( ReviewImproved.enabled() )
             node.contents('.rangySelectionBoundary').remove();
             node[0].normalize();
 
-            var contents = node.contents() ; 
+            var contents = node.contents() ;
             range.setStart( contents[ issue.start_node ], issue.start_offset );
             range.setEnd( contents[ issue.end_node ], issue.end_offset );
 
@@ -206,7 +206,11 @@ if ( ReviewImproved.enabled() && config.isReview ) {
         var segment = UI.Segment.find( sid );
         // TODO: refactor this, the click to activate a
         // segment is not a good way to handle.
-        segment.el.find('.errorTaggingArea').click();
+        if (segment && segment.el) {
+           //dofoteinakis: the first time going into the review page (i.e. from igognito window)
+           //this is undefined.
+           segment.el.find('.errorTaggingArea').click();
+         }
     });
 
     $.extend(ReviewImproved, {
@@ -214,7 +218,7 @@ if ( ReviewImproved.enabled() && config.isReview ) {
             var path  = sprintf('/api/v2/jobs/%s/%s/segments/%s/translation-issues',
                   config.id_job, config.password, sid);
             var segment = UI.Segment.find( sid );
-            
+
             var deferreds = _.map( data_array, function( data ) {
                 return $.post( path, data )
                 .done(function( data ) {

--- a/public/js/cat_source/ui.core.js
+++ b/public/js/cat_source/ui.core.js
@@ -1395,24 +1395,12 @@ UI = {
 					$('#file-' + fid).append(newFile);
 				}
 			}
-            // if (LXQ.enabled())
-            // $.each(this.segments,function(i,seg) {
-            // if (!starting)
-            // if (LXQ.hasOwnProperty('lexiqaData') && LXQ.lexiqaData.hasOwnProperty('lexiqaWarnings') &&
-            //     LXQ.lexiqaData.lexiqaWarnings.hasOwnProperty(seg.sid)) {
-            //         console.log('in loadmore segments, segment: '+seg.sid+' already has qa info...');
-            //         //FOTDDD
-            //         LXQ.redoHighlighting(seg.sid,true);
-            //         LXQ.redoHighlighting(seg.sid,false);
-            //     }
-            // });
 		});
 
-        $(document).trigger('files:appended');
+        $(document).trigger('files:appended', {data: files});
 
 		if (starting) {
 			this.init();
-            // LXQ.getLexiqaWarnings();
 		}
 
 	},
@@ -1534,12 +1522,14 @@ UI = {
     },
 
     saveSegment: function(segment) {
-		this.setTranslation({
-            id_segment: this.getSegmentId(segment),
-            status: this.getStatusForAutoSave( segment ) ,
-            caller: 'autosave'
-        });
-		segment.addClass('saved');
+      if (segment) {
+    		this.setTranslation({
+                id_segment: this.getSegmentId(segment),
+                status: this.getStatusForAutoSave( segment ) ,
+                caller: 'autosave'
+            });
+    		segment.addClass('saved');
+      }
 	},
 
 	renderAndScrollToSegment: function(sid) {


### PR DESCRIPTION
Update includes:

Use the new lexiQA API to create a project in lexiQA with the Matecat project TMX. This allows the creation of all segments at once and we avoid sending multiple requests when the page loads.
Use only the matecat JobId as the project identifier. This allows to use the same QA data across jobs with changed password (avoids project recreation in lexiQA)
Removed dead code and comments.
Matecat fixes: Fixed an exception when translate (or review) loads and there is no initial segment selected

@freegenie @Ostico  This update requires a specific version of lexiQA, so it will not work in the production system. For this purpose you need to point the matecat server you are testing on to (https://)testbackend.lexiqa.net