### PR TITLE
Remove dependency with DQF_ENABLED config

### DIFF
--- a/lib/Model/FeatureSet.php
+++ b/lib/Model/FeatureSet.php
@@ -114,17 +114,6 @@ class FeatureSet {
     }
 
     /**
-     * Loads the features starting from a given team.
-     *
-     * @param TeamStruct $team
-     */
-    public function loadFromTeam( TeamStruct $team ) {
-        $dao = new OwnerFeatures_OwnerFeatureDao() ;
-        $features = $dao->getByTeam( $team ) ;
-        $this->features = static::merge( $this->features, $features ) ;
-    }
-
-    /**
      * Returns the filtered subject variable passed to all enabled features.
      *
      * @param $method

--- a/lib/Model/LQA/ModelDao.php
+++ b/lib/Model/LQA/ModelDao.php
@@ -63,43 +63,52 @@ class ModelDao extends DataAccess_AbstractDao {
      * Recursively create categories and subcategories based on the
      * QA model definition.
      *
+     * @param       $json
+     *
+     * @return ModelStruct
+     *
      */
     public static function createModelFromJsonDefinition( $json ) {
         $model_root = $json['model'];
         $model = ModelDao::createRecord( $model_root );
 
         $default_severities = $model_root['severities'];
-        $categories = $model_root['categories'];
+        $categories         = $model_root['categories'];
 
-        foreach($categories as $record) {
-            self::insertRecord($record, $model->id, null, $default_severities);
+        foreach($categories as $category) {
+            self::insertCategory($category, $model->id, null, $default_severities);
         }
 
         return $model ;
     }
 
-    private static function insertRecord($record, $model_id, $parent_id, $default_severities) {
-        if ( !array_key_exists('severities', $record) ) {
-            $record['severities'] = $default_severities ;
+    private static function insertCategory( $category, $model_id, $parent_id, $default_severities) {
+        if ( !array_key_exists('severities', $category) ) {
+            $category['severities'] = $default_severities ;
         }
 
-        $options = null ;
+        /*
+         * Any other key found in the json array will populate the `options` field
+         */
+        $options = [] ;
 
-        if ( INIT::$DQF_ENABLED )  { // TODO: find a better way to avoid this dependency
-            $options = json_encode( ['dqf_id' => $record['dqf_id'] ] ) ;
+        foreach( array_keys( $category ) as $key ) {
+            if ( ! in_array( $key, ['label', 'severities', 'subcategories' ] ) )  {
+                $options[ $key ] = $category[ $key ] ;
+            }
         }
 
-        $category = CategoryDao::createRecord(array(
+        $category_record = CategoryDao::createRecord(array(
                 'id_model'   => $model_id,
-                'label'      => $record['label'],
-                'options'    => $options,
+                'label'      => $category['label'],
+                'options'    => ( empty( $options ) ? null : json_encode( $options ) ),
                 'id_parent'  => $parent_id,
-                'severities' => json_encode( $record['severities'] )
+                'severities' => json_encode( $category['severities'] )
         ));
 
-        if ( array_key_exists('subcategories', $record) && !empty( $record['subcategories'] ) ) {
-            foreach( $record['subcategories'] as $sub ) {
-                self::insertRecord($sub, $model_id, $category->id, $default_severities);
+        if ( array_key_exists('subcategories', $category) && !empty( $category['subcategories'] ) ) {
+            foreach( $category['subcategories'] as $sub ) {
+                self::insertCategory($sub, $model_id, $category_record->id, $default_severities);
             }
         }
     }

--- a/lib/Plugins/Features/ReviewImproved.php
+++ b/lib/Plugins/Features/ReviewImproved.php
@@ -310,9 +310,10 @@ class ReviewImproved extends BaseFeature {
     /**
      * Sets the QA model fom the uploaded file which was previously validated
      * and added to the project structure.
+     *
+     * @param $projectStructure
      */
     private function setQaModelFromJsonFile( $projectStructure ) {
-
         $model_json = $projectStructure['features']
             ['review_improved']['__meta']['qa_model'];
 


### PR DESCRIPTION
This removes dependency with DQF_ENABLED config in ModelDao.php which was only needed to know if it was necessary to lookup for a `dqf_id` option in the json struct defined in qa_model.json. 

If any extraneous key is found in qa_model.json, it is automatically added to options field. 

This allows to rollout the DQF feature with DQF_ENABLED = false and have it enabled on per user basis using owner_features table. 
