### PR TITLE
Make ActiveMQ credentials configurable

### DIFF
--- a/inc/INIT.php
+++ b/inc/INIT.php
@@ -41,6 +41,7 @@ class INIT {
     public static $REDIS_SERVERS       = array();
     public static $QUEUE_BROKER_ADDRESS;
     public static $QUEUE_JMX_ADDRESS;
+    public static $QUEUE_CREDENTIALS;
     public static $USE_COMPILED_ASSETS = false;
 
     /**

--- a/inc/config.ini.sample
+++ b/inc/config.ini.sample
@@ -21,6 +21,7 @@ REDIS_SERVERS = "tcp://localhost:6379?database=0"
 QUEUE_BROKER_ADDRESS = "tcp://localhost:61613"
 QUEUE_DQF_ADDRESS = "tcp://localhost:61613"
 QUEUE_JMX_ADDRESS = "http://localhost:8161"
+QUEUE_CREDENTIALS = "admin:admin"
 SSE_BASE_URL = "http://localhost/sse"          ;no trailing slash here
 STORAGE_DIR = "/home/matecat/cattool/local_storage"         ;provide an absolute path
 
@@ -65,6 +66,7 @@ REDIS_SERVERS = "tcp://localhost:6379"
 QUEUE_BROKER_ADDRESS = "tcp://localhost:61613"
 QUEUE_DQF_ADDRESS = "tcp://localhost:61613"
 QUEUE_JMX_ADDRESS = "http://localhost:8161"
+QUEUE_CREDENTIALS = "admin:admin"
 SSE_BASE_URL = "http://localhost/sse"          ;no trailing slash here
 STORAGE_DIR = "/home/matecat/cattool/local_storage"         ;provide an absolute path
 
@@ -96,6 +98,7 @@ REDIS_SERVERS = "tcp://localhost:6379"
 QUEUE_BROKER_ADDRESS = "tcp://localhost:61613"
 QUEUE_DQF_ADDRESS = "tcp://localhost:61613"
 QUEUE_JMX_ADDRESS = "http://localhost:8161"
+QUEUE_CREDENTIALS = "admin:admin"
 SSE_BASE_URL = "http://localhost/sse"          ;no trailing slash here
 STORAGE_DIR = "/home/matecat/cattool/storage"         ;provide an absolute path
 

--- a/lib/Utils/AMQHandler.php
+++ b/lib/Utils/AMQHandler.php
@@ -148,7 +148,7 @@ class AMQHandler extends Stomp {
                 CURLOPT_CONNECTTIMEOUT => 5, // a timeout to call itself should not be too much higher :D
                 CURLOPT_SSL_VERIFYPEER => true,
                 CURLOPT_SSL_VERIFYHOST => 2,
-                CURLOPT_HTTPHEADER => array( 'Authorization: Basic '. base64_encode("admin:admin") )
+                CURLOPT_HTTPHEADER => array( 'Authorization: Basic '. base64_encode(INIT::$QUEUE_CREDENTIALS) )
         );
 
         $resource = $mHandler->createResource( $queue_interface_url, $options );
@@ -191,7 +191,7 @@ class AMQHandler extends Stomp {
                 CURLOPT_CONNECTTIMEOUT => 5, // a timeout to call itself should not be too much higher :D
                 CURLOPT_SSL_VERIFYPEER => true,
                 CURLOPT_SSL_VERIFYHOST => 2,
-                CURLOPT_HTTPHEADER => array( 'Authorization: Basic '. base64_encode("admin:admin") )
+                CURLOPT_HTTPHEADER => array( 'Authorization: Basic '. base64_encode(INIT::$QUEUE_CREDENTIALS) )
         );
 
         $resource = $mHandler->createResource( $queue_interface_url, $options );

--- a/test/unit/TestContribution/SetContributionTest.php
+++ b/test/unit/TestContribution/SetContributionTest.php
@@ -33,7 +33,7 @@ class SetContributionTest extends \AbstractTest {
                         CURLOPT_CONNECTTIMEOUT => 5, // a timeout to call itself should not be too much higher :D
                         CURLOPT_SSL_VERIFYPEER => true,
                         CURLOPT_SSL_VERIFYHOST => 2,
-                        CURLOPT_HTTPHEADER     => array( 'Authorization: Basic ' . base64_encode( "admin:admin" ) )
+                        CURLOPT_HTTPHEADER     => array( 'Authorization: Basic ' . base64_encode( INIT::$QUEUE_CREDENTIALS ) )
                 )
         );
         $curl->multiExec();

--- a/test/unit/TestContribution/SetContributionWorkerTest.php
+++ b/test/unit/TestContribution/SetContributionWorkerTest.php
@@ -60,7 +60,7 @@ class SetContributionWorkerTest extends AbstractTest implements SplObserver {
                         CURLOPT_CONNECTTIMEOUT => 5, // a timeout to call itself should not be too much higher :D
                         CURLOPT_SSL_VERIFYPEER => true,
                         CURLOPT_SSL_VERIFYHOST => 2,
-                        CURLOPT_HTTPHEADER     => array( 'Authorization: Basic ' . base64_encode( "admin:admin" ) )
+                        CURLOPT_HTTPHEADER     => array( 'Authorization: Basic ' . base64_encode( INIT::$QUEUE_CREDENTIALS ) )
                 )
         );
         $curl->multiExec();


### PR DESCRIPTION
Removed hard coded "admin:admin" as ActiveMQ credentials and added it to the configuration.