### PR TITLE
Fix: Translation mismatches Tab

### DIFF
--- a/public/js/cat_source/ui.core.js
+++ b/public/js/cat_source/ui.core.js
@@ -1154,7 +1154,89 @@ UI = {
             // Decode the string from the server
             var transDecoded = this.translation;
             // Make the diff between the text with the same codification
-            var diff_obj = UI.execDiff(mainStr, transDecoded);
+
+            var placeholderPH = /(&lt;ph id="mtc_.*?\/&gt;)/g;
+
+            /**
+             * UI.execDiff works at character level, when a tag differs only for a part of it in the source/translation it breaks the tag
+             * Ex:
+             *
+             * Those 2 tags differs only by their IDs
+             *
+             * Original string: &lt;ph id="mtc_1" equiv-text="base64:JXt1c2VyX2NvbnRleHQuZGltX2NpdHl8fQ=="/&gt;
+             * New String:      &lt;ph id="mtc_2" equiv-text="base64:JXt1c2VyX2NvbnRleHQuZGltX2NpdHl8fQ=="/&gt;
+             *
+             * After the dom rendering of the UI.dmp.diff_prettyHtml function
+             *
+             *  <span contenteditable="false" class="locked style-tag ">
+             *      <span contenteditable="false" class="locked locked-inside tag-html-container-open">&lt;ph id="mtc_</span>
+             *
+             *      <!-- ###### the only diff is the ID of the tag ###### -->
+             *      <del class="diff">1</del>
+             *      <ins class="diff">2</ins>
+             *      <!-- ###### the only diff is the ID of the tag ###### -->
+             *
+             *      <span>" equiv-text="base64:JXt1c2VyX2NvbnRleHQuZGltX2NpdHl8fQ==</span>
+             *      <span contenteditable="false" class="locked locked-inside inside-attribute" data-original="base64:JXt1c2VyX2NvbnRleHQuZGltX2NpdHl8fQ=="></span>
+             *  </span>
+             *
+             *  When this happens, the function UI.transformTextForLockTags fails to find the PH tag by regexp and do not lock the tags or lock it in a wrong way
+             *
+             *  So, transform the string in a single character ( Private Use Unicode char ) for the diff function, place it in a map and reinsert in the diff_obj after the UI.execDiff executed
+             *
+             * //U+E000..U+F8FF, 6,400 Private-Use Characters Unicode, should be impossible to have those in source/target
+             */
+            var charCodePlaceholder = 57344;
+            var replacementsMap = {};
+            var reverseMapElements = {};
+
+            var listMainStr = mainStr.match( placeholderPH );
+            listMainStr.forEach( ( element ) => {
+                var actualCharCode = String.fromCharCode( charCodePlaceholder );
+
+                /**
+                 * override because we already have an element in the map, so the content is the same
+                 * ( duplicated TAG, should be impossible but it's easy to cover the case ),
+                 * use such character
+                 */
+                if( reverseMapElements[ element ] ){
+                    actualCharCode = reverseMapElements[ element ];
+                }
+
+                replacementsMap[ actualCharCode ] = element;
+                reverseMapElements[ element ] = actualCharCode; // fill the reverse map with the current element ( override if equal )
+                mainStr = mainStr.replace( element, actualCharCode );
+                charCodePlaceholder++;
+            } );
+
+            var listTransDecoded = transDecoded.match( placeholderPH );
+            listTransDecoded.forEach( ( element ) => {
+                var actualCharCode = String.fromCharCode( charCodePlaceholder );
+
+                /**
+                 * override because we already have an element in the map, so the content is the same
+                 * ( tag is present in source and target )
+                 * use such character
+                 */
+                if( reverseMapElements[ element ] ){
+                    actualCharCode = reverseMapElements[ element ];
+                }
+
+                replacementsMap[ actualCharCode ] = element;
+                reverseMapElements[ element ] = actualCharCode; // fill the reverse map with the current element ( override if equal )
+                transDecoded = transDecoded.replace( element, actualCharCode );
+                charCodePlaceholder++;
+            } );
+
+            var diff_obj = UI.execDiff( mainStr, transDecoded );
+
+            //replace the original string in the diff object by the character placeholder
+            Object.keys( diff_obj ).forEach( ( element ) => {
+                if( replacementsMap[ diff_obj[ element ][ 1 ] ] ){
+                    diff_obj[ element ][ 1 ] = replacementsMap[ diff_obj[ element ][ 1 ] ];
+                }
+            } );
+
             var translation = UI.transformTextForLockTags(UI.dmp.diff_prettyHtml(diff_obj));
             $('.sub-editor.alternatives .overflow', segment).append('<ul class="graysmall" data-item="' + (index + 1) + '">' +
                 '<li class="sugg-source">' +


### PR DESCRIPTION
- Translation mismatches DIFF breaks tag lock when there are tags that differs only by a part of them.