### PR TITLE
added outsource disablement by env var

### DIFF
--- a/inc/Bootstrap.php
+++ b/inc/Bootstrap.php
@@ -388,7 +388,17 @@ class Bootstrap {
             self::$CONFIG['ENV'] = getenv( 'ENV' );
         }
 
-        return self::$CONFIG[ self::$CONFIG['ENV'] ];
+        $env = self::$CONFIG[ self::$CONFIG['ENV'] ];
+
+        // check if outsource is disabled by environment
+        $enable_outsource = getenv( 'ENABLE_OUTSOURCE' );
+
+        if ( $enable_outsource == "false" ) {
+                self::$CONFIG["ENABLE_OUTSOURCE"] = false;
+                Log::doJsonLog("DISABLED OUTSOURCE");
+        }
+
+        return $env;
     }
 
     /**


### PR DESCRIPTION
This allows to set an env var ENABLE_OUTSOURCE="false" and disable outsource quotation in volume analysis at runtime.

When ENABLE_OUTSOURCE is not defined, outsource is enabled as usual.