### PR TITLE
Detect MIME Type improvement

### DIFF
--- a/lib/Utils/Mime2Extension.php
+++ b/lib/Utils/Mime2Extension.php
@@ -3108,13 +3108,13 @@ $reference = [
 //                        6 => 'dic',
                         7 => 'srt'
                 ],
-//            'text/x-fortran'                   =>
-//                    array(
-//                        0 => 'f',
-//                        1 => 'for',
-//                        2 => 'f77',
-//                        3 => 'f90',
-//                    ),
+            'text/x-fortran'                   =>
+                    array(
+                        0 => 'f',
+                        1 => 'for',
+                        2 => 'f77',
+                        3 => 'f90',
+                    ),
 //            'text/x-java-source'               =>
 //                    array(
 //                        0 => 'java',

--- a/lib/Utils/fileupload/upload.class.php
+++ b/lib/Utils/fileupload/upload.class.php
@@ -316,16 +316,16 @@ class UploadHandler {
      * @return mixed|string
      */
     private function getMimeContentType( $filename ) {
+        if ( function_exists( 'mime_content_type' ) ) {
+            return mime_content_type( $filename );
+        }
+
         if ( function_exists( 'finfo_open' ) ) {
             $finfo     = finfo_open( FILEINFO_MIME_TYPE );
             $finfoFile = finfo_file( $finfo, $filename );
             finfo_close( $finfo );
 
             return $finfoFile;
-        }
-
-        if ( function_exists( 'mime_content_type' ) ) {
-            return mime_content_type( $filename );
         }
 
         return 'application/octet-stream';

--- a/lib/Utils/fileupload/upload.class.php
+++ b/lib/Utils/fileupload/upload.class.php
@@ -232,8 +232,8 @@ class UploadHandler {
         $file->name     = $this->trim_file_name( $name );
         $file->size     = intval( $size );
         $file->tmp_name = $uploaded_file;
-        //$file->type = $type; // Override and ignore the client type definition
-        $file->type = mime_content_type( $file->tmp_name );
+
+        $file->type = $this->getMimeContentType( $file->tmp_name );
 
         if ( $this->validate( $uploaded_file, $file, $error, $index ) ) {
             $file_path   = $this->options[ 'upload_dir' ] . $file->name;
@@ -296,6 +296,39 @@ class UploadHandler {
         $file->convert = true;
 
         return $file;
+    }
+
+    /**
+     * Detection of MIME Type improvement
+     * Using File Information extention
+     * https://www.php.net/manual/en/fileinfo.installation.php
+     *
+     * File Information seems to be slightly better than mime_content_type function
+     * because tries to guess the content type and encoding of a file by looking for certain magic byte sequences at specific positions within the file.
+     * While this is not a bullet proof approach the heuristics used do a very good job.
+     *
+     * Even though some false positive are always possible. Take a look here:
+     *
+     * https://stackoverflow.com/questions/16190929/detecting-a-mime-type-fails-in-php
+     *
+     * @param $filename
+     *
+     * @return mixed|string
+     */
+    private function getMimeContentType( $filename ) {
+        if ( function_exists( 'finfo_open' ) ) {
+            $finfo     = finfo_open( FILEINFO_MIME_TYPE );
+            $finfoFile = finfo_file( $finfo, $filename );
+            finfo_close( $finfo );
+
+            return $finfoFile;
+        }
+
+        if ( function_exists( 'mime_content_type' ) ) {
+            return mime_content_type( $filename );
+        }
+
+        return 'application/octet-stream';
     }
 
     public function get() {

--- a/lib/Utils/fileupload/upload.class.php
+++ b/lib/Utils/fileupload/upload.class.php
@@ -235,6 +235,10 @@ class UploadHandler {
 
         $file->type = $this->getMimeContentType( $file->tmp_name );
 
+        if(false === $file->type){
+            $file->error = "Mime type was not recognized";
+        }
+
         if ( $this->validate( $uploaded_file, $file, $error, $index ) ) {
             $file_path   = $this->options[ 'upload_dir' ] . $file->name;
             $append_file = !$this->options[ 'discard_aborted_uploads' ] &&
@@ -300,7 +304,8 @@ class UploadHandler {
 
     /**
      * Detection of MIME Type improvement
-     * Using File Information extention
+     *
+     * Using File Information extention asa backup method
      * https://www.php.net/manual/en/fileinfo.installation.php
      *
      * File Information seems to be slightly better than mime_content_type function
@@ -311,9 +316,11 @@ class UploadHandler {
      *
      * https://stackoverflow.com/questions/16190929/detecting-a-mime-type-fails-in-php
      *
+     * Returns false in case of failure
+     *
      * @param $filename
      *
-     * @return mixed|string
+     * @return string|bool
      */
     private function getMimeContentType( $filename ) {
         if ( function_exists( 'mime_content_type' ) ) {


### PR DESCRIPTION
1) Detect MIME Type improvement using File Information PECL library;
2) Restored 'text/x-fortran' as allowed extension (because of mime type false positives);

Sometimes the detection of mime type with PHP gives false positives; for example, a simple txt file with lines that begin with a single C letter plus spaces can be encoded as 'text/x-fortran', because this letter combination seems to be a Fortran style comment.

For more information see here:

https://stackoverflow.com/questions/16190929/detecting-a-mime-type-fails-in-php