### PR TITLE
Allineamento codici linguistici Tswana

### DIFF
--- a/lib/Utils/Langs/supported_langs.json
+++ b/lib/Utils/Langs/supported_langs.json
@@ -2262,10 +2262,10 @@
             "localized":[{
                 "en":"Tswana"
             }],
-            "isocode":"tsn",
+            "isocode":"tn",
             "enabled":true,
             "rtl":false,
-            "rfc3066code":"tsn-BW"
+            "rfc3066code":"tn-BW"
         }
     ,
         {


### PR DESCRIPTION
Tswana - ISO-2: tsn - ISO-1: tn - ISORegionCode:  BW - rfc3066: tn-BW (Tswana)
è stato inserito tsn invece di tn
{
            "localized":[{
                "en":"Tswana"
            }],
            "isocode":"tsn",
            "enabled":true,
            "rtl":false,
            "rfc3066code":"tsn-BW"
        }