### PR TITLE
Fixing new lines issue

### DIFF
--- a/lib/Utils/AsyncTasks/Workers/GetContributionWorker.php
+++ b/lib/Utils/AsyncTasks/Workers/GetContributionWorker.php
@@ -206,8 +206,9 @@ class GetContributionWorker extends AbstractWorker {
                 //this should every time be ok because MT preserve tags, but we use the check on the errors
                 //for logic correctness
                 if ( !$QA->thereAreErrors() ) {
-                    $match[ 'raw_translation' ] = $QA->getTrgNormalized();
-                    $match[ 'translation' ]     = $Filter->fromLayer1ToLayer2( $match[ 'raw_translation' ] );
+                    $match[ 'raw_translation' ] = $QA->getTrgNormalized();                                    // DomDocument class forces the conversion of some entities like &#10;
+                    $match[ 'raw_translation' ] = $Filter->fromLayer2ToLayer1($match[ 'raw_translation' ]);   // Convert \n to decimal entity &#10;
+                    $match[ 'translation' ]     = $Filter->fromLayer1ToLayer2( $match[ 'raw_translation' ] ); // Convert &#10; to layer2 placeholder for the UI
                 } else {
                     $this->_doLog( $QA->getErrors() );
                 }


### PR DESCRIPTION
@Ostico it seems to be impossible to force `DomDocument` class to preserve some entities like `&#10; `.

I propose to use `fromLayer2ToLayer1` filter to `$match[ 'raw_translation' ]` in order to restore entities and then use `fromLayer1ToLayer2` on it to obtain` $match[ 'translation' ]` as before:

```
$match[ 'raw_translation' ] = $QA->getTrgNormalized();  // DomDocument class forces the conversion of some entities like &#10;
$match[ 'raw_translation' ] = $Filter->fromLayer2ToLayer1($match[ 'raw_translation' ]);   // Convert \n to decimal entity &#10;
$match[ 'translation' ]     = $Filter->fromLayer1ToLayer2( $match[ 'raw_translation' ] ); // Convert &#10; to layer2 placeholder for the UI
```

The fix seems to work, I propose to deploy it on **staging** environment to test it more extensively.