### PR TITLE
Xliff 2.0 handling fixes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.173.19",
+            "version": "3.174.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "63c6feca49bf4083f33bf250401c0c286759e101"
+                "reference": "b3ddabdcbbc2340c5312446f3a2109342974b020"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/63c6feca49bf4083f33bf250401c0c286759e101",
-                "reference": "63c6feca49bf4083f33bf250401c0c286759e101",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b3ddabdcbbc2340c5312446f3a2109342974b020",
+                "reference": "b3ddabdcbbc2340c5312446f3a2109342974b020",
                 "shasum": ""
             },
             "require": {
@@ -25,9 +25,9 @@
                 "ext-pcre": "*",
                 "ext-simplexml": "*",
                 "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.4.1",
-                "mtdowling/jmespath.php": "^2.5",
+                "guzzlehttp/promises": "^1.4.0",
+                "guzzlehttp/psr7": "^1.7.0",
+                "mtdowling/jmespath.php": "^2.6",
                 "php": ">=5.5"
             },
             "require-dev": {
@@ -92,9 +92,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.173.19"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.174.0"
             },
-            "time": "2021-03-01T19:15:59+00:00"
+            "time": "2021-03-15T18:17:20+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -453,16 +453,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631"
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/60d379c243457e073cff02bc323a2a86cb355631",
-                "reference": "60d379c243457e073cff02bc323a2a86cb355631",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
                 "shasum": ""
             },
             "require": {
@@ -502,9 +502,9 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.4.0"
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
             },
-            "time": "2020-09-30T07:37:28+00:00"
+            "time": "2021-03-07T09:25:29+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -756,16 +756,16 @@
         },
         {
             "name": "matecat/xliff-parser",
-            "version": "v1.0.47",
+            "version": "v1.0.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/xliff-parser.git",
-                "reference": "17a2d77faa8ca67a37e4f606d0e1d16187d6fe6f"
+                "reference": "622ead9ccce3cb4a0512f41cf11240c4ba384068"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/xliff-parser/zipball/17a2d77faa8ca67a37e4f606d0e1d16187d6fe6f",
-                "reference": "17a2d77faa8ca67a37e4f606d0e1d16187d6fe6f",
+                "url": "https://api.github.com/repos/matecat/xliff-parser/zipball/622ead9ccce3cb4a0512f41cf11240c4ba384068",
+                "reference": "622ead9ccce3cb4a0512f41cf11240c4ba384068",
                 "shasum": ""
             },
             "require": {
@@ -801,9 +801,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matecat/xliff-parser/issues",
-                "source": "https://github.com/matecat/xliff-parser/tree/v1.0.47"
+                "source": "https://github.com/matecat/xliff-parser/tree/v1.0.48"
             },
-            "time": "2021-03-02T16:49:43+00:00"
+            "time": "2021-03-15T15:51:00+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1233,16 +1233,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.5",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "7c751ea006577e4c2e83326d90c8b1e8c11b8ede"
+                "reference": "906a5fafabe5e6ba51ef3dc65b2722a677908837"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/7c751ea006577e4c2e83326d90c8b1e8c11b8ede",
-                "reference": "7c751ea006577e4c2e83326d90c8b1e8c11b8ede",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/906a5fafabe5e6ba51ef3dc65b2722a677908837",
+                "reference": "906a5fafabe5e6ba51ef3dc65b2722a677908837",
                 "shasum": ""
             },
             "require": {
@@ -1324,7 +1324,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.5"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.6"
             },
             "funding": [
                 {
@@ -1340,7 +1340,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-12T16:18:16+00:00"
+            "time": "2021-03-10T13:58:31+00:00"
         },
         {
             "name": "phptal/phptal",

--- a/lib/Model/Segments/SegmentDao.php
+++ b/lib/Model/Segments/SegmentDao.php
@@ -699,10 +699,12 @@ class Segments_SegmentDao extends DataAccess_AbstractDao {
             st.translation, 
             st.status,
             st.eq_word_count,
-            s.raw_word_count
+            s.raw_word_count,
+            od.map as data_ref_map
         FROM files 
         JOIN segments s ON s.id_file = files.id
         LEFT JOIN segment_translations st ON s.id = st.id_segment AND st.id_job = :id_job
+        LEFT JOIN segment_original_data od ON s.id = od.id_segment
         WHERE files.id = :id_file
 ";
 

--- a/lib/Model/Segments/SegmentOriginalDataDao.php
+++ b/lib/Model/Segments/SegmentOriginalDataDao.php
@@ -49,11 +49,14 @@ class Segments_SegmentOriginalDataDao extends DataAccess_AbstractDao {
             " ( :id_segment, :map ) "
         );
 
+        // remove any carriage return or extra space from map
         $json = json_encode($map);
+        $string = str_replace(["\\n", "\\r"], '', $json);
+        $string = trim(preg_replace('/\s+/', ' ', $string));
 
         $stmt->execute( [
                 'id_segment' => $id_segment,
-                'map' => $json
+                'map' => $string
         ] );
     }
 }

--- a/lib/Utils/QA.php
+++ b/lib/Utils/QA.php
@@ -385,6 +385,8 @@ class QA {
             '&apos;',
             '&amp;#39;',
             '&#39;',
+            '&nbsp;',
+            '&quot;',
             '&amp;amp;',
             '&amp;',
     ];

--- a/lib/Utils/XliffReplacer/XliffReplacerCallback.php
+++ b/lib/Utils/XliffReplacer/XliffReplacerCallback.php
@@ -11,6 +11,12 @@ use SubFiltering\Filters\DataRefReplace;
 class XliffReplacerCallback implements XliffReplacerCallbackInterface {
 
     /**
+     * @var Filter
+     */
+    private $filter;
+
+
+    /**
      * @var string
      */
     private $targetLang;
@@ -29,6 +35,7 @@ class XliffReplacerCallback implements XliffReplacerCallbackInterface {
      * @throws \Exception
      */
     public function __construct( \FeatureSet $featureSet, $targetLang ) {
+        $this->filter     = Filter::getInstance( $featureSet );
         $this->featureSet = $featureSet;
         $this->targetLang = $targetLang;
     }
@@ -36,7 +43,28 @@ class XliffReplacerCallback implements XliffReplacerCallbackInterface {
     /**
      * @inheritDoc
      */
-    public function thereAreErrors( $segment, $translation ) {
+    public function thereAreErrors( $segment, $translation, array $dataRefMap = [] ) {
+
+        $segment     = $this->filter->fromLayer0ToLayer1( $segment );
+        $translation = $this->filter->fromLayer0ToLayer1( $translation );
+
+        //
+        // ------------------------------------
+        // NOTE 2021-01-25
+        // ------------------------------------
+        //
+        // In Matecat there are some special characters mapped in data_ref_map (like &#39; for example)
+        // that can be omitted in the target.
+        // In this case no |||UNTRANSLATED_CONTENT_START||| should be found in the target
+        //
+        // To skip these characters QA class needs replaced version of segment and target for _addThisElementToDomMap() function
+        //
+        if(!empty($dataRefMap)){
+            $dataRefReplacer     = new DataRefReplacer( $dataRefMap );
+            $segment     = $dataRefReplacer->replace( $segment );
+            $translation = $dataRefReplacer->replace( $translation );
+        }
+
         $check = new QA ( $segment, $translation );
         $check->setFeatureSet( $this->featureSet );
         $check->setTargetSegLang( $this->targetLang );

--- a/migrations/20210316184906_alter_table_segment_original_data.php
+++ b/migrations/20210316184906_alter_table_segment_original_data.php
@@ -1,0 +1,9 @@
+<?php
+
+class AlterSegmentOriginalData extends AbstractMatecatMigration {
+
+    public $sql_up = [ 'CREATE index id_segment_idx on segment_original_data( id_segment )' ];
+
+    public $sql_down = [ 'DROP INDEX `id_segment_idx` ON segment_original_data' ];
+
+}

--- a/support_scripts/grunt/package.json
+++ b/support_scripts/grunt/package.json
@@ -46,13 +46,13 @@
     "react-transition-group": "^4.2.2",
     "react-window": "^1.8.3",
     "showdown": "^1.9.1",
-    "xss": "^1.0.8",
     "sprintf-js": "^1.1.1",
+    "xss": "^1.0.8",
     "yarn": "^1.22.4"
   },
   "devDependencies": {
-    "grunt-cli": "^1.3.2",
     "babel-preset-stage-2": "^6.24.1",
+    "grunt-cli": "^1.3.2",
     "prettier": "2.0.5"
   },
   "babel": {


### PR DESCRIPTION
- restored xliff parser v1.0.45 (now 1.0.48)
- added two more characters to exlusion map in QA
- improved segment original data persistence
- added migration for segment original data table