### PR TITLE
:art: Enable prettier for support_scripts folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,9 +2,9 @@
 /public
 /nodejs
 /lib
-/support_scripts
 /test
 /inc
 /README.md
 /LICENSE.md
 /composer.*
+package-lock.json

--- a/support_scripts/grunt/Gruntfile.js
+++ b/support_scripts/grunt/Gruntfile.js
@@ -63,7 +63,10 @@ module.exports = function (grunt) {
       libs: {
         options: {
           transform: [
-            ['babelify', {presets: [babelPresetEnv, babelPresetReact, babelPresetStage2]}],
+            [
+              'babelify',
+              {presets: [babelPresetEnv, babelPresetReact, babelPresetStage2]},
+            ],
           ],
           browserifyOptions: {
             paths: [__dirname + '/node_modules'],
@@ -76,7 +79,10 @@ module.exports = function (grunt) {
       components: {
         options: {
           transform: [
-            ['babelify', {presets: [babelPresetEnv, babelPresetReact, babelPresetStage2]}],
+            [
+              'babelify',
+              {presets: [babelPresetEnv, babelPresetReact, babelPresetStage2]},
+            ],
           ],
           browserifyOptions: {
             paths: [__dirname + '/node_modules'],
@@ -89,7 +95,10 @@ module.exports = function (grunt) {
       qualityReport: {
         options: {
           transform: [
-            ['babelify', {presets: [babelPresetEnv, babelPresetReact, babelPresetStage2]}],
+            [
+              'babelify',
+              {presets: [babelPresetEnv, babelPresetReact, babelPresetStage2]},
+            ],
           ],
           browserifyOptions: {
             paths: [__dirname + '/node_modules'],

--- a/support_scripts/tasks/model.json
+++ b/support_scripts/tasks/model.json
@@ -1,138 +1,184 @@
 {
-	"model": {
-        "version" : 1,
+  "model": {
+    "version": 1,
 
-		"label": "Ebay 1",
-		"categories": [{
-			"label": "Accuracy",
-			"subcategories": [{
-				"label": "Mistranslation",
-				"severities": [{
-					"label": "Neutral",
-					"penalty": 0
-				}, {
-					"label": "Minor",
-					"penalty": 1
-				}, {
-					"label": "Major",
-					"penalty": 3
-				}, {
-					"label": "Critical",
-					"penalty": 4
-				}]
-			}, {
-				"label": "Addition",
-				"severities": [{
-					"label": "Neutral",
-					"penalty": 0
-				}, {
-					"label": "Minor",
-					"penalty": 1
-				}, {
-					"label": "Major",
-					"penalty": 3
-				}, {
-					"label": "Critical",
-					"penalty": 4
-				}]
-			}, {
-				"label": "Omission",
-				"severities": [{
-					"label": "Neutral",
-					"penalty": 0
-				}, {
-					"label": "Minor",
-					"penalty": 1
-				}, {
-					"label": "Major",
-					"penalty": 3
-				}, {
-					"label": "Critical",
-					"penalty": 4
-				}]
+    "label": "Ebay 1",
+    "categories": [
+      {
+        "label": "Accuracy",
+        "subcategories": [
+          {
+            "label": "Mistranslation",
+            "severities": [
+              {
+                "label": "Neutral",
+                "penalty": 0
+              },
+              {
+                "label": "Minor",
+                "penalty": 1
+              },
+              {
+                "label": "Major",
+                "penalty": 3
+              },
+              {
+                "label": "Critical",
+                "penalty": 4
+              }
+            ]
+          },
+          {
+            "label": "Addition",
+            "severities": [
+              {
+                "label": "Neutral",
+                "penalty": 0
+              },
+              {
+                "label": "Minor",
+                "penalty": 1
+              },
+              {
+                "label": "Major",
+                "penalty": 3
+              },
+              {
+                "label": "Critical",
+                "penalty": 4
+              }
+            ]
+          },
+          {
+            "label": "Omission",
+            "severities": [
+              {
+                "label": "Neutral",
+                "penalty": 0
+              },
+              {
+                "label": "Minor",
+                "penalty": 1
+              },
+              {
+                "label": "Major",
+                "penalty": 3
+              },
+              {
+                "label": "Critical",
+                "penalty": 4
+              }
+            ]
+          },
+          {
+            "label": "Untranslated",
+            "severities": [
+              {
+                "label": "Neutral",
+                "penalty": 0
+              },
+              {
+                "label": "Minor",
+                "penalty": 1
+              },
+              {
+                "label": "Major",
+                "penalty": 3
+              },
+              {
+                "label": "Critical",
+                "penalty": 4
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "label": "Terminology",
+        "severities": [
+          {
+            "label": "Neutral",
+            "penalty": 0
+          },
+          {
+            "label": "Minor",
+            "penalty": 1
+          },
+          {
+            "label": "Major",
+            "penalty": 3
+          },
+          {
+            "label": "Critical",
+            "penalty": 4
+          }
+        ]
+      },
+      {
+        "label": "Fluency",
+        "subcategories": [
+          {
+            "label": "Spelling"
+          },
+          {
+            "label": "Grammar"
+          },
+          {
+            "label": "Punctuation"
+          }
+        ]
+      },
+      {
+        "label": "Style",
+        "subcategories": [
+          {
+            "label": "Company Style",
+            "severities": [
+              {
+                "label": "Neutral",
+                "penalty": 0
+              },
+              {
+                "label": "Minor",
+                "penalty": 1
+              },
+              {
+                "label": "Major",
+                "penalty": 3
+              },
+              {
+                "label": "Critical",
+                "penalty": 10
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "severities": [
+      {
+        "label": "Neutral",
+        "penalty": 0
+      },
+      {
+        "label": "Minor",
+        "penalty": 1
+      },
+      {
+        "label": "Major",
+        "penalty": 3
+      },
+      {
+        "label": "Critical",
+        "penalty": 8
+      }
+    ],
 
-			}, {
-				"label": "Untranslated",
-				"severities": [{
-					"label": "Neutral",
-					"penalty": 0
-				}, {
-					"label": "Minor",
-					"penalty": 1
-				}, {
-					"label": "Major",
-					"penalty": 3
-				}, {
-					"label": "Critical",
-					"penalty": 4
-				}]
-			}]
-		}, {
-			"label": "Terminology",
-			"severities": [{
-				"label": "Neutral",
-				"penalty": 0
-			}, {
-				"label": "Minor",
-				"penalty": 1
-			}, {
-				"label": "Major",
-				"penalty": 3
-			}, {
-				"label": "Critical",
-				"penalty": 4
-			}]
-		}, {
-			"label": "Fluency",
-			"subcategories": [{
-				"label": "Spelling"
-			}, {
-				"label": "Grammar"
-			}, {
-				"label": "Punctuation"
-			}]
-		}, {
-			"label": "Style",
-			"subcategories": [{
-				"label": "Company Style",
-				"severities": [{
-					"label": "Neutral",
-					"penalty": 0
-				}, {
-					"label": "Minor",
-					"penalty": 1
-				}, {
-					"label": "Major",
-					"penalty": 3
-				}, {
-					"label": "Critical",
-					"penalty": 10
-				}]
-			}]
-		}],
-		"severities": [
-			{
-				"label": "Neutral",
-				"penalty": 0
-			}, {
-				"label": "Minor",
-				"penalty": 1
-			}, {
-				"label": "Major",
-				"penalty": 3
-			}, {
-				"label": "Critical",
-				"penalty": 8
-			}
-        ],
-
-        "passfail" : {
-            "type" : "points_per_thousand",
-            "options" : {
-                "limit" : 20
-            }
-        }
-
-	}
-
+    "passfail": {
+      "type": "points_per_thousand",
+      "options": {
+        "limit": 20
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Contents
- ignore package-lock.json files by prettier (they are generated automatically by npm)
- remove `support_scripts` folder from the prettierignore
