### PR TITLE
:art: enable formatting for public folder files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,4 @@
-/node_modules
-/public/api/dist
-/public/**/build
 /public/css/fonts
-/public/css/sass/components/segment/Editor.scss
 /public/holidays
 /public/js
 /nodejs
@@ -13,5 +9,14 @@
 /LICENSE.md
 /composer.*
 
+# Build related files
+/node_modules
+/public/**/build
+
+# Automated files
 package-lock.json
+
+# Tracked minified files (should be removed from tracking in the future..)
 *.min.js
+/public/api/dist
+/public/css/sass/components/segment/Editor.scss

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,9 @@
 /node_modules
 /public/api/dist
-/public/css
+/public/**/build
+/public/css/fonts
+/public/css/sass/components/segment/Editor.scss
+# /public/css
 /public/holidays
 /public/img
 /public/js

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,6 @@
 /public/**/build
 /public/css/fonts
 /public/css/sass/components/segment/Editor.scss
-# /public/css
 /public/holidays
 /public/img
 /public/js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,9 @@
 /node_modules
-/public
+/public/api/dist
+/public/css
+/public/holidays
+/public/img
+/public/js
 /nodejs
 /lib
 /test
@@ -7,4 +11,6 @@
 /README.md
 /LICENSE.md
 /composer.*
+
 package-lock.json
+*.min.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,6 @@
 /public/css/fonts
 /public/css/sass/components/segment/Editor.scss
 /public/holidays
-/public/img
 /public/js
 /nodejs
 /lib

--- a/public/api/swagger-source.js
+++ b/public/api/swagger-source.js
@@ -1,3466 +1,3388 @@
 var spec = {
+  swagger: '2.0',
+  info: {
+    title: 'MateCat API',
+    description:
+      'We developed a set of Rest API to let you integrate Matecat in your translation management system or in any other application. Use our API to create projects and check their status.',
+    version: '2.0.0',
+  },
+  host: config.swagger_host,
+  schemes: ['http', 'https'],
+  produces: ['application/json'],
+  paths: {
+    '/api/v2/projects/{id_project}/{password}': {
+      get: {
+        tags: ['Project'],
+        summary: 'Get project information',
+        description: 'Retrieve information on the specified Project',
 
-    "swagger": "2.0",
-    "info": {
-        "title": "MateCat API",
-        "description": "We developed a set of Rest API to let you integrate Matecat in your translation management system or in any other application. Use our API to create projects and check their status.",
-        "version": "2.0.0"
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The project ID',
+            required: true,
+            type: 'integer',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The project Password',
+            required: true,
+            type: 'string',
+          },
+        ],
+
+        responses: {
+          200: {
+            description: 'The metadata for the requested project.',
+            schema: {
+              $ref: '#/definitions/Project',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
     },
-    "host": config.swagger_host,
-    "schemes": ["http",
-        "https"],
-    "produces": [
-        "application/json"
-    ],
-    "paths": {
-        "/api/v2/projects/{id_project}/{password}": {
-            "get": {
-                "tags": [ "Project" ],
-                "summary": "Get project information",
-                "description": "Retrieve information on the specified Project",
+    '/api/v1/new': {
+      post: {
+        tags: ['Project'],
+        summary: 'Create new Project on Matecat in detached mode',
+        description:
+          'Create new Project on Matecat With HTTP POST ( multipart/form-data ) protocol.\n/' +
+          'new has a maximum file size limit of 200 MB per file and a max number of files of 600. ' +
+          'This API will process the project creation in background. Client can poll the v1 project creation status API ' +
+          'to be notified when the project is actually created.',
 
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The project ID",
-                        "required": true,
-                        "type": "integer"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The project Password",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-
-                "responses": {
-                    "200": {
-                        "description": "The metadata for the requested project.",
-                        "schema": {
-                            "$ref": "#/definitions/Project"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v1/new": {
-            "post": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Create new Project on Matecat in detached mode",
-                "description": "Create new Project on Matecat With HTTP POST ( multipart/form-data ) protocol.\n/" +
-                "new has a maximum file size limit of 200 MB per file and a max number of files of 600. " +
-                "This API will process the project creation in background. Client can poll the v1 project creation status API " +
-                "to be notified when the project is actually created.",
-
-                "parameters": [
-                    {
-                        "name": "files",
-                        "in": "formData",
-                        "description": "The file(s) to be uploaded. You may also upload your own translation memories (TMX).",
-                        "required": true,
-                        "type": "file"
-                    },
-                    {
-                        "name": "project_name",
-                        "in": "formData",
-                        "description": "The name of the project you want create.",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "source_lang",
-                        "in": "formData",
-                        "description": "RFC 5646 language+region Code ( en-US case sensitive ) as specified in W3C standards.",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "target_lang",
-                        "in": "formData",
-                        "description": "RFC 5646 language+region Code ( en-US case sensitive ) as specified in W3C standards. Multiple languages must be comma separated ( it-IT,fr-FR,es-ES case sensitive)",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "tms_engine",
-                        "in": "formData",
-                        "description": "Identifier for Memory Server 0 means disabled, 1 means MyMemory)",
-                        "required": false,
-                        "type": "integer",
-                        "default": 1
-                    },
-                    {
-                        "name": "mt_engine",
-                        "in": "formData",
-                        "description": "Identifier for Machine Translation Service 0 means disabled, 1 means get MT from MyMemory).",
-                        "required": false,
-                        "type": "integer",
-                        "default": 1
-                    },
-                    {
-                        "name": "private_tm_key",
-                        "in": "formData",
-                        "description": "Private key(s) for MyMemory.  If a TMX file is uploaded and no key is provided, a new key will be created. - Existing MyMemory private keys or new to create" +
-                        " a new key. - Multiple keys must be comma separated. Up to 5 keys allowed. (xxx345cvf,new,s342f234fc) - If you want to set read, write or both on your private key you can" +
-                        " add after the key 'r' for read, 'w' for write or 'rw' for both  separated by ':' (xxx345cvf:r,new:w,s342f234fc:rw) - Only available if tms_engine is set to 1 or if is not used",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "subject",
-                        "in": "formData",
-                        "description": "The subject of the project you want to create.",
-                        "required": false,
-                        "type": "string",
-                        "default": "general"
-                    },
-                    {
-                        "name": "segmentation_rule",
-                        "in": "formData",
-                        "description": "The segmentation rule you want to use to parse your file.",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "owner_email",
-                        "in": "formData",
-                        "description": "The email of the owner of the project. This parameter is deprecated and being replaced by authentication headers.",
-                        "required": false,
-                        "type": "string",
-                        "default": "anonymous"
-                    },
-                    {
-                        "name": "due_date",
-                        "in": "formData",
-                        "description": "If you want to set a due date for your project, send this param with a timestamp",
-                        "required": false,
-                        "type": "string",
-                    },
-                    {
-                        "name": "id_team",
-                        "in": "formData",
-                        "description": "The team you want to assign this project",
-                        "required": false,
-                        "type": "string",
-                    },
-                    {
-                        "name": "lexiqa",
-                        "in": "formData",
-                        "description": "Enable lexiQA QA check. Requires purchase of a license from lexiQA.",
-                        "required": false,
-                        "type": "string",
-                        "default": 0,
-                    },
-                    {
-                        "name": "speech2text",
-                        "in": "formData",
-                        "description": "Improved accessibility thanks to a speech-to-text component to dictate your translations instead of typing them.",
-                        "required": false,
-                        "type": "integer",
-                        "default": 0,
-                    },
-                    {
-                        "name": "get_public_matches",
-                        "in": "formData",
-                        "description": "Enable suggestions from the Public TM",
-                        "required": false,
-                        "type": "string",
-                        "default": "true",
-                        "enum": ["true",
-                            "false"]
-                    },
-                    {
-                        "name": "pretranslate_100",
-                        "in": "formData",
-                        "description": "Pre-translate 100% matches from TM",
-                        "required": false,
-                        "type": "integer",
-                        "default": 0,
-                    },
-                    {
-                        "name": "metadata",
-                        "in": "formData",
-                        "description": 'Metadata for the project must be sent in JSON format Key:Value es: {"key1":"value1", "key2":"value2"}',
-                        "required": false,
-                        "type": "string",
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The metadata for the created project.",
-                        "schema": {
-                            "$ref": "#/definitions/NewProject"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/status": {
-            "get": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Retrieve the status of a project",
-                "description": "Check Status of a created Project With HTTP POST ( application/x-www-form-urlencoded ) protocol",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "query",
-                        "description": "The identifier of the project, should be the value returned by the /new method.",
-                        "required": true,
-                        "type": "integer"
-                    },
-                    {
-                        "name": "project_pass",
-                        "in": "query",
-                        "description": "The password associated with the project, should be the value returned by the /new method ( associated with the id_project )",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "An array of price estimates by product",
-                        "schema": {
-                            "$ref": "#/definitions/Status"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/change_project_password": {
-            "post": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Change password",
-                "description": "Change the password of a project.",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "formData",
-                        "description": "The id of the project you want to update.",
-                        "required": true,
-                        "type": "integer"
-                    },
-                    {
-                        "name": "old_pass",
-                        "in": "formData",
-                        "description": "The OLD password of the project you want to update.",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "new_pass",
-                        "in": "formData",
-                        "description": "The NEW password of the project you want to update.",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "An array of price estimates by product",
-                        "schema": {
-                            "$ref": "#/definitions/ChangePasswordResponse"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/projects/{id_project}/{password}/creation_status": {
-            "get": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Shows creation status of a project",
-                "description": "Shows creation status of a project.",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "urls",
-                        "schema": {
-                            "$ref": "#/definitions/ProjectCreationStatus"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/projects/{id_project}/{password}/completion_status": {
-            "get": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Shows project completion statuses",
-                "description": "Shows project completion statuses, " +
-                "it is related to the phases defined by the click on Marked As Completed button.",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "integer"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Statuses",
-                        "schema": {
-                            "$ref": "#/definitions/CompletionStatusItem"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}": {
-            "get": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Job Info",
-                "description": "Get all information about a Job",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Job Information",
-                        "schema": {
-                            "$ref": "#/definitions/Chunk"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/translation/{id_job}/{password}": {
-            "get": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Download Translation",
-                "description": "Download the Job translation",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Job translation"
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v1/jobs/{id_job}/{password}/stats": {
-            "get": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Statistics",
-                "description": "Statistics",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Statistics",
-                        "schema": {
-                            "$ref": "#/definitions/Stats"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/cancel": {
-            "post": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Cancel API",
-                "description": "API to cancel a Job",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ChangeStatus",
-                        "schema": {
-                            "$ref": "#/definitions/ChangeStatus"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/archive": {
-            "post": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Archive API",
-                "description": "API to archive a Job",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ChangeStatus",
-                        "schema": {
-                            "$ref": "#/definitions/ChangeStatus"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/active": {
-            "post": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Active API",
-                "description": "API to active a Job",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ChangeStatus",
-                        "schema": {
-                            "$ref": "#/definitions/ChangeStatus"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/projects/{id_project}/{password}/urls": {
-            "get": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Urls of a Project",
-                "description": "Urls of a Project",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "urls",
-                        "schema": {
-                            "$ref": "#/definitions/Urls"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-
-        "/api/v2/projects/{id_project}/{password}/due_date": {
-            "post": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Create due date",
-                "description": "Create due date given a project",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "due_date",
-                        "in": "formData",
-                        "description": "Date you want to set as due date. Date must be in the future",
-                        "required": true,
-                        "type": "integer"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Project",
-                        "schema": {
-                            "$ref": "#/definitions/Project"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
+        parameters: [
+          {
+            name: 'files',
+            in: 'formData',
+            description:
+              'The file(s) to be uploaded. You may also upload your own translation memories (TMX).',
+            required: true,
+            type: 'file',
+          },
+          {
+            name: 'project_name',
+            in: 'formData',
+            description: 'The name of the project you want create.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'source_lang',
+            in: 'formData',
+            description:
+              'RFC 5646 language+region Code ( en-US case sensitive ) as specified in W3C standards.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'target_lang',
+            in: 'formData',
+            description:
+              'RFC 5646 language+region Code ( en-US case sensitive ) as specified in W3C standards. Multiple languages must be comma separated ( it-IT,fr-FR,es-ES case sensitive)',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'tms_engine',
+            in: 'formData',
+            description:
+              'Identifier for Memory Server 0 means disabled, 1 means MyMemory)',
+            required: false,
+            type: 'integer',
+            default: 1,
+          },
+          {
+            name: 'mt_engine',
+            in: 'formData',
+            description:
+              'Identifier for Machine Translation Service 0 means disabled, 1 means get MT from MyMemory).',
+            required: false,
+            type: 'integer',
+            default: 1,
+          },
+          {
+            name: 'private_tm_key',
+            in: 'formData',
+            description:
+              'Private key(s) for MyMemory.  If a TMX file is uploaded and no key is provided, a new key will be created. - Existing MyMemory private keys or new to create' +
+              ' a new key. - Multiple keys must be comma separated. Up to 5 keys allowed. (xxx345cvf,new,s342f234fc) - If you want to set read, write or both on your private key you can' +
+              " add after the key 'r' for read, 'w' for write or 'rw' for both  separated by ':' (xxx345cvf:r,new:w,s342f234fc:rw) - Only available if tms_engine is set to 1 or if is not used",
+            required: false,
+            type: 'string',
+          },
+          {
+            name: 'subject',
+            in: 'formData',
+            description: 'The subject of the project you want to create.',
+            required: false,
+            type: 'string',
+            default: 'general',
+          },
+          {
+            name: 'segmentation_rule',
+            in: 'formData',
+            description:
+              'The segmentation rule you want to use to parse your file.',
+            required: false,
+            type: 'string',
+          },
+          {
+            name: 'owner_email',
+            in: 'formData',
+            description:
+              'The email of the owner of the project. This parameter is deprecated and being replaced by authentication headers.',
+            required: false,
+            type: 'string',
+            default: 'anonymous',
+          },
+          {
+            name: 'due_date',
+            in: 'formData',
+            description:
+              'If you want to set a due date for your project, send this param with a timestamp',
+            required: false,
+            type: 'string',
+          },
+          {
+            name: 'id_team',
+            in: 'formData',
+            description: 'The team you want to assign this project',
+            required: false,
+            type: 'string',
+          },
+          {
+            name: 'lexiqa',
+            in: 'formData',
+            description:
+              'Enable lexiQA QA check. Requires purchase of a license from lexiQA.',
+            required: false,
+            type: 'string',
+            default: 0,
+          },
+          {
+            name: 'speech2text',
+            in: 'formData',
+            description:
+              'Improved accessibility thanks to a speech-to-text component to dictate your translations instead of typing them.',
+            required: false,
+            type: 'integer',
+            default: 0,
+          },
+          {
+            name: 'get_public_matches',
+            in: 'formData',
+            description: 'Enable suggestions from the Public TM',
+            required: false,
+            type: 'string',
+            default: 'true',
+            enum: ['true', 'false'],
+          },
+          {
+            name: 'pretranslate_100',
+            in: 'formData',
+            description: 'Pre-translate 100% matches from TM',
+            required: false,
+            type: 'integer',
+            default: 0,
+          },
+          {
+            name: 'metadata',
+            in: 'formData',
+            description:
+              'Metadata for the project must be sent in JSON format Key:Value es: {"key1":"value1", "key2":"value2"}',
+            required: false,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'The metadata for the created project.',
+            schema: {
+              $ref: '#/definitions/NewProject',
             },
-            "put": {
-                "tags": [
-                    "Project"
-                ],
-                "consumes": [
-                    "application/json"
-                ],
-                "summary": "Update due date",
-                "description": "Update due date given a project",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "body",
-                        "in": "body",
-                        "description": "Date you want to set as due date. Date must be in the future",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "required": ["due_date"],
-                            "properties": {
-                                "due_date": {"type": "integer"},
-                            }
-
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Project",
-                        "schema": {
-                            "$ref": "#/definitions/Project"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Delete due date",
-                "description": "Delete due date given a project",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Project",
-                        "schema": {
-                            "$ref": "#/definitions/Project"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "/api/v2/projects/{id_project}/{password}/cancel": {
-            "post": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Cancel API",
-                "description": "API to cancel a Project",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ChangeStatus",
-                        "schema": {
-                            "$ref": "#/definitions/ChangeStatus"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/projects/{id_project}/{password}/archive": {
-            "post": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Archive API",
-                "description": "API to archive a Project",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ChangeStatus",
-                        "schema": {
-                            "$ref": "#/definitions/ChangeStatus"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/projects/{id_project}/{password}/active": {
-            "post": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Active API",
-                "description": "API to active a Project",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "ChangeStatus",
-                        "schema": {
-                            "$ref": "#/definitions/ChangeStatus"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/projects/{id_project}/{password}/jobs/{id_job}/merge": {
-            "post": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Merge",
-                "description": "Merge a splitted project",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "formData",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "formData",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_job",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "urls"
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/projects/{id_project}/{password}/jobs/{id_job}/{job_password}/split/{num_split}/check": {
-            "post": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Split Check",
-                "description": "Check a job can be splitted",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "job_password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "num_split",
-                        "in": "path",
-                        "description": "Number of chuck you want to split",
-                        "required": true,
-                        "type": "integer"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Split",
-                        "schema": {
-                            "$ref": "#/definitions/Split"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/projects/{id_project}/{password}/jobs/{id_job}/{job_password}/split/{num_split}/apply": {
-            "post": {
-                "tags": [
-                    "Project"
-                ],
-                "summary": "Split Job",
-                "description": "Check a job can be splitted",
-                "parameters": [
-                    {
-                        "name": "id_project",
-                        "in": "path",
-                        "description": "The id of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the project",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "job_password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "num_split",
-                        "in": "path",
-                        "description": "Number of chuck you want to split",
-                        "required": true,
-                        "type": "integer"
-                    },
-                    {
-                        "name": "split_values",
-                        "in": "formData",
-                        "description": "Number of word count values of each chunk returned in split check API",
-                        "type": "array",
-                        "items": {"type": "double"}
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Split",
-                        "schema": {
-                            "$ref": "#/definitions/Split"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/translator": {
-            "get": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Gets the translator assigned to a job",
-                "description": "Gets the translator assigned to a job.",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Job",
-                        "schema": {
-                            "$ref": "#/definitions/JobTranslatorItem"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Assigns a job to a translator",
-                "description": "Assigns a job to a translator.",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "email",
-                        "in": "formData",
-                        "description": "email of the translator to assign the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "delivery_date",
-                        "in": "formData",
-                        "description": "deliery date for the assignment, expressed as timestamp",
-                        "required": true,
-                        "type": "integer"
-                    },
-                    {
-                        "name": "timezone",
-                        "in": "formData",
-                        "description": "time zone to convert the delivery_date param expressed as offset based on UTC. Example 1.0, -7.0 etc.",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Job",
-                        "schema": {
-                            "$ref": "#/definitions/JobTranslatorItem"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/comments": {
-            "get": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Get segment comments in a job",
-                "description": "Gets the list of comments on all job segments.",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "from_id",
-                        "in": "query",
-                        "description": "Only return records starting from this id included",
-                        "required": false,
-                        "type": "integer"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Comments",
-                        "schema": {
-                            "$ref": "#/definitions/Comments"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/quality-report": {
-            "get": {
-                "tags": [
-                    "Job",
-                    "Quality Report"
-                ],
-                "summary": "Quality report",
-                "description": "Quality report",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Quality report",
-                        "schema": {
-                            "$ref": "#/definitions/QualityReport"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/teams": {
-            "get": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "List available teams",
-                "description": "Returns a list of all teams the current user is member of.",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "Teams",
-                        "schema": {
-                            "$ref": "#/definitions/TeamList"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "Create a new team",
-                "description": "Creates a new team.",
-                "parameters": [
-                    {
-                        "name": "type",
-                        "type": "string",
-                        "in": "fromData",
-                        "required": true,
-                    },
-                    {
-                        "name": "name",
-                        "type": "string",
-                        "in": "fromData",
-                        "required": true
-                    },
-                    {
-                        "name": "members",
-                        "type": "array",
-                        "in": "fromData",
-                        "items": {
-                            "type": "string",
-                            "format": "email",
-                            "collectionFormat": "multi"
-                        },
-                        "description": "Array of email addresses of people to invite in a project",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Team",
-                        "schema": {
-                            "$ref": "#/definitions/TeamItem"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-        },
-        "/api/v2/teams/{id_team}": {
-            "put": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "Update team",
-                "description": "Update team.",
-                "parameters": [
-                    {
-                        "name": "id_team",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                    },
-                    {
-                        "name": "body",
-                        "in": "body",
-                        "description": "Parameters in JSON Body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "name": {"type": "string"},
-                            }
-
-                        }
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Team",
-                        "schema": {
-                            "$ref": "#/definitions/TeamItem"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-        },
-        "/api/v2/teams/{id_team}/members": {
-            "get": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "List team members",
-                "description": "List team members.",
-                "parameters": [
-                    {
-                        "name": "id_team",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Team",
-                        "schema": {
-                            "$ref": "#/definitions/TeamMembersList"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "Create new team memberships",
-                "description": "Create new team memberships.",
-                "parameters": [
-                    {
-                        "name": "id_team",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                    },
-                    {
-                        "name": "members",
-                        "type": "array",
-                        "in": "fromData",
-                        "items": {
-                            "type": "string",
-                            "format": "email",
-                            "collectionFormat": "multi"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Team",
-                        "schema": {
-                            "$ref": "#/definitions/TeamMembersList"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-        },
-        "/api/v2/teams/{id_team}/members/{id_member}": {
-            "delete": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "List team members",
-                "description": "List team members.",
-                "parameters": [
-                    {
-                        "name": "id_team",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "id_member",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                        "description": "Id of the user to remove from team"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Team",
-                        "schema": {
-                            "$ref": "#/definitions/TeamMembersList"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-        },
-        "/api/v2/teams/{id_team}/projects": {
-            "get": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "Get the list of projects in a team",
-                "description": "Get the list of projects in a team.",
-                "parameters": [
-                    {
-                        "name": "id_team",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Team",
-                        "schema": {
-                            "$ref": "#/definitions/ProjectList"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-        },
-        "/api/v2/teams/{id_team}/projects/{id_project}": {
-            "get": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "Get a project in a team scope",
-                "description": "Get a project in a team scope.",
-                "parameters": [
-                    {
-                        "name": "id_team",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                    },
-                    {
-                        "name": "id_project",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Team",
-                        "schema": {
-                            "$ref": "#/definitions/ProjectItem"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "Update a team's project",
-                "description": "Updates a team's project.",
-                "parameters": [
-                    {
-                        "name": "id_team",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                    },
-                    {
-                        "name": "id_project",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                    },
-                    {
-                        "name": "body",
-                        "in": "body",
-                        "description": "Parameters in JSON Body",
-                        "required": true,
-                        "schema": {
-                            "type": "object",
-                            "properties": {
-                                "id_assignee": {"type": "integer"},
-                                "id_team": {"type": "integer"},
-                                "name": {"type": "string"},
-                            }
-
-                        }
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Team",
-                        "schema": {
-                            "$ref": "#/definitions/ProjectItem"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/teams/{id_team}/projects/{project_name}": {
-            "get": {
-                "tags": [
-                    "Teams",
-                ],
-                "summary": "Get projects in a team scope",
-                "description": "Get projects in a team scope by name.",
-                "parameters": [
-                    {
-                        "name": "id_team",
-                        "type": "integer",
-                        "in": "path",
-                        "required": true,
-                    },
-                    {
-                        "name": "project_name",
-                        "type": "string",
-                        "in": "path",
-                        "required": true,
-                        "description": "The name can also be a part of a project name"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Team",
-                        "schema": {
-                            "$ref": "#/definitions/ProjectsItems"
-                        },
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/translation-issues": {
-            "get": {
-                "tags": [
-                    "Job",
-                    "Translation Issues"
-                ],
-                "summary": "Project translation issues",
-                "description": "Project translation issues",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Translation issues",
-                        "schema": {
-                            "$ref": "#/definitions/TranslationIssues"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/translation-versions": {
-            "get": {
-                "tags": [
-                    "Job",
-                    "Translation Versions"
-                ],
-                "summary": "Project translation versions",
-                "description": "Project translation versions",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Translation Versions",
-                        "schema": {
-                            "$ref": "#/definitions/TranslationVersions"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-versions": {
-            "get": {
-                "tags": [
-                    "Job",
-                    "Translation Versions"
-                ],
-                "summary": "Segment versions",
-                "description": "Segment versions",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_segment",
-                        "in": "path",
-                        "description": "The id of the segment",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Segment versions",
-                        "schema": {
-                            "$ref": "#/definitions/TranslationVersions"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-versions/{version_number}": {
-            "get": {
-                "tags": [
-                    "Job",
-                    "Translation Versions"
-                ],
-                "summary": "Get a Segment translation version",
-                "description": "Get a Segment translation version",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_segment",
-                        "in": "path",
-                        "description": "The id of the segment",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "version_number",
-                        "in": "path",
-                        "description": "The version number",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Segment version",
-                        "schema": {
-                            "$ref": "#/definitions/TranslationVersion"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-issues": {
-            "post": {
-                "tags": [
-                    "Job",
-                    "Translation Issues"
-                ],
-                "summary": "Create translation issues",
-                "description": "Create translation issues",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "formData",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "formData",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_segment",
-                        "in": "formData",
-                        "description": "The id of the segment",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "version_number",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_segment",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_job",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_category",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "severity",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "translation_version",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "target_text",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "start_node",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "start_offset",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "end_node",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "end_offset",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "is_full_segment",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "comment",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Segment version",
-                        "schema": {
-                            "$ref": "#/definitions/Issue"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-issues/{id_issue}": {
-            "post": {
-                "tags": [
-                    "Job",
-                    "Translation Issues"
-                ],
-                "summary": "Update translation issues",
-                "description": "Update translation issues",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "formData",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "formData",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_segment",
-                        "in": "formData",
-                        "description": "The id of the segment",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_issue",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "rebutted_at",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Update Translation issue"
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Job",
-                    "Translation Issues"
-                ],
-                "summary": "Delete a translation Issue",
-                "description": "Delete a translation Issue",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_segment",
-                        "in": "path",
-                        "description": "The id of the segment",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_issue",
-                        "in": "path",
-                        "description": "The id of the issue",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Delete",
-                        "schema": {
-                            "$ref": "#/definitions/Issue"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-issues/{id_issue}/comments": {
-            "post": {
-                "tags": [
-                    "Job",
-                    "Translation Issues"
-                ],
-                "summary": "Add comment to a translation issue",
-                "description": "Create a comment translation issue",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "formData",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "formData",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_segment",
-                        "in": "formData",
-                        "description": "The id of the segment",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_issue",
-                        "in": "formData",
-                        "description": "The id of the issue",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "comment",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_qa_entry",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "source_page",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "uid",
-                        "in": "formData",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Add comment"
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "get": {
-                "tags": [
-                    "Job",
-                    "Translation Issues"
-                ],
-                "summary": "Get comments",
-                "description": "Get comments",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_segment",
-                        "in": "path",
-                        "description": "The id of the segment",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "id_issue",
-                        "in": "path",
-                        "description": "The id of the issue",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Get comments"
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/jobs/{id_job}/{password}/options": {
-            "post": {
-                "tags": [
-                    "Job",
-                    "Options"
-                ],
-                "summary": "Update Options",
-                "description": "Update Options (speech2text, guess tags, lexiqa)",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "formData",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "formData",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "speech2text",
-                        "in": "formData",
-                        "description": "To enable Speech To Text option",
-                        "required": false,
-                        "type": "boolean"
-                    },
-                    {
-                        "name": "tag_projection",
-                        "in": "formData",
-                        "description": "To enable Guess Tags option",
-                        "type": "boolean",
-                        "required": false
-                    },
-                    {
-                        "name": "lexiqa",
-                        "in": "formData",
-                        "description": "To enable lexiqa option",
-                        "type": "boolean",
-                        "required": false
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Update Options",
-                        "schema": {
-                            "$ref": "#/definitions/Options"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/TMX/id_job/password": {
-            "post": {
-                "tags": [
-                    "Job"
-                ],
-                "summary": "Download Job TMX",
-                "description": "Download the Job TMX ",
-                "parameters": [
-                    {
-                        "name": "id_job",
-                        "in": "path",
-                        "description": "The id of the job",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "path",
-                        "description": "The password of the job (Translate password)",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Job TMX",
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/glossaries/import/": {
-            "post": {
-                "tags": [
-                    "Glossary"
-                ],
-                "summary": "Import Glossary",
-                "description": "Import glossary file (.xlsx)",
-                "parameters": [
-                    {
-                        "name": "files",
-                        "in": "formData",
-                        "description": "The file(s) to be uploaded",
-                        "required": true,
-                        "type": "file"
-                    },
-                    {
-                        "name": "name",
-                        "in": "formData",
-                        "description": "The file name.",
-                        "type": "string",
-                        "required": false
-                    },
-                    {
-                        "name": "tm_key",
-                        "in": "formData",
-                        "description": "The tm key.",
-                        "required": false,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Import Glossary"
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/glossaries/import/status/{tm_key}": {
-            "get": {
-                "summary": "Glossary Upload status.",
-                "description": "Glossary Upload status.",
-                "parameters": [
-                    {
-                        "name": "tm_key",
-                        "in": "path",
-                        "description": "The tm key.",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "name",
-                        "in": "query",
-                        "description": "The file name.",
-                        "type": "string"
-                    }
-                ],
-                "tags": [
-                    "Glossary"
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Glossary Upload status",
-                        "schema": {
-                            "$ref": "#/definitions/UploadGlossaryStatusObject"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/glossaries/export/{tm_key}": {
-            "get": {
-                "tags": [
-                    "Glossary"
-                ],
-                "summary": "Download Glossary",
-                "description": "download Glossary",
-                "parameters": [
-                    {
-                        "name": "tm_key",
-                        "in": "path",
-                        "description": "The tm key.",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Glossary"
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/engines/list": {
-            "get": {
-                "tags": [
-                    "Engines"
-                ],
-                "summary": "Retrieve personal engine list.",
-                "description": "Retrieve personal engine list ( Google, Microsoft, etc. ).",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "Engine List",
-                        "schema": {
-                            "$ref": "#/definitions/EnginesList"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/keys/list": {
-            "get": {
-                "tags": [
-                    "TM keys"
-                ],
-                "summary": "Retrieve private TM keys list.",
-                "description": "Retrieve private TM keys list.",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "Keys List",
-                        "schema": {
-                            "$ref": "#/definitions/KeysList"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/api/v2/languages": {
-            "get": {
-                "tags": [
-                    "Languages"
-                ],
-                "summary": "Supported languages list.",
-                "description": "List of supported languages.",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "Languages List",
-                        "schema": {
-                            "$ref": "#/definitions/Languages"
-                        }
-                    },
-                    "default": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        }
+      },
     },
-    "definitions": {
-        "NewProject": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "description": "Return the creation status of the project. The statuses can be:OK indicating that the creation worked.FAIL indicating that the creation is failed.",
-                    "enum": [
-                        "OK",
-                        "FAIL"
-                    ]
-                },
-                "id_project": {
-                    "type": "string",
-                    "description": "Return the unique id of the project just created. If creation status is FAIL this key will simply be omitted from the result."
-                },
-                "project_pass": {
-                    "type": "string",
-                    "description": "Return the password of the project just created. If creation status is FAIL this key will simply be omitted from the result."
-                },
-                "new_keys": {
-                    "type": "string",
-                    "description": "If you specified new as one or more value in the private_tm_key parameter, the new created keys are returned as CSV string (4rcf34rc,r34rcfewf3r2). Otherwise empty string is returned"
-                }
-            }
+    '/api/status': {
+      get: {
+        tags: ['Project'],
+        summary: 'Retrieve the status of a project',
+        description:
+          'Check Status of a created Project With HTTP POST ( application/x-www-form-urlencoded ) protocol',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'query',
+            description:
+              'The identifier of the project, should be the value returned by the /new method.',
+            required: true,
+            type: 'integer',
+          },
+          {
+            name: 'project_pass',
+            in: 'query',
+            description:
+              'The password associated with the project, should be the value returned by the /new method ( associated with the id_project )',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'An array of price estimates by product',
+            schema: {
+              $ref: '#/definitions/Status',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Status": {
-            "type": "object",
-            "properties": {
-                "errors": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "A list of objects containing error message at system wide level. Every error has a negative numeric code and a textual message ( currently the only error reported is the wrong version number in config.inc.php file and happens only after Matecat updates, so you should never see it )."
-                },
-                "data": {
-                    "$ref": "#/definitions/Data-Status"
-                },
-                "status": {
-                    "type": "string",
-                    "description": "The analysis status of the project. ANALYZING - analysis/creation still in progress; NO_SEGMENTS_FOUND - the project has no segments to analyze (have you uploaded a file containing only images?); ANALYSIS_NOT_ENABLED - no analysis will be performed because of Matecat configuration; DONE - the analysis/creation is completed; FAIL - the analysis/creation is failed.",
-                    "enum": [
-                        "ANALYZING",
-                        "NO_SEGMENTS_FOUND",
-                        "ANALYSIS_NOT_ENABLED",
-                        "DONE",
-                        "FAIL"
-                    ]
-                },
-                "analyze": {
-                    "type": "string",
-                    "description": "A link to the analyze page; it's a human readable version of this API output"
-                },
-                "jobs": {
-                    "$ref": "#/definitions/Jobs-Status"
-                }
-            }
+      },
+    },
+    '/api/change_project_password': {
+      post: {
+        tags: ['Project'],
+        summary: 'Change password',
+        description: 'Change the password of a project.',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'formData',
+            description: 'The id of the project you want to update.',
+            required: true,
+            type: 'integer',
+          },
+          {
+            name: 'old_pass',
+            in: 'formData',
+            description: 'The OLD password of the project you want to update.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'new_pass',
+            in: 'formData',
+            description: 'The NEW password of the project you want to update.',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'An array of price estimates by product',
+            schema: {
+              $ref: '#/definitions/ChangePasswordResponse',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Data-Status": {
-            "type": "object",
-            "description": "Holds all progress statisticts for every job and for overall project. It contains jobs and summary sub-sections.",
-            "properties": {
-                "jobs": {
-                    "$ref": "#/definitions/Jobs"
-                },
-                "summary": {
-                    "$ref": "#/definitions/Summary"
-                }
-            }
+      },
+    },
+    '/api/v2/projects/{id_project}/{password}/creation_status': {
+      get: {
+        tags: ['Project'],
+        summary: 'Shows creation status of a project',
+        description: 'Shows creation status of a project.',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'urls',
+            schema: {
+              $ref: '#/definitions/ProjectCreationStatus',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Jobs-Status": {
-            "type": "object",
-            "description": "Section jobs contains all metadata about job (like URIs, quality reports and languages)",
-            "properties": {
-                "langpairs": {
-                    "type": "object",
-                    "description": "the language pairs for your project; an entry for every chunk in the project, with the id-password combination as key and the language pair as the value"
-                },
-                "job-url": {
-                    "type": "object",
-                    "description": "the links to the chunks of the project; an entry for every chunk in the project, with the id-password combination as key and the link to the chunk as the value."
-                },
-                "job-quality-details": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "a structure containing, for each chunk, an array of 5 objects, each object is a quality check performed on the job; the object contains the type of the check (Typing, Translation, Terminology, Language Quality, Style), the quantity of errors found, the allowed errors threshold and the rating given by the errors/threshold ratio (same as quality-overall)"
-                },
-                "quality-overall": {
-                    "type": "object",
-                    "description": "the overall quality rating for each chunk (Very good, Good, Acceptable, Poor, Fail)"
-                }
-            }
+      },
+    },
+    '/api/v2/projects/{id_project}/{password}/completion_status': {
+      get: {
+        tags: ['Project'],
+        summary: 'Shows project completion statuses',
+        description:
+          'Shows project completion statuses, ' +
+          'it is related to the phases defined by the click on Marked As Completed button.',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'integer',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Statuses',
+            schema: {
+              $ref: '#/definitions/CompletionStatusItem',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Summary": {
-            "type": "object",
-            "description": "Sub-section summary holds statistict for the whole project that are not related to single job objects.",
-            "properties": {
-                "NAME": {
-                    "type": "string",
-                    "description": "A list of objects containing error message at system wide level. Every error has a negative numeric code and a textual message ( currently the only error reported is the wrong version number in config.inc.php file and happens only after Matecat updates, so you should never see it )."
-                },
-                "STATUS": {
-                    "type": "string",
-                    "description": "The status the project is from analysis perspective. NEW - just created, not analyzed yet, FAST_OK - preliminary (fast) analysis completed, now running translations (\"TM\") analysis, DONE - analysis complete.",
-                    "enum": [
-                        "NEW",
-                        "FAST_OK",
-                        "DONE"
-                    ]
-                },
-                "IN_QUEUE_BEFORE": {
-                    "type": "string",
-                    "description": "Number of segments belonging to other projects that are being analyzed before yours; it's the wait time for you."
-                },
-                "TOTAL_SEGMENTS": {
-                    "type": "string",
-                    "description": "number of segments belonging to your project."
-                },
-                "SEGMENTS_ANALYZED": {
-                    "type": "string",
-                    "description": "analysis progress, on TOTAL_SEGMENTS"
-                },
-                "TOTAL_RAW_WC": {
-                    "type": "string",
-                    "description": "number of words (word count) of your project, as extracted by the textual parsers"
-                },
-                "TOTAL_STANDARD_WC": {
-                    "type": "string",
-                    "description": "word count, minus the sentences that are repeated"
-                },
-                "TOTAL_FAST_WC": {
-                    "type": "string",
-                    "description": "word count, minus the sentences that are partially repeated"
-                },
-                "TOTAL_TM_WC": {
-                    "type": "string",
-                    "description": "word count, with sentences found in the cloud translation memory discounted from the total; this depends on the percentage of overlapping between the sentences of your project and the past translations"
-                },
-                "TOTAL_PAYABLE": {
-                    "type": "string",
-                    "description": "total word count, after analysis."
-                }
-            }
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}': {
+      get: {
+        tags: ['Job'],
+        summary: 'Job Info',
+        description: 'Get all information about a Job',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Job Information',
+            schema: {
+              $ref: '#/definitions/Chunk',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Jobs": {
-            "type": "object",
-            "description": "Sub-section jobs holds statistict for all the job objects. The numerical keys on the first level are the IDs of the jobs contained in the project. Each job identifies a target language; as such, there is a 1-1 mapping between ID and target languages in your project. A job holds a chunks and a totals section.",
-            "properties": {
-                "id_job": {
-                    "$ref": "#/definitions/Job"
-                }
-            }
+      },
+    },
+    '/translation/{id_job}/{password}': {
+      get: {
+        tags: ['Job'],
+        summary: 'Download Translation',
+        description: 'Download the Job translation',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Job translation',
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Job": {
-            "type": "object",
-            "description": "The numerical keys on the first level are the IDs of the jobs contained in the project. Each job identifies a target language; as such, there is a 1-1 mapping between ID and target languages in your project.",
-            "properties": {
-                "chunk": {
-                    "type": "object",
-                    "description": "A structure modeling a portion of content to translate.  A whole file can be splitted in multiple chunks, to be distributed to multiple translators, or can be enveloped in a single chunk. Each chunk has a password as first level key and a numerical ID as second level key to identify different chunks for the same file. Each chunk contains the same structure of the totals section. The sum of the chunks equals to the totals."
-                },
-                "totals": {
-                    "$ref": "#/definitions/Totals"
-                }
-            }
+      },
+    },
+    '/api/v1/jobs/{id_job}/{password}/stats': {
+      get: {
+        tags: ['Job'],
+        summary: 'Statistics',
+        description: 'Statistics',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Statistics',
+            schema: {
+              $ref: '#/definitions/Stats',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Totals": {
-            "type": "object",
-            "description": "Contains all analysis statistics for all files in the current job (i.e., all files that have to be translated in a target language)",
-            "properties": {
-                "job_pass": {
-                    "$ref": "#/definitions/Total"
-                }
-            }
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/cancel': {
+      post: {
+        tags: ['Job'],
+        summary: 'Cancel API',
+        description: 'API to cancel a Job',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'ChangeStatus',
+            schema: {
+              $ref: '#/definitions/ChangeStatus',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Total": {
-            "type": "object",
-            "description": "password as first level key.",
-            "properties": {
-                "TOTAL_PAYABLE": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "total word count, after analysis"
-                },
-                "REPETITIONS": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "cumulative word count for the segments that repeat themselves in the file"
-                },
-                "INTERNAL_MATCHES": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "cumulative word count for the segments that fuzzily overlap with others in the file, while not being an exact repetition"
-                },
-                "MT": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "cumulative word count for all segments that can be translated with machine translation; it accounts for all the information that could not be discounted by repetitions, internal matches or translation memory"
-                },
-                "NEW": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "cumulative word count for segments that can't be discounted with repetition or internal matches; it's the net translation effort"
-                },
-                "TM_100": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "cumulative word count for the exact matches found in TM server"
-                },
-                "TM_75_99": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "cumulative word count for partial matches in the TM that cover 75-99% of each segment"
-                },
-                "ICE": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "cumulative word count for 100% TM matches that also share the same context with the TM"
-                },
-                "NUMBERS_ONLY": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    },
-                    "description": "cumulative word counts for segments made of numberings, dates and similar not translatable data ( i.e. 93 / 127 )"
-                }
-            }
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/archive': {
+      post: {
+        tags: ['Job'],
+        summary: 'Archive API',
+        description: 'API to archive a Job',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'ChangeStatus',
+            schema: {
+              $ref: '#/definitions/ChangeStatus',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "ChangePasswordResponse": {
-            "type": "object",
-            "properties": {
-                "status": {
-                    "type": "string",
-                    "description": "Return the exit status of the action. The statuses can be OK or FAIL",
-                    "enum": [
-                        "OK",
-                        "FAIL"
-                    ]
-                },
-                "id_project": {
-                    "type": "string",
-                    "description": "Returns the id of the project just updated"
-                },
-                "project_pass": {
-                    "type": "string",
-                    "description": "Returns the new pass of the project just updated"
-                },
-                "message": {
-                    "type": "string",
-                    "description": "Return the error message for the action if the status is FAIL"
-                }
-            }
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/active': {
+      post: {
+        tags: ['Job'],
+        summary: 'Active API',
+        description: 'API to active a Job',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'ChangeStatus',
+            schema: {
+              $ref: '#/definitions/ChangeStatus',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Stats": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "integer"
-                },
-                "DRAFT": {
-                    "type": "number"
-                },
-                "TRANSLATED": {
-                    "type": "number"
-                },
-                "APPROVED": {
-                    "type": "number"
-                },
-                "REJECTED": {
-                    "type": "number"
-                },
-                "TOTAL": {
-                    "type": "number"
-                },
-                "PROGRESS": {
-                    "type": "number"
-                },
-                "TOTAL_FORMATTED": {
-                    "type": "number"
-                },
-                "PROGRESS_FORMATTED": {
-                    "type": "string"
-                },
-                "APPROVED_FORMATTED": {
-                    "type": "string"
-                },
-                "REJECTED_FORMATTED": {
-                    "type": "string"
-                },
-                "DRAFT_FORMATTED": {
-                    "type": "string"
-                },
-                "TRANSLATED_FORMATTED": {
-                    "type": "string"
-                },
-                "APPROVED_PERC": {
-                    "type": "number"
-                },
-                "REJECTED_PERC": {
-                    "type": "number"
-                },
-                "DRAFT_PERC": {
-                    "type": "number"
-                },
-                "TRANSLATED_PERC": {
-                    "type": "number"
-                },
-                "PROGRESS_PERC": {
-                    "type": "number"
-                },
-                "TRANSLATED_PERC_FORMATTED": {
-                    "type": "number"
-                },
-                "DRAFT_PERC_FORMATTED": {
-                    "type": "number"
-                },
-                "APPROVED_PERC_FORMATTED": {
-                    "type": "number"
-                },
-                "REJECTED_PERC_FORMATTED": {
-                    "type": "number"
-                },
-                "PROGRESS_PERC_FORMATTED": {
-                    "type": "number"
-                },
-                "TODO_FORMATTED": {
-                    "type": "string"
-                },
-                "DOWNLOAD_STATUS": {
-                    "type": "string"
-                },
-                "ANALYSIS_COMPLETE": {
-                    "type": "string"
-                }
-            }
+      },
+    },
+    '/api/v2/projects/{id_project}/{password}/urls': {
+      get: {
+        tags: ['Project'],
+        summary: 'Urls of a Project',
+        description: 'Urls of a Project',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'urls',
+            schema: {
+              $ref: '#/definitions/Urls',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Urls": {
-            "type": "object",
-            "properties": {
-                "files": {
-                    "$ref": "#/definitions/Files"
-                },
-                "jobs": {
-                    "$ref": "#/definitions/UrlsJobs"
-                }
-            }
+      },
+    },
+
+    '/api/v2/projects/{id_project}/{password}/due_date': {
+      post: {
+        tags: ['Project'],
+        summary: 'Create due date',
+        description: 'Create due date given a project',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'due_date',
+            in: 'formData',
+            description:
+              'Date you want to set as due date. Date must be in the future',
+            required: true,
+            type: 'integer',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Project',
+            schema: {
+              $ref: '#/definitions/Project',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Files": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/JobFile"
-            }
+      },
+      put: {
+        tags: ['Project'],
+        consumes: ['application/json'],
+        summary: 'Update due date',
+        description: 'Update due date given a project',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'body',
+            in: 'body',
+            description:
+              'Date you want to set as due date. Date must be in the future',
+            required: true,
+            schema: {
+              type: 'object',
+              required: ['due_date'],
+              properties: {
+                due_date: {type: 'integer'},
+              },
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Project',
+            schema: {
+              $ref: '#/definitions/Project',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "JobFile": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "original_download_url": {
-                    "type": "string"
-                },
-                "translation_download_url": {
-                    "type": "string"
-                },
-                "xliff_download_url": {
-                    "type": "string"
-                }
-            }
+      },
+      delete: {
+        tags: ['Project'],
+        summary: 'Delete due date',
+        description: 'Delete due date given a project',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Project',
+            schema: {
+              $ref: '#/definitions/Project',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "UrlsJobs": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/UrlsJob"
-            }
+      },
+    },
+    '/api/v2/projects/{id_project}/{password}/cancel': {
+      post: {
+        tags: ['Project'],
+        summary: 'Cancel API',
+        description: 'API to cancel a Project',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'ChangeStatus',
+            schema: {
+              $ref: '#/definitions/ChangeStatus',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "UrlsJob": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "target_lang": {
-                    "type": "string"
-                },
-                "chunks": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Url"
-                    }
-                }
-            }
+      },
+    },
+    '/api/v2/projects/{id_project}/{password}/archive': {
+      post: {
+        tags: ['Project'],
+        summary: 'Archive API',
+        description: 'API to archive a Project',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'ChangeStatus',
+            schema: {
+              $ref: '#/definitions/ChangeStatus',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Url": {
-            "type": "object",
-            "properties": {
-                "password": {
-                    "type": "string"
-                },
-                "translate_url": {
-                    "type": "string"
-                },
-                "revise_url": {
-                    "type": "string"
-                }
-            }
+      },
+    },
+    '/api/v2/projects/{id_project}/{password}/active': {
+      post: {
+        tags: ['Project'],
+        summary: 'Active API',
+        description: 'API to active a Project',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'ChangeStatus',
+            schema: {
+              $ref: '#/definitions/ChangeStatus',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "TranslationIssues": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Issue"
-            }
+      },
+    },
+    '/api/v2/projects/{id_project}/{password}/jobs/{id_job}/merge': {
+      post: {
+        tags: ['Project'],
+        summary: 'Merge',
+        description: 'Merge a splitted project',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'formData',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'formData',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_job',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'urls',
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Issue": {
-            "type": "object",
-            "properties": {
-                "comment": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "id_category": {
-                    "type": "string"
-                },
-                "id_job": {
-                    "type": "string"
-                },
-                "id_segment": {
-                    "type": "string"
-                },
-                "is_full_segment": {
-                    "type": "string"
-                },
-                "severity": {
-                    "type": "string"
-                },
-                "start_node": {
-                    "type": "string"
-                },
-                "start_offset": {
-                    "type": "string"
-                },
-                "end_node": {
-                    "type": "string"
-                },
-                "end_offset": {
-                    "type": "string"
-                },
-                "translation_version": {
-                    "type": "string"
-                },
-                "target_text": {
-                    "type": "string"
-                },
-                "penality_points": {
-                    "type": "string"
-                },
-                "rebutted_at": {
-                    "type": "string"
-                }
-            }
+      },
+    },
+    '/api/v2/projects/{id_project}/{password}/jobs/{id_job}/{job_password}/split/{num_split}/check': {
+      post: {
+        tags: ['Project'],
+        summary: 'Split Check',
+        description: 'Check a job can be splitted',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'job_password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'num_split',
+            in: 'path',
+            description: 'Number of chuck you want to split',
+            required: true,
+            type: 'integer',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Split',
+            schema: {
+              $ref: '#/definitions/Split',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Comments": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Comment"
-            }
+      },
+    },
+    '/api/v2/projects/{id_project}/{password}/jobs/{id_job}/{job_password}/split/{num_split}/apply': {
+      post: {
+        tags: ['Project'],
+        summary: 'Split Job',
+        description: 'Check a job can be splitted',
+        parameters: [
+          {
+            name: 'id_project',
+            in: 'path',
+            description: 'The id of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the project',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'job_password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'num_split',
+            in: 'path',
+            description: 'Number of chuck you want to split',
+            required: true,
+            type: 'integer',
+          },
+          {
+            name: 'split_values',
+            in: 'formData',
+            description:
+              'Number of word count values of each chunk returned in split check API',
+            type: 'array',
+            items: {type: 'double'},
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Split',
+            schema: {
+              $ref: '#/definitions/Split',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Comment": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "id_job": {
-                    "type": "string"
-                },
-                "id_segment": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "full_name": {
-                    "type": "string"
-                },
-                "uid": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "resolved_at": {
-                    "type": "string"
-                },
-                "source_page": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "mwssage_type": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/translator': {
+      get: {
+        tags: ['Job'],
+        summary: 'Gets the translator assigned to a job',
+        description: 'Gets the translator assigned to a job.',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Job',
+            schema: {
+              $ref: '#/definitions/JobTranslatorItem',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "QualityReport": {
-            "type": "object",
-            "properties": {
-                "chunk": {
-                    "type": "object"
-                },
-                "job": {
-                    "type": "object"
-                },
-                "project": {
-                    "type": "object"
-                }
-            }
+      },
+      post: {
+        tags: ['Job'],
+        summary: 'Assigns a job to a translator',
+        description: 'Assigns a job to a translator.',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'email',
+            in: 'formData',
+            description: 'email of the translator to assign the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'delivery_date',
+            in: 'formData',
+            description:
+              'deliery date for the assignment, expressed as timestamp',
+            required: true,
+            type: 'integer',
+          },
+          {
+            name: 'timezone',
+            in: 'formData',
+            description:
+              'time zone to convert the delivery_date param expressed as offset based on UTC. Example 1.0, -7.0 etc.',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Job',
+            schema: {
+              $ref: '#/definitions/JobTranslatorItem',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "TranslationVersions": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/TranslationVersion"
-            }
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/comments': {
+      get: {
+        tags: ['Job'],
+        summary: 'Get segment comments in a job',
+        description: 'Gets the list of comments on all job segments.',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'from_id',
+            in: 'query',
+            description: 'Only return records starting from this id included',
+            required: false,
+            type: 'integer',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Comments',
+            schema: {
+              $ref: '#/definitions/Comments',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "TranslationVersion": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "id_segment": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "id_job": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "translation": {
-                    "type": "string"
-                },
-                "version_number": {
-                    "type": "string"
-                },
-                "propagated_from": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "created_at": {
-                    "type": "string"
-                }
-            }
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/quality-report': {
+      get: {
+        tags: ['Job', 'Quality Report'],
+        summary: 'Quality report',
+        description: 'Quality report',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Quality report',
+            schema: {
+              $ref: '#/definitions/QualityReport',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "Options": {
-            "type": "object",
-            "properties": {
-                "speech2text": {
-                    "type": "integer"
-                },
-                "tag_projection": {
-                    "type": "integer"
-                },
-                "lexiqa": {
-                    "type": "integer"
-                }
-            }
+      },
+    },
+    '/api/v2/teams': {
+      get: {
+        tags: ['Teams'],
+        summary: 'List available teams',
+        description:
+          'Returns a list of all teams the current user is member of.',
+        parameters: [],
+        responses: {
+          200: {
+            description: 'Teams',
+            schema: {
+              $ref: '#/definitions/TeamList',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "UploadGlossaryStatusObject": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    }
-                },
-                "data": {
-                    "$ref": "#/definitions/UploadGlossaryStatus"
-                },
-                "success": {
-                    "type": "boolean"
-                }
-            }
+      },
+      post: {
+        tags: ['Teams'],
+        summary: 'Create a new team',
+        description: 'Creates a new team.',
+        parameters: [
+          {
+            name: 'type',
+            type: 'string',
+            in: 'fromData',
+            required: true,
+          },
+          {
+            name: 'name',
+            type: 'string',
+            in: 'fromData',
+            required: true,
+          },
+          {
+            name: 'members',
+            type: 'array',
+            in: 'fromData',
+            items: {
+              type: 'string',
+              format: 'email',
+              collectionFormat: 'multi',
+            },
+            description:
+              'Array of email addresses of people to invite in a project',
+            required: true,
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Team',
+            schema: {
+              $ref: '#/definitions/TeamItem',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
         },
-        "UploadGlossaryStatus": {
-            "type": "object",
-            "properties": {
-                "done": {
-                    "type": "integer"
+      },
+    },
+    '/api/v2/teams/{id_team}': {
+      put: {
+        tags: ['Teams'],
+        summary: 'Update team',
+        description: 'Update team.',
+        parameters: [
+          {
+            name: 'id_team',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+          {
+            name: 'body',
+            in: 'body',
+            description: 'Parameters in JSON Body',
+            required: true,
+            schema: {
+              type: 'object',
+              properties: {
+                name: {type: 'string'},
+              },
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Team',
+            schema: {
+              $ref: '#/definitions/TeamItem',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/teams/{id_team}/members': {
+      get: {
+        tags: ['Teams'],
+        summary: 'List team members',
+        description: 'List team members.',
+        parameters: [
+          {
+            name: 'id_team',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Team',
+            schema: {
+              $ref: '#/definitions/TeamMembersList',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+      post: {
+        tags: ['Teams'],
+        summary: 'Create new team memberships',
+        description: 'Create new team memberships.',
+        parameters: [
+          {
+            name: 'id_team',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+          {
+            name: 'members',
+            type: 'array',
+            in: 'fromData',
+            items: {
+              type: 'string',
+              format: 'email',
+              collectionFormat: 'multi',
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Team',
+            schema: {
+              $ref: '#/definitions/TeamMembersList',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/teams/{id_team}/members/{id_member}': {
+      delete: {
+        tags: ['Teams'],
+        summary: 'List team members',
+        description: 'List team members.',
+        parameters: [
+          {
+            name: 'id_team',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+          {
+            name: 'id_member',
+            type: 'integer',
+            in: 'path',
+            required: true,
+            description: 'Id of the user to remove from team',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Team',
+            schema: {
+              $ref: '#/definitions/TeamMembersList',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/teams/{id_team}/projects': {
+      get: {
+        tags: ['Teams'],
+        summary: 'Get the list of projects in a team',
+        description: 'Get the list of projects in a team.',
+        parameters: [
+          {
+            name: 'id_team',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Team',
+            schema: {
+              $ref: '#/definitions/ProjectList',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/teams/{id_team}/projects/{id_project}': {
+      get: {
+        tags: ['Teams'],
+        summary: 'Get a project in a team scope',
+        description: 'Get a project in a team scope.',
+        parameters: [
+          {
+            name: 'id_team',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+          {
+            name: 'id_project',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Team',
+            schema: {
+              $ref: '#/definitions/ProjectItem',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+      put: {
+        tags: ['Teams'],
+        summary: "Update a team's project",
+        description: "Updates a team's project.",
+        parameters: [
+          {
+            name: 'id_team',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+          {
+            name: 'id_project',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+          {
+            name: 'body',
+            in: 'body',
+            description: 'Parameters in JSON Body',
+            required: true,
+            schema: {
+              type: 'object',
+              properties: {
+                id_assignee: {type: 'integer'},
+                id_team: {type: 'integer'},
+                name: {type: 'string'},
+              },
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Team',
+            schema: {
+              $ref: '#/definitions/ProjectItem',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/teams/{id_team}/projects/{project_name}': {
+      get: {
+        tags: ['Teams'],
+        summary: 'Get projects in a team scope',
+        description: 'Get projects in a team scope by name.',
+        parameters: [
+          {
+            name: 'id_team',
+            type: 'integer',
+            in: 'path',
+            required: true,
+          },
+          {
+            name: 'project_name',
+            type: 'string',
+            in: 'path',
+            required: true,
+            description: 'The name can also be a part of a project name',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Team',
+            schema: {
+              $ref: '#/definitions/ProjectsItems',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/translation-issues': {
+      get: {
+        tags: ['Job', 'Translation Issues'],
+        summary: 'Project translation issues',
+        description: 'Project translation issues',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Translation issues',
+            schema: {
+              $ref: '#/definitions/TranslationIssues',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/translation-versions': {
+      get: {
+        tags: ['Job', 'Translation Versions'],
+        summary: 'Project translation versions',
+        description: 'Project translation versions',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Translation Versions',
+            schema: {
+              $ref: '#/definitions/TranslationVersions',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-versions': {
+      get: {
+        tags: ['Job', 'Translation Versions'],
+        summary: 'Segment versions',
+        description: 'Segment versions',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_segment',
+            in: 'path',
+            description: 'The id of the segment',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Segment versions',
+            schema: {
+              $ref: '#/definitions/TranslationVersions',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-versions/{version_number}': {
+      get: {
+        tags: ['Job', 'Translation Versions'],
+        summary: 'Get a Segment translation version',
+        description: 'Get a Segment translation version',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_segment',
+            in: 'path',
+            description: 'The id of the segment',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'version_number',
+            in: 'path',
+            description: 'The version number',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Segment version',
+            schema: {
+              $ref: '#/definitions/TranslationVersion',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-issues': {
+      post: {
+        tags: ['Job', 'Translation Issues'],
+        summary: 'Create translation issues',
+        description: 'Create translation issues',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'formData',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'formData',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_segment',
+            in: 'formData',
+            description: 'The id of the segment',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'version_number',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_segment',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_job',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_category',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'severity',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'translation_version',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'target_text',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'start_node',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'start_offset',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'end_node',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'end_offset',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'is_full_segment',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'comment',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Segment version',
+            schema: {
+              $ref: '#/definitions/Issue',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-issues/{id_issue}': {
+      post: {
+        tags: ['Job', 'Translation Issues'],
+        summary: 'Update translation issues',
+        description: 'Update translation issues',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'formData',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'formData',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_segment',
+            in: 'formData',
+            description: 'The id of the segment',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_issue',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'rebutted_at',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Update Translation issue',
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+      delete: {
+        tags: ['Job', 'Translation Issues'],
+        summary: 'Delete a translation Issue',
+        description: 'Delete a translation Issue',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_segment',
+            in: 'path',
+            description: 'The id of the segment',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_issue',
+            in: 'path',
+            description: 'The id of the issue',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Delete',
+            schema: {
+              $ref: '#/definitions/Issue',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/segments/{id_segment}/translation-issues/{id_issue}/comments': {
+      post: {
+        tags: ['Job', 'Translation Issues'],
+        summary: 'Add comment to a translation issue',
+        description: 'Create a comment translation issue',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'formData',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'formData',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_segment',
+            in: 'formData',
+            description: 'The id of the segment',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_issue',
+            in: 'formData',
+            description: 'The id of the issue',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'comment',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_qa_entry',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'source_page',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'uid',
+            in: 'formData',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Add comment',
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+      get: {
+        tags: ['Job', 'Translation Issues'],
+        summary: 'Get comments',
+        description: 'Get comments',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_segment',
+            in: 'path',
+            description: 'The id of the segment',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'id_issue',
+            in: 'path',
+            description: 'The id of the issue',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Get comments',
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/jobs/{id_job}/{password}/options': {
+      post: {
+        tags: ['Job', 'Options'],
+        summary: 'Update Options',
+        description: 'Update Options (speech2text, guess tags, lexiqa)',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'formData',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'formData',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'speech2text',
+            in: 'formData',
+            description: 'To enable Speech To Text option',
+            required: false,
+            type: 'boolean',
+          },
+          {
+            name: 'tag_projection',
+            in: 'formData',
+            description: 'To enable Guess Tags option',
+            type: 'boolean',
+            required: false,
+          },
+          {
+            name: 'lexiqa',
+            in: 'formData',
+            description: 'To enable lexiqa option',
+            type: 'boolean',
+            required: false,
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Update Options',
+            schema: {
+              $ref: '#/definitions/Options',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/TMX/id_job/password': {
+      post: {
+        tags: ['Job'],
+        summary: 'Download Job TMX',
+        description: 'Download the Job TMX ',
+        parameters: [
+          {
+            name: 'id_job',
+            in: 'path',
+            description: 'The id of the job',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'password',
+            in: 'path',
+            description: 'The password of the job (Translate password)',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Job TMX',
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/glossaries/import/': {
+      post: {
+        tags: ['Glossary'],
+        summary: 'Import Glossary',
+        description: 'Import glossary file (.xlsx)',
+        parameters: [
+          {
+            name: 'files',
+            in: 'formData',
+            description: 'The file(s) to be uploaded',
+            required: true,
+            type: 'file',
+          },
+          {
+            name: 'name',
+            in: 'formData',
+            description: 'The file name.',
+            type: 'string',
+            required: false,
+          },
+          {
+            name: 'tm_key',
+            in: 'formData',
+            description: 'The tm key.',
+            required: false,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Import Glossary',
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/glossaries/import/status/{tm_key}': {
+      get: {
+        summary: 'Glossary Upload status.',
+        description: 'Glossary Upload status.',
+        parameters: [
+          {
+            name: 'tm_key',
+            in: 'path',
+            description: 'The tm key.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'name',
+            in: 'query',
+            description: 'The file name.',
+            type: 'string',
+          },
+        ],
+        tags: ['Glossary'],
+        responses: {
+          200: {
+            description: 'Glossary Upload status',
+            schema: {
+              $ref: '#/definitions/UploadGlossaryStatusObject',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/glossaries/export/{tm_key}': {
+      get: {
+        tags: ['Glossary'],
+        summary: 'Download Glossary',
+        description: 'download Glossary',
+        parameters: [
+          {
+            name: 'tm_key',
+            in: 'path',
+            description: 'The tm key.',
+            required: true,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'Glossary',
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/engines/list': {
+      get: {
+        tags: ['Engines'],
+        summary: 'Retrieve personal engine list.',
+        description:
+          'Retrieve personal engine list ( Google, Microsoft, etc. ).',
+        parameters: [],
+        responses: {
+          200: {
+            description: 'Engine List',
+            schema: {
+              $ref: '#/definitions/EnginesList',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/keys/list': {
+      get: {
+        tags: ['TM keys'],
+        summary: 'Retrieve private TM keys list.',
+        description: 'Retrieve private TM keys list.',
+        parameters: [],
+        responses: {
+          200: {
+            description: 'Keys List',
+            schema: {
+              $ref: '#/definitions/KeysList',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v2/languages': {
+      get: {
+        tags: ['Languages'],
+        summary: 'Supported languages list.',
+        description: 'List of supported languages.',
+        parameters: [],
+        responses: {
+          200: {
+            description: 'Languages List',
+            schema: {
+              $ref: '#/definitions/Languages',
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+  },
+  definitions: {
+    NewProject: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          description:
+            'Return the creation status of the project. The statuses can be:OK indicating that the creation worked.FAIL indicating that the creation is failed.',
+          enum: ['OK', 'FAIL'],
+        },
+        id_project: {
+          type: 'string',
+          description:
+            'Return the unique id of the project just created. If creation status is FAIL this key will simply be omitted from the result.',
+        },
+        project_pass: {
+          type: 'string',
+          description:
+            'Return the password of the project just created. If creation status is FAIL this key will simply be omitted from the result.',
+        },
+        new_keys: {
+          type: 'string',
+          description:
+            'If you specified new as one or more value in the private_tm_key parameter, the new created keys are returned as CSV string (4rcf34rc,r34rcfewf3r2). Otherwise empty string is returned',
+        },
+      },
+    },
+    Status: {
+      type: 'object',
+      properties: {
+        errors: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            'A list of objects containing error message at system wide level. Every error has a negative numeric code and a textual message ( currently the only error reported is the wrong version number in config.inc.php file and happens only after Matecat updates, so you should never see it ).',
+        },
+        data: {
+          $ref: '#/definitions/Data-Status',
+        },
+        status: {
+          type: 'string',
+          description:
+            'The analysis status of the project. ANALYZING - analysis/creation still in progress; NO_SEGMENTS_FOUND - the project has no segments to analyze (have you uploaded a file containing only images?); ANALYSIS_NOT_ENABLED - no analysis will be performed because of Matecat configuration; DONE - the analysis/creation is completed; FAIL - the analysis/creation is failed.',
+          enum: [
+            'ANALYZING',
+            'NO_SEGMENTS_FOUND',
+            'ANALYSIS_NOT_ENABLED',
+            'DONE',
+            'FAIL',
+          ],
+        },
+        analyze: {
+          type: 'string',
+          description:
+            "A link to the analyze page; it's a human readable version of this API output",
+        },
+        jobs: {
+          $ref: '#/definitions/Jobs-Status',
+        },
+      },
+    },
+    'Data-Status': {
+      type: 'object',
+      description:
+        'Holds all progress statisticts for every job and for overall project. It contains jobs and summary sub-sections.',
+      properties: {
+        jobs: {
+          $ref: '#/definitions/Jobs',
+        },
+        summary: {
+          $ref: '#/definitions/Summary',
+        },
+      },
+    },
+    'Jobs-Status': {
+      type: 'object',
+      description:
+        'Section jobs contains all metadata about job (like URIs, quality reports and languages)',
+      properties: {
+        langpairs: {
+          type: 'object',
+          description:
+            'the language pairs for your project; an entry for every chunk in the project, with the id-password combination as key and the language pair as the value',
+        },
+        'job-url': {
+          type: 'object',
+          description:
+            'the links to the chunks of the project; an entry for every chunk in the project, with the id-password combination as key and the link to the chunk as the value.',
+        },
+        'job-quality-details': {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            'a structure containing, for each chunk, an array of 5 objects, each object is a quality check performed on the job; the object contains the type of the check (Typing, Translation, Terminology, Language Quality, Style), the quantity of errors found, the allowed errors threshold and the rating given by the errors/threshold ratio (same as quality-overall)',
+        },
+        'quality-overall': {
+          type: 'object',
+          description:
+            'the overall quality rating for each chunk (Very good, Good, Acceptable, Poor, Fail)',
+        },
+      },
+    },
+    Summary: {
+      type: 'object',
+      description:
+        'Sub-section summary holds statistict for the whole project that are not related to single job objects.',
+      properties: {
+        NAME: {
+          type: 'string',
+          description:
+            'A list of objects containing error message at system wide level. Every error has a negative numeric code and a textual message ( currently the only error reported is the wrong version number in config.inc.php file and happens only after Matecat updates, so you should never see it ).',
+        },
+        STATUS: {
+          type: 'string',
+          description:
+            'The status the project is from analysis perspective. NEW - just created, not analyzed yet, FAST_OK - preliminary (fast) analysis completed, now running translations ("TM") analysis, DONE - analysis complete.',
+          enum: ['NEW', 'FAST_OK', 'DONE'],
+        },
+        IN_QUEUE_BEFORE: {
+          type: 'string',
+          description:
+            "Number of segments belonging to other projects that are being analyzed before yours; it's the wait time for you.",
+        },
+        TOTAL_SEGMENTS: {
+          type: 'string',
+          description: 'number of segments belonging to your project.',
+        },
+        SEGMENTS_ANALYZED: {
+          type: 'string',
+          description: 'analysis progress, on TOTAL_SEGMENTS',
+        },
+        TOTAL_RAW_WC: {
+          type: 'string',
+          description:
+            'number of words (word count) of your project, as extracted by the textual parsers',
+        },
+        TOTAL_STANDARD_WC: {
+          type: 'string',
+          description: 'word count, minus the sentences that are repeated',
+        },
+        TOTAL_FAST_WC: {
+          type: 'string',
+          description:
+            'word count, minus the sentences that are partially repeated',
+        },
+        TOTAL_TM_WC: {
+          type: 'string',
+          description:
+            'word count, with sentences found in the cloud translation memory discounted from the total; this depends on the percentage of overlapping between the sentences of your project and the past translations',
+        },
+        TOTAL_PAYABLE: {
+          type: 'string',
+          description: 'total word count, after analysis.',
+        },
+      },
+    },
+    Jobs: {
+      type: 'object',
+      description:
+        'Sub-section jobs holds statistict for all the job objects. The numerical keys on the first level are the IDs of the jobs contained in the project. Each job identifies a target language; as such, there is a 1-1 mapping between ID and target languages in your project. A job holds a chunks and a totals section.',
+      properties: {
+        id_job: {
+          $ref: '#/definitions/Job',
+        },
+      },
+    },
+    Job: {
+      type: 'object',
+      description:
+        'The numerical keys on the first level are the IDs of the jobs contained in the project. Each job identifies a target language; as such, there is a 1-1 mapping between ID and target languages in your project.',
+      properties: {
+        chunk: {
+          type: 'object',
+          description:
+            'A structure modeling a portion of content to translate.  A whole file can be splitted in multiple chunks, to be distributed to multiple translators, or can be enveloped in a single chunk. Each chunk has a password as first level key and a numerical ID as second level key to identify different chunks for the same file. Each chunk contains the same structure of the totals section. The sum of the chunks equals to the totals.',
+        },
+        totals: {
+          $ref: '#/definitions/Totals',
+        },
+      },
+    },
+    Totals: {
+      type: 'object',
+      description:
+        'Contains all analysis statistics for all files in the current job (i.e., all files that have to be translated in a target language)',
+      properties: {
+        job_pass: {
+          $ref: '#/definitions/Total',
+        },
+      },
+    },
+    Total: {
+      type: 'object',
+      description: 'password as first level key.',
+      properties: {
+        TOTAL_PAYABLE: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description: 'total word count, after analysis',
+        },
+        REPETITIONS: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            'cumulative word count for the segments that repeat themselves in the file',
+        },
+        INTERNAL_MATCHES: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            'cumulative word count for the segments that fuzzily overlap with others in the file, while not being an exact repetition',
+        },
+        MT: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            'cumulative word count for all segments that can be translated with machine translation; it accounts for all the information that could not be discounted by repetitions, internal matches or translation memory',
+        },
+        NEW: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            "cumulative word count for segments that can't be discounted with repetition or internal matches; it's the net translation effort",
+        },
+        TM_100: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            'cumulative word count for the exact matches found in TM server',
+        },
+        TM_75_99: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            'cumulative word count for partial matches in the TM that cover 75-99% of each segment',
+        },
+        ICE: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            'cumulative word count for 100% TM matches that also share the same context with the TM',
+        },
+        NUMBERS_ONLY: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+          description:
+            'cumulative word counts for segments made of numberings, dates and similar not translatable data ( i.e. 93 / 127 )',
+        },
+      },
+    },
+    ChangePasswordResponse: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          description:
+            'Return the exit status of the action. The statuses can be OK or FAIL',
+          enum: ['OK', 'FAIL'],
+        },
+        id_project: {
+          type: 'string',
+          description: 'Returns the id of the project just updated',
+        },
+        project_pass: {
+          type: 'string',
+          description: 'Returns the new pass of the project just updated',
+        },
+        message: {
+          type: 'string',
+          description:
+            'Return the error message for the action if the status is FAIL',
+        },
+      },
+    },
+    Stats: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'integer',
+        },
+        DRAFT: {
+          type: 'number',
+        },
+        TRANSLATED: {
+          type: 'number',
+        },
+        APPROVED: {
+          type: 'number',
+        },
+        REJECTED: {
+          type: 'number',
+        },
+        TOTAL: {
+          type: 'number',
+        },
+        PROGRESS: {
+          type: 'number',
+        },
+        TOTAL_FORMATTED: {
+          type: 'number',
+        },
+        PROGRESS_FORMATTED: {
+          type: 'string',
+        },
+        APPROVED_FORMATTED: {
+          type: 'string',
+        },
+        REJECTED_FORMATTED: {
+          type: 'string',
+        },
+        DRAFT_FORMATTED: {
+          type: 'string',
+        },
+        TRANSLATED_FORMATTED: {
+          type: 'string',
+        },
+        APPROVED_PERC: {
+          type: 'number',
+        },
+        REJECTED_PERC: {
+          type: 'number',
+        },
+        DRAFT_PERC: {
+          type: 'number',
+        },
+        TRANSLATED_PERC: {
+          type: 'number',
+        },
+        PROGRESS_PERC: {
+          type: 'number',
+        },
+        TRANSLATED_PERC_FORMATTED: {
+          type: 'number',
+        },
+        DRAFT_PERC_FORMATTED: {
+          type: 'number',
+        },
+        APPROVED_PERC_FORMATTED: {
+          type: 'number',
+        },
+        REJECTED_PERC_FORMATTED: {
+          type: 'number',
+        },
+        PROGRESS_PERC_FORMATTED: {
+          type: 'number',
+        },
+        TODO_FORMATTED: {
+          type: 'string',
+        },
+        DOWNLOAD_STATUS: {
+          type: 'string',
+        },
+        ANALYSIS_COMPLETE: {
+          type: 'string',
+        },
+      },
+    },
+    Urls: {
+      type: 'object',
+      properties: {
+        files: {
+          $ref: '#/definitions/Files',
+        },
+        jobs: {
+          $ref: '#/definitions/UrlsJobs',
+        },
+      },
+    },
+    Files: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/JobFile',
+      },
+    },
+    JobFile: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+        },
+        name: {
+          type: 'string',
+        },
+        original_download_url: {
+          type: 'string',
+        },
+        translation_download_url: {
+          type: 'string',
+        },
+        xliff_download_url: {
+          type: 'string',
+        },
+      },
+    },
+    UrlsJobs: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/UrlsJob',
+      },
+    },
+    UrlsJob: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+        },
+        target_lang: {
+          type: 'string',
+        },
+        chunks: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/Url',
+          },
+        },
+      },
+    },
+    Url: {
+      type: 'object',
+      properties: {
+        password: {
+          type: 'string',
+        },
+        translate_url: {
+          type: 'string',
+        },
+        revise_url: {
+          type: 'string',
+        },
+      },
+    },
+    TranslationIssues: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/Issue',
+      },
+    },
+    Issue: {
+      type: 'object',
+      properties: {
+        comment: {
+          type: 'string',
+        },
+        created_at: {
+          type: 'string',
+        },
+        id: {
+          type: 'string',
+        },
+        id_category: {
+          type: 'string',
+        },
+        id_job: {
+          type: 'string',
+        },
+        id_segment: {
+          type: 'string',
+        },
+        is_full_segment: {
+          type: 'string',
+        },
+        severity: {
+          type: 'string',
+        },
+        start_node: {
+          type: 'string',
+        },
+        start_offset: {
+          type: 'string',
+        },
+        end_node: {
+          type: 'string',
+        },
+        end_offset: {
+          type: 'string',
+        },
+        translation_version: {
+          type: 'string',
+        },
+        target_text: {
+          type: 'string',
+        },
+        penality_points: {
+          type: 'string',
+        },
+        rebutted_at: {
+          type: 'string',
+        },
+      },
+    },
+    Comments: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/Comment',
+      },
+    },
+    Comment: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+        },
+        id_job: {
+          type: 'string',
+        },
+        id_segment: {
+          type: 'string',
+        },
+        created_at: {
+          type: 'string',
+        },
+        email: {
+          type: 'string',
+        },
+        full_name: {
+          type: 'string',
+        },
+        uid: {
+          type: 'integer',
+          format: 'int32',
+        },
+        resolved_at: {
+          type: 'string',
+        },
+        source_page: {
+          type: 'integer',
+          format: 'int32',
+        },
+        mwssage_type: {
+          type: 'integer',
+          format: 'int32',
+        },
+        message: {
+          type: 'string',
+        },
+      },
+    },
+    QualityReport: {
+      type: 'object',
+      properties: {
+        chunk: {
+          type: 'object',
+        },
+        job: {
+          type: 'object',
+        },
+        project: {
+          type: 'object',
+        },
+      },
+    },
+    TranslationVersions: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/TranslationVersion',
+      },
+    },
+    TranslationVersion: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'integer',
+          format: 'int32',
+        },
+        id_segment: {
+          type: 'integer',
+          format: 'int32',
+        },
+        id_job: {
+          type: 'integer',
+          format: 'int32',
+        },
+        translation: {
+          type: 'string',
+        },
+        version_number: {
+          type: 'string',
+        },
+        propagated_from: {
+          type: 'integer',
+          format: 'int32',
+        },
+        created_at: {
+          type: 'string',
+        },
+      },
+    },
+    Options: {
+      type: 'object',
+      properties: {
+        speech2text: {
+          type: 'integer',
+        },
+        tag_projection: {
+          type: 'integer',
+        },
+        lexiqa: {
+          type: 'integer',
+        },
+      },
+    },
+    UploadGlossaryStatusObject: {
+      type: 'object',
+      properties: {
+        error: {
+          type: 'array',
+          items: {
+            type: 'object',
+          },
+        },
+        data: {
+          $ref: '#/definitions/UploadGlossaryStatus',
+        },
+        success: {
+          type: 'boolean',
+        },
+      },
+    },
+    UploadGlossaryStatus: {
+      type: 'object',
+      properties: {
+        done: {
+          type: 'integer',
+        },
+        total: {
+          type: 'integer',
+        },
+        source_lang: {
+          type: 'string',
+        },
+        target_lang: {
+          type: 'string',
+        },
+        completed: {
+          type: 'boolean',
+        },
+      },
+    },
+
+    Languages: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/Language',
+      },
+    },
+
+    Language: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'string',
+          description: 'Rfc code',
+        },
+        name: {
+          type: 'string',
+          description: 'Language name',
+        },
+        direction: {
+          type: 'string',
+          enum: ['ltr', 'rtl'],
+          description:
+            'Language direction, ltr (left-to-right text) or rtl (right-to-left text)',
+        },
+      },
+    },
+    PendingInvitation: {
+      type: 'array',
+      items: {
+        type: 'string',
+        description: 'Email address of the invited user',
+      },
+    },
+
+    TeamMembersList: {
+      type: 'object',
+      properties: {
+        members: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/TeamMember',
+          },
+        },
+        pending_invitations: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/PendingInvitation',
+          },
+        },
+      },
+    },
+
+    TeamMember: {
+      type: 'object',
+      properties: {
+        id: {type: 'integer'},
+        id_team: {type: 'integer'},
+        user: {
+          type: 'object',
+          $ref: '#/definitions/User',
+        },
+      },
+    },
+
+    User: {
+      type: 'object',
+      properties: {
+        uid: {type: 'integer'},
+        first_name: {type: 'string'},
+        last_name: {type: 'string'},
+        email: {type: 'string'},
+        has_password: {type: 'boolean'},
+      },
+    },
+
+    TeamList: {
+      type: 'object',
+      properties: {
+        teams: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/Team',
+          },
+        },
+      },
+    },
+
+    TeamItem: {
+      type: 'object',
+      properties: {
+        team: {
+          type: 'object',
+          $ref: '#/definitions/Team',
+        },
+      },
+    },
+
+    Team: {
+      type: 'object',
+      properties: {
+        id: {type: 'integer', required: true},
+        name: {type: 'string', required: true},
+        type: {
+          type: 'string',
+          enum: ['general', 'personal'],
+          required: true,
+        },
+        created_at: {
+          type: 'string',
+          format: 'date-time',
+          required: true,
+        },
+        created_by: {type: 'integer', required: true},
+        pending_invitations: {type: 'array', items: 'string'},
+      },
+    },
+
+    EnginesList: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/Engine',
+      },
+    },
+    Engine: {
+      type: 'object',
+      properties: {
+        id: {type: 'integer', required: true},
+        name: {type: 'string', required: true},
+        type: {
+          type: 'string',
+          enum: ['MT', 'TM'],
+          required: true,
+        },
+        description: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+
+    KeysList: {
+      type: 'object',
+      properties: {
+        private_keys: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/Key',
+          },
+        },
+        shared_keys: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/Key',
+          },
+        },
+      },
+    },
+    Key: {
+      type: 'object',
+      properties: {
+        key: {type: 'string', required: true},
+        name: {type: 'string', required: true},
+      },
+    },
+
+    ProjectList: {
+      type: 'object',
+      properties: {
+        projects: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/Project',
+          },
+        },
+      },
+    },
+    ProjectItem: {
+      type: 'object',
+      properties: {
+        project: {
+          type: 'object',
+          $ref: '#/definitions/Project',
+        },
+      },
+    },
+
+    ProjectsItems: {
+      type: 'object',
+      properties: {
+        projects: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/Project',
+          },
+        },
+      },
+    },
+
+    Project: {
+      type: 'object',
+      properties: {
+        id: {type: 'integer'},
+        password: {type: 'string'},
+        name: {type: 'string'},
+        id_team: {type: 'integer'},
+        id_assignee: {type: 'integer'},
+        create_date: {type: 'string', format: 'date-time'},
+        fast_analysis_wc: {type: 'float'},
+        standard_analysis_wc: {type: 'float'},
+        project_slug: {type: 'string'},
+        features: {type: 'string'},
+        is_cancelled: {type: 'boolean'},
+        is_archived: {type: 'boolean'},
+        remote_file_service: {type: 'string'},
+        jobs: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/ExtendedJob',
+          },
+        },
+      },
+    },
+
+    CompletionStatusItem: {
+      type: 'object',
+      properties: {
+        project_status: {
+          type: 'object',
+          properties: {
+            revise: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: {type: 'string'},
+                  password: {type: 'string'},
+                  completed: {type: 'boolean'},
+                  completed_at: {type: 'string', format: 'date-time'},
+                  event_id: {type: 'string'},
                 },
-                "total": {
-                    "type": "integer"
+              },
+            },
+            translate: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: {type: 'string'},
+                  password: {type: 'string'},
+                  completed: {type: 'boolean'},
+                  completed_at: {type: 'string', format: 'date-time'},
+                  event_id: {type: 'string'},
                 },
-                "source_lang": {
-                    "type": "string"
-                },
-                "target_lang": {
-                    "type": "string"
-                },
-                "completed": {
-                    "type": "boolean"
-                }
-            }
+              },
+            },
+            id: {type: 'string'},
+            completed: {type: 'boolean'},
+          },
+        },
+      },
+    },
+
+    Chunk: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'integer',
+        },
+        chunks: {
+          type: 'array',
+          items: {
+            type: 'object',
+            $ref: '#/definitions/ExtendedJob',
+          },
+        },
+      },
+    },
+
+    ExtendedJob: {
+      type: 'object',
+
+      properties: {
+        id: {type: 'integer'},
+        password: {type: 'string'},
+        source: {type: 'string'},
+        target: {type: 'string'},
+        sourceTxt: {type: 'string'},
+        targetTxt: {type: 'string'},
+        status: {type: 'string'},
+        subject: {type: 'string'},
+        owner: {type: 'string', format: 'email'},
+        open_threads_count: {type: 'integer'},
+        create_timestamp: {type: 'integer'},
+        created_at: {type: 'string', format: 'date-time'},
+        create_date: {type: 'string', format: 'date-time'},
+        formatted_create_date: {type: 'string'},
+        quality_overall: {type: 'string'},
+        pee: {type: 'integer'},
+        tte: {type: 'integer', format: 'seconds'},
+        private_tm_key: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+        warnings_count: {type: 'integer'},
+        warning_segments: {
+          type: 'array',
+          items: {
+            type: 'integer',
+          },
+        },
+        outsource: {
+          type: 'object',
+          $ref: '#/definitions/OutsourceConfirmation',
         },
 
-        "Languages": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Language"
-            }
+        translator: {
+          type: 'object',
+          $ref: '#/definitions/Translator',
         },
 
-        "Language": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "string",
-                    "description": "Rfc code"
+        total_raw_wc: {type: 'float'},
+        urls: {
+          type: 'object',
+          $ref: '#/definitions/JobUrl',
+        },
+        stats: {
+          type: 'object',
+          $ref: '#/definitions/Stats',
+        },
+        quality_summary: {
+          type: 'object',
+          $ref: '#/definitions/QualitySummary',
+        },
+      },
+    },
+
+    QualitySummary: {
+      type: 'object',
+      properties: {
+        equivalent_class: {type: 'integer'},
+        quality_overall: {type: 'string'},
+        errors_count: {type: 'integer'},
+        revise_issues: {
+          type: 'object',
+          properties: {
+            typing: {type: 'object', $ref: '#/definitions/ReviseIssue'},
+            translation: {type: 'object', $ref: '#/definitions/ReviseIssue'},
+            terminology: {type: 'object', $ref: '#/definitions/ReviseIssue'},
+            language_quality: {
+              type: 'object',
+              $ref: '#/definitions/ReviseIssue',
+            },
+            style: {type: 'object', $ref: '#/definitions/ReviseIssue'},
+          },
+        },
+      },
+    },
+
+    ReviseIssue: {
+      type: 'object',
+      properties: {
+        allowed: {type: 'number'},
+        found: {type: 'integer'},
+      },
+    },
+
+    JobUrl: {
+      type: 'object',
+      properties: {
+        translate_url: {type: 'string'},
+        revise_url: {type: 'string'},
+        original_download_url: {type: 'string'},
+        translation_download_url: {type: 'string'},
+        xliff_download_url: {type: 'string'},
+      },
+    },
+
+    JobTranslatorItem: {
+      type: 'object',
+      properties: {
+        id: {type: 'integer'},
+        password: {type: 'password'},
+        translator: {
+          type: 'object',
+          $ref: '#/definitions/Translator',
+        },
+      },
+    },
+
+    Translator: {
+      type: 'object',
+      properties: {
+        email: {type: 'string', format: 'email'},
+        added_by: {type: 'integer'},
+        delivery_date: {type: 'string'},
+        delivery_timestamp: {type: 'string'},
+        source: {type: 'string'},
+        target: {type: 'string'},
+        id_translator_profile: {type: 'integer'},
+        user: {
+          type: 'object',
+          $ref: '#/definitions/User',
+        },
+      },
+    },
+
+    OutsourceConfirmation: {
+      type: 'object',
+      properties: {
+        create_timestamp: {
+          type: 'string',
+          format: 'date-time',
+          required: true,
+        },
+        delivery_timestamp: {
+          type: 'integer',
+        },
+        quote_review_link: {},
+      },
+    },
+
+    ExtendedJobItem: {
+      type: 'object',
+      properties: {
+        job: {
+          $ref: '#/definitions/ExtendedJob',
+        },
+      },
+    },
+
+    ProjectCreationStatus: {
+      type: 'object',
+      properties: {
+        status: {type: 'integer'},
+        message: {type: 'string'},
+        id_project: {type: 'integer'},
+        project_pass: {type: 'string'},
+        project_name: {type: 'string'},
+        new_keys: {type: 'string'},
+        analyze_url: {type: 'string'},
+      },
+    },
+
+    Error: {
+      type: 'object',
+      properties: {
+        errors: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              code: 'integer',
+              message: 'string',
+            },
+          },
+        },
+        data: {
+          type: 'array',
+          items: {type: 'object'},
+          description:
+            'This property contains any debug data that can ' +
+            'serve for better understanding of the error',
+        },
+      },
+    },
+
+    Split: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          properties: {
+            raw_word_count: 'float',
+            eq_word_count: 'float',
+            job_first_segment: 'integer',
+            job_last_segment: 'integer',
+            id: 'integer',
+            show_in_cattool: 'integer',
+            chunks: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  eq_word_count: 'integer',
+                  raw_word_count: 'integer',
+                  segment_start: 'integer',
+                  segment_end: 'integer',
+                  last_opened_segment: 'integer',
                 },
-                "name": {
-                    "type": "string",
-                    "description": "Language name"
-                },
-                "direction": {
-                    "type": "string",
-                    "enum": ["ltr",
-                        "rtl"],
-                "description": "Language direction, ltr (left-to-right text) or rtl (right-to-left text)"
-                }
-            }
+              },
+            },
+          },
         },
-        "PendingInvitation": {
-            "type": "array",
-            "items": {
-                "type": "string",
-                "description": "Email address of the invited user"
-            }
+      },
+    },
+
+    ChangeStatus: {
+      type: 'object',
+      properties: {
+        code: {type: 'integer', required: true},
+        data: {type: 'string', required: true},
+        status: {
+          type: 'string',
+          enum: ['active', 'cancelled', 'archived'],
+          required: true,
         },
+      },
+    },
 
-        "TeamMembersList": {
-            "type": "object",
-            "properties": {
-                "members": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/TeamMember"
-                    }
-                },
-                "pending_invitations": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/PendingInvitation"
-                    }
-                }
-            }
+    Segment: {
+      type: 'object',
+      properties: {
+        id_segment: {type: 'integer'},
+        autopropagated_from: {type: 'string'},
+        status: {type: 'string'},
+        translation: {type: 'string'},
+        translation_date: {type: 'string'},
+        match_type: {type: 'string'},
+        context_hash: {type: 'string'},
+        locked: {type: 'integer'},
+        version_number: {type: 'integer'},
+        issues: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/Issue',
+          },
         },
-
-        "TeamMember": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "integer"},
-                "id_team": {"type": "integer"},
-                "user": {
-                    "type": "object",
-                    "$ref": "#/definitions/User"
-                }
-            }
-        },
-
-        "User": {
-            "type": "object",
-            "properties": {
-                "uid": {"type": "integer"},
-                "first_name": {"type": "string"},
-                "last_name": {"type": "string"},
-                "email": {"type": "string"},
-                "has_password": {"type": "boolean"}
-            }
-        },
-
-        "TeamList": {
-            "type": "object",
-            "properties": {
-                "teams": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Team"
-                    }
-                }
-            }
-        },
-
-        "TeamItem": {
-            "type": "object",
-            "properties": {
-                "team": {
-                    "type": "object",
-                    "$ref": "#/definitions/Team"
-                }
-            }
-        },
-
-        "Team": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "integer", "required": true},
-                "name": {"type": "string", "required": true},
-                "type": {
-                    "type": "string",
-                    "enum": ["general",
-                        "personal"],
-                    "required": true
-                },
-                "created_at": {
-                    "type": "string",
-                    "format": "date-time",
-                    "required": true
-                },
-                "created_by": {"type": "integer", "required": true},
-                "pending_invitations": {"type": "array", "items": "string"}
-            }
-        },
-
-        "EnginesList": {
-            "type": "array",
-            "items": {
-                "$ref": "#/definitions/Engine"
-            }
-        },
-        "Engine": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "integer", "required": true},
-                "name": {"type": "string", "required": true},
-                "type": {
-                    "type": "string",
-                    "enum": ["MT",
-                        "TM"],
-                    "required": true
-                },
-                "description": {
-                    "type": "string",
-                    "required": true
-                }
-            }
-        },
-
-        "KeysList": {
-            "type": "object",
-            "properties": {
-                "private_keys": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Key"
-                    }
-                },
-                "shared_keys": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Key"
-                    }
-                }
-            }
-        },
-        "Key": {
-            "type": "object",
-            "properties": {
-                "key": {"type": "string", "required": true},
-                "name": {"type": "string", "required": true},
-            }
-        },
-
-        "ProjectList": {
-            "type": "object",
-            "properties": {
-                "projects": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Project"
-                    }
-                }
-            }
-        },
-        "ProjectItem": {
-            "type": "object",
-            "properties": {
-
-                "project": {
-                    "type": "object",
-                    "$ref": "#/definitions/Project"
-                }
-            }
-        },
-
-        "ProjectsItems": {
-            "type": "object",
-            "properties": {
-                "projects": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Project"
-                    }
-                }
-            }
-        },
-
-        "Project": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "integer"},
-                "password": {"type": "string"},
-                "name": {"type": "string"},
-                "id_team": {"type": "integer"},
-                "id_assignee": {"type": "integer"},
-                "create_date": {"type": "string", "format": "date-time"},
-                "fast_analysis_wc": {"type": "float"},
-                "standard_analysis_wc": {"type": "float"},
-                "project_slug": {"type": "string"},
-                "features": {"type": "string"},
-                "is_cancelled": {"type": "boolean"},
-                "is_archived": {"type": "boolean"},
-                "remote_file_service": {"type": "string"},
-                "jobs": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/ExtendedJob"
-                    }
-                }
-            }
-        },
-
-        "CompletionStatusItem": {
-            "type": "object",
-            "properties": {
-                "project_status": {
-                    "type": "object",
-                    "properties": {
-                        "revise": {
-                            "type": "array",
-                            "items":{
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "string"},
-                                    "password": {"type": "string"},
-                                    "completed": {"type": "boolean"},
-                                    "completed_at": {"type": "string", "format": "date-time"},
-                                    "event_id": {"type": "string"}
-                                }
-                            }
-                        },
-                        "translate": {
-                            "type": "array",
-                            "items":{
-                                "type": "object",
-                                "properties": {
-                                    "id": {"type": "string"},
-                                    "password": {"type": "string"},
-                                    "completed": {"type": "boolean"},
-                                    "completed_at": {"type": "string", "format": "date-time"},
-                                    "event_id": {"type": "string"}
-                                }
-                            }
-                        },
-                        "id": {"type": "string"},
-                        "completed": {"type": "boolean"}
-                    }
-                }
-            }
-        },
-
-        "Chunk": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "integer"
-                },
-                "chunks": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "$ref": "#/definitions/ExtendedJob"
-                    }
-                }
-            }
-        },
-
-        "ExtendedJob": {
-            "type": "object",
-
-            "properties": {
-                "id": {"type": "integer"},
-                "password": {"type": "string"},
-                "source": {"type": "string"},
-                "target": {"type": "string"},
-                "sourceTxt": {"type": "string"},
-                "targetTxt": {"type": "string"},
-                "status": {"type": "string"},
-                "subject": {"type": "string"},
-                "owner": {"type": "string", "format": "email"},
-                "open_threads_count": {"type": "integer"},
-                "create_timestamp": {"type": "integer"},
-                "created_at": {"type": "string", "format": "date-time"},
-                "create_date": {"type": "string", "format": "date-time"},
-                "formatted_create_date": {"type": "string"},
-                "quality_overall": {"type": "string"},
-                "pee": {"type": "integer"},
-                "tte": {"type": "integer", "format": "seconds"},
-                "private_tm_key": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "warnings_count": {"type": "integer"},
-                "warning_segments": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "outsource": {
-                    "type": "object",
-                    "$ref": "#/definitions/OutsourceConfirmation"
-                },
-
-                "translator": {
-                    "type": "object",
-                    "$ref": "#/definitions/Translator"
-                },
-
-                "total_raw_wc": {"type": "float"},
-                "urls": {
-                    "type": "object",
-                    "$ref": "#/definitions/JobUrl"
-                },
-                "stats": {
-                    "type": "object",
-                    "$ref": "#/definitions/Stats"
-                },
-                "quality_summary": {
-                    "type": "object",
-                    "$ref": "#/definitions/QualitySummary"
-                },
-            }
-        },
-
-        "QualitySummary": {
-            "type": "object",
-            "properties": {
-                "equivalent_class": {"type": "integer"},
-                "quality_overall": {"type": "string"},
-                "errors_count": {"type": "integer"},
-                "revise_issues": {
-                    "type": "object",
-                    "properties": {
-                        "typing": {"type": "object", "$ref": "#/definitions/ReviseIssue"},
-                        "translation": {"type": "object", "$ref": "#/definitions/ReviseIssue"},
-                        "terminology": {"type": "object", "$ref": "#/definitions/ReviseIssue"},
-                        "language_quality": {"type": "object", "$ref": "#/definitions/ReviseIssue"},
-                        "style": {"type": "object", "$ref": "#/definitions/ReviseIssue"},
-
-                    }
-                }
-            }
-        },
-
-        "ReviseIssue": {
-            "type": "object",
-            "properties": {
-                "allowed": {"type": "number"},
-                "found": {"type": "integer"},
-            }
-        },
-
-        "JobUrl": {
-            "type": "object",
-            "properties": {
-                "translate_url": {"type": "string"},
-                "revise_url": {"type": "string"},
-                "original_download_url": {"type": "string"},
-                "translation_download_url": {"type": "string"},
-                "xliff_download_url": {"type": "string"}
-            }
-        },
-
-        "JobTranslatorItem": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "integer"},
-                "password": {"type": "password"},
-                "translator": {
-                    "type": "object",
-                    "$ref": "#/definitions/Translator"
-                }
-            }
-        },
-
-        "Translator": {
-            "type": "object",
-            "properties": {
-                "email": {"type": "string", "format": "email"},
-                "added_by": {"type": "integer"},
-                "delivery_date": {"type": "string"},
-                "delivery_timestamp": {"type": "string"},
-                "source": {"type": "string"},
-                "target": {"type": "string"},
-                "id_translator_profile": {"type": "integer"},
-                "user": {
-                    "type": "object",
-                    "$ref": "#/definitions/User"
-                }
-            }
-        },
-
-        "OutsourceConfirmation": {
-            "type": "object",
-            "properties": {
-                "create_timestamp": {
-                    "type": "string",
-                    "format": "date-time",
-                    "required": true
-                },
-                "delivery_timestamp": {
-                    "type": "integer",
-                },
-                "quote_review_link": {}
-            }
-        },
-
-        "ExtendedJobItem": {
-            "type": "object",
-            "properties": {
-                "job": {
-                    "$ref": "#/definitions/ExtendedJob"
-                }
-            }
-        },
-
-        "ProjectCreationStatus": {
-            "type": "object",
-            "properties": {
-                "status": {"type": "integer"},
-                "message": {"type": "string"},
-                "id_project": {"type": "integer"},
-                "project_pass": {"type": "string"},
-                "project_name": {"type": "string"},
-                "new_keys": {"type": "string"},
-                "analyze_url": {"type": "string"}
-            }
-        },
-
-        "Error": {
-            "type": "object",
-            "properties": {
-                "errors": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "code": "integer",
-                            "message": "string"
-                        }
-                    }
-                },
-                "data": {
-                    "type": "array",
-                    "items": {"type": "object"},
-                    "description": "This property contains any debug data that can " +
-                    "serve for better understanding of the error"
-                }
-            }
-        },
-
-        "Split": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "object",
-                    "properties": {
-                        "raw_word_count": "float",
-                        "eq_word_count": "float",
-                        "job_first_segment": "integer",
-                        "job_last_segment": "integer",
-                        "id": "integer",
-                        "show_in_cattool": "integer",
-                        "chunks": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "eq_word_count": "integer",
-                                    "raw_word_count": "integer",
-                                    "segment_start": "integer",
-                                    "segment_end": "integer",
-                                    "last_opened_segment": "integer",
-
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-
-        "ChangeStatus": {
-            "type": "object",
-            "properties": {
-                "code": {"type": "integer", "required": true},
-                "data": {"type": "string", "required": true},
-                "status": {
-                    "type": "string",
-                    "enum": ["active",
-                        "cancelled",
-                        "archived"],
-                    "required": true
-                }
-            }
-        },
-
-        "Segment": {
-            "type": "object",
-            "properties": {
-                "id_segment": {"type": "integer"},
-                "autopropagated_from": {"type": "string"},
-                "status": {"type": "string"},
-                "translation": {"type": "string"},
-                "translation_date": {"type": "string"},
-                "match_type": {"type": "string"},
-                "context_hash": {"type": "string"},
-                "locked": {"type": "integer"},
-                "version_number": {"type": "integer"},
-                "issues": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/Issue"
-                    }
-                }
-            }
-        }
-    }
-};
+      },
+    },
+  },
+}

--- a/public/css/libs/calendar.css
+++ b/public/css/libs/calendar.css
@@ -8,7 +8,6 @@
  *
  */
 
-
 /*******************************
             Popup
 *******************************/
@@ -18,11 +17,10 @@
   padding: 0;
   border: none;
   -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
-
 
 /*******************************
             Calendar
@@ -31,7 +29,6 @@
 .ui.calendar .calendar:focus {
   outline: 0;
 }
-
 
 /*******************************
             Grid
@@ -44,7 +41,6 @@
 .ui.calendar .ui.popup .ui.grid > .column {
   width: auto;
 }
-
 
 /*******************************
             Table
@@ -128,13 +124,12 @@
 }
 .ui.calendar .calendar:focus .ui.table tbody tr td.focus,
 .ui.calendar .calendar.active .ui.table tbody tr td.focus {
-  box-shadow: inset 0 0 0 1px #85B7D9;
+  box-shadow: inset 0 0 0 1px #85b7d9;
 }
 .ui.calendar .calendar:focus .ui.table.inverted tbody tr td.focus,
 .ui.calendar .calendar.active .ui.table.inverted tbody tr td.focus {
-  box-shadow: inset 0 0 0 1px #85B7D9;
+  box-shadow: inset 0 0 0 1px #85b7d9;
 }
-
 
 /*******************************
          Theme Overrides

--- a/public/css/libs/jquery.powertip.css
+++ b/public/css/libs/jquery.powertip.css
@@ -1,95 +1,102 @@
 /* PowerTip Plugin */
 #powerTip {
-	cursor: default;
-	background-color: #333;
-	background-color: rgba(0, 0, 0, 0.8);
-	border-radius: 6px;
-	color: #fff;
-	display: none;
-	padding: 10px;
-	position: absolute;
-	white-space: nowrap;
-	z-index: 2147483647;
+  cursor: default;
+  background-color: #333;
+  background-color: rgba(0, 0, 0, 0.8);
+  border-radius: 6px;
+  color: #fff;
+  display: none;
+  padding: 10px;
+  position: absolute;
+  white-space: nowrap;
+  z-index: 2147483647;
 }
 #powerTip:before {
-	content: "";
-	position: absolute;
+  content: '';
+  position: absolute;
 }
-#powerTip.n:before, #powerTip.s:before {
-	border-right: 5px solid transparent;
-	border-left: 5px solid transparent;
-	left: 50%;
-	margin-left: -5px;
+#powerTip.n:before,
+#powerTip.s:before {
+  border-right: 5px solid transparent;
+  border-left: 5px solid transparent;
+  left: 50%;
+  margin-left: -5px;
 }
-#powerTip.e:before, #powerTip.w:before {
-	border-bottom: 5px solid transparent;
-	border-top: 5px solid transparent;
-	margin-top: -5px;
-	top: 50%;
+#powerTip.e:before,
+#powerTip.w:before {
+  border-bottom: 5px solid transparent;
+  border-top: 5px solid transparent;
+  margin-top: -5px;
+  top: 50%;
 }
 #powerTip.n:before {
-	border-top: 10px solid #333;
-	border-top: 10px solid rgba(0, 0, 0, 0.8);
-	bottom: -10px;
+  border-top: 10px solid #333;
+  border-top: 10px solid rgba(0, 0, 0, 0.8);
+  bottom: -10px;
 }
 #powerTip.e:before {
-	border-right: 10px solid #333;
-	border-right: 10px solid rgba(0, 0, 0, 0.8);
-	left: -10px;
+  border-right: 10px solid #333;
+  border-right: 10px solid rgba(0, 0, 0, 0.8);
+  left: -10px;
 }
 #powerTip.s:before {
-	border-bottom: 10px solid #333;
-	border-bottom: 10px solid rgba(0, 0, 0, 0.8);
-	top: -10px;
+  border-bottom: 10px solid #333;
+  border-bottom: 10px solid rgba(0, 0, 0, 0.8);
+  top: -10px;
 }
 #powerTip.w:before {
-	border-left: 10px solid #333;
-	border-left: 10px solid rgba(0, 0, 0, 0.8);
-	right: -10px;
+  border-left: 10px solid #333;
+  border-left: 10px solid rgba(0, 0, 0, 0.8);
+  right: -10px;
 }
-#powerTip.ne:before, #powerTip.se:before {
-	border-right: 10px solid transparent;
-	border-left: 0;
-	left: 10px;
+#powerTip.ne:before,
+#powerTip.se:before {
+  border-right: 10px solid transparent;
+  border-left: 0;
+  left: 10px;
 }
-#powerTip.nw:before, #powerTip.sw:before {
-	border-left: 10px solid transparent;
-	border-right: 0;
-	right: 10px;
+#powerTip.nw:before,
+#powerTip.sw:before {
+  border-left: 10px solid transparent;
+  border-right: 0;
+  right: 10px;
 }
-#powerTip.ne:before, #powerTip.nw:before {
-	border-top: 10px solid #333;
-	border-top: 10px solid rgba(0, 0, 0, 0.8);
-	bottom: -10px;
+#powerTip.ne:before,
+#powerTip.nw:before {
+  border-top: 10px solid #333;
+  border-top: 10px solid rgba(0, 0, 0, 0.8);
+  bottom: -10px;
 }
-#powerTip.se:before, #powerTip.sw:before {
-	border-bottom: 10px solid #333;
-	border-bottom: 10px solid rgba(0, 0, 0, 0.8);
-	top: -10px;
+#powerTip.se:before,
+#powerTip.sw:before {
+  border-bottom: 10px solid #333;
+  border-bottom: 10px solid rgba(0, 0, 0, 0.8);
+  top: -10px;
 }
-#powerTip.nw-alt:before, #powerTip.ne-alt:before,
-#powerTip.sw-alt:before, #powerTip.se-alt:before {
-	border-top: 10px solid #333;
-	border-top: 10px solid rgba(0, 0, 0, 0.8);
-	bottom: -10px;
-	border-left: 5px solid transparent;
-	border-right: 5px solid transparent;
-	left: 10px;
+#powerTip.nw-alt:before,
+#powerTip.ne-alt:before,
+#powerTip.sw-alt:before,
+#powerTip.se-alt:before {
+  border-top: 10px solid #333;
+  border-top: 10px solid rgba(0, 0, 0, 0.8);
+  bottom: -10px;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  left: 10px;
 }
 #powerTip.ne-alt:before {
-	left: auto;
-	right: 10px;
+  left: auto;
+  right: 10px;
 }
-#powerTip.sw-alt:before, #powerTip.se-alt:before {
-	border-top: none;
-	border-bottom: 10px solid #333;
-	border-bottom: 10px solid rgba(0, 0, 0, 0.8);
-	bottom: auto;
-	top: -10px;
+#powerTip.sw-alt:before,
+#powerTip.se-alt:before {
+  border-top: none;
+  border-bottom: 10px solid #333;
+  border-bottom: 10px solid rgba(0, 0, 0, 0.8);
+  bottom: auto;
+  top: -10px;
 }
 #powerTip.se-alt:before {
-	left: auto;
-	right: 10px;
+  left: auto;
+  right: 10px;
 }
-
-

--- a/public/css/libs/theme.bootstrap.css
+++ b/public/css/libs/theme.bootstrap.css
@@ -3,142 +3,160 @@
  *************/
 /* jQuery Bootstrap Theme */
 .tablesorter-bootstrap {
-	width: 100%;
+  width: 100%;
 }
 .tablesorter-bootstrap thead th,
 .tablesorter-bootstrap thead td,
 .tablesorter-bootstrap tfoot th,
 .tablesorter-bootstrap tfoot td {
-	font: 14px/20px Arial, Sans-serif;
-	font-weight: bold;
-	padding: 4px;
-	margin: 0 0 18px;
-	background-color: #eee;
+  font: 14px/20px Arial, Sans-serif;
+  font-weight: bold;
+  padding: 4px;
+  margin: 0 0 18px;
+  background-color: #eee;
 }
 
 .tablesorter-bootstrap .tablesorter-header {
-	cursor: pointer;
+  cursor: pointer;
 }
 .tablesorter-bootstrap .sorter-false {
-	cursor: default;
+  cursor: default;
 }
 
 .tablesorter-bootstrap .tablesorter-header-inner {
-	position: relative;
-	padding: 4px 18px 4px 4px;
+  position: relative;
+  padding: 4px 18px 4px 4px;
 }
 
 /* bootstrap uses <i> for icons */
 .tablesorter-bootstrap .tablesorter-header i.tablesorter-icon {
-	font-size: 11px;
-	position: absolute;
-	right: 2px;
-	top: 50%;
-	margin-top: -7px; /* half the icon height; older IE doesn't like this */
-	width: 14px;
-	height: 14px;
-	background-repeat: no-repeat;
-	line-height: 14px;
-	display: inline-block;
+  font-size: 11px;
+  position: absolute;
+  right: 2px;
+  top: 50%;
+  margin-top: -7px; /* half the icon height; older IE doesn't like this */
+  width: 14px;
+  height: 14px;
+  background-repeat: no-repeat;
+  line-height: 14px;
+  display: inline-block;
 }
 
 /* black unsorted icon */
 .tablesorter-bootstrap .bootstrap-icon-unsorted {
-	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAMAAADOvxanAAAAVFBMVEUAAABCQkJZWVkZGRnJyckgICAZGRkZGRn8/PweHh4dHR0aGhoaGhpUVFQbGxvQ0NDc3NxMTExSUlIbGxvr6+s4ODhKSkogICAtLS00NDQzMzMnJydSEPrQAAAAGHRSTlMA1ssZRLgdAQbDyisqsZo8QdXUq0r9xPepSRwiAAAAX0lEQVQI13XHSQKAIAwEwQAKxn13Ev7/T2Pu9qmarJKPXIicI4PH4hxaKNrhm2S8bJK5h4YzKHrzJNtK6yYT/TdXzpS5zuYg4MSQYF6i4IHExdw1UVRi05HPrrvT53a+qyMFC9t04gcAAAAASUVORK5CYII=);
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOCAMAAADOvxanAAAAVFBMVEUAAABCQkJZWVkZGRnJyckgICAZGRkZGRn8/PweHh4dHR0aGhoaGhpUVFQbGxvQ0NDc3NxMTExSUlIbGxvr6+s4ODhKSkogICAtLS00NDQzMzMnJydSEPrQAAAAGHRSTlMA1ssZRLgdAQbDyisqsZo8QdXUq0r9xPepSRwiAAAAX0lEQVQI13XHSQKAIAwEwQAKxn13Ev7/T2Pu9qmarJKPXIicI4PH4hxaKNrhm2S8bJK5h4YzKHrzJNtK6yYT/TdXzpS5zuYg4MSQYF6i4IHExdw1UVRi05HPrrvT53a+qyMFC9t04gcAAAAASUVORK5CYII=);
 }
 
 /* white unsorted icon */
 .tablesorter-bootstrap .icon-white.bootstrap-icon-unsorted {
-	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOBAMAAAALT/umAAAAKlBMVEUAAAD///////////////////////////////////////////////////+Gu8ovAAAADXRSTlMA4EXKBtQqvR0+sxmalc142gAAAFdJREFUCNdjYGDoamAAAjZbMxCVfvd6AgMDd+3du9UMDKx3hWSvMjBwXZww8RYDGuC53NB8h4GB8a617UUGBs7Yu3cjGRhYVO9eVQFKOskKOQApFmUgBwBZ+xXRTttNdAAAAABJRU5ErkJggg==);
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAAOBAMAAAALT/umAAAAKlBMVEUAAAD///////////////////////////////////////////////////+Gu8ovAAAADXRSTlMA4EXKBtQqvR0+sxmalc142gAAAFdJREFUCNdjYGDoamAAAjZbMxCVfvd6AgMDd+3du9UMDKx3hWSvMjBwXZww8RYDGuC53NB8h4GB8a617UUGBs7Yu3cjGRhYVO9eVQFKOskKOQApFmUgBwBZ+xXRTttNdAAAAABJRU5ErkJggg==);
 }
 
 /* since bootstrap (table-striped) uses nth-child(), we just use this to add a zebra stripe color */
 .tablesorter-bootstrap > tbody > tr.odd > td,
-.tablesorter-bootstrap > tbody > tr.tablesorter-hasChildRow.odd:hover ~ tr.tablesorter-hasChildRow.odd ~ .tablesorter-childRow.odd > td {
-	background-color: #f9f9f9;
+.tablesorter-bootstrap
+  > tbody
+  > tr.tablesorter-hasChildRow.odd:hover
+  ~ tr.tablesorter-hasChildRow.odd
+  ~ .tablesorter-childRow.odd
+  > td {
+  background-color: #f9f9f9;
 }
 .tablesorter-bootstrap > tbody > tr.hover > td,
 .tablesorter-bootstrap > tbody > tr.odd:hover > td,
 .tablesorter-bootstrap > tbody > tr.even:hover > td,
-.tablesorter-bootstrap > tbody > tr.tablesorter-hasChildRow.odd:hover ~ .tablesorter-childRow.odd > td,
-.tablesorter-bootstrap > tbody > tr.tablesorter-hasChildRow.even:hover ~ .tablesorter-childRow.even > td {
-	background-color: #f5f5f5;
+.tablesorter-bootstrap
+  > tbody
+  > tr.tablesorter-hasChildRow.odd:hover
+  ~ .tablesorter-childRow.odd
+  > td,
+.tablesorter-bootstrap
+  > tbody
+  > tr.tablesorter-hasChildRow.even:hover
+  ~ .tablesorter-childRow.even
+  > td {
+  background-color: #f5f5f5;
 }
 .tablesorter-bootstrap > tbody > tr.even > td,
-.tablesorter-bootstrap > tbody > tr.tablesorter-hasChildRow.even:hover ~ tr.tablesorter-hasChildRow.even ~ .tablesorter-childRow.even > td {
-	background-color: #fff;
+.tablesorter-bootstrap
+  > tbody
+  > tr.tablesorter-hasChildRow.even:hover
+  ~ tr.tablesorter-hasChildRow.even
+  ~ .tablesorter-childRow.even
+  > td {
+  background-color: #fff;
 }
 
 /* processing icon */
 .tablesorter-bootstrap .tablesorter-processing {
-	background-image: url('data:image/gif;base64,R0lGODlhFAAUAKEAAO7u7lpaWgAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQBCgACACwAAAAAFAAUAAACQZRvoIDtu1wLQUAlqKTVxqwhXIiBnDg6Y4eyx4lKW5XK7wrLeK3vbq8J2W4T4e1nMhpWrZCTt3xKZ8kgsggdJmUFACH5BAEKAAIALAcAAAALAAcAAAIUVB6ii7jajgCAuUmtovxtXnmdUAAAIfkEAQoAAgAsDQACAAcACwAAAhRUIpmHy/3gUVQAQO9NetuugCFWAAAh+QQBCgACACwNAAcABwALAAACE5QVcZjKbVo6ck2AF95m5/6BSwEAIfkEAQoAAgAsBwANAAsABwAAAhOUH3kr6QaAcSrGWe1VQl+mMUIBACH5BAEKAAIALAIADQALAAcAAAIUlICmh7ncTAgqijkruDiv7n2YUAAAIfkEAQoAAgAsAAAHAAcACwAAAhQUIGmHyedehIoqFXLKfPOAaZdWAAAh+QQFCgACACwAAAIABwALAAACFJQFcJiXb15zLYRl7cla8OtlGGgUADs=');
-	background-position: center center !important;
-	background-repeat: no-repeat !important;
+  background-image: url('data:image/gif;base64,R0lGODlhFAAUAKEAAO7u7lpaWgAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQBCgACACwAAAAAFAAUAAACQZRvoIDtu1wLQUAlqKTVxqwhXIiBnDg6Y4eyx4lKW5XK7wrLeK3vbq8J2W4T4e1nMhpWrZCTt3xKZ8kgsggdJmUFACH5BAEKAAIALAcAAAALAAcAAAIUVB6ii7jajgCAuUmtovxtXnmdUAAAIfkEAQoAAgAsDQACAAcACwAAAhRUIpmHy/3gUVQAQO9NetuugCFWAAAh+QQBCgACACwNAAcABwALAAACE5QVcZjKbVo6ck2AF95m5/6BSwEAIfkEAQoAAgAsBwANAAsABwAAAhOUH3kr6QaAcSrGWe1VQl+mMUIBACH5BAEKAAIALAIADQALAAcAAAIUlICmh7ncTAgqijkruDiv7n2YUAAAIfkEAQoAAgAsAAAHAAcACwAAAhQUIGmHyedehIoqFXLKfPOAaZdWAAAh+QQFCgACACwAAAIABwALAAACFJQFcJiXb15zLYRl7cla8OtlGGgUADs=');
+  background-position: center center !important;
+  background-repeat: no-repeat !important;
 }
 
 /* caption */
 .caption {
-	background-color: #fff;
+  background-color: #fff;
 }
 
 /* filter widget */
 .tablesorter-bootstrap .tablesorter-filter-row input.tablesorter-filter,
 .tablesorter-bootstrap .tablesorter-filter-row select.tablesorter-filter {
-	width: 98%;
-	margin: 0;
-	padding: 4px 6px;
-	color: #333;
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	box-sizing: border-box;
-	-webkit-transition: height 0.1s ease;
-	-moz-transition: height 0.1s ease;
-	-o-transition: height 0.1s ease;
-	transition: height 0.1s ease;
+  width: 98%;
+  margin: 0;
+  padding: 4px 6px;
+  color: #333;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  -webkit-transition: height 0.1s ease;
+  -moz-transition: height 0.1s ease;
+  -o-transition: height 0.1s ease;
+  transition: height 0.1s ease;
 }
 .tablesorter-bootstrap .tablesorter-filter-row .tablesorter-filter.disabled {
-	background-color: #eee;
-	color: #555;
-	cursor: not-allowed;
-	border: 1px solid #ccc;
-	border-radius: 4px;
-	box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
-	box-sizing: border-box;
-	transition: height 0.1s ease;
+  background-color: #eee;
+  color: #555;
+  cursor: not-allowed;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
+  box-sizing: border-box;
+  transition: height 0.1s ease;
 }
 .tablesorter-bootstrap .tablesorter-filter-row {
-	background-color: #efefef;
+  background-color: #efefef;
 }
 .tablesorter-bootstrap .tablesorter-filter-row td {
-	background-color: #efefef;
-	line-height: normal;
-	text-align: center;
-	padding: 4px 6px;
-	vertical-align: middle;
-	-webkit-transition: line-height 0.1s ease;
-	-moz-transition: line-height 0.1s ease;
-	-o-transition: line-height 0.1s ease;
-	transition: line-height 0.1s ease;
+  background-color: #efefef;
+  line-height: normal;
+  text-align: center;
+  padding: 4px 6px;
+  vertical-align: middle;
+  -webkit-transition: line-height 0.1s ease;
+  -moz-transition: line-height 0.1s ease;
+  -o-transition: line-height 0.1s ease;
+  transition: line-height 0.1s ease;
 }
 /* hidden filter row */
 .tablesorter-bootstrap .tablesorter-filter-row.hideme td {
-	padding: 2px; /* change this to modify the thickness of the closed border row */
-	margin: 0;
-	line-height: 0;
+  padding: 2px; /* change this to modify the thickness of the closed border row */
+  margin: 0;
+  line-height: 0;
 }
 .tablesorter-bootstrap .tablesorter-filter-row.hideme * {
-	height: 1px;
-	min-height: 0;
-	border: 0;
-	padding: 0;
-	margin: 0;
-	/* don't use visibility: hidden because it disables tabbing */
-	opacity: 0;
-	filter: alpha(opacity=0);
+  height: 1px;
+  min-height: 0;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  /* don't use visibility: hidden because it disables tabbing */
+  opacity: 0;
+  filter: alpha(opacity=0);
 }
 /* rows hidden by filtering (needed for child rows) */
 .tablesorter .filtered {
-	display: none;
+  display: none;
 }
 
 /* pager plugin */
@@ -146,16 +164,16 @@
   padding: 4px 6px;
 }
 .tablesorter-bootstrap .tablesorter-pager .pagedisplay {
-	border: 0;
+  border: 0;
 }
 /* tfoot i for pager controls */
 .tablesorter-bootstrap tfoot i {
-	font-size: 11px;
+  font-size: 11px;
 }
 
 /* ajax error row */
 .tablesorter .tablesorter-errorRow td {
-	text-align: center;
-	cursor: pointer;
-	background-color: #e6bf99;
+  text-align: center;
+  cursor: pointer;
+  background-color: #e6bf99;
 }

--- a/public/css/sass/_mixins.scss
+++ b/public/css/sass/_mixins.scss
@@ -1,68 +1,68 @@
-@mixin linear-gradient($fallback, $params...){
-    background-color: $fallback;
-    background-image: -webkit-linear-gradient($params);
-    background-image:    -moz-linear-gradient($params);
-    background-image:      -o-linear-gradient($params);
-    background-image:         linear-gradient($params);
+@mixin linear-gradient($fallback, $params...) {
+  background-color: $fallback;
+  background-image: -webkit-linear-gradient($params);
+  background-image: -moz-linear-gradient($params);
+  background-image: -o-linear-gradient($params);
+  background-image: linear-gradient($params);
 }
 
 @mixin box-shadow($params...) {
-    -webkit-box-shadow: $params;
-       -moz-box-shadow: $params;
-            box-shadow: $params;
+  -webkit-box-shadow: $params;
+  -moz-box-shadow: $params;
+  box-shadow: $params;
 }
 
 @mixin animation-duration($time) {
   -webkit-animation-duration: $time;
-     -moz-animation-duration: $time;
-          animation-duration: $time;
+  -moz-animation-duration: $time;
+  animation-duration: $time;
 }
 
 @mixin animation-name($name) {
   -webkit-animation-name: $name;
-     -moz-animation-name: $name;
-          animation-name: $name;
+  -moz-animation-name: $name;
+  animation-name: $name;
 }
 
 @mixin animation-iteration-count($count) {
   -webkit-animation-iteration-count: $count;
-     -moz-animation-iteration-count: $count;
-          animation-iteration-count: $count;
+  -moz-animation-iteration-count: $count;
+  animation-iteration-count: $count;
 }
 
 @mixin animation-play-state($play) {
   -webkit-animation-play-state: $play;
-     -moz-animation-play-state: $play;
-          animation-play-state: $play;
+  -moz-animation-play-state: $play;
+  animation-play-state: $play;
 }
 
 @mixin animation-timing-function($function) {
   -webkit-animation-timing-function: $function;
-     -moz-animation-timing-function: $function;
-          animation-timing-function: $function;
+  -moz-animation-timing-function: $function;
+  animation-timing-function: $function;
 }
 
 @mixin animation-direction($direction) {
   -webkit-animation-direction: $direction;
-     -moz-animation-direction: $direction;
-          animation-direction: $direction;
+  -moz-animation-direction: $direction;
+  animation-direction: $direction;
 }
 
 @mixin keyframes($name) {
-    @-webkit-keyframes #{$name} {
-        @content;
-    }
-    @-moz-keyframes #{$name} {
-        @content;
-    }
-    @keyframes #{$name} {
-        @content;
-    }
+  @-webkit-keyframes #{$name} {
+    @content;
+  }
+  @-moz-keyframes #{$name} {
+    @content;
+  }
+  @keyframes #{$name} {
+    @content;
+  }
 }
 
 @mixin toolbar-button-background($icon, $iconSize, $background) {
-    background-image: $icon, $background;
-    background-size: $iconSize $iconSize, auto auto;
-    background-position: center center, 0% 0%;
-    background-repeat: no-repeat, repeat;
+  background-image: $icon, $background;
+  background-size: $iconSize $iconSize, auto auto;
+  background-position: center center, 0% 0%;
+  background-repeat: no-repeat, repeat;
 }

--- a/public/css/sass/analyze_main.scss
+++ b/public/css/sass/analyze_main.scss
@@ -1,27 +1,27 @@
-@import "vendor_mc/semantic/matecat_semantic";
+@import 'vendor_mc/semantic/matecat_semantic';
 
-@import "commons/colors";
-@import "commons/matecat_fonts";
-@import "commons/filter-teams";
-@import "commons/nav-bar";
-@import "commons/icons";
-@import "commons/shadows";
-@import "commons/project";
-@import "commons/divider";
-@import "commons/progress-mc-bar";
-@import "commons/buttons";
-@import "popup";
+@import 'commons/colors';
+@import 'commons/matecat_fonts';
+@import 'commons/filter-teams';
+@import 'commons/nav-bar';
+@import 'commons/icons';
+@import 'commons/shadows';
+@import 'commons/project';
+@import 'commons/divider';
+@import 'commons/progress-mc-bar';
+@import 'commons/buttons';
+@import 'popup';
 
 //libs: move it?
 @import '../libs/calendar.css';
 
 @import 'common-modals';
 @import 'modals/split_modal';
-@import "notifications";
+@import 'notifications';
 
-@import "commons/sub-header";
-@import "commons/team-member";
+@import 'commons/sub-header';
+@import 'commons/team-member';
 
-@import "commons/analyze";
-@import "commons/outsource";
-@import "commons/date-picker-translator";
+@import 'commons/analyze';
+@import 'commons/outsource';
+@import 'commons/date-picker-translator';

--- a/public/css/sass/cattool.scss
+++ b/public/css/sass/cattool.scss
@@ -44,10 +44,9 @@ body.cattool {
       display: grid;
       position: relative;
       grid-column-gap: 10px;
-      grid-template-columns: minmax(80px, 120px) minmax(80px, 420px) minmax(
-          140px,
-          350px
-        ) minmax(172px, 0.2fr) minmax(116px, 0.2fr) minmax(316px, 0.4fr);
+      grid-template-columns:
+        minmax(80px, 120px) minmax(80px, 420px) minmax(140px, 350px)
+        minmax(172px, 0.2fr) minmax(116px, 0.2fr) minmax(316px, 0.4fr);
       align-items: center;
       padding: 0 12px 0 14px;
       height: 44px;

--- a/public/css/sass/cattool.scss
+++ b/public/css/sass/cattool.scss
@@ -1,200 +1,202 @@
 @import '_mixins';
 
 body.cattool {
-    display: flex;
-    height: 100vh;
-    flex-direction: column;
-	overflow-y: hidden !important;
-	padding: unset;
-	background-color: $grey5;
+  display: flex;
+  height: 100vh;
+  flex-direction: column;
+  overflow-y: hidden !important;
+  padding: unset;
+  background-color: $grey5;
 
   /*header*/
   header {
-	top: 0;
-	left: 0;
-	width: 100%;
-	position: relative;
-	z-index: 12;
-	padding: 0;
-	transition: margin-top 200ms ease-out;
-	-webkit-transition: margin-top 200ms ease-out;
-	box-sizing: content-box;
-	min-width: 1024px;
+    top: 0;
+    left: 0;
+    width: 100%;
+    position: relative;
+    z-index: 12;
+    padding: 0;
+    transition: margin-top 200ms ease-out;
+    -webkit-transition: margin-top 200ms ease-out;
+    box-sizing: content-box;
+    min-width: 1024px;
   }
 
   .main-container {
-	width: 100%;
-	height: 100%;
-	flex: 1;
-	overflow: hidden;
+    width: 100%;
+    height: 100%;
+    flex: 1;
+    overflow: hidden;
   }
 
   .stats-foo {
-	//height: 44px;
-	background-color: $white;
-	width: 100%;
-	//position: fixed;
-	bottom: 0;
-	left: 0;
-	z-index: 2;
-	display: grid;
-	min-width:1024px;
+    //height: 44px;
+    background-color: $white;
+    width: 100%;
+    //position: fixed;
+    bottom: 0;
+    left: 0;
+    z-index: 2;
+    display: grid;
+    min-width: 1024px;
 
-	.footer-body {
-		display: grid;
-		position: relative;
-		grid-column-gap: 10px;
-		grid-template-columns: minmax(80px, 120px) minmax(80px, 420px) minmax(140px, 350px) minmax(172px, 0.2fr) minmax(116px, 0.2fr) minmax(316px, 0.4fr);
-		align-items: center;
-		padding: 0 12px 0 14px;
-		height: 44px;
+    .footer-body {
+      display: grid;
+      position: relative;
+      grid-column-gap: 10px;
+      grid-template-columns: minmax(80px, 120px) minmax(80px, 420px) minmax(
+          140px,
+          350px
+        ) minmax(172px, 0.2fr) minmax(116px, 0.2fr) minmax(316px, 0.4fr);
+      align-items: center;
+      padding: 0 12px 0 14px;
+      height: 44px;
 
-	  .item {
-		font-size: 14px;
-		font-weight: bold;
-		font-style: normal;
-		font-stretch: normal;
-		line-height: 1.5;
-		color: black;
+      .item {
+        font-size: 14px;
+        font-weight: bold;
+        font-style: normal;
+        font-stretch: normal;
+        line-height: 1.5;
+        color: black;
 
-		  p {
-			  margin:0;
-			  float: none;
+        p {
+          margin: 0;
+          float: none;
 
-			  white-space: nowrap;
-			  overflow: hidden;
-			  text-overflow: ellipsis;
-		  }
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
 
-		  #job_id {
-			  text-align:left;
-		  }
+        #job_id {
+          text-align: left;
+        }
 
+        &.language {
+          display: grid;
+          justify-self: end;
+        }
 
-		  &.language {
-			  display: grid;
-			  justify-self: end;
-		  }
+        .to-arrow {
+          font-size: 14px;
+          font-weight: bold;
+          color: #999999;
+        }
 
-		.to-arrow {
-		  font-size: 14px;
-		  font-weight: bold;
-		  color: #999999;
-		}
+        #stat-todo {
+          font-weight: bold;
+          font-size: 14px;
 
-		#stat-todo {
-		  	font-weight: bold;
-			font-size: 14px;
+          span {
+            color: black;
+            text-decoration: underline;
+            &:hover {
+              text-decoration: none;
+            }
+          }
+        }
 
-		  span {
-				color: black;
-			    text-decoration: underline;
-				&:hover {
-					text-decoration: none;
-				}
-		  }
-		}
+        #job_id {
+          font-weight: 200;
+          font-size: 14px;
+        }
 
-		#job_id {
-		  font-weight: 200;
-		  font-size: 14px;
-		}
+        .statistics-core {
+          font-size: 14px;
+          font-weight: 200;
 
-		.statistics-core {
-		  font-size: 14px;
-		  font-weight: 200;
+          a {
+            span {
+              color: black;
+              text-decoration: underline;
+              &:hover {
+                text-decoration: none;
+              }
+            }
+          }
+        }
+      }
 
-		  a {
-			span {
-			  	color: black;
-				text-decoration: underline;
-				&:hover {
-					text-decoration: none;
-				}
-			}
-		  }
-		}
-	  }
+      .progress-bar {
+        display: grid;
+        grid-template-columns: 1fr 44px;
+        grid-column-gap: 8px;
 
-	  .progress-bar {
-		display: grid;
-		grid-template-columns: 1fr 44px;
-		grid-column-gap: 8px;
+        .percent {
+          font-weight: 600;
+        }
 
-		.percent {
-		  font-weight: 600;
-		}
+        .meter {
+          margin: 0 !important;
+          height: auto;
 
-		.meter {
-		  margin: 0 !important;
-		  height: auto;
+          @-webkit-keyframes move-bg {
+            from {
+              -webkit-transform: translateX(0);
+            }
+            to {
+              -webkit-transform: translateX(46px);
+            }
+          }
 
-			@-webkit-keyframes move-bg {
-				from {
-					-webkit-transform: translateX(0);
-				}
-				to {
-					-webkit-transform: translateX(46px);
-				}
-			}
+          @keyframes move-bg {
+            from {
+              transform: translateX(0);
+            }
+            to {
+              transform: translateX(46px);
+            }
+          }
 
-			@keyframes move-bg {
-				from {
-					transform: translateX(0);
-				}
-				to {
-					transform: translateX(46px);
-				}
-			}
+          .bg-loader {
+            position: absolute;
+            left: -46px;
+            right: 0;
+            top: 0;
+            bottom: 0;
+            z-index: 1;
 
-			.bg-loader{
-				position: absolute;
-				left: -46px;
-				right: 0;
-				top: 0;
-				bottom: 0;
-				z-index: 1;
+            background: -webkit-repeating-linear-gradient(
+              110deg,
+              #e8e8e8 0px,
+              #e8e8e8 10px,
+              #d8d8d8 0px,
+              #d8d8d8 20px
+            );
+            background: repeating-linear-gradient(
+              110deg,
+              #e8e8e8 0px,
+              #e8e8e8 10px,
+              #d8d8d8 0px,
+              #d8d8d8 20px
+            );
 
-				background: -webkit-repeating-linear-gradient(
-								110deg,
-								#e8e8e8 0px,
-								#e8e8e8 10px,
-								#D8D8D8 0px,
-								#D8D8D8 20px
-				);
-				background: repeating-linear-gradient(
-								110deg,
-								#e8e8e8 0px,
-								#e8e8e8 10px,
-								#D8D8D8 0px,
-								#D8D8D8 20px
-				);
+            -webkit-animation-name: move-bg;
+            -webkit-animation-duration: 0.8s;
+            -webkit-animation-timing-function: linear;
+            -webkit-animation-iteration-count: infinite;
 
-				-webkit-animation-name: move-bg;
-				-webkit-animation-duration: .8s;
-				-webkit-animation-timing-function: linear;
-				-webkit-animation-iteration-count: infinite;
+            animation-name: move-bg;
+            animation-duration: 0.8s;
+            animation-timing-function: linear;
+            animation-iteration-count: infinite;
+          }
 
-				animation-name: move-bg;
-				animation-duration: .8s;
-				animation-timing-function: linear;
-				animation-iteration-count: infinite;
-			}
-
-		  a {
-			&:after {
-			  background-image: none;
-			}
-		  }
-		}
-	  }
-		.statistics-details {
-			display: grid;
-			grid-template-columns: minmax(144px,0.4fr) minmax(168px,0.6fr);
-			grid-column-gap: 4px;
-			justify-self: end;
-		}
-	}
+          a {
+            &:after {
+              background-image: none;
+            }
+          }
+        }
+      }
+      .statistics-details {
+        display: grid;
+        grid-template-columns: minmax(144px, 0.4fr) minmax(168px, 0.6fr);
+        grid-column-gap: 4px;
+        justify-self: end;
+      }
+    }
   }
 }
 
@@ -208,41 +210,40 @@ Styles from other css files should be ported over time.
 }
 
 .segment-side-buttons {
-    /* styles based on .sid line 376 style.css */
-    cursor: default;
-    display: block;
-    font-size: 12px;
-    padding-bottom: 1px;
-    position: absolute;
-    text-align: center;
-    text-decoration: none;
-    right: -7%;
-    width: 7%;
-    top: 0;
-    height: 100%;
+  /* styles based on .sid line 376 style.css */
+  cursor: default;
+  display: block;
+  font-size: 12px;
+  padding-bottom: 1px;
+  position: absolute;
+  text-align: center;
+  text-decoration: none;
+  right: -7%;
+  width: 7%;
+  top: 0;
+  height: 100%;
 }
 
-
-.segmentButton, .toolbar a {
+.segmentButton,
+.toolbar a {
   height: 20px;
   zoom: 0.8;
   min-width: 20px;
   cursor: pointer;
   border-radius: 3px;
   padding: 2px;
-  border: 1px solid #C6C6C6;
+  border: 1px solid #c6c6c6;
   /*@include box-shadow(0 1px 1px rgba(0,0,0,.1));
   @include linear-gradient(#f8f8f8, top, #f8f8f8, #f1f1f1);*/
 
   &:hover {
-	color: #000000;
+    color: #000000;
   }
 
-    &:active {
-        background-color: #fff;
-    }
+  &:active {
+    background-color: #fff;
+  }
 }
-
 
 .position-sing-in {
   position: relative;
@@ -273,47 +274,49 @@ Styles from other css files should be ported over time.
   .loader,
   .warnings,
   .toolbar {
-	display: none !important;
+    display: none !important;
   }
 }
 
 //Remove
-.ui.popup{
-	&.user-menu-tooltip {
-		right: 42px !important;
-	}
-	&.three-dots-menu-tooltip {
-		min-width: 300px;
-	}
-	&.user-menu-tooltip, &.three-dots-menu-tooltip, &.files-instructions-tooltip  {
-		h4.header {
-			box-shadow: none !important;
-			background: transparent !important;
-			text-decoration: none;
-			border-bottom: none;
-			color: black;
-		}
-		.content {
-			width: 100%;
-			background-color: transparent !important;
-			border: none;
-			padding: unset;
-		}
-		.content p {
-			font-size: 15px;
-			text-align: left !important;
-			background-color: transparent !important;
-			padding-top: 10px;
-			min-width: 180px;
-		}
+.ui.popup {
+  &.user-menu-tooltip {
+    right: 42px !important;
+  }
+  &.three-dots-menu-tooltip {
+    min-width: 300px;
+  }
+  &.user-menu-tooltip,
+  &.three-dots-menu-tooltip,
+  &.files-instructions-tooltip {
+    h4.header {
+      box-shadow: none !important;
+      background: transparent !important;
+      text-decoration: none;
+      border-bottom: none;
+      color: black;
+    }
+    .content {
+      width: 100%;
+      background-color: transparent !important;
+      border: none;
+      padding: unset;
+    }
+    .content p {
+      font-size: 15px;
+      text-align: left !important;
+      background-color: transparent !important;
+      padding-top: 10px;
+      min-width: 180px;
+    }
 
-		a.close-popup-teams {
-			float: right;
-			cursor: pointer;
-			text-decoration: underline;
-			&:hover {
-				text-decoration: none;
-			}
-		}
-	}
+    a.close-popup-teams {
+      float: right;
+      cursor: pointer;
+      text-decoration: underline;
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
 }

--- a/public/css/sass/common-main.scss
+++ b/public/css/sass/common-main.scss
@@ -1,4 +1,4 @@
-@import "commons/colors";
+@import 'commons/colors';
 @import 'popup';
 @import 'common';
 @import 'common-modals';

--- a/public/css/sass/common-modals.scss
+++ b/public/css/sass/common-modals.scss
@@ -1,22 +1,36 @@
-@import "modals/instructionsModal";
+@import 'modals/instructionsModal';
 body.side-popup {
-    overflow: hidden !important;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
+  overflow: hidden !important;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
 }
-h1, h2, h3, h4, h5, h6 {
-    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }
 h2 {
-    font-size: 22px;
+  font-size: 22px;
 }
 a {
-    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }
-ul, li, ol, p, button, .button, .primary, input, input[type="text"] input[type="email"] .input{
-    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+ul,
+li,
+ol,
+p,
+button,
+.button,
+.primary,
+input,
+input[type='text'] input[type='email'] .input {
+  font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }
-::-webkit-input-placeholder { /* Chrome/Opera/Safari */
-    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+::-webkit-input-placeholder {
+  /* Chrome/Opera/Safari */
+  font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }
 
 /***********************/
@@ -25,529 +39,521 @@ ul, li, ol, p, button, .button, .primary, input, input[type="text"] input[type="
 #logoutlink,
 .reset-password,
 #resendlink {
-    margin-bottom: 10px;
-    text-decoration: underline;
-    float: left;
-    cursor: pointer;
-    color: $linkBlue;
-    &:hover {
-        text-decoration: none;
-        color: $linkBlueHover;
-    }
+  margin-bottom: 10px;
+  text-decoration: underline;
+  float: left;
+  cursor: pointer;
+  color: $linkBlue;
+  &:hover {
+    text-decoration: none;
+    color: $linkBlueHover;
+  }
 }
 
 #resendlink {
-    float: none;
+  float: none;
 }
 
-
-
 a.ui.primary.right.floated.button.tiny.register-ok {
-    border: 1px solid black;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
-    font-size: 16px;
-    padding: 6px 19px;
+  border: 1px solid black;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
+  font-size: 16px;
+  padding: 6px 19px;
 }
 
 #welcomebox {
-    float: right;
-    cursor: pointer;
-    position: relative;
-    text-decoration: underline;
-    margin-left: 8px;
+  float: right;
+  cursor: pointer;
+  position: relative;
+  text-decoration: underline;
+  margin-left: 8px;
 }
 
 .manage #welcomebox {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 #welcomebox .icon-sort-up {
-    font-size: 22px;
-    float: right;
-    margin-left: 9px;
-
+  font-size: 22px;
+  float: right;
+  margin-left: 9px;
 }
 
 .user-menu {
-    position: absolute;
-    top: -92px;
-    background-color: white;
-    color: black;
-    text-align: left;
-    font-size: 19px;
-    left: -60px;
-    box-shadow: 0px 0px 16px 0px rgba(0, 0, 0, 0.4);
-    visibility: hidden;
-    transform: translateY(1em);
-    transition: all 0.3s ease-in-out 0s, visibility 0s linear 0.3s, z-index 0s linear 0.01s;
-    z-index: -1;
-    opacity: 0;
+  position: absolute;
+  top: -92px;
+  background-color: white;
+  color: black;
+  text-align: left;
+  font-size: 19px;
+  left: -60px;
+  box-shadow: 0px 0px 16px 0px rgba(0, 0, 0, 0.4);
+  visibility: hidden;
+  transform: translateY(1em);
+  transition: all 0.3s ease-in-out 0s, visibility 0s linear 0.3s,
+    z-index 0s linear 0.01s;
+  z-index: -1;
+  opacity: 0;
 }
 
 .user-menu li {
-    width: 120px;
-    height: 20px;
-    padding: 10px;
-    line-height: 20px;
-    border-bottom: 1px solid black;
+  width: 120px;
+  height: 20px;
+  padding: 10px;
+  line-height: 20px;
+  border-bottom: 1px solid black;
 }
 
 #welcomebox:hover .user-menu {
-    visibility: visible;
-    opacity: 1;
-    z-index: 1;
-    transform: translateY(0%);
-    transition-delay: 0s, 0s, 0.3s;
+  visibility: visible;
+  opacity: 1;
+  z-index: 1;
+  transform: translateY(0%);
+  transition-delay: 0s, 0s, 0.3s;
 }
 
 .success-modal {
-    padding: 20px;
+  padding: 20px;
 }
 
 .validation-error {
-    text-align: left;
-    float: left;
-    color: red;
+  text-align: left;
+  float: left;
+  color: red;
 }
 
 .validation-error.email-translator-error {
-    position: relative;
-    top: -25px;
-    left: 18px;
-    padding: 0px;
-    margin-bottom: 0px;
-    height: 0px;
-    display: none;
+  position: relative;
+  top: -25px;
+  left: 18px;
+  padding: 0px;
+  margin-bottom: 0px;
+  height: 0px;
+  display: none;
 }
 
 .user-info-form,
 .user-reset-password,
 .user-gdrive {
-    margin: 0 auto;
-    width: 100%;
-    float: left;
-    position: relative;
+  margin: 0 auto;
+  width: 100%;
+  float: left;
+  position: relative;
 }
 
 .user-reset-password {
-    width: 100%;
+  width: 100%;
 }
 
 .preferences-modal .user-info-form {
-    font-size: 18px;
-    line-height: 30px;
-    margin-bottom: 30px;
-    background-color: white;
-    //border-bottom: 1px solid #ccc;
-    padding: 35px 20px 20px 50px;
+  font-size: 18px;
+  line-height: 30px;
+  margin-bottom: 30px;
+  background-color: white;
+  //border-bottom: 1px solid #ccc;
+  padding: 35px 20px 20px 50px;
 }
 
-.preferences-modal .user-dqf ,
-.preferences-modal .user-gdrive
-{
-    //border: 1px solid #ccc;
-    padding: 10px 0 0 10px;
-    border-radius: 4px;
-    background: white;
-    width: 100%;
-    min-height: 50px;
-    margin-bottom: 25px;
-    margin-top: 10px;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
+.preferences-modal .user-dqf,
+.preferences-modal .user-gdrive {
+  //border: 1px solid #ccc;
+  padding: 10px 0 0 10px;
+  border-radius: 4px;
+  background: white;
+  width: 100%;
+  min-height: 50px;
+  margin-bottom: 25px;
+  margin-top: 10px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
-.preferences-modal .user-api,
-{
+.preferences-modal .user-api {
+  border-radius: 4px;
+  background: white;
+  width: 100%;
+  min-height: 54px;
+  margin-bottom: 25px;
+  margin-top: 10px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 15px 10px;
+  flex-flow: row wrap;
+  .user-api-text {
+    width: 70%;
+    order: 1;
+    label,
+    textarea {
+      resize: none;
+      line-height: 20px;
+      float: left;
+      font-size: 15px;
+      text-align: left;
+      word-wrap: break-word;
+      color: $grey1;
+      white-space: nowrap;
+      width: 100%;
+      border: none;
+      &:focus {
+        outline: none;
+      }
+    }
+  }
+  .user-api-buttons {
+    order: 2;
+  }
+  .user-api-message {
+    order: 3;
+    flex: 1 100%;
+    line-height: 40px;
+    margin-top: 13px;
+    border: 1px solid $greenDefault;
+    background-color: #f7fdf7;
     border-radius: 4px;
-    background: white;
-    width: 100%;
-    min-height: 54px;
-    margin-bottom: 25px;
-    margin-top: 10px;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
     display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    padding: 15px 10px;
-    flex-flow: row wrap;
-    .user-api-text {
-        width: 70%;
-        order: 1;
-        label, textarea {
-            resize: none;
-            line-height: 20px;
-            float: left;
-            font-size: 15px;
-            text-align: left;
-            word-wrap: break-word;
-            color: $grey1;
-            white-space: nowrap;
-            width: 100%;
-            border: none;
-            &:focus {
-                outline: none;
-            }
-        }
+    justify-content: center;
+    flex-flow: row;
+    padding: 10px;
+    i {
+      color: $greenDefault;
+      margin-top: 8px;
+      margin-left: 20px;
     }
-    .user-api-buttons {
-        order: 2;
+    .user-api-message-content {
+      margin-left: 10px;
+      line-height: 30px;
     }
-    .user-api-message {
-        order: 3;
-        flex: 1 100%;
-        line-height: 40px;
-        margin-top: 13px;
-        border: 1px solid $greenDefault;
-        background-color: #f7fdf7;
-        border-radius: 4px;
-        display: flex;
-        justify-content: center;
-        flex-flow: row;
-        padding: 10px;
-        i {
-            color: $greenDefault;
-            margin-top: 8px;
-            margin-left: 20px;
-        }
-        .user-api-message-content {
-            margin-left: 10px;
-            line-height: 30px;
-        }
-    }
-    &.user-api-created textarea,
-    &.user-api-created label {
-        color: $black;
-    }
-
+  }
+  &.user-api-created textarea,
+  &.user-api-created label {
+    color: $black;
+  }
 }
 
 .user-name {
-    margin-left: 15px;
-    line-height: 25px;
+  margin-left: 15px;
+  line-height: 25px;
 }
 
-
 .user-info-form img {
-    border-radius: 500rem;
+  border-radius: 500rem;
 }
 
 .preferences-modal .user-name strong {
-    font-size: 22px;
+  font-size: 22px;
 }
 
 .preferences-modal .avatar-user {
-    width: 50px;
-    height: 50px;
-    line-height: 50px;
-    text-align: center;
-    font-size: 21px;
-    color: #fff;
-    padding: 0;
-    background: #b7b7b7;
-    border: 1px solid #ccc;
-    -moz-border-radius: 50px;
-    -webkit-border-radius: 50px;
-    border-radius: 50px;
+  width: 50px;
+  height: 50px;
+  line-height: 50px;
+  text-align: center;
+  font-size: 21px;
+  color: #fff;
+  padding: 0;
+  background: #b7b7b7;
+  border: 1px solid #ccc;
+  -moz-border-radius: 50px;
+  -webkit-border-radius: 50px;
+  border-radius: 50px;
 }
 
 .preferences-modal .user-info-attributes {
-    padding: 20px 50px;
+  padding: 20px 50px;
 }
 
 .preferences-modal .user-info-form label {
-    float: left;
-    margin-top: 7px;
-    font-size: 16px;
+  float: left;
+  margin-top: 7px;
+  font-size: 16px;
 }
 
 .preferences-modal .user-reset-password label {
-    float: left;
-    font-size: 18px;
-    margin-top: 25px;
+  float: left;
+  font-size: 18px;
+  margin-top: 25px;
 }
 
 .preferences-modal,
 .dqf-modal {
-    .dqf-container {
-        padding: 40px;
+  .dqf-container {
+    padding: 40px;
+  }
+  .user-dqf {
+    border: 1px solid #ccc;
+    padding: 15px;
+    border-radius: 4px;
+    background: $grey2;
+    min-height: 40px;
+    margin-bottom: 25px;
+    margin-top: 10px;
+    input {
+      max-width: 100%;
+      //color: #999 !important;
+      //cursor: not-allowed;
+      //background: $grey2;
     }
-    .user-dqf  {
-        border: 1px solid #ccc;
-        padding: 15px;
-        border-radius: 4px;
-        background: $grey2;
-        min-height: 40px;
-        margin-bottom: 25px;
-        margin-top: 10px;
-        input {
-            max-width: 100%;
-            //color: #999 !important;
-            //cursor: not-allowed;
-            //background: $grey2;
-        }
-        .dqf-message {
-            float: right;
-            margin-top: 10px;
-        }
+    .dqf-message {
+      float: right;
+      margin-top: 10px;
     }
-    .button {
-        font-family: Calibri, Arial, Helvetica, sans-serif;
-        vertical-align: top;
-        border: 1px solid #797979;
-        border-radius: 2px;
-        font-size: 16px;
-        margin-bottom: 15px;
-        margin-left: 80%;
-        background-color: $translatedBlue;
-        transition: 0.3s ease;
-        color: #FFFFFF;
-        text-shadow: none;
-        background-image: none;
-        cursor: pointer;
-        display: inline-block;
-        min-height: 1em;
-        outline: none;
-        padding: 0.78571429em 1.5em 0.78571429em;
-        font-weight: bold;
-        line-height: 1em;
-        font-style: normal;
-        text-align: center;
-        text-decoration: none;
-        user-select: none;
-        &:hover {
-            background-color: #08b3de;
-            box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important
-        }
+  }
+  .button {
+    font-family: Calibri, Arial, Helvetica, sans-serif;
+    vertical-align: top;
+    border: 1px solid #797979;
+    border-radius: 2px;
+    font-size: 16px;
+    margin-bottom: 15px;
+    margin-left: 80%;
+    background-color: $translatedBlue;
+    transition: 0.3s ease;
+    color: #ffffff;
+    text-shadow: none;
+    background-image: none;
+    cursor: pointer;
+    display: inline-block;
+    min-height: 1em;
+    outline: none;
+    padding: 0.78571429em 1.5em 0.78571429em;
+    font-weight: bold;
+    line-height: 1em;
+    font-style: normal;
+    text-align: center;
+    text-decoration: none;
+    user-select: none;
+    &:hover {
+      background-color: #08b3de;
+      box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+        0 2px 4px rgba(0, 0, 0, 0.24) !important;
     }
-    .dqf-options-container {
-        h2 {
-            margin-bottom: 10px;
-        }
-        width: 100%;
-        overflow-y: hidden;
-        padding-top: 15px;
+  }
+  .dqf-options-container {
+    h2 {
+      margin-bottom: 10px;
     }
+    width: 100%;
+    overflow-y: hidden;
+    padding-top: 15px;
+  }
 
-    .dqf-option {
-        width: 48%;
-        float: left;
-        text-align: left;
-        padding: 5px;
-        padding-bottom: 20px;
-    }
+  .dqf-option {
+    width: 48%;
+    float: left;
+    text-align: left;
+    padding: 5px;
+    padding-bottom: 20px;
+  }
 
-    .dqf-option h4 {
-        float: left;
-        margin-top: 5px;
-        margin-left: 10px;
-        font-size: 15px;
-    }
+  .dqf-option h4 {
+    float: left;
+    margin-top: 5px;
+    margin-left: 10px;
+    font-size: 15px;
+  }
 
-    .dqf-option select {
-        &.error {
-            border: 1px solid red;
-            color: black;
-        }
-        float: right !important;
-        width: 65%;
-        height: 30px;
-        padding: 5px;
-        border: 1px solid #ccc;
-        margin: 1px 0 5px 0;
-        font: inherit;
+  .dqf-option select {
+    &.error {
+      border: 1px solid red;
+      color: black;
     }
+    float: right !important;
+    width: 65%;
+    height: 30px;
+    padding: 5px;
+    border: 1px solid #ccc;
+    margin: 1px 0 5px 0;
+    font: inherit;
+  }
 }
 
-
-.preferences-modal  {
-    .dqf-container {
-        padding: 0px;
-    }
+.preferences-modal {
+  .dqf-container {
+    padding: 0px;
+  }
 }
 
 .onoffswitch-drive {
-    position: relative;
-    width: 60px;
-    zoom: 0.7;
-    margin-top: 3px;
-    float: left;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
+  position: relative;
+  width: 60px;
+  zoom: 0.7;
+  margin-top: 3px;
+  float: left;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
 }
 
 .preferences-modal .onoffswitch-drive {
-    position: absolute;
+  position: absolute;
 }
 
 .user-info-form .grey-txt {
-    color: $grey1;
+  color: $grey1;
 }
 
 .user-gdrive > label {
-    line-height: 20px;
-    float: left;
-    margin: 2px 10px 12px 65px;
-    font-size: 15px;
-    max-width: 75%;
-    text-align: left;
-    word-wrap: break-word;
-    color: $grey1;
+  line-height: 20px;
+  float: left;
+  margin: 2px 10px 12px 65px;
+  font-size: 15px;
+  max-width: 75%;
+  text-align: left;
+  word-wrap: break-word;
+  color: $grey1;
 }
 
 .preferences-modal .user-gdrive > label {
-    margin: 4px 10px 10px 95px;
+  margin: 4px 10px 10px 95px;
 }
 
-
 .user-menu-flat {
-    margin-right: 8px;
-    float: right;
+  margin-right: 8px;
+  float: right;
 }
 
 .user-menu-flat li {
-    text-decoration: underline;
-    cursor: pointer;
-    padding-right: 0;
+  text-decoration: underline;
+  cursor: pointer;
+  padding-right: 0;
 }
 
 .user-menu-flat li:first-child {
-    border-left: 1px solid;
-    margin-left: 4px;
+  border-left: 1px solid;
+  margin-left: 4px;
 }
 
 .user-menu-flat li:last-child {
-    border-right: none;
+  border-right: none;
 }
 
 .reset-password.btn-confirm-medium {
-    float: left;
+  float: left;
 }
 
 .login-container-right {
-    width: 41%;
-    padding: 3% 1% 3% 25px;
-    font-size: 17px;
-    display: inline-block;
-    float: left;
-    box-sizing: border-box;
-    //background: url(https://www.matecat.com/wp-content/themes/stanleywp/images/bgfeat5.png) no-repeat;
-    //background-size: 84%;
-    //background-position: 370% center;
-    padding-top: 30px;
+  width: 41%;
+  padding: 3% 1% 3% 25px;
+  font-size: 17px;
+  display: inline-block;
+  float: left;
+  box-sizing: border-box;
+  //background: url(https://www.matecat.com/wp-content/themes/stanleywp/images/bgfeat5.png) no-repeat;
+  //background-size: 84%;
+  //background-position: 370% center;
+  padding-top: 30px;
 }
 
 .login-container-left {
-    width: 59%;
-    display: inline-block;
-    padding: 20px 0;
-    background: #f8f8f8;
-    border-left: 1px solid #ccc;
-    box-sizing: border-box;
-    text-align: center;
+  width: 59%;
+  display: inline-block;
+  padding: 20px 0;
+  background: #f8f8f8;
+  border-left: 1px solid #ccc;
+  box-sizing: border-box;
+  text-align: center;
 }
 
 .login-container-right h2,
 .login-container-right p,
 .login-container-right ul {
-    text-align: left;
+  text-align: left;
 }
 
 .add-project-manage {
-    padding-left: 0px !important;
-    margin-left: 20px !important;
+  padding-left: 0px !important;
+  margin-left: 20px !important;
 }
 
 .login-container-right ul {
-    margin-left: 30px;
-    margin-top: 25px;
-    margin-bottom: 60px;
+  margin-left: 30px;
+  margin-top: 25px;
+  margin-bottom: 60px;
 }
 
 .login-container-right .register-button {
-    margin-top: 30px;
-    float: left;
-    margin-left: 50px;
+  margin-top: 30px;
+  float: left;
+  margin-left: 50px;
 }
 
 .google-login-button {
-    background: url(../img/btn_gg_sprite.png) no-repeat;
-    background-position: 0 0;
+  background: url(../img/btn_gg_sprite.png) no-repeat;
+  background-position: 0 0;
 }
 
 .google-login-button:hover {
-    background: url(../img/btn_gg_sprite.png) no-repeat;
-    background-position: 0 -101px;
-    box-shadow: none !important;
-
+  background: url(../img/btn_gg_sprite.png) no-repeat;
+  background-position: 0 -101px;
+  box-shadow: none !important;
 }
 
 .google-login-button:focus {
-    background: url(../img/btn_gg_sprite.png) no-repeat;
-    background-position: 0 -50px;
-
+  background: url(../img/btn_gg_sprite.png) no-repeat;
+  background-position: 0 -50px;
 }
 
 .google-login-button,
 .google-login-button:hover,
 .google-login-button:focus {
-    background-size: 100%;
-    border: none;
-    height: 30px;
-    box-shadow: none !important;
+  background-size: 100%;
+  border: none;
+  height: 30px;
+  box-shadow: none !important;
 }
 
 .forgot-password {
-    cursor: pointer;
-    text-decoration: underline;
-    color: $linkBlue;
+  cursor: pointer;
+  text-decoration: underline;
+  color: $linkBlue;
 }
 
-.preferences-modal input[type=text],
-.preferences-modal input[type=password],
-.dqf-modal input[type=text],
-.dqf-modal input[type=password],
+.preferences-modal input[type='text'],
+.preferences-modal input[type='password'],
+.dqf-modal input[type='text'],
+.dqf-modal input[type='password'],
 .login-container-left input,
-.register-form-container input[type=text],
-.register-form-container input[type=password],
+.register-form-container input[type='text'],
+.register-form-container input[type='password'],
 .forgot-password-modal input,
 .reset-password-modal input,
 .user-info-form input {
-    margin-top: 5px;
-    font-size: 14px;
-    width: 100%;
-    padding: .7em .6em;
-    display: inline-block;
-    border: 1px solid #ccc;
-    box-shadow: inset 0 1px 3px #ddd;
-    border-radius: 4px;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    font-size: 15px;
-    color: #333;
+  margin-top: 5px;
+  font-size: 14px;
+  width: 100%;
+  padding: 0.7em 0.6em;
+  display: inline-block;
+  border: 1px solid #ccc;
+  box-shadow: inset 0 1px 3px #ddd;
+  border-radius: 4px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  font-size: 15px;
+  color: #333;
 }
 
 .dqf-modal input[disabled] {
-    color: #999;
-    cursor: not-allowed;
-    background: $grey2;
+  color: #999;
+  cursor: not-allowed;
+  background: $grey2;
 }
 
 .user-info-form input {
-    margin-top: 5px;
-    width: 100%;
-    color: #000;
+  margin-top: 5px;
+  width: 100%;
+  color: #000;
 }
 
 .login-container-right li {
-    margin-bottom: 15px;
-    margin-right: 42px;
+  margin-bottom: 15px;
+  margin-right: 42px;
 }
 
 .google-login-button,
@@ -556,290 +562,290 @@ a.ui.primary.right.floated.button.tiny.register-ok {
 .register-submit,
 .send-password-button,
 .reset-password-button {
-    width: 160px;
-    margin-left: 0px;
+  width: 160px;
+  margin-left: 0px;
 }
 
 .login-form-container,
 .register-form-container {
-    margin: 0 auto;
+  margin: 0 auto;
 }
 
 .login-form-container {
-    width: 225px;
+  width: 225px;
 }
 
 .forgot-password-modal,
 .reset-password-modal {
-    width: 100%;
-    margin: 0 auto;
-    padding: 20px 0;
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px 0;
 }
 
 .preferences-modal input:disabled {
-    color: #999;
-    cursor: not-allowed;
-    background: $grey2;
+  color: #999;
+  cursor: not-allowed;
+  background: $grey2;
 }
 
 .preferences-modal .reset-password {
-    margin-right: 20px;
+  margin-right: 20px;
 }
 
 .forgot-password-modal {
-    background: url(../img/matecat_watch-left-border.png) no-repeat -34px 136px;
-    background-size: 23%;
-    /*width: 385px;*/
-    padding: 25px 96px;
-    text-align: right;
+  background: url(../img/matecat_watch-left-border.png) no-repeat -34px 136px;
+  background-size: 23%;
+  /*width: 385px;*/
+  padding: 25px 96px;
+  text-align: right;
 }
 
 .forgot-password-modal p {
-    text-align: left;
+  text-align: left;
 }
 
 .reset-password-modal {
-    padding: 5% 10%;
-    width: 80%;
+  padding: 5% 10%;
+  width: 80%;
 }
 
 .register-modal {
-    padding: 25px 15%;
-    text-align: center;
+  padding: 25px 15%;
+  text-align: center;
 }
 
 .register-modal h2 {
-    padding: 10px 0 10px 0;
+  padding: 10px 0 10px 0;
 }
 
 .register-modal .google-login-button {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .preference-modal-message {
-    box-shadow: 0 2px 2px #e2e2e2;
-    border-radius: 2px;
-    border: 1px solid #ccc;
-    line-height: 20px;
-    padding: 10px 15px;
-    background: rgb(195, 224, 195);
-    /*margin-top: 20px;*/
-    margin-bottom: 10px;
+  box-shadow: 0 2px 2px #e2e2e2;
+  border-radius: 2px;
+  border: 1px solid #ccc;
+  line-height: 20px;
+  padding: 10px 15px;
+  background: rgb(195, 224, 195);
+  /*margin-top: 20px;*/
+  margin-bottom: 10px;
 }
 
 .button-loader {
-    background: url(../img/loader.gif) center center no-repeat;
-    width: 20px;
-    height: 20px;
-    visibility: hidden;
-    position: absolute;
-    background-size: 20px 20px;
-    left: 15px;
-    opacity: 0;
+  background: url(../img/loader.gif) center center no-repeat;
+  width: 20px;
+  height: 20px;
+  visibility: hidden;
+  position: absolute;
+  background-size: 20px 20px;
+  left: 15px;
+  opacity: 0;
 }
 
 .button-loader.show {
-    visibility: visible;
-    opacity: 1;
-    -webkit-transition: all 0.3s ease-in;
-    -moz-transition: all 0.3s ease-in;
-    -o-transition: all 0.3s ease-in;
+  visibility: visible;
+  opacity: 1;
+  -webkit-transition: all 0.3s ease-in;
+  -moz-transition: all 0.3s ease-in;
+  -o-transition: all 0.3s ease-in;
 }
 
 /***********************/
 
 /********Modal window ****/
 .matecat-modal,
-.matecat-modal-overlay
-{
-    display: block;
-    z-index: 13;
-    position: fixed;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgb(0, 0, 0);
-    background-color: rgba(0, 0, 0, 0.4);
-    p {
-        line-height: 20px;
+.matecat-modal-overlay {
+  display: block;
+  z-index: 13;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0, 0, 0);
+  background-color: rgba(0, 0, 0, 0.4);
+  p {
+    line-height: 20px;
+  }
+  .matecat-modal-header {
+    text-align: left;
+    min-height: 47px;
+    border-radius: 4px 4px 0 0;
+    overflow: visible;
+    max-height: inherit;
+    font-size: 23px;
+    background: #002b5c;
+    padding: 10px 10px 7px 24px;
+    background-size: 35px;
+    color: #fff;
+    margin: 0 !important;
+    display: grid;
+    grid-template-columns: 40px 1fr 24px;
+    position: relative;
+    grid-column-gap: 16px;
+    h2 {
+      margin: 0 !important;
+      line-height: 30px;
+      font-size: 24px;
+      width: auto !important;
+      float: none !important;
+      font-family: Calibri, Arial, Helvetica, sans-serif;
     }
-    .matecat-modal-header {
-        text-align: left;
-        min-height: 47px;
-        border-radius: 4px 4px 0 0;
-        overflow: visible;
-        max-height: inherit;
-        font-size: 23px;
-        background: #002b5c;
-        padding: 10px 10px 7px 24px;
-        background-size: 35px;
-        color: #fff;
-        margin: 0 !important;
-        display: grid;
-        grid-template-columns: 40px 1fr 24px;
-        position: relative;
-        grid-column-gap: 16px;
-        h2 {
-            margin: 0 !important;
-            line-height: 30px;
-            font-size: 24px;
-            width: auto !important;
-            float: none !important;
-            font-family: Calibri, Arial, Helvetica, sans-serif;
-        }
+  }
+  .modal-logo {
+    background-size: inherit;
+    background: url(../../img/Logo-Onlycat-white.svg) no-repeat;
+    background-position-y: center;
+    background-size: contain;
+    width: 40px;
+    height: 26px;
+  }
+  /* Modal Body */
+  .matecat-modal-body {
+    min-height: 50px;
+    /*color: #000;*/
+    background-color: $grey5;
+    border-radius: 0 0 4px 4px;
+    margin: 0 auto;
+    overflow: hidden;
+    text-align: left;
+    h1 {
+      text-align: center;
     }
-    .modal-logo {
-        background-size: inherit;
-        background: url(../../img/Logo-Onlycat-white.svg) no-repeat;
-        background-position-y: center;
-        background-size: contain;
-        width: 40px;
-        height: 26px;
+  }
+  /* Modal Footer */
+  .matecat-modal-footer {
+    padding: 2px 16px;
+    color: black;
+    text-align: left;
+    min-height: 30px;
+  }
+  /* Modal Content */
+  .matecat-modal-content {
+    margin: auto;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 60%;
+    border-radius: 4px;
+    -webkit-animation-name: animatetop;
+    -webkit-animation-duration: 0.4s;
+    animation-name: animatetop;
+    animation-duration: 0.4s;
+    text-align: center;
+    max-width: 600px;
+    min-width: 400px;
+    //-webkit-box-shadow: 0 1px 20px #000;
+    //box-shadow: 0 1px 20px #6f6e6e;
+    .half-form-left {
+      margin-right: 4%;
     }
-    /* Modal Body */
-    .matecat-modal-body {
-        min-height: 50px;
-        /*color: #000;*/
-        background-color: $grey5;
-        border-radius: 0 0 4px 4px;
-        margin: 0 auto;
-        overflow: hidden;
-        text-align: left;
-        h1 {
-            text-align: center;
-        }
+    .half-form {
+      width: 48%;
+      float: left;
     }
-    /* Modal Footer */
-    .matecat-modal-footer {
-        padding: 2px 16px;
-        color: black;
-        text-align: left;
-        min-height: 30px;
-    }
-    /* Modal Content */
-    .matecat-modal-content {
-        margin: auto;
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transform: translate(-50%, -50%);
-        width: 60%;
-        border-radius: 4px;
-        -webkit-animation-name: animatetop;
-        -webkit-animation-duration: 0.4s;
-        animation-name: animatetop;
-        animation-duration: 0.4s;
-        text-align: center;
-        max-width: 600px;
-        min-width: 400px;
-        //-webkit-box-shadow: 0 1px 20px #000;
-        //box-shadow: 0 1px 20px #6f6e6e;
-        .half-form-left {
-            margin-right: 4%;
-        }
-        .half-form {
-            width: 48%;
-            float: left;
-        }
-    }
+  }
 }
 
 .matecat-modal-overlay {
-    display: block;
-    z-index: 13;
-    position: fixed;
-    left: 6px;
-    bottom: 48px;
-    top: unset;
-    width: 325px;
-    height: 342px;
-    overflow: auto;
-    background-color: unset;
-    .modal-logo {
-        width: 34px;
+  display: block;
+  z-index: 13;
+  position: fixed;
+  left: 6px;
+  bottom: 48px;
+  top: unset;
+  width: 325px;
+  height: 342px;
+  overflow: auto;
+  background-color: unset;
+  .modal-logo {
+    width: 34px;
+  }
+  .matecat-modal-content {
+    width: 320px;
+    min-width: unset;
+    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+      0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  }
+  .matecat-modal-header {
+    text-align: left;
+    min-height: 32px;
+    border-radius: 4px 4px 0 0;
+    overflow: visible;
+    max-height: inherit;
+    background: #002b5c;
+    padding: 6px 10px 3px 24px;
+    background-size: 31px;
+    color: #fff;
+    margin: 0 !important;
+    display: grid;
+    grid-template-columns: 35px 1fr 24px;
+    position: relative;
+    grid-column-gap: 16px;
+    h2 {
+      font-size: 21px;
     }
-    .matecat-modal-content {
-        width: 320px;
-        min-width: unset;
-        box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important
+  }
+  .matecat-modal-body {
+    h1 {
+      font-size: 1.7rem;
     }
-    .matecat-modal-header {
-        text-align: left;
-        min-height: 32px;
-        border-radius: 4px 4px 0 0;
-        overflow: visible;
-        max-height: inherit;
-        background: #002b5c;
-        padding: 6px 10px 3px 24px;
-        background-size: 31px;
-        color: #fff;
-        margin: 0 !important;
-        display: grid;
-        grid-template-columns: 35px 1fr 24px;
-        position: relative;
-        grid-column-gap: 16px;
-        h2 {
-            font-size: 21px;
-        }
+    .matecat-modal-textarea {
+      padding: 0;
     }
-    .matecat-modal-body {
-        h1 {
-            font-size: 1.7rem;
-        }
-        .matecat-modal-textarea {
-            padding: 0;
-        }
-        .matecat-modal-middle {
-            padding: 0 20px;
-        }
-        .matecat-modal-top, .matecat-modal-bottom {
-            padding: 15px 17px;
-        }
-        .ui.button {
-            font-size: 15px;
-        }
-        .ui.button.cancel-button {
-            //margin-right: 45px;
-        }
+    .matecat-modal-middle {
+      padding: 0 20px;
     }
-
+    .matecat-modal-top,
+    .matecat-modal-bottom {
+      padding: 15px 17px;
+    }
+    .ui.button {
+      font-size: 15px;
+    }
+    .ui.button.cancel-button {
+      //margin-right: 45px;
+    }
+  }
 }
 
 .preferences-modal {
-    text-align: left;
+  text-align: left;
 }
 
 .preferences-modal h2 {
-    margin: 0;
-    padding: 0 0 0 15px;
-    font-size: 20px;
-    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 0 0 0 15px;
+  font-size: 20px;
+  font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
 }
 
 .user-link {
-    float: left;
-    clear: both;
-    font-size: 16px;
-    margin-left: 66px;
-    height: 20px;
-    margin-top: 12px;
+  float: left;
+  clear: both;
+  font-size: 16px;
+  margin-left: 66px;
+  height: 20px;
+  margin-top: 12px;
 }
 
 /* The Close Button */
 .close-matecat-modal {
-    color: #fff;
-    float: right;
-    font-size: 20px;
-    font-weight: bold;
+  color: #fff;
+  float: right;
+  font-size: 20px;
+  font-weight: bold;
 }
 
 .close-matecat-modal:hover,
 .close-matecat-modal:focus {
-    color: red;
-    text-decoration: none;
-    cursor: pointer;
+  color: red;
+  text-decoration: none;
+  cursor: pointer;
 }
 
 /***********************/
@@ -847,150 +853,154 @@ a.ui.primary.right.floated.button.tiny.register-ok {
 /* On-off switch */
 
 .onoffswitch {
-    position: relative;
-    width: 60px;
-    zoom: 0.7;
-    margin-top: 1px;
-    float: left;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
+  position: relative;
+  width: 60px;
+  zoom: 0.7;
+  margin-top: 1px;
+  float: left;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
 }
 
 .onoffswitch-checkbox {
-    display: none;
+  display: none;
 }
 
 .onoffswitch-label {
-    display: block !important;
-    overflow: hidden;
-    cursor: pointer !important;
-    border: 2px solid #ccc;
-    border-radius: 20px;
-    height: 30px !important;
-    padding-left: initial !important;
-    margin-right: -2px;
-    box-sizing: content-box;
+  display: block !important;
+  overflow: hidden;
+  cursor: pointer !important;
+  border: 2px solid #ccc;
+  border-radius: 20px;
+  height: 30px !important;
+  padding-left: initial !important;
+  margin-right: -2px;
+  box-sizing: content-box;
 }
 
 .onoffswitch-label:before,
 .onoffswitch-label:after {
-    border: none !important;
+  border: none !important;
 }
 
 .onoffswitch-inner {
-    display: block;
-    width: 200%;
-    margin-left: -100%;
-    transition: margin 0.3s ease-in 0s;
+  display: block;
+  width: 200%;
+  margin-left: -100%;
+  transition: margin 0.3s ease-in 0s;
 }
 
 .onoffswitch-inner:before,
 .onoffswitch-inner:after {
-    display: block;
-    float: left;
-    width: 50%;
-    height: 30px;
-    padding: 0;
-    text-align: left;
-    line-height: 30px;
-    font-size: 15px;
-    color: white;
-    font-weight: bold;
-    box-sizing: border-box;
+  display: block;
+  float: left;
+  width: 50%;
+  height: 30px;
+  padding: 0;
+  text-align: left;
+  line-height: 30px;
+  font-size: 15px;
+  color: white;
+  font-weight: bold;
+  box-sizing: border-box;
 }
 
 .onoffswitch-inner:before {
-    content: "";
-    padding-left: 10px;
-    background-color: $linkBlue;
-    color: #FFFFFF;
+  content: '';
+  padding-left: 10px;
+  background-color: $linkBlue;
+  color: #ffffff;
 }
 
 .onoffswitch-inner:after {
-    content: "";
-    padding-right: 7px;
-    background-color: #EEEEEE;
-    color: #999999;
-    text-align: right;
+  content: '';
+  padding-right: 7px;
+  background-color: #eeeeee;
+  color: #999999;
+  text-align: right;
 }
 
 .onoffswitch-switch {
-    display: block;
-    width: 22px;
-    margin: 4px;
-    background: #FFFFFF;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    right: 25px;
-    border: 2px solid #ccc;
-    border-radius: 20px;
-    transition: all 0.3s ease-in 0s;
+  display: block;
+  width: 22px;
+  margin: 4px;
+  background: #ffffff;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 25px;
+  border: 2px solid #ccc;
+  border-radius: 20px;
+  transition: all 0.3s ease-in 0s;
 }
 
 .onoffswitch-label-status-active {
-    display: none;
-    font-weight: bold;
-    color: $linkBlue;
+  display: none;
+  font-weight: bold;
+  color: $linkBlue;
 }
 
 .onoffswitch-label-status-inactive,
 .onoffswitch-label-status-unavailable {
-    display: block;
-    color: #999999;
+  display: block;
+  color: #999999;
 }
 
 .onoffswitch-label:hover {
-    border-color: #A1A1A1;
+  border-color: #a1a1a1;
 }
 
 .onoffswitch-label-status-active,
 .onoffswitch-label-status-inactive,
 .onoffswitch-label-status-unavailable {
-    position: absolute;
-    left: 80px;
-    font-size: 24px;
-    top: 6px;
-    line-height: 20px;
+  position: absolute;
+  left: 80px;
+  font-size: 24px;
+  top: 6px;
+  line-height: 20px;
 }
 
 .onoffswitch-label-status-unavailable {
-    display: none;
+  display: none;
 }
 
 .option-unavailable .onoffswitch-label-status-unavailable {
-    display: inline;
+  display: inline;
 }
 
 .option-unavailable .onoffswitch-label-status-inactive {
-    display: none;
+  display: none;
 }
 
-.onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-label-status-active {
-    display: block;
+.onoffswitch-checkbox:checked
+  + .onoffswitch-label
+  .onoffswitch-label-status-active {
+  display: block;
 }
 
-.onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-label-status-inactive {
-    display: none;
+.onoffswitch-checkbox:checked
+  + .onoffswitch-label
+  .onoffswitch-label-status-inactive {
+  display: none;
 }
 
 .onoffswitch-label-ok {
-    display: block;
-    position: absolute;
-    right: -50px;
+  display: block;
+  position: absolute;
+  right: -50px;
 }
 
 .onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-label-ok {
-    display: none;
+  display: none;
 }
 
 .onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-inner {
-    margin-left: 0;
+  margin-left: 0;
 }
 
 .onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-switch {
-    right: 0px;
+  right: 0px;
 }
 
 /* buttons */
@@ -998,712 +1008,713 @@ a.ui.primary.right.floated.button.tiny.register-ok {
 .matecat-modal-content .disabled,
 .matecat-modal-content .disabled:hover,
 .matecat-modal-content .disabled:active {
-    opacity: 0.5 !important;
-    cursor: default;
-    -moz-box-shadow: none;
-    -webkit-box-shadow: none;
-    border: 1px solid #666;
+  opacity: 0.5 !important;
+  cursor: default;
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  border: 1px solid #666;
 }
 
 .matecat-modal-content .btn-confirm-medium:hover,
 .matecat-modal-content .btn-confirm-small:hover {
-    cursor: pointer;
-    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-    color: #ffffff;
+  cursor: pointer;
+  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  color: #ffffff;
 }
 
 .matecat-modal-content .btn-confirm-medium:active {
-    box-shadow: none !important;
+  box-shadow: none !important;
 }
 
 .matecat-modal-content .btn-confirm-medium {
-    color: #fff;
-    background: $translatedBlue;
-    border: 1px solid #848689;
-    font-weight: bold;
-    text-decoration: none;
-    padding: 8px 18px;
-    border-radius: 2px;
-    font-size: 18px;
-    margin: 16px 0 16px 0px;
-    display: inline-block;
-    text-align: center;
-    position: relative;
+  color: #fff;
+  background: $translatedBlue;
+  border: 1px solid #848689;
+  font-weight: bold;
+  text-decoration: none;
+  padding: 8px 18px;
+  border-radius: 2px;
+  font-size: 18px;
+  margin: 16px 0 16px 0px;
+  display: inline-block;
+  text-align: center;
+  position: relative;
 }
 
 .matecat-modal-content .btn-confirm-medium.google-login-button {
-    background: url(../../img/btn_gg_sprite.png) no-repeat;
-    background-position: 0 0;
-    background-size: cover;
-    border: none;
-
+  background: url(../../img/btn_gg_sprite.png) no-repeat;
+  background-position: 0 0;
+  background-size: cover;
+  border: none;
 }
 
-.matecat-modal-content .btn-confirm-medium.google-login-button, .matecat-modal-content .btn-confirm-medium.google-login-button:hover, .matecat-modal-content .btn-confirm-medium.google-login-button:focus {
-    background-size: cover;
-    border: none;
-    height: 30px;
-    width: 160px;
-    margin-left: 0;
-    margin-top: 5px;
-    margin-bottom: 0;
-    box-sizing: content-box;
+.matecat-modal-content .btn-confirm-medium.google-login-button,
+.matecat-modal-content .btn-confirm-medium.google-login-button:hover,
+.matecat-modal-content .btn-confirm-medium.google-login-button:focus {
+  background-size: cover;
+  border: none;
+  height: 30px;
+  width: 160px;
+  margin-left: 0;
+  margin-top: 5px;
+  margin-bottom: 0;
+  box-sizing: content-box;
 }
 
 .matecat-modal-content .btn-confirm-medium.google-login-button:hover {
-    background: url(../../img/btn_gg_sprite.png) no-repeat;
-    background-position: 0 -101px;
-    background-size: cover;
-    box-shadow: none !important;
+  background: url(../../img/btn_gg_sprite.png) no-repeat;
+  background-position: 0 -101px;
+  background-size: cover;
+  box-shadow: none !important;
 }
 
 .matecat-modal-content .btn-confirm-medium.sing-in {
-    margin-left: 0px;
+  margin-left: 0px;
 }
 
 .matecat-modal-content .btn-confirm-medium.sing-up {
-    //margin-left: 0px;
+  //margin-left: 0px;
 }
 
 .matecat-modal-content .btn-confirm-medium.register-now {
-    margin-left: 0px;
+  margin-left: 0px;
 }
 
 .matecat-modal-content .disabled,
 .matecat-modal-content .disabled:hover,
 .matecat-modal-content .disabled:active {
-    cursor: default;
-    -moz-box-shadow: none;
-    -webkit-box-shadow: none;
-    background: #d6d6d6;
+  cursor: default;
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  background: #d6d6d6;
 }
 
-.x-popup, .x-popup2 {
-    font-family: 'icomoon';
-    speak: none;
-    font-style: normal;
-    font-weight: normal;
-    font-variant: normal;
-    text-transform: none;
-    line-height: 1;
-    &:hover {
-        color: $darkBlueTransparent;
-    }
+.x-popup,
+.x-popup2 {
+  font-family: 'icomoon';
+  speak: none;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  &:hover {
+    color: $darkBlueTransparent;
+  }
 
-    /* Better Font Rendering =========== */
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-.x-popup:before, .x-popup2:before {
-    content: "\f057";
+.x-popup:before,
+.x-popup2:before {
+  content: '\f057';
 }
-.matecat-modal-content,  .matecat-modal-overlay-content{
-    font-size: 16px;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
+.matecat-modal-content,
+.matecat-modal-overlay-content {
+  font-size: 16px;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
 
-    .matecat-modal-middle,
-    .matecat-modal-bottom,
-    .matecat-modal-top{
-        padding: 25px;
-        .ui.members-list {
-            min-height: 45px;
-            .ui.divided.list {
+  .matecat-modal-middle,
+  .matecat-modal-bottom,
+  .matecat-modal-top {
+    padding: 25px;
+    .ui.members-list {
+      min-height: 45px;
+      .ui.divided.list {
+        top: 0px;
+        left: 0px;
+        bottom: 0px;
+        right: 0px;
 
-                top: 0px;
-                left: 0px;
-                bottom: 0px;
-                right: 0px;
-
-                overflow-y: auto;
-                max-height: 210px;
-                position: relative!important;
-                padding: 0;
-                .item {
-                    border-top: none !important
-                }
-            }
-            ::-webkit-scrollbar {
-                width: 10px;
-            }
-
-            /* Track */
-            ::-webkit-scrollbar-track {
-                -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-                -webkit-border-radius: 10px;
-                border-radius: 10px;
-            }
-
-            /* Handle */
-            ::-webkit-scrollbar-thumb {
-                -webkit-border-radius: 10px;
-                border-radius: 10px;
-                background: #a7a5a5;
-                -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
-            }
-            ::-webkit-scrollbar-thumb:window-inactive {
-                background: #a7a5a5;
-            }
-            &.team {
-                .item {
-                    padding: 5px 10px;
-                    &:hover {
-                        .mini.ui.button.right.floated  {
-                            display: inherit;
-                        }
-                        .content.pending-msg {
-                            display: none;
-                        }
-                    }
-                    .image {
-                        width: 40px !important;
-                        max-width: 40px;
-                        height: 40px;
-                        background-color: $grey2;
-                        border-radius: 50%;
-                        vertical-align: middle;
-                        text-align: center;
-                        font-size: 17px;
-                    }
-
-                    .content.user {
-                        font-weight: bold;
-                        width: 340px;
-                        &.invited {
-                            font-weight: 100;
-                        }
-                    }
-                    .content.email-user-invited {
-                        font-weight: 100;
-                        font-size: 14px;
-                        color: $grey1;
-                    }
-                    .content.pending-msg,
-                    .content.invite-sent-msg{
-                        font-weight: 100;
-                        font-size: 14px;
-                        color: $grey1;
-                        margin-top: 13px;
-                    }
-
-                    .mini.ui.button.right.floated {
-                        margin-top: 6px;
-                        border: 1px solid #797979;
-                        display: none;
-                        border-radius: 2px;
-                        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-                        font-size: 14px;
-                        padding: 6px 15px;
-                        background-color: #f6f6f6;
-                        &:hover {
-                            box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                        }
-                        &:focus {
-                            box-shadow: none !important;
-                        }
-                        &:active {
-                            box-shadow: none !important;
-                        }
-                    }
-                    .mini.ui.primary.button {
-                        border: 1px solid #797979;
-                        border-radius: 2px;
-                        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-                        font-size: 14px;
-                        padding: 6px 15px;
-                        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-                        i {
-                            opacity: 1;
-                        }
-                    }
-                    .ui.primary.button {
-                        border: 1px solid #797979;
-                        border-radius: 2px;
-                        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-                    }
-                    .mini.ui.icon.button {
-                        width: 30px;
-                        height: 30px;
-                        line-height: 20px;
-                        text-align: center;
-                        vertical-align: bottom;
-                        border: 1px solid #797979;
-                        border-radius: 2px;
-
-                    }
-                }
-            }
+        overflow-y: auto;
+        max-height: 210px;
+        position: relative !important;
+        padding: 0;
+        .item {
+          border-top: none !important;
         }
-    }
+      }
+      ::-webkit-scrollbar {
+        width: 10px;
+      }
 
-    .matecat-modal-text {
-        padding: 10px 10px;
-        font-size: 17px;
-    }
-    .matecat-modal-textarea {
-        padding: 10px 10px;
-        resize: none;
-        textarea {
-            padding: 10px;
-            border: 1px solid grey;
-            border-radius: 4px;
+      /* Track */
+      ::-webkit-scrollbar-track {
+        -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+        -webkit-border-radius: 10px;
+        border-radius: 10px;
+      }
+
+      /* Handle */
+      ::-webkit-scrollbar-thumb {
+        -webkit-border-radius: 10px;
+        border-radius: 10px;
+        background: #a7a5a5;
+        -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
+      }
+      ::-webkit-scrollbar-thumb:window-inactive {
+        background: #a7a5a5;
+      }
+      &.team {
+        .item {
+          padding: 5px 10px;
+          &:hover {
+            .mini.ui.button.right.floated {
+              display: inherit;
+            }
+            .content.pending-msg {
+              display: none;
+            }
+          }
+          .image {
+            width: 40px !important;
+            max-width: 40px;
+            height: 40px;
+            background-color: $grey2;
+            border-radius: 50%;
+            vertical-align: middle;
+            text-align: center;
+            font-size: 17px;
+          }
+
+          .content.user {
+            font-weight: bold;
+            width: 340px;
+            &.invited {
+              font-weight: 100;
+            }
+          }
+          .content.email-user-invited {
+            font-weight: 100;
+            font-size: 14px;
+            color: $grey1;
+          }
+          .content.pending-msg,
+          .content.invite-sent-msg {
+            font-weight: 100;
+            font-size: 14px;
+            color: $grey1;
+            margin-top: 13px;
+          }
+
+          .mini.ui.button.right.floated {
+            margin-top: 6px;
+            border: 1px solid #797979;
+            display: none;
+            border-radius: 2px;
+            font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica,
+              sans-serif;
+            font-size: 14px;
+            padding: 6px 15px;
+            background-color: #f6f6f6;
+            &:hover {
+              box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+                0 2px 4px rgba(0, 0, 0, 0.24) !important;
+            }
+            &:focus {
+              box-shadow: none !important;
+            }
+            &:active {
+              box-shadow: none !important;
+            }
+          }
+          .mini.ui.primary.button {
+            border: 1px solid #797979;
+            border-radius: 2px;
+            font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica,
+              sans-serif;
+            font-size: 14px;
+            padding: 6px 15px;
+            font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica,
+              sans-serif;
+            i {
+              opacity: 1;
+            }
+          }
+          .ui.primary.button {
+            border: 1px solid #797979;
+            border-radius: 2px;
+            font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica,
+              sans-serif;
+          }
+          .mini.ui.icon.button {
+            width: 30px;
+            height: 30px;
+            line-height: 20px;
+            text-align: center;
+            vertical-align: bottom;
+            border: 1px solid #797979;
+            border-radius: 2px;
+          }
         }
+      }
     }
+  }
 
-    .check-conditions {
-        margin-left: 5px;
+  .matecat-modal-text {
+    padding: 10px 10px;
+    font-size: 17px;
+  }
+  .matecat-modal-textarea {
+    padding: 10px 10px;
+    resize: none;
+    textarea {
+      padding: 10px;
+      border: 1px solid grey;
+      border-radius: 4px;
     }
+  }
+
+  .check-conditions {
+    margin-left: 5px;
+  }
 }
 
 .pull-left {
-    float: left;
+  float: left;
 }
 
 .pull-right {
-    float: right !important;
+  float: right !important;
 }
 
-
-.create-team-modal, .modify-team-modal, .shortcuts-modal {
-    .create-team {
-        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        padding: 11px 22px;
-        vertical-align: top;
-        font-size: 18px;
-        margin-right: 0px;
-        border-radius: 2px;
-        &.primary.button {
-            border-radius: 2px;
-        }
+.create-team-modal,
+.modify-team-modal,
+.shortcuts-modal {
+  .create-team {
+    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    padding: 11px 22px;
+    vertical-align: top;
+    font-size: 18px;
+    margin-right: 0px;
+    border-radius: 2px;
+    &.primary.button {
+      border-radius: 2px;
     }
+  }
 }
-
 
 .modify-team-modal {
-
 }
 
-
 .ui.fluid.input > input {
-    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    box-shadow: inset 0 1px 3px #ddd;
-    font-size: 15px;
+  font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  box-shadow: inset 0 1px 3px #ddd;
+  font-size: 15px;
 }
 
 .ui.multiple.search.dropdown {
-    width: 100%;
-    box-shadow: inset 0 1px 3px #ddd;
-    font-size: 15px;
+  width: 100%;
+  box-shadow: inset 0 1px 3px #ddd;
+  font-size: 15px;
 }
 
-
 .btn-cancel.outsource-cancel-date {
-    height: 16px;
-    &:hover {
-        color: #333333;
-    }
+  height: 16px;
+  &:hover {
+    color: #333333;
+  }
 }
 
 .login-form-container {
-    .form-divider {
-        margin-bottom: 15px;
-    }
+  .form-divider {
+    margin-bottom: 15px;
+  }
 }
 .register-modal {
-    .form-divider {
-        margin-top: 25px;
-        margin-bottom: 10px;
-    }
-    .condition-google {
-        font-size: 12px;
-    }
+  .form-divider {
+    margin-top: 25px;
+    margin-bottom: 10px;
+  }
+  .condition-google {
+    font-size: 12px;
+  }
 }
 
 .form-divider {
+  width: 100%;
+  margin: 0 auto;
+  text-align: center;
+  position: relative;
+  height: 20px;
+  line-height: 20px;
+  margin-top: 15px;
 
-    width: 100%;
-    margin: 0 auto;
-    text-align: center;
-    position: relative;
-    height: 20px;
-    line-height: 20px;
-    margin-top: 15px;
+  .divider-line {
+    height: 2px;
+    width: 40%;
+    background-color: #c5c5c5;
+    margin-top: 10px;
+    display: block;
+    float: left;
+  }
 
-
-    .divider-line {
-        height: 2px;
-        width: 40%;
-        background-color: #c5c5c5;
-        margin-top: 10px;
-        display: block;
-        float: left;
-    }
-
-    span {
-        float: left;
-        width: 20%;
-        color: #656565;
-    }
+  span {
+    float: left;
+    width: 20%;
+    color: #656565;
+  }
 }
-
-
-
 
 .matecat-modal-content {
-    .message-modal {
-        padding: 25px 0;
-    }
+  .message-modal {
+    padding: 25px 0;
+  }
 
-    .matecat-modal-middle {
-        padding: 0 25px;
-        .ui.primary.button, .ui.red.button {
-            font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-            border: 1px solid #797979;
-            border-radius: 2px;
-        }
+  .matecat-modal-middle {
+    padding: 0 25px;
+    .ui.primary.button,
+    .ui.red.button {
+      font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+      border: 1px solid #797979;
+      border-radius: 2px;
     }
-    .create-team-modal {
-        .ui.members-list {
-            .ui.divided.list {
-                .item:first-child {
+  }
+  .create-team-modal {
+    .ui.members-list {
+      .ui.divided.list {
+        .item:first-child {
+        }
+      }
+      .ui.divided.list.disabled {
+        border: none;
+        background-color: white;
+      }
+    }
+  }
+  .modify-team-modal {
+    .matecat-modal-top {
+      .ui.fluid.input {
+        i {
+          display: none;
+        }
+        &:hover {
+          i {
+            display: inherit;
+          }
+        }
+      }
+      .ui.icon.input > input:focus ~ i.icon {
+        opacity: 1;
+        display: inherit;
+      }
+    }
+    .ui.members-list {
+      //min-height: 180px;
+      min-height: initial !important;
+      .ui.divided.list {
+        max-height: 210px;
+        .item:first-child {
+          //border-top: none !important;
+        }
+      }
+    }
+  }
+  .change-team-modal {
+    height: 305px;
+    .matecat-modal-top {
+      .move-ribbon {
+        background: #e8e8e8;
+        padding: 8px 15px;
+        border-radius: 4px;
+        .project-name {
+          font-weight: 600;
+        }
+        .project-id {
+          float: right;
+        }
+      }
+    }
+    .button {
+      font-size: 18px;
+      padding: 11px 22px;
+    }
+    .dropdown {
+      .menu {
+        max-height: 85px !important;
+      }
+      ::-webkit-scrollbar {
+        width: 10px;
+      }
 
-                }
-            }
-            .ui.divided.list.disabled {
-                border: none;
-                background-color: white;
-            }
-        }
-    }
-    .modify-team-modal {
-        .matecat-modal-top {
-            .ui.fluid.input {
-                i {
-                    display: none;
-                }
-                &:hover {
-                    i {
-                        display: inherit;
-                    }
-                }
-            }
-            .ui.icon.input > input:focus ~ i.icon {
-                opacity: 1;
-                display: inherit;
-            }
-        }
-        .ui.members-list {
-            //min-height: 180px;
-            min-height: initial!important;
-            .ui.divided.list {
-                max-height: 210px;
-                .item:first-child {
-                    //border-top: none !important;
-                }
-            }
-        }
-    }
-    .change-team-modal {
-        height: 305px;
-        .matecat-modal-top {
-            .move-ribbon {
-                background: #e8e8e8;
-                padding: 8px 15px;
-                border-radius: 4px;
-                .project-name {
-                    font-weight: 600;
-                }
-                .project-id {
-                    float: right;
-                }
-            }
-        }
-        .button {
-            font-size: 18px;
-            padding: 11px 22px;
-        }
-        .dropdown {
-            .menu {
-                max-height: 85px !important;
-            }
-            ::-webkit-scrollbar {
-                width: 10px;
-            }
+      /* Track */
+      ::-webkit-scrollbar-track {
+        -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
+        -webkit-border-radius: 10px;
+        border-radius: 10px;
+      }
 
-            /* Track */
-            ::-webkit-scrollbar-track {
-                -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-                -webkit-border-radius: 10px;
-                border-radius: 10px;
-            }
-
-            /* Handle */
-            ::-webkit-scrollbar-thumb {
-                -webkit-border-radius: 10px;
-                border-radius: 10px;
-                background: #a7a5a5;
-                -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
-            }
-            ::-webkit-scrollbar-thumb:window-inactive {
-                background: #a7a5a5;
-            }
-            .default.text {
-                color: #000;
-            }
-        }
+      /* Handle */
+      ::-webkit-scrollbar-thumb {
+        -webkit-border-radius: 10px;
+        border-radius: 10px;
+        background: #a7a5a5;
+        -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
+      }
+      ::-webkit-scrollbar-thumb:window-inactive {
+        background: #a7a5a5;
+      }
+      .default.text {
+        color: #000;
+      }
     }
+  }
 }
 
-
-
 a.login-button.btn-confirm-medium.sing-in.disabled:hover {
-    border: 1px solid #848689;
+  border: 1px solid #848689;
 }
 
 .dropdown > .menu {
-    z-index: 100000000;
+  z-index: 100000000;
 }
 
 .popup.popup-confirm.confirm_checkbox {
-    .boxed {
-        padding-right: 20px;
-        padding-bottom: 15px;
-    }
+  .boxed {
+    padding-right: 20px;
+    padding-bottom: 15px;
+  }
 }
 
-
 .shortcuts-modal {
-    .matecat-modal-top {
-        padding: 15px 25px;
-    }
-    .matecat-modal-middle {
-        padding: 10px 15px;
-        max-height: 530px;
-        overflow: auto;
-        .shortcut-list {
-            &:not(:first-of-type) {
-                padding-top: 10px;
+  .matecat-modal-top {
+    padding: 15px 25px;
+  }
+  .matecat-modal-middle {
+    padding: 10px 15px;
+    max-height: 530px;
+    overflow: auto;
+    .shortcut-list {
+      &:not(:first-of-type) {
+        padding-top: 10px;
+      }
+      h2 {
+        padding-left: 10px;
+        padding-bottom: 10px;
+        border-bottom: 1px solid #dee7e8;
+      }
+      .shortcut-item-list {
+        .shortcut-item {
+          padding: 7px 0 7px 10px;
+          margin: 3px 0;
+          &:first-child {
+            margin-top: 10px;
+          }
+          &:hover {
+            background: #f1f1f1;
+          }
+          .shortcut-title,
+          .shortcut-keys {
+            display: inline-block;
+            width: 50%;
+          }
+          .shortcut-keys {
+            .shortcuts {
+              text-align: right;
+              color: #03bdee;
             }
-            h2 {
-                padding-left: 10px;
-                padding-bottom: 10px;
-                border-bottom: 1px solid #dee7e8;
-            }
-            .shortcut-item-list {
-                .shortcut-item {
-                padding: 7px 0 7px 10px;
-                margin: 3px 0;
+            .mac,
+            .standard {
+              .keys {
+                content: '';
+                font-family: 'Courier New';
+                display: inline-block;
+                margin-left: 5px;
+                margin-right: 5px;
+                background: #909798;
+                padding: 0 5px;
+                line-height: 20px;
+                font-size: 12px;
+                color: white;
+                border-radius: 2px;
                 &:first-child {
-                    margin-top: 10px;
+                  margin-left: 0px !important;
                 }
-                &:hover {
-                    background: #f1f1f1;
+                &.ctrl:after {
+                  content: 'Ctrl';
                 }
-                .shortcut-title, .shortcut-keys {
-                    display: inline-block;
-                    width: 50%;
+                &.Meta:after {
+                  content: 'Cmd';
                 }
-                .shortcut-keys {
-                    .shortcuts {
-                        text-align: right;
-                        color: #03bdee;
-                    }
-                    .mac, .standard {
-                        .keys {
-                            content: "";
-                            font-family: "Courier New";
-                            display: inline-block;
-                            margin-left: 5px;
-                            margin-right: 5px;
-                            background: #909798;
-                            padding: 0 5px;
-                            line-height: 20px;
-                            font-size: 12px;
-                            color: white;
-                            border-radius: 2px;
-                            &:first-child {
-                                margin-left: 0px !important;
-                            }
-                            &.ctrl:after {
-                                content: "Ctrl";
-                            }
-                            &.Meta:after {
-                                content: "Cmd";
-                            }
-                            &.shift:after {
-                                content: "Shift";
-                            }
-                            &.return:after {
-                                Content: "Enter";
-                            }
-                            &.meta:after {
-                                content: "Cmd";
-                            }
-                            &.alt:after {
-                                content: "Alt";
-                            }
-                            &.\31 :after {
-                                content: "1";
-                            }
-                            &.\32 :after {
-                                content: "2";
-                            }
-                            &.\33 :after {
-                                content: "3";
-                            }
-                            &.a:after {
-                                content: "A";
-                            }
-                            &.c:after {
-                                content: "C";
-                            }
-                            &.h:after {
-                                content: "H";
-                            }
-                            &.i:after {
-                                content: "I";
-                            }
-                            &.l:after {
-                                content: "L";
-                            }
-                            &.n:after {
-                                content: "N";
-                            }
-                            &.p:after {
-                                content: "P";
-                            }
-                            &.z:after {
-                                content: "Z";
-                            }
-                            &.f:after {
-                                content: "F";
-                            }
-                            &.k:after {
-                                content: "K";
-                            }
-                            &.y:after {
-                                content: "Y";
-                            }
-                            &.s:after {
-                                content: "S";
-                            }
-                            &.t:after {
-                                content: "T";
-                            }
-                            &.up:after {
-                                content: "Arrow up";
-                            }
-                            &.right:after {
-                                content: "Arrow right";
-                            }
-                            &.left:after {
-                                content: "Arrow left";
-                            }
-                            &.down:after {
-                                content: "Arrow down";
-                            }
-                            &.pagedown:after {
-                                content: "Page Down";
-                            }
-                            &.pageup:after {
-                                content: "Page Up";
-                            }
-                            &.previous:after {
-                                content: "<";
-                            }
-                            &.next:after {
-                                content: ">";
-                            }
-                            &.home:after {
-                                content: "Home";
-                            }
-                            &.arrows:after {
-                                content: "Arrows";
-                            }
-                            &.arrows-enter:after {
-                                content: "Arrows/Enter";
-                            }
-                        }
-                    }
+                &.shift:after {
+                  content: 'Shift';
                 }
+                &.return:after {
+                  content: 'Enter';
+                }
+                &.meta:after {
+                  content: 'Cmd';
+                }
+                &.alt:after {
+                  content: 'Alt';
+                }
+                &.\31 :after {
+                  content: '1';
+                }
+                &.\32 :after {
+                  content: '2';
+                }
+                &.\33 :after {
+                  content: '3';
+                }
+                &.a:after {
+                  content: 'A';
+                }
+                &.c:after {
+                  content: 'C';
+                }
+                &.h:after {
+                  content: 'H';
+                }
+                &.i:after {
+                  content: 'I';
+                }
+                &.l:after {
+                  content: 'L';
+                }
+                &.n:after {
+                  content: 'N';
+                }
+                &.p:after {
+                  content: 'P';
+                }
+                &.z:after {
+                  content: 'Z';
+                }
+                &.f:after {
+                  content: 'F';
+                }
+                &.k:after {
+                  content: 'K';
+                }
+                &.y:after {
+                  content: 'Y';
+                }
+                &.s:after {
+                  content: 'S';
+                }
+                &.t:after {
+                  content: 'T';
+                }
+                &.up:after {
+                  content: 'Arrow up';
+                }
+                &.right:after {
+                  content: 'Arrow right';
+                }
+                &.left:after {
+                  content: 'Arrow left';
+                }
+                &.down:after {
+                  content: 'Arrow down';
+                }
+                &.pagedown:after {
+                  content: 'Page Down';
+                }
+                &.pageup:after {
+                  content: 'Page Up';
+                }
+                &.previous:after {
+                  content: '<';
+                }
+                &.next:after {
+                  content: '>';
+                }
+                &.home:after {
+                  content: 'Home';
+                }
+                &.arrows:after {
+                  content: 'Arrows';
+                }
+                &.arrows-enter:after {
+                  content: 'Arrows/Enter';
+                }
+              }
             }
-            }
+          }
         }
+      }
     }
-    .matecat-modal-bottom {
-        padding: 15px 25px;
-    }
+  }
+  .matecat-modal-bottom {
+    padding: 15px 25px;
+  }
 }
 
 .copy-source-modal {
-    padding: 30px 25px 20px;
-    h3 {
-        font-size: 20px;
+  padding: 30px 25px 20px;
+  h3 {
+    font-size: 20px;
+  }
+  .buttons-popup-container {
+    padding: 25px 0 30px;
+    border-bottom: 1px solid #f2f4f7;
+    label {
+      font-size: 18px;
+      margin-right: 10px;
+      position: relative;
+      top: 2px;
     }
-    .buttons-popup-container {
-        padding: 25px 0 30px;
-        border-bottom: 1px solid #f2f4f7;
-        label {
-            font-size: 18px;
-            margin-right: 10px;
-            position: relative;
-            top: 2px;
-        }
-        .btn-cancel, .btn-ok {
-            padding: 10px 15px;
-            margin-left: 5px;
-        }
-        .btn-cancel {
-            margin-right: 16px;
-            font-weight: 100;
-        }
-        .notes-action {
-            padding-left: 196px;
-            position: relative;
-            top: 2px;
-            font-size: 12px;
-            margin-top: 12px;
-        }
+    .btn-cancel,
+    .btn-ok {
+      padding: 10px 15px;
+      margin-left: 5px;
     }
-    .boxed {
-        padding: 15px 0 0;
-        text-align: right;
-        label {
-            position: relative;
-            top: 1px;
-            padding-right: 2px;
-        }
+    .btn-cancel {
+      margin-right: 16px;
+      font-weight: 100;
     }
+    .notes-action {
+      padding-left: 196px;
+      position: relative;
+      top: 2px;
+      font-size: 12px;
+      margin-top: 12px;
+    }
+  }
+  .boxed {
+    padding: 15px 0 0;
+    text-align: right;
+    label {
+      position: relative;
+      top: 1px;
+      padding-right: 2px;
+    }
+  }
 }
 .matecat-modal-content {
-    .boxed {
-        padding: 25px 15px 0;
-        text-align: left;
-        label {
-            position: relative;
-            top: -2px;
-            padding-right: 2px;
-        }
+  .boxed {
+    padding: 25px 15px 0;
+    text-align: left;
+    label {
+      position: relative;
+      top: -2px;
+      padding-right: 2px;
     }
+  }
 }
 
-[data-name="confirmCopyAllSources"] {
-    input, label {
-        display: inline-block;
-        vertical-align: middle;
-    }
-    label {
-        margin-left: 5px;
-    }
-    .text-container-top {
-        padding: 20px !important;
-        margin-top: 0 !important;
-    }
-    .popup p {
-        margin-bottom: 0;
-    }
-    .boxed {
-        padding-right: 20px;
-        padding-bottom: 0 !important;
-    }
+[data-name='confirmCopyAllSources'] {
+  input,
+  label {
+    display: inline-block;
+    vertical-align: middle;
+  }
+  label {
+    margin-left: 5px;
+  }
+  .text-container-top {
+    padding: 20px !important;
+    margin-top: 0 !important;
+  }
+  .popup p {
+    margin-bottom: 0;
+  }
+  .boxed {
+    padding-right: 20px;
+    padding-bottom: 0 !important;
+  }
 }

--- a/public/css/sass/common.scss
+++ b/public/css/sass/common.scss
@@ -1,5 +1,6 @@
-html, body {
-    height: 100%;
+html,
+body {
+  height: 100%;
 }
 
 body {
@@ -13,27 +14,27 @@ body {
   -moz-transition: all 100ms ease-in;
 }
 
-input, textarea {
+input,
+textarea {
   font-family: calibri, Arial, Helvetica, sans-serif;
   font-size: 16px;
 }
 
 @media (max-width: 500px) {
-
   body {
-	min-width: 0 !important;
-	width: 100%;
+    min-width: 0 !important;
+    width: 100%;
   }
   .iepopup {
-	width: 100% !important;
-	margin-left: auto !important;
-	margin-right: auto !important;
-	left: 0 !important;
-	border: 0px solid #fff !important;
-	box-shadow: none !important;
+    width: 100% !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    left: 0 !important;
+    border: 0px solid #fff !important;
+    box-shadow: none !important;
   }
   .iepopup img {
-	width: 20% !important;
+    width: 20% !important;
   }
 }
 
@@ -62,13 +63,12 @@ ul {
   background-size: cover;
   //margin-top: 5px;
   position: relative;
-
 }
 .offline .logo {
   margin-left: 13px;
 }
 
-.normal-foo{
+.normal-foo {
   background-color: $grey4;
   min-width: 992px;
 
@@ -77,51 +77,51 @@ ul {
   bottom: 0;
   left: 0;
   z-index: 2;
-  .footer-body{
+  .footer-body {
     display: grid;
     position: relative;
     grid-column-gap: 24px;
     padding: 12px 64px;
     height: 60px;
     //grid-template-columns: minmax(auto,440px) auto;
-    grid-template-columns: minmax(auto,440px) auto;
+    grid-template-columns: minmax(auto, 440px) auto;
     align-items: center;
-    .info{
+    .info {
       display: grid;
       align-items: center;
       grid-template-columns: 40px auto;
       grid-column-gap: 8px;
-      .logo{
+      .logo {
         background-position: center;
         background-size: cover;
       }
-      .description{
+      .description {
         color: $grey1;
         font-weight: 100;
         font-size: 12px;
         text-align: left;
         line-height: 14px;
-        .link{
+        .link {
           color: #00aee4;
           text-decoration: underline;
         }
       }
     }
   }
-  .side-info{
+  .side-info {
     padding: 0 16px;
     display: grid;
     align-items: center;
     box-shadow: none;
-    grid-template-columns: repeat(3, minmax(auto,max-content));
+    grid-template-columns: repeat(3, minmax(auto, max-content));
     justify-content: right;
-    .item{
+    .item {
       padding: 0 16px;
       border-right: 1px solid #afafaf;
       &:last-child {
         border: none;
       }
-      a{
+      a {
         margin: 0;
         padding: 0;
         color: $grey1;
@@ -146,7 +146,8 @@ footer ul {
   /*    border-right: 1px solid #333; */
 }
 
-footer nav ul, footer ul.external-links {
+footer nav ul,
+footer ul.external-links {
   border-right: none;
 }
 
@@ -162,7 +163,8 @@ footer li {
   padding: 5px 5px;
   float: left;
 }
-footer nav li, footer ul.external-links li {
+footer nav li,
+footer ul.external-links li {
   height: 18px;
   padding-top: 0px;
   border-right: 1px solid #fff;
@@ -177,7 +179,6 @@ ul.statistics-details {
   border: none;
   height: unset;
 }
-
 
 ul.statistics-details li {
   border-right: 1px solid #fff;
@@ -203,16 +204,15 @@ a.edit_1:before {
 }
 
 a.edit_2:before {
-  color: #FFCC00;
+  color: #ffcc00;
 }
 
 a.edit_3:before {
-  color: #FF5656;
+  color: #ff5656;
 }
 
-
 a[class^='edit_']:before {
-  content: "a";
+  content: 'a';
   content: ' \25CF';
   text-decoration: none;
   padding-right: 3px;
@@ -230,11 +230,12 @@ footer nav {
   float: right;
 }
 
-footer a, footer #stat-todo span {
+footer a,
+footer #stat-todo span {
   text-shadow: none;
   font-weight: 100;
   cursor: pointer;
-  color: black
+  color: black;
 }
 #stat-eqwords strong {
   font-weight: bold;
@@ -253,7 +254,6 @@ footer a:hover {
 .editlog {
   margin-right: 23px;
 }
-
 
 /*stats*/
 footer #statistics {
@@ -275,12 +275,11 @@ footer #statistics {
   float: right !important;
 }
 
-
 .stats {
   display: none;
   width: 460px;
   height: 220px;
-  background-color: #FFF;
+  background-color: #fff;
   z-index: 99999999;
   position: fixed;
   bottom: 33px;
@@ -298,7 +297,6 @@ footer #statistics {
   color: #000;
 }
 
-
 /*browser supported box */
 
 .iepopup.nobrowser {
@@ -308,7 +306,6 @@ footer #statistics {
   box-shadow: none;
   border: none;
 }
-
 
 .iepopup .logoblack {
   background-size: 200px auto;
@@ -331,7 +328,6 @@ footer #statistics {
   margin: 20px;
 }
 
-
 .iepopup .col-2 {
   width: 46%;
   padding: 0%;
@@ -339,19 +335,18 @@ footer #statistics {
   min-height: 400px;
   margin-right: 4%;
   line-height: 40px;
-  box-shadow: 0px 2px 3px #E9E9E9;
+  box-shadow: 0px 2px 3px #e9e9e9;
   border-radius: 2px;
-  border: 1px solid #CCC;
+  border: 1px solid #ccc;
 }
 
 .iepopup .col-2:last-child {
   margin-right: 0px;
 }
 
-
 .iepopup .col-2:hover {
-  border: 1px solid #3AA9DD;
-  box-shadow: 0px 0px 3px #3AA9DD;
+  border: 1px solid #3aa9dd;
+  box-shadow: 0px 0px 3px #3aa9dd;
 }
 
 .button-learn {
@@ -363,15 +358,15 @@ footer #statistics {
   border-radius: 4px;
   text-decoration: none;
   color: #fff !important;
-  border-bottom: 3px solid #1B5D7B !important;
+  border-bottom: 3px solid #1b5d7b !important;
 }
 
 .button-learn-2 {
-  background: none repeat scroll 0% 0% #F4F4F4;
+  background: none repeat scroll 0% 0% #f4f4f4;
   position: relative;
   border-width: 1px 1px 3px !important;
   border-style: solid !important;
-  border-color: #E4E4E4 #E4E4E4 #CCC !important;
+  border-color: #e4e4e4 #e4e4e4 #ccc !important;
   -moz-border-top-colors: none !important;
   -moz-border-right-colors: none !important;
   -moz-border-bottom-colors: none !important;
@@ -387,7 +382,7 @@ footer #statistics {
 }
 
 .col-b .button-learn-2:hover {
-  color: #3AA9DD !important;
+  color: #3aa9dd !important;
 }
 
 .col-2.col-b .button-learn-2 img {
@@ -400,7 +395,6 @@ footer #statistics {
 .col-b h3 {
   margin-bottom: 125px;
 }
-
 
 .iepopup {
   width: 800px;
@@ -421,7 +415,7 @@ footer #statistics {
 
 .iepopup ul a {
   padding: 0px 0 0 0;
-  color: #39699A;
+  color: #39699a;
   text-decoration: underline;
 }
 
@@ -476,22 +470,19 @@ footer #statistics {
 
 .topMenu ::-webkit-scrollbar-track {
   -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-
-
 }
 
 .topMenu ::-webkit-scrollbar-thumb {
-	  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
+  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
 }
 
 /*end-scrollbar*/
 /* mgmt panel  */
 
-
-.mgmt-panel-tm .tablestats, .mgmt-panel.gl {
+.mgmt-panel-tm .tablestats,
+.mgmt-panel.gl {
   display: block;
 }
-
 
 /*end mgmt panel */
 
@@ -519,7 +510,6 @@ footer #statistics {
   float: left;
   color: #333 !important;
   margin-right: 4px;
-
 }
 
 .dropdown span {
@@ -544,13 +534,12 @@ footer #statistics {
 }
 
 .login-info {
-
   padding: 6px 0;
   color: #fff;
 }
 
-
-.dropdown-icon { /* Little arrow */
+.dropdown-icon {
+  /* Little arrow */
   width: 23px;
   height: 21px;
 }
@@ -564,7 +553,6 @@ footer #statistics {
   font-size: 1.1em;
   margin-top: -1px;
 }
-
 
 /* No CSS3 support */
 
@@ -587,7 +575,6 @@ footer #statistics {
   color: #333;
 }
 
-
 /*end dropdown menu profile */
 
 /*.topMenu ul li {
@@ -605,7 +592,6 @@ footer #statistics {
   -moz-transition: all 100ms ease-in;
 }
 
-
 .currSegment a {
   background: #efefef;
 }
@@ -614,7 +600,6 @@ footer #statistics {
   font-weight: bold;
   border-left: 3px solid #ffcc00;
 }
-
 
 .topMenu ul li a:hover {
   background: #f2f4f7;
@@ -633,12 +618,11 @@ footer #statistics {
   padding-top: 2px;
   margin-top: -3px;
   line-height: 11px;
-  background: #FBF3AA;
+  background: #fbf3aa;
   margin-left: 5px;
   color: #717171;
   box-shadow: 1px 1px 1px #999;
 }
-
 
 .tooltip:hover span {
   opacity: 1;
@@ -655,8 +639,8 @@ footer #statistics {
   font-weight: 400;
   font-size: 15px;
   text-align: center;
-  border: 1px solid #727272;;
-  background: #FFF8BA;
+  border: 1px solid #727272;
+  background: #fff8ba;
   text-indent: 0px;
   border-radius: 5px;
   position: absolute;
@@ -674,7 +658,8 @@ footer #statistics {
   z-index: 1000000000000000;
 }
 
-.tooltip span:before, .tooltip span:after {
+.tooltip span:before,
+.tooltip span:after {
   content: '';
   position: absolute;
   bottom: -11px;
@@ -683,22 +668,21 @@ footer #statistics {
   height: 0;
   border-left: 10px solid transparent;
   border-right: 10px solid transparent;
-  border-top: 10px solid #727272;;
+  border-top: 10px solid #727272;
 }
 
 .tooltip span:after {
   bottom: -10px;
   margin-left: -1px;
-  border-top: 10px solid #FFF8BA;;
+  border-top: 10px solid #fff8ba;
 }
-
 
 .mgmt-table-tm .boxed {
   border-radius: 4px;
   border: 1px dashed #ccc;
   padding: 10px;
   margin-bottom: 20px;
-  background: #F7F7F7;
+  background: #f7f7f7;
 }
 
 #editlog-boxed {
@@ -707,7 +691,7 @@ footer #statistics {
   padding: 10px;
   margin-bottom: 10px;
   margin-top: 15px;
-  background: #F7F7F7;
+  background: #f7f7f7;
   font-size: 17px;
 }
 
@@ -736,9 +720,8 @@ footer #statistics {
   float: right;
 }
 
-
 /*popup*/
-.modal[data-type=view] {
+.modal[data-type='view'] {
   display: none;
 }
 
@@ -746,7 +729,8 @@ footer #statistics {
   display: none;
 }
 
-.popup-outer, .mgmt-popup-outer {
+.popup-outer,
+.mgmt-popup-outer {
   background: #000;
   position: fixed;
   top: 0;
@@ -778,7 +762,6 @@ footer #statistics {
   background-color: #fff;
 }
 
-
 .modal .popup p.waiting {
   background: url(../../img/loading.gif) 38% 3px no-repeat !important;
   background-size: 24px !important;
@@ -804,7 +787,6 @@ footer #statistics {
   width: 100%;
   padding: 20px;
 }
-
 
 .options-box {
   margin: 0;
@@ -838,7 +820,6 @@ footer #statistics {
   margin-top: 0px;
 }
 
-
 .advanced-options-box .options-box h3 {
   text-align: right;
   font-size: 19px;
@@ -868,7 +849,6 @@ footer #statistics {
   vertical-align: middle;
   margin-left: 5px;
 }
-
 
 .advanced-options-box .options-box select,
 .advanced-options-box .options-box input {
@@ -929,16 +909,16 @@ footer #statistics {
 }
 
 .onoffswitch-inner:before {
-  content: "";
+  content: '';
   padding-left: 10px;
   background-color: #22c4ee;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .onoffswitch-inner:after {
-  content: "";
+  content: '';
   padding-right: 7px;
-  background-color: #EEEEEE;
+  background-color: #eeeeee;
   color: #999999;
   text-align: right;
 }
@@ -947,7 +927,7 @@ footer #statistics {
   display: block;
   width: 22px;
   margin: 4px;
-  background: #FFFFFF;
+  background: #ffffff;
   position: absolute;
   top: 0;
   bottom: 0;
@@ -970,7 +950,7 @@ footer #statistics {
 }
 
 .onoffswitch-label:hover {
-  border-color: #A1A1A1;
+  border-color: #a1a1a1;
 }
 
 .onoffswitch-label-status-active,
@@ -982,7 +962,6 @@ footer #statistics {
   top: 6px;
   line-height: 20px;
 }
-
 
 .onoffswitch-label-status-unavailable {
   display: none;
@@ -996,11 +975,15 @@ footer #statistics {
   display: none;
 }
 
-.onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-label-status-active {
+.onoffswitch-checkbox:checked
+  + .onoffswitch-label
+  .onoffswitch-label-status-active {
   display: block;
 }
 
-.onoffswitch-checkbox:checked + .onoffswitch-label .onoffswitch-label-status-inactive {
+.onoffswitch-checkbox:checked
+  + .onoffswitch-label
+  .onoffswitch-label-status-inactive {
   display: none;
 }
 
@@ -1081,7 +1064,6 @@ footer #statistics {
   cursor: pointer;
 }
 
-
 /********** TM panel End **********/
 
 span.notify {
@@ -1090,10 +1072,10 @@ span.notify {
 
 .action .dropdown a.disabled {
   opacity: 1 !important;
-  color: #B5B5B5 !important;
+  color: #b5b5b5 !important;
   border: none;
   border-bottom: 1px solid #e6e8ea !important;
-  background: #F1F1F1 !important;
+  background: #f1f1f1 !important;
 }
 
 td.addtmxtd {
@@ -1114,9 +1096,8 @@ input.email-export-tmx {
   right: 130px;
   margin-top: -2px;
   background-size: 15px;
-  background-color: #D6D6D6;
+  background-color: #d6d6d6;
 }
-
 
 .uploadloader {
   background: url(../../img/loader.gif) center center no-repeat;
@@ -1140,14 +1121,14 @@ input.email-export-tmx {
   right: inherit;
 }
 
-.continuebtn, .continuebtn:hover {
+.continuebtn,
+.continuebtn:hover {
   background: #7eaf3e;
 }
 
 .mgmt-table-mt td.action .btn {
   border-radius: 2px;
 }
-
 
 .mgmt-table-mt th.description {
   width: 40%;
@@ -1182,12 +1163,12 @@ form.add-TM-Form {
   display: none;
   float: left;
   width: 80%;
-  color: #F00;
+  color: #f00;
   position: relative;
 }
 
 .notify td {
-  background: #FFFA8B !important;
+  background: #fffa8b !important;
   padding: 5px 25px;
   text-align: right;
 }
@@ -1235,8 +1216,10 @@ form.add-TM-Form {
   top: -50px;
 }
 
-.tm-error-key:before, .tm-error-key:after,
-.tm-error-grants:before, .tm-error-grants:after {
+.tm-error-key:before,
+.tm-error-key:after,
+.tm-error-grants:before,
+.tm-error-grants:after {
   content: '';
   position: absolute;
   width: 0;
@@ -1246,12 +1229,14 @@ form.add-TM-Form {
   border-top: 10px solid rgba(0, 0, 0, 0.1);
 }
 
-.tm-error-key:before, .tm-error-key:after {
+.tm-error-key:before,
+.tm-error-key:after {
   bottom: -15px;
   left: 43%;
 }
 
-.tm-error-grants:before, .tm-error-grants:after {
+.tm-error-grants:before,
+.tm-error-grants:after {
   bottom: -15px;
   left: 43%;
 }
@@ -1272,7 +1257,10 @@ form.add-TM-Form {
   font-size: 18px;
 }
 
-.popup h1, .popup-tm h1, .popup-languages.slide h1, .slide-panel h1 {
+.popup h1,
+.popup-tm h1,
+.popup-languages.slide h1,
+.slide-panel h1 {
   overflow: visible;
   max-height: inherit;
   font-size: 24px;
@@ -1285,7 +1273,8 @@ form.add-TM-Form {
   text-align: left;
 }
 
-.popup-tm h1, .popup-languages.slide h1 {
+.popup-tm h1,
+.popup-languages.slide h1 {
   height: 60px;
   padding: 10px 13px 7px 58px;
 }
@@ -1307,20 +1296,17 @@ form.add-TM-Form {
   color: black;
 }
 
-
-
 .popup-confirm .btn-ok {
   /* TODO REVIEW  this rule breaks the popup button alignment in confirm change language after file conversion */
   /*float: left;*/
   margin-left: 10px;
 }
 
-.popup .inner
-{
-	width: 45px;
-	border-right: 1px solid #003366;
-	border-radius: 0 0 0 6px;
-    }
+.popup .inner {
+  width: 45px;
+  border-right: 1px solid #003366;
+  border-radius: 0 0 0 6px;
+}
 
 .popup .login-button {
   width: 330px;
@@ -1335,7 +1321,9 @@ form.add-TM-Form {
   cursor: pointer;
 }
 
-.popup .x-popup, .mgmt-panel .x-popup, .slide-panel .x-popup {
+.popup .x-popup,
+.mgmt-panel .x-popup,
+.slide-panel .x-popup {
   color: #fff;
   text-decoration: none;
   display: block;
@@ -1347,7 +1335,9 @@ form.add-TM-Form {
   background-size: 22px;
 }
 
-.popup .x-popup:hover, .slide-panel .x-popup:hover, .x-popup2:hover {
+.popup .x-popup:hover,
+.slide-panel .x-popup:hover,
+.x-popup2:hover {
   color: $darkBlueTransparent;
 }
 
@@ -1360,18 +1350,15 @@ form.add-TM-Form {
   margin-top: 10px;
 }
 
-
 .uploadtm.disabled {
   background: $translatedBlue !important;
 }
-
 
 .popup .btn-ok,
 .popup .btn-cancel {
   padding: 1px 18px;
   margin: 16px 0 16px 20px;
   display: inline-block;
-
 }
 
 .mgmt-panel-tm .btn-ok,
@@ -1393,11 +1380,9 @@ form.add-TM-Form {
   margin-right: 0px;
 }
 
-
 .btn-cancel.in-popup {
   padding: 7px 18px !important;
 }
-
 
 .hide {
   display: none;
@@ -1417,7 +1402,13 @@ form.add-TM-Form {
   font-size: 18px;
   color: #333;
   background: #f6f6f6;
-  background: -webkit-gradient(linear, left top, left bottom, from(#f6f6f6), to(#e2e3e5));
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#f6f6f6),
+    to(#e2e3e5)
+  );
   background: -moz-linear-gradient(top, #f6f6f6, #e2e3e5);
   background: linear-gradient(top, #f6f6f6, #e2e3e5);
 }
@@ -1435,12 +1426,14 @@ form.add-TM-Form {
   width: 290px;
 }
 
-
 .popup .btnsplit .btn-cancel {
   margin: 0;
 }
 
-.popup .btn-cancel, .btn-grey, .slide-panel .btn-cancel, .btn-grey {
+.popup .btn-cancel,
+.btn-grey,
+.slide-panel .btn-cancel,
+.btn-grey {
   color: $grey2;
   background: white;
   border: 1px solid $grey2;
@@ -1480,7 +1473,6 @@ form.add-TM-Form {
   //box-shadow: inset 0 0 1px 1px #888;
 }
 
-
 .popup .btn-ok.right,
 .popup .btn-cancel.right,
 .popup-tm .btn-ok.right,
@@ -1490,7 +1482,8 @@ form.add-TM-Form {
   float: right;
 }
 
-#chooseMultilang, #cancelMultilang {
+#chooseMultilang,
+#cancelMultilang {
   padding: 4px 18px;
   margin-left: 10px;
 }
@@ -1501,13 +1494,16 @@ form.add-TM-Form {
   color: #333333;
 }
 
-
 .mgmt-panel-tm .nav-tabs {
   background: #002b5c;
   display: block;
 }
 
-.mgmt-add-tm, .mgmt-add-gl, .addrow-tm, .addrow-gl, .dataTables_paginate {
+.mgmt-add-tm,
+.mgmt-add-gl,
+.addrow-tm,
+.addrow-gl,
+.dataTables_paginate {
   display: none;
 }
 
@@ -1523,7 +1519,6 @@ form.add-TM-Form {
   clear: both;
 }
 
-
 div.mgmt-container {
   margin: 0 auto;
   overflow: hidden;
@@ -1534,10 +1529,8 @@ div.mgmt-container {
   min-height: 400px;
 }
 
-
 .mgmt-tm .priority {
   /*width:5%!important;*/
-
 }
 
 .mgmt-tm .privatekey {
@@ -1545,11 +1538,13 @@ div.mgmt-container {
   font-size: 13px;
 }
 
-td.description, th.description {
+td.description,
+th.description {
   width: 491px !important;
 }
 
-th.owner, td.owner {
+th.owner,
+td.owner {
   width: 46px !important;
 }
 
@@ -1564,7 +1559,6 @@ th.owner, td.owner {
   text-align: center;
 }
 
-
 .mgmt-table-mt td {
   padding: 10px !important;
 }
@@ -1575,24 +1569,23 @@ th.owner, td.owner {
   text-align: center;
 }
 
-
-.mgmt-tm th.action, .mgmt-tm td.action {
+.mgmt-tm th.action,
+.mgmt-tm td.action {
   width: 186px !important;
 }
 
-th.activate, td.activate {
+th.activate,
+td.activate {
   width: 55px !important;
   text-align: center;
 }
-
 
 #inactivetm th.check,
 #inactivetm th.privatekey,
 #inactivetm th.owner,
 #inactivetm th.action,
 #activetm th.privatekey,
-#activetm th.owner
-#ativetm th.action {
+#activetm th.owner #ativetm th.action {
   visibility: hidden;
 }
 
@@ -1648,7 +1641,8 @@ input.message-share-tmx-input-email {
   border-radius: 2px;
 }
 
-span.message-share-tmx-email, .message-share-tmx-openemailpopup {
+span.message-share-tmx-email,
+.message-share-tmx-openemailpopup {
   text-decoration: underline;
   cursor: pointer;
 }
@@ -1665,7 +1659,6 @@ select#mt_engine_int {
   margin: 20px 0;
   width: 90%;
 }
-
 
 .mgmt-tm .progress {
   display: block;
@@ -1684,7 +1677,6 @@ select#mt_engine_int {
   width: 99px;
 }
 
-
 .back-mgmt {
   padding: 20px;
   margin-right: 20px;
@@ -1698,7 +1690,9 @@ select#mt_engine_int {
   margin: 2%;
 }
 
-.slide-panel table, .mgmt-gl, .mgmt-tm-nested {
+.slide-panel table,
+.mgmt-gl,
+.mgmt-tm-nested {
   font-size: 15px;
   width: 100%;
   margin-bottom: 20px;
@@ -1707,7 +1701,7 @@ select#mt_engine_int {
 }
 
 .privatekey .btn-ok {
-  margin: 0 !important
+  margin: 0 !important;
 }
 
 .btn-grey.uploadtm {
@@ -1740,9 +1734,9 @@ span.text-req {
   box-shadow: inset 0 0 1px 1px #888;
 }
 
-
-.file_upload_error, .error {
-  color: #FF3300;
+.file_upload_error,
+.error {
+  color: #ff3300;
 }
 
 .error {
@@ -1758,7 +1752,8 @@ input.error {
   padding: 7px 0px !important;
 }
 
-.mgmt-tm .btn-ok, .mgmt-tm .btn-grey {
+.mgmt-tm .btn-ok,
+.mgmt-tm .btn-grey {
   cursor: pointer !important;
   font-size: 14px;
 }
@@ -1785,7 +1780,6 @@ div.mt-error-key {
 
 .mgmt-table-mt .uploadtm.btn-ok {
   margin: 15px 0 15px 20px;
-
 }
 
 .mgmt-tm .btn-grey:last-child {
@@ -1893,7 +1887,6 @@ td.uploadfile {
   text-overflow: initial;
 }
 
-
 .popup-tm tr.mine td.description .edit-desc:hover {
   box-shadow: 0px 0px 0px 1px #ccc;
   cursor: text;
@@ -1909,8 +1902,7 @@ td.uploadfile {
   background: $translatedBlue;
 }
 
-
-td.uploadfile input[type="file"] {
+td.uploadfile input[type='file'] {
   margin-right: 20px;
 }
 
@@ -1950,7 +1942,8 @@ td.uploadfile .uploadprogress .error {
   margin-right: 9px;
 }
 
-.dataTables_length, .dataTables_info {
+.dataTables_length,
+.dataTables_info {
   display: none;
 }
 
@@ -1959,25 +1952,26 @@ td.uploadfile .uploadprogress .error {
   margin-top: 10px;
 }
 
-.check.sorting:after, .action.sorting:after {
+.check.sorting:after,
+.action.sorting:after {
   display: none;
 }
 
 .sorting_asc:after {
-  content: "\f0dd";
+  content: '\f0dd';
   float: right;
   margin-top: -4px;
 }
 
 .sorting_desc:after {
-  content: "\f0de";
+  content: '\f0de';
   float: right;
   line-height: 1px !important;
   margin-top: 10px;
 }
 
 .sorting:after {
-  content: "\f0dc";
+  content: '\f0dc';
   float: right;
 }
 
@@ -1985,7 +1979,6 @@ td.uploadfile .uploadprogress .error {
   float: right;
   margin-top: 10px;
 }
-
 
 /*
 #activetm {margin-bottom: 15px;}
@@ -1995,13 +1988,13 @@ td.uploadfile .uploadprogress .error {
   background: #6d6e71;
 }
 
-
 #activetm tbody {
   display: block;
   background: #e4f2fb;
 }
 
-tr.tm-error, td.tm-error {
+tr.tm-error,
+td.tm-error {
   border: 1px solid red !important;
 }
 
@@ -2021,8 +2014,8 @@ tr.mymemory td.dragrow .status {
   padding: 10px 17px 20px 5px;
   height: 20px;
   width: initial !important;
-  border-top: 1px solid #E1E1E1;
-  box-shadow: inset 0px 2px 5px 0px #E4E4E4;
+  border-top: 1px solid #e1e1e1;
+  box-shadow: inset 0px 2px 5px 0px #e4e4e4;
   position: relative;
   box-sizing: content-box;
 }
@@ -2094,7 +2087,6 @@ td.uploadfile p {
   background: #f6f6f6 !important;
 }
 
-
 /* Export TMX container */
 #activetm td.download-tmx-container,
 #inactivetm td.download-tmx-container,
@@ -2106,8 +2098,8 @@ td.uploadfile p {
   background: #fff;
   padding: 10px 17px 20px 5px;
   height: 53px;
-  border-top: 1px solid #E1E1E1;
-  box-shadow: inset 0px 2px 5px 0px #E4E4E4;
+  border-top: 1px solid #e1e1e1;
+  box-shadow: inset 0px 2px 5px 0px #e4e4e4;
   position: relative;
 }
 
@@ -2130,7 +2122,7 @@ input.email-export-tmx {
 }
 
 .export-tmx-button-label:before {
-  content: "\f00c";
+  content: '\f00c';
   padding-right: 7px;
   vertical-align: text-top;
 }
@@ -2149,7 +2141,8 @@ input.email-export-tmx {
 
 /*** New Buttons  ***/
 
-.btn-orange-small, .btn-orange-medium {
+.btn-orange-small,
+.btn-orange-medium {
   background: #f26522;
   width: 35px;
   height: 35px;
@@ -2188,7 +2181,7 @@ input.email-export-tmx {
 
 .btn-orange-medium .text:before,
 .btn-orange-small .text:before {
-  content: "\f00d";
+  content: '\f00d';
   vertical-align: text-top;
 }
 
@@ -2223,7 +2216,7 @@ input.email-export-tmx {
 }
 
 .btn-confirm-small .text:before {
-  content: "\f00c";
+  content: '\f00c';
   padding-right: 7px;
   vertical-align: text-top;
 }
@@ -2255,7 +2248,13 @@ input.email-export-tmx {
   padding: 8px 18px;
   border-radius: 2px;
   font-size: 18px;
-  background: -webkit-gradient(linear, left top, left bottom, from($translatedBlue), to(#119ec4));
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from($translatedBlue),
+    to(#119ec4)
+  );
   background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
   background: linear-gradient(top, $translatedBlue, #119ec4);
   margin: 16px 0 16px 20px;
@@ -2322,7 +2321,7 @@ span.email-export-tmx-email-error {
 }
 
 .canceladd-export-tmx:before {
-  content: "\f00d";
+  content: '\f00d';
   vertical-align: text-top;
 }
 
@@ -2333,7 +2332,6 @@ span.email-export-tmx-email-error {
 
 /************************/
 .anonymous td.dragrow {
-
   background-image: none !important;
   cursor: initial;
 }
@@ -2345,16 +2343,13 @@ span.email-export-tmx-email-error {
 }
 */
 
-
 .mine .downloadtmx {
   display: block !important;
 }
 
-
 .mgmt-tm .downloadtmx {
   /*display: none !important; */
 }
-
 
 tr.mine.ui-sortable-helper {
   border-bottom: 1px solid #ccc;
@@ -2386,7 +2381,7 @@ td.no-gutter {
 }
 
 #inactivetm thead {
-  background: #6D6E71;
+  background: #6d6e71;
 }
 
 .mgmt-container .icon-search {
@@ -2402,7 +2397,8 @@ td.no-gutter {
   margin-bottom: 10px;
 }
 
-#activetm td, .activemt td {
+#activetm td,
+.activemt td {
   background: #e4f2fb !important;
 }
 
@@ -2420,11 +2416,13 @@ td.no-gutter {
   background: #fff;
 }
 
-#inactivetm td, table.mgmt-mt td {
+#inactivetm td,
+table.mgmt-mt td {
   background: #f3f3f3;
 }
 
-.mgmt-tm th, .mgmt-mt th {
+.mgmt-tm th,
+.mgmt-mt th {
   padding: 8px 5px;
   background: #fff;
 }
@@ -2443,7 +2441,8 @@ td.no-gutter {
   box-shadow: inset 0 1px 0 0 #fff;
 }
 
-td.engine-name, td.enable-mt {
+td.engine-name,
+td.enable-mt {
   overflow: hidden;
 }
 
@@ -2457,10 +2456,10 @@ td.engine-name, td.enable-mt {
   box-sizing: border-box;
 }
 
-.addtmxrow td, .new td {
+.addtmxrow td,
+.new td {
   background: #fff !important;
 }
-
 
 .mgmt-panel select {
   width: 230px;
@@ -2501,8 +2500,8 @@ p.required {
   margin-bottom: -3px;
 }
 
-
-.mgmt-add-tm input, .mgmt-add-gl input {
+.mgmt-add-tm input,
+.mgmt-add-gl input {
   font-size: 12px !important;
   height: 22px;
   color: #999999;
@@ -2542,9 +2541,10 @@ p.required {
   border-radius: 6px;
 }
 
-.more-info-tip:after, .more-info-tip:before {
+.more-info-tip:after,
+.more-info-tip:before {
   border: solid transparent;
-  content: " ";
+  content: ' ';
   height: 0;
   width: 0;
   margin-left: -36px;
@@ -2584,10 +2584,11 @@ p.required {
 }
 
 tr.disabled td {
-  background: #F3F3F3 !important;
+  background: #f3f3f3 !important;
 }
 
-.provider-field.disabled, .provider-field.disabled:hover {
+.provider-field.disabled,
+.provider-field.disabled:hover {
   border: initial;
   background: initial;
 }
@@ -2601,12 +2602,12 @@ tr.disabled td {
   clear: both;
 }
 
-
 .offline span.msg span {
   vertical-align: middle;
 }
 
-.slide-panel table th, .mgmt-gl th {
+.slide-panel table th,
+.mgmt-gl th {
   background: #6d6e71;
   color: #fff;
   height: 20px;
@@ -2629,10 +2630,9 @@ tr.disabled td {
   padding: 4px 16px !important;
 }
 
-
 .wrapper-dropdown-5:after {
   /* Little arrow */
-  content: "";
+  content: '';
   width: 0;
   height: 0;
   position: absolute;
@@ -2657,7 +2657,8 @@ tr.disabled td {
   max-height: 0;
   overflow: hidden;
   z-index: 3;
-  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.24) !important;
 }
 
 .wrapper-dropdown-5:hover {
@@ -2785,7 +2786,7 @@ tr.disabled td {
   margin-bottom: 5px;
   width: 100%;
   padding-left: 9px;
-  &.checkbox-label{
+  &.checkbox-label {
     width: auto;
   }
 }
@@ -2810,18 +2811,17 @@ tr.disabled td {
 }
 
 .insert-tm input:focus {
-  border-color: #96C8DA !important;
+  border-color: #96c8da !important;
   box-shadow: none;
   outline: none;
 }
 
-.insert-tm input[type="checkbox"] {
+.insert-tm input[type='checkbox'] {
   width: 13px;
   height: 13px;
 }
 
 .insert-tm {
-
   margin: 0 auto;
   overflow: hidden;
   margin-bottom: 30px;
@@ -2832,7 +2832,6 @@ tr.disabled td {
   margin: 15px 0 25px;
 }
 
-
 .contact-box {
   border: 1px dashed #ccc;
   height: 90px;
@@ -2840,7 +2839,6 @@ tr.disabled td {
   margin-top: 20px;
   padding: 2%;
 }
-
 
 .step1 {
   width: 100%;
@@ -2874,13 +2872,11 @@ tr.disabled td {
 }
 
 .mgmt-table-mt select {
-
 }
 
 td.mt-provider {
   width: 170px;
 }
-
 
 td.action .btn {
   cursor: pointer;
@@ -2908,9 +2904,8 @@ td.action .btn:hover {
 a.btn.pull-left.addtmx.tmx-import-slider {
   padding-right: 36px !important;
   padding-left: 36px !important;
-  margin-left: 6px
+  margin-left: 6px;
 }
-
 
 td.action .btn .text {
   margin: 0 !important;
@@ -2948,7 +2943,9 @@ a.memory-mgmt.pull-right {
   padding: 10px 15px;
 }
 
-.nav-tabs > li.active > a, .nav-tabs > li.active > a:hover, .nav-tabs > li.active > a:focus {
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:hover,
+.nav-tabs > li.active > a:focus {
   /* color: #555; */
   /* cursor: default; */
   /* background-color: #fff; */
@@ -2965,7 +2962,6 @@ a.memory-mgmt.pull-right {
   margin: 0px 0 -1px 0;
   outline: none;
   padding-top: 5px !important;
-
 }
 
 .nav-tabs > li > a {
@@ -2995,7 +2991,7 @@ a.memory-mgmt.pull-right {
 }
 
 .description .mgmt-input {
-  width: 430px;;
+  width: 430px;
 }
 
 .mgmt-panel .block {
@@ -3075,24 +3071,71 @@ tr.new.badgrants .fileupload {
   height: 15px;
   margin-bottom: 5px;
   width: 0%;
-  background: #58B551;
-  border-right: 1px solid #58B551 !important;
+  background: #58b551;
+  border-right: 1px solid #58b551 !important;
   border-radius: 0;
 }
 
 #activetm .uploadprogress .progress:after,
 #inactivetm .uploadprogress .progress:after {
-  content: "";
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
   bottom: 0;
   right: 0;
-  background-image: -webkit-gradient(linear, 0 0, 100% 100%, color-stop(.25, rgba(255, 255, 255, .2)), color-stop(.25, transparent), color-stop(.5, transparent), color-stop(.5, rgba(255, 255, 255, .2)), color-stop(.75, rgba(255, 255, 255, .2)), color-stop(.75, transparent), to(transparent));
-  background-image: -webkit-linear-gradient(-45deg, rgba(255, 255, 255, .2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .2) 50%, rgba(255, 255, 255, .2) 75%, transparent 75%, transparent);
-  background-image: -moz-linear-gradient(-45deg, rgba(255, 255, 255, .2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .2) 50%, rgba(255, 255, 255, .2) 75%, transparent 75%, transparent);
-  background-image: -ms-linear-gradient(-45deg, rgba(255, 255, 255, .2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .2) 50%, rgba(255, 255, 255, .2) 75%, transparent 75%, transparent);
-  background-image: -o-linear-gradient(-45deg, rgba(255, 255, 255, .2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .2) 50%, rgba(255, 255, 255, .2) 75%, transparent 75%, transparent);
+  background-image: -webkit-gradient(
+    linear,
+    0 0,
+    100% 100%,
+    color-stop(0.25, rgba(255, 255, 255, 0.2)),
+    color-stop(0.25, transparent),
+    color-stop(0.5, transparent),
+    color-stop(0.5, rgba(255, 255, 255, 0.2)),
+    color-stop(0.75, rgba(255, 255, 255, 0.2)),
+    color-stop(0.75, transparent),
+    to(transparent)
+  );
+  background-image: -webkit-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-image: -moz-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-image: -ms-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-image: -o-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
   z-index: 1;
   -webkit-background-size: 50px 50px;
   -moz-background-size: 50px 50px;
@@ -3100,7 +3143,6 @@ tr.new.badgrants .fileupload {
   -webkit-animation: move 2s linear infinite;
   overflow: hidden;
 }
-
 
 .description textarea {
   padding: 3px 4px;
@@ -3123,8 +3165,8 @@ tr.new .message {
   color: green;
 }
 
-
-.addrow-tm .block, .addrow-gl .block {
+.addrow-tm .block,
+.addrow-gl .block {
   width: 46%;
 }
 
@@ -3148,7 +3190,7 @@ section mark.searchMarker {
 
 section mark.searchMarker.currSearchItem,
 section.currSearchSegment mark.searchMarker {
-  background: #F7D315;
+  background: #f7d315;
   /*	background: #00c1e6; */
 }
 
@@ -3183,7 +3225,6 @@ section.currSearchSegment mark.searchMarker {
   color: #999999 !important;
   font-weight: normal !important;
 }
-
 
 .claim span {
   font-weight: bold;
@@ -3371,7 +3412,6 @@ section.currSearchSegment mark.searchMarker {
 
 /* Google Sheet */
 
-
 #jobMenu span {
   height: 30px;
   padding: 5px;
@@ -3393,147 +3433,143 @@ section.currSearchSegment mark.searchMarker {
 
 @media (max-height: 500px) {
   .register-modal {
-	overflow-x: hidden;
-	height: 300px;
-	overflow-y: scroll;
+    overflow-x: hidden;
+    height: 300px;
+    overflow-y: scroll;
   }
-
 }
 
 @media (max-height: 300px) {
-
   .preferences-modal {
-	overflow-x: hidden;
-	height: 200px;
-	overflow-y: scroll;
+    overflow-x: hidden;
+    height: 200px;
+    overflow-y: scroll;
   }
-
 }
-
 
 /* retina display query */
 @media only screen and (-webkit-min-device-pixel-ratio: 2),
-only screen and (min--moz-device-pixel-ratio: 2),
-only screen and (-o-min-device-pixel-ratio: 2/1),
-only screen and (min-device-pixel-ratio: 2),
-only screen and (min-resolution: 192dpi),
-only screen and (in-resolution: 2dppx) {
+  only screen and (min--moz-device-pixel-ratio: 2),
+  only screen and (-o-min-device-pixel-ratio: 2/1),
+  only screen and (min-device-pixel-ratio: 2),
+  only screen and (min-resolution: 192dpi),
+  only screen and (in-resolution: 2dppx) {
   .preview span {
-	height: 30px;
-	width: 30px;
-	display: block;
-	background-size: 25px;
+    height: 30px;
+    width: 30px;
+    display: block;
+    background-size: 25px;
   }
   .extdoc {
-	background: url(../../img/matecat_file_icons2x.png) 6px 0 no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px 0 no-repeat !important;
   }
   /* .doc, .dot, . docx, .dotx, .docm, .dotm, .odt, .sxw*/
   .extppt {
-	background: url(../../img/matecat_file_icons2x.png) 6px -34px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -34px no-repeat !important;
   }
   /* .pot, .pps, .ppt, .potm, .potx, .ppsm, .ppsx, .pptm, .pptx, .odp, .sxi*/
   .exthtm {
-	background: url(../../img/matecat_file_icons2x.png) 6px -70px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -70px no-repeat !important;
   }
   /* .htm, .html, .xhtml */
   .extpdf {
-	background: url(../../img/matecat_file_icons2x.png) 6px -104px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -104px no-repeat !important;
   }
   /* .pdf */
   .extxls {
-	background: url(../../img/matecat_file_icons2x.png) 6px -140px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -140px no-repeat !important;
   }
   /* .xls, .xlt, .xlsm, .xlsx, .xltx, .ods, .sxc, .csv */
   .exttxt {
-	background: url(../../img/matecat_file_icons2x.png) 6px -172px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -172px no-repeat !important;
   }
   /* .txt */
   .extxif {
-	background: url(../../img/matecat_file_icons2x.png) 6px -208px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -208px no-repeat !important;
   }
   /* .xliff */
   .extttx {
-	background: url(../../img/matecat_file_icons2x.png) 6px -242px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -242px no-repeat !important;
   }
   /* .ttx */
   .extitd {
-	background: url(../../img/matecat_file_icons2x.png) 6px -276px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -276px no-repeat !important;
   }
   /* .itd */
   .extxlf {
-	background: url(../../img/matecat_file_icons2x.png) 6px -310px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -310px no-repeat !important;
   }
   /* .xlf */
   .extmif {
-	background: url(../../img/matecat_file_icons2x.png) 6px -342px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -342px no-repeat !important;
   }
   /* .mif */
   .extidd {
-	background: url(../../img/matecat_file_icons2x.png) 6px -378px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -378px no-repeat !important;
   }
   /* .idml, .inx, .icml */
   .extqxp {
-	background: url(../../img/matecat_file_icons2x.png) 6px -412px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -412px no-repeat !important;
   }
   /* .xtg */
   .extxml {
-	background: url(../../img/matecat_file_icons2x.png) 6px -446px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -446px no-repeat !important;
   }
   /* .xml */
   .extrcc {
-	background: url(../../img/matecat_file_icons2x.png) 6px -484px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -484px no-repeat !important;
   }
   /* .rc */
   .extres {
-	background: url(../../img/matecat_file_icons2x.png) 6px -516px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -516px no-repeat !important;
   }
   /* .resx */
   .extsgl {
-	background: url(../../img/matecat_file_icons2x.png) 6px -552px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -552px no-repeat !important;
   }
   /* .sgml */
   .extsgm {
-	background: url(../../img/matecat_file_icons2x.png) 6px -584px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -584px no-repeat !important;
   }
   /* .sgm */
   .extpro {
-	background: url(../../img/matecat_file_icons2x.png) 6px -618px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -618px no-repeat !important;
   }
   /* .properties */
   .extdit {
-	background: url(../../img/matecat_file_icons2x.png) 6px -652px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -652px no-repeat !important;
   }
   /* .dita */
   .exttag {
-	background: url(../../img/matecat_file_icons2x.png) 6px -686px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -686px no-repeat !important;
   }
   /* .tag */
   .exttmx {
-	background: url(../../img/matecat_file_icons2x.png) 6px -722px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -722px no-repeat !important;
   }
   /* .tmx */
   .extstr {
-	background: url(../../img/matecat_file_icons2x.png) 6px -758px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -758px no-repeat !important;
   }
   /* .str */
   .extzip {
-	background: url(../../img/matecat_file_icons2x.png) 6px -792px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -792px no-repeat !important;
   }
   /* .zip */
   .exticml {
-	background: url(../../img/matecat_file_icons2x.png) 6px -826px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -826px no-repeat !important;
   }
   /* .icml */
   .extimg {
-	background: url(../../img/matecat_file_icons2x.png) 6px -860px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -860px no-repeat !important;
   }
   /* .bmp, .gif, .jpeg, .png, .tiff */
   .extwix {
-	background: url(../../img/matecat_file_icons2x.png) 6px -894px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -894px no-repeat !important;
   }
   /* .srt */
   .extsrt {
-	background: url(../../img/matecat_file_icons2x.png) 6px -928px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -928px no-repeat !important;
   }
   /* .sbv */
   .extsbv {
@@ -3545,34 +3581,33 @@ only screen and (in-resolution: 2dppx) {
   }
   /* .po */
   .extpo {
-	background: url(../../img/matecat_file_icons2x.png) 6px -962px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -962px no-repeat !important;
   }
   /* .po */
   .extg {
-	background: url(../../img/matecat_file_icons2x.png) 6px -996px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -996px no-repeat !important;
   }
   /* .g */
   .exts {
-	background: url(../../img/matecat_file_icons_ts2x.png) 6px 0px no-repeat !important;
+    background: url(../../img/matecat_file_icons_ts2x.png) 6px 0px no-repeat !important;
   }
   /* .ts */
   .extgsli {
-	background: url(../../img/matecat_file_icons2x.png) 6px -1033px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -1033px no-repeat !important;
   }
   /* Google Slides */
   .extgdoc {
-	background: url(../../img/matecat_file_icons2x.png) 6px -1070px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -1070px no-repeat !important;
   }
   /* Google Document */
   .extgsheet {
-	background: url(../../img/matecat_file_icons2x.png) 6px -1107px no-repeat !important;
+    background: url(../../img/matecat_file_icons2x.png) 6px -1107px no-repeat !important;
   }
   /* Google Sheet */
 
-.fileinput-button {
-	background: $translatedBlue;
+  .fileinput-button {
+    background: $translatedBlue;
   }
-
 }
 
 .active-tm-key-link {
@@ -3581,7 +3616,9 @@ only screen and (in-resolution: 2dppx) {
   color: #39699a;
 }
 
-.tm-error-message, .tm-warning-message, .tm-success-message {
+.tm-error-message,
+.tm-warning-message,
+.tm-success-message {
   display: none;
   -moz-border-radius: 2px;
   box-shadow: 0 2px 2px #e2e2e2;
@@ -3617,7 +3654,7 @@ p.tm-warning-message {
 }
 
 .tm-success-message {
-  border-top: 3px solid #4F8A10;
+  border-top: 3px solid #4f8a10;
   background-color: #d1e0d1;
 }
 
@@ -3628,34 +3665,36 @@ p.tm-warning-message {
   z-index: 1;
 }
 
-.mgmt-panel .tm-error-message, .mgmt-panel .tm-warning-message, .mgmt-panel .tm-success-message {
+.mgmt-panel .tm-error-message,
+.mgmt-panel .tm-warning-message,
+.mgmt-panel .tm-success-message {
   font-size: 15px;
   vertical-align: middle;
   line-height: 36px;
 }
 
-
 .warning-message {
-  background: #FFFA8B !important;
-  border-color: #6D6E71;
+  background: #fffa8b !important;
+  border-color: #6d6e71;
   padding: 10px 0 10px 1%;
   text-indent: 0;
   width: 98.8%;
   color: #000;
 }
 
-.tm-warning-message, .tm-error-message, .tm-success-message {
+.tm-warning-message,
+.tm-error-message,
+.tm-success-message {
   margin: 0 0 15px !important;
 }
-
 
 @font-face {
   font-family: 'icomoon';
   src: url('../fonts/icomoon.eot?7sjwen');
   src: url('../fonts/icomoon.eot?7sjwen#iefix') format('embedded-opentype'),
-  url('../fonts/icomoon.ttf?7sjwen') format('truetype'),
-  url('../fonts/icomoon.woff?7sjwen') format('woff'),
-  url('../fonts/icomoon.svg?7sjwen#icomoon') format('svg');
+    url('../fonts/icomoon.ttf?7sjwen') format('truetype'),
+    url('../fonts/icomoon.woff?7sjwen') format('woff'),
+    url('../fonts/icomoon.svg?7sjwen#icomoon') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -3666,7 +3705,7 @@ p.tm-warning-message {
 */
 
 .icon-copy-key:before {
-  content: "\e92c";
+  content: '\e92c';
 }
 
 /*
@@ -3769,33 +3808,30 @@ header .filter:before,
   -moz-osx-font-smoothing: grayscale;
 }
 
-
 header .filter:before {
-  content: "\f0b0";
+  content: '\f0b0';
 }
 
 .usetm .text:before {
-  content: "\f144";
+  content: '\f144';
   padding: 0 10px 0 0;
   vertical-align: text-top;
-
 }
 
-
 .editToolbar .uppercase:after {
-  content: "\ea6c";
+  content: '\ea6c';
   font-size: 20px;
   display: block;
 }
 
 .editToolbar .lowercase:after {
-  content: "\ea6b";
+  content: '\ea6b';
   font-size: 20px;
   display: block;
 }
 
 .editToolbar .capitalize:after {
-  content: "\ea5f";
+  content: '\ea5f';
   font-size: 16px;
   padding: 3px 2px 1px 2px;
   display: block;
@@ -3805,13 +3841,12 @@ header .filter:before {
   display: none;
 }
 
-
 .splitpoint:before {
-  content: "\f03d";
+  content: '\f03d';
 }
 
 .splitpoint:hover .splitpoint-delete:after {
-  content: "\f00d";
+  content: '\f00d';
   color: red;
   position: absolute;
   font-size: 18px;
@@ -3820,46 +3855,47 @@ header .filter:before {
 }
 
 .login-modal .login-container-right li:before {
-  content: "\ea10";
+  content: '\ea10';
   margin-left: -40px;
   padding: 11px;
   color: #3aa9dd;
 }
 
 .icon-tag-expand:before {
-  content: "...";
+  content: '...';
   margin-top: -5px;
   float: left;
 }
 
 .splitbtn:before {
-  content: "\f065";
+  content: '\f065';
   margin-right: 3px;
 }
 
 .sub-editor .gl-search .set-glossary:before {
-  content: "\f055";
+  content: '\f055';
   transform: rotate(180deg);
   display: inline-block;
 }
 
 .mergebtn:before {
-  content: "\f066";
+  content: '\f066';
   margin-right: 3px;
 }
 
-.fileupload-buttonbar .fileinput-button:before, #add-files:before {
-  content: "\f067";
+.fileupload-buttonbar .fileinput-button:before,
+#add-files:before {
+  content: '\f067';
   font-size: 14px;
   margin-right: 5px;
 }
 
 .close:before {
-  content: "\ea0d";
+  content: '\ea0d';
 }
 
 .header .close:before {
-  content: "\ea0d";
+  content: '\ea0d';
   text-align: center;
   margin-top: 0px;
   margin-left: -1px;
@@ -3868,7 +3904,7 @@ header .filter:before {
 }
 
 .notific:before {
-  content: "\f058";
+  content: '\f058';
   font-size: 25px;
 }
 
@@ -3877,8 +3913,8 @@ header .filter:before {
 .mbc-warnings:before,
 .error-symbol:before,
 .text .alternatives:before {
-  content: "\f071";
-  color: #D65959;
+  content: '\f071';
+  color: #d65959;
   margin-right: 10px;
 }
 
@@ -3888,41 +3924,40 @@ header .filter:before {
 }
 
 .currSegment a:before {
-  content: "\f112";
+  content: '\f112';
   transform: rotate(180deg);
   display: inline-block;
   margin-right: 10px;
 }
 
 .notific.error:before {
-  content: "\f071";
+  content: '\f071';
   font-size: 25px;
 }
 
 #point2seg:after {
-  content: "\e903";
+  content: '\e903';
   font-size: 24px;
 }
 
 #filterSwitch:before {
-  content: "\f002";
+  content: '\f002';
 }
 
 #clear-all-gdrive:before,
 #clear-all-files:before {
-  content: "\f00d";
+  content: '\f00d';
   font-size: 14px;
   margin-right: 5px;
 }
 
 #swaplang:after {
-  content: "\f0ec";
+  content: '\f0ec';
 }
-
 
 .review .breadcrumbs #pname:before,
 .cattool .breadcrumbs #pname:before {
-  content: "\f0dd";
+  content: '\f0dd';
   font-size: 18px;
   display: inline-block;
   margin-right: 10px;
@@ -3937,7 +3972,7 @@ header .filter:before {
 }
 
 .more-options:before {
-  content: "\e8b8";
+  content: '\e8b8';
 }
 
 .translate-box .more-options:before {
@@ -3946,34 +3981,34 @@ header .filter:before {
 }
 
 .graysmall:hover .trash:before {
-  content: "\f014";
+  content: '\f014';
 }
 
 .more:before {
-  content: "\f196";
+  content: '\f196';
 }
 
 .cancel button:before,
 .delete button:before {
-  content: "\f014";
+  content: '\f014';
   font-size: 13px;
   vertical-align: middle;
 }
 
 .delete button.zip_row:before {
-  content: "Clear Archive";
+  content: 'Clear Archive';
   font-size: 12px;
   font-weight: bold;
   font-family: Calibri, Arial, Helvetica, sans-serif;
 }
 
 .more.minus:before {
-  content: "\f147";
+  content: '\f147';
 }
 
 .canceladdtmx.btn-grey .text:before,
 .canceladdglossary.btn-grey .text:before {
-  content: "\f00d";
+  content: '\f00d';
   vertical-align: text-top;
 }
 
@@ -3991,13 +4026,13 @@ header .filter:before {
 }
 
 .deleteTM .text:before {
-  content: "\f014";
+  content: '\f014';
   padding-right: 5px;
   vertical-align: text-top;
 }
 
 .noticon:after {
-  content: "\e605";
+  content: '\e605';
   color: red;
   font-size: 18px;
   position: absolute;
@@ -4006,23 +4041,27 @@ header .filter:before {
   transform: rotate(-45deg);
 }
 
-a.cancel-project:before, a.resume-project:before {
-  content: "\f014";
+a.cancel-project:before,
+a.resume-project:before {
+  content: '\f014';
 }
 
 a.activity-log:before {
-  content: "\e900";
+  content: '\e900';
   font-size: 18px;
   vertical-align: top;
 }
 
-a.archive-project:before, a.unarchive-project:before {
-  content: "\e606";
+a.archive-project:before,
+a.unarchive-project:before {
+  content: '\e606';
   font-size: 14px;
 }
 
-.noticon:after, a.unarchive-project:after, a.resume-project:after {
-  content: "\e607";
+.noticon:after,
+a.unarchive-project:after,
+a.resume-project:after {
+  content: '\e607';
   color: red;
   font-size: 16px;
   position: absolute;
@@ -4034,45 +4073,43 @@ a.archive-project:before, a.unarchive-project:before {
 .privatekey.tablesorter-header .tablesorter-header-inner:after,
 .owner.tablesorter-header .tablesorter-header-inner:after,
 .description.tablesorter-header .tablesorter-header-inner:after {
-  content: "\f0dc";
+  content: '\f0dc';
   float: right;
 }
-
 
 .privatekey.tablesorter-headerDesc .tablesorter-header-inner:after,
 .owner.tablesorter-headerDesc .tablesorter-header-inner:after,
 .description.tablesorter-headerDesc .tablesorter-header-inner:after {
-  content: "\f0e0";
+  content: '\f0e0';
   float: right;
 }
 
 .privatekey.tablesorter-headerAsc .tablesorter-header-inner:after,
 .owner.tablesorter-headerAsc .tablesorter-header-inner:after,
 .description.tablesorter-headerAsc .tablesorter-header-inner:after {
-  content: "\f0dd";
+  content: '\f0dd';
   float: right;
-
 }
 
 .x-popup:before,
 .x-popup2:before {
-  content: "\f057";
+  content: '\f057';
 }
 
 .subfile p:before {
-  content: "\ea58";
+  content: '\ea58';
   margin-right: 5px;
   color: #555;
 }
 
 .add-tm:before {
-  content: "\f067";
+  content: '\f067';
   padding: 0 10px 0 0;
   vertical-align: text-top;
 }
 
 .uploadkey:before {
-  content: "\f00c";
+  content: '\f00c';
   padding-right: 7px;
   vertical-align: text-top;
 }
@@ -4090,14 +4127,14 @@ th.description.tablesorter-header:hover {
 }
 
 .disabletm .text:before {
-  content: "\f056";
+  content: '\f056';
   padding-right: 5px;
   vertical-align: text-top;
 }
 
 .addtmxfile .text:before,
 .addglossaryfile .text:before {
-  content: "\ea10";
+  content: '\ea10';
   padding-right: 5px;
   vertical-align: text-top;
 }
@@ -4109,7 +4146,7 @@ th.description.tablesorter-header:hover {
 
 .open-popup-addtm-tr:before,
 .downloadtmx .text:before {
-  content: "\e602";
+  content: '\e602';
   padding-right: 5px;
   vertical-align: text-top;
 }
@@ -4145,7 +4182,6 @@ th.description.tablesorter-header:hover {
   background: rgba(187, 187, 187, 0.14);
 }
 
-
 .tab.review .error-type th {
   text-align: center;
   padding: 10px 4px;
@@ -4167,374 +4203,372 @@ th.description.tablesorter-header:hover {
 }
 
 .icon-uniE96B:before {
-  content: "\e96b";
+  content: '\e96b';
 }
 
 .icon-uniE96D:before {
-  content: "\e96d";
+  content: '\e96d';
 }
 
 .icon-uniE96E:before {
-  content: "\e96e";
+  content: '\e96e';
 }
 
 .icon-uniE970:before {
-  content: "\e970";
+  content: '\e970';
 }
 
 .icon-error_outline:before {
-  content: "\e001";
+  content: '\e001';
 }
 
 .icon-format_color_fill:before {
-  content: "\e23a";
+  content: '\e23a';
 }
 
 .icon-power-cord:before {
-  content: "\e291";
+  content: '\e291';
 }
 
 .icon-power-cord2:before {
-  content: "\e292";
+  content: '\e292';
 }
 
 .icon-file_download:before {
-  content: "\e2c4";
+  content: '\e2c4';
 }
 
 .icon-collections_bookmark:before {
-  content: "\e431";
+  content: '\e431';
 }
 
 .icon-user22:before {
-  content: "\e601";
+  content: '\e601';
 }
 
 .icon-upload:before {
-  content: "\e602";
+  content: '\e602';
 }
 
 .icon-download:before {
-  content: "\e603";
+  content: '\e603';
 }
 
 .icon-stop:before {
-  content: "\e604";
+  content: '\e604';
 }
 
 .icon-info:before {
-  content: "\e605";
+  content: '\e605';
 }
 
 .icon-drawer:before {
-  content: "\e606";
+  content: '\e606';
 }
 
 .icon-minus:before {
-  content: "\e607";
+  content: '\e607';
 }
 
 .icon-settings:before {
-  content: "\e8b8";
+  content: '\e8b8';
 }
 
 .icon-download-logs:before {
-  content: "\e900";
+  content: '\e900';
 }
 
 .icon-zip:before {
-  content: "\e901";
+  content: '\e901';
 }
 
 .icon-mic:before {
-  content: "\e91e";
+  content: '\e91e';
 }
 
 .icon-bubble2:before {
-  content: "\e96f";
+  content: '\e96f';
 }
 
 .icon-cancel-circle:before {
-  content: "\ea0d";
+  content: '\ea0d';
 }
 
 .icon-make-group:before {
-  content: "\ea58";
+  content: '\ea58';
 }
 
 .icon-text-height:before {
-  content: "\ea5f";
+  content: '\ea5f';
 }
 
 .icon-superscript2:before {
-  content: "\ea6b";
+  content: '\ea6b';
 }
 
 .icon-subscript2:before {
-  content: "\ea6c";
+  content: '\ea6c';
 }
 
 .icon-refresh:before {
-  content: "\f021";
+  content: '\f021';
 }
 
 .icon-split:before {
-  content: "\f03d";
+  content: '\f03d';
 }
 
 .icon-edit:before {
-  content: "\f044";
+  content: '\f044';
 }
 
 .icon-play:before {
-  content: "\f04b";
+  content: '\f04b';
 }
 
 .icon-chevron-left:before {
-  content: "\f053";
+  content: '\f053';
 }
 
 .icon-eye:before {
-  content: "\f06e";
+  content: '\f06e';
 }
 
 .icon-navicon:before {
-  content: "\f0c9";
+  content: '\f0c9';
 }
 
 .icon-google-plus-square2:before {
-  content: "\f0d5";
+  content: '\f0d5';
 }
 
 .icon-sort-up:before {
-  content: "\f0e0";
+  content: '\f0e0';
 }
 
 .icon-code:before {
-  content: "\f121";
+  content: '\f121';
 }
 
 .icon-star-half-empty:before {
-  content: "\f123";
+  content: '\f123';
 }
 
 .icon-play-circle:before {
-  content: "\f144";
+  content: '\f144';
 }
 
 .icon-users:before {
-  content: "\e972";
+  content: '\e972';
 }
 
 .icon-share:before {
-  content: "\ea82";
+  content: '\ea82';
 }
 
 .icon-lock:before {
-  content: "\e98f";
+  content: '\e98f';
 }
 
 .icon-unlocked:before {
-  content: "\e990";
+  content: '\e990';
 }
 
 .icon-earth:before {
-  content: "\e9ca";
+  content: '\e9ca';
 }
 
 .icon-user2:before {
-  content: "\e600";
+  content: '\e600';
 }
 
 .icon-checkmark:before {
-  content: "\ea10";
+  content: '\ea10';
 }
 
 .icon-search:before {
-  content: "\f002";
+  content: '\f002';
 }
 
 .icon-envelope-o:before {
-  content: "\f003";
+  content: '\f003';
 }
 
 .icon-heart:before {
-  content: "\f004";
+  content: '\f004';
 }
 
 .icon-star:before {
-  content: "\f005";
+  content: '\f005';
 }
 
 .icon-user:before {
-  content: "\f007";
+  content: '\f007';
 }
 
 .icon-check:before {
-  content: "\f00c";
+  content: '\f00c';
 }
 
 .icon-times:before {
-  content: "\f00d";
+  content: '\f00d';
 }
 
 .icon-power-off:before {
-  content: "\f011";
+  content: '\f011';
 }
 
 .icon-gear:before {
-  content: "\f013";
+  content: '\f013';
 }
 
 .icon-trash-o:before {
-  content: "\f014";
+  content: '\f014';
 }
 
 .icon-share-square-o:before {
-  content: "\f045";
+  content: '\f045';
 }
 
 .icon-chevron-right:before {
-  content: "\f054";
+  content: '\f054';
 }
 
 .icon-plus-circle:before {
-  content: "\f055";
+  content: '\f055';
 }
 
 .icon-times-circle:before {
-  content: "\f057";
+  content: '\f057';
 }
 
 .icon-check-circle:before {
-  content: "\f058";
+  content: '\f058';
 }
 
 .icon-times-circle-o:before {
-  content: "\f05c";
+  content: '\f05c';
 }
 
 .icon-check-circle-o:before {
-  content: "\f05d";
+  content: '\f05d';
 }
 
 .icon-expand:before {
-  content: "\f065";
+  content: '\f065';
 }
 
 .icon-compress:before {
-  content: "\f066";
+  content: '\f066';
 }
 
 .icon-plus:before {
-  content: "\f067";
+  content: '\f067';
 }
 
 .icon-warning:before {
-  content: "\f071";
+  content: '\f071';
 }
 
 .icon-sign-in:before {
-  content: "\f090";
+  content: '\f090';
 }
 
 .icon-wrench:before {
-  content: "\f0ad";
+  content: '\f0ad';
 }
 
 .icon-tasks:before {
-  content: "\f0ae";
+  content: '\f0ae';
 }
 
 .icon-filter:before {
-  content: "\f0b0";
+  content: '\f0b0';
 }
 
 .icon-google-plus-square:before {
-  content: "\f0d4";
+  content: '\f0d4';
 }
 
 .icon-unsorted:before {
-  content: "\f0dc";
+  content: '\f0dc';
 }
 
 .icon-sort-down:before {
-  content: "\f0dd";
+  content: '\f0dd';
 }
 
 .icon-exchange:before {
-  content: "\f0ec";
+  content: '\f0ec';
 }
 
 .icon-mail-reply:before {
-  content: "\f112";
+  content: '\f112';
 }
 
 .icon-minus-square-o:before {
-  content: "\f147";
+  content: '\f147';
 }
 
 .icon-stack-exchange:before {
-  content: "\f18d";
+  content: '\f18d';
 }
 
 .icon-plus-square-o:before {
-  content: "\f196";
+  content: '\f196';
 }
 
 .icon-language:before {
-  content: "\f1ab";
+  content: '\f1ab';
 }
 
 .icon-paw:before {
-  content: "\f1b0";
+  content: '\f1b0';
 }
 
 .icon-file-text:before {
-  content: "\e922";
+  content: '\e922';
 }
 
 .icon-file:before {
-  content: "\e904";
+  content: '\e904';
 }
 
 .icon-unlocked3:before {
-  content: "\ea8a";
+  content: '\ea8a';
 }
 
 .icon-picture:before {
-  content: "\e95d";
+  content: '\e95d';
 }
 
 .icon-window:before {
-  content: "\e933";
+  content: '\e933';
 }
-
 
 .icon-gdrive:before {
   content: url(../../img/logo-drive-16-gray.png);
 }
 
 .icon-preview-bottom-window:before {
-  content: "\ea8b";
+  content: '\ea8b';
 }
 
 .icon-preview-new-window:before {
-  content: "\ea8c";
+  content: '\ea8c';
 }
 
 .icon-no-preview:before {
-  content: "\ea8d";
+  content: '\ea8d';
 }
 
 .icon-go-to-first:before {
-  content: "\ea8e";
+  content: '\ea8e';
 }
 
 .icon-go-to-last:before {
-  content: "\ea8f";
+  content: '\ea8f';
 }
-
 
 /* side-popup adjustments */
 body.side-popup {
@@ -4543,21 +4577,20 @@ body.side-popup {
 
 @font-face {
   font-family: Calibri;
-  src: local(Calibri),
-  url('../fonts/calibri-webfont.woff') format('woff'),
-  url('../fonts/calibri-webfont.ttf') format('truetype'),
-  url('../fonts/calibri-webfont.eot'),
-  url('../fonts/calibri-webfont.eot?#iefix') format('embedded-opentype');
+  src: local(Calibri), url('../fonts/calibri-webfont.woff') format('woff'),
+    url('../fonts/calibri-webfont.ttf') format('truetype'),
+    url('../fonts/calibri-webfont.eot'),
+    url('../fonts/calibri-webfont.eot?#iefix') format('embedded-opentype');
 }
 
 @font-face {
   font-family: Calibri;
   font-weight: bold;
   src: local('Calibri Bold'),
-  url('../fonts/calibri_bold-webfont.woff') format('woff'),
-  url('../fonts/calibri_bold-webfont.ttf') format('truetype'),
-  url('../fonts/calibri_bold-webfont.eot'),
-  url('../fonts/calibri_bold-webfont.eot?#iefix') format('embedded-opentype');
+    url('../fonts/calibri_bold-webfont.woff') format('woff'),
+    url('../fonts/calibri_bold-webfont.ttf') format('truetype'),
+    url('../fonts/calibri_bold-webfont.eot'),
+    url('../fonts/calibri_bold-webfont.eot?#iefix') format('embedded-opentype');
 }
 
 #menu-site li {
@@ -4592,59 +4625,64 @@ body.side-popup {
   color: $darkBlueHover !important;
 }
 
-
 #menu-site li a:hover {
   color: #3aa9dd;
 }
 
 @media only screen and (min-device-width: 320px) and (max-device-width: 480px) {
-  header, .wrapper-claim, .wrapper-upload, footer, #template-upload, #template-download, .wrapper-claim, .wrapper-bottom {
-	display: none !important;
+  header,
+  .wrapper-claim,
+  .wrapper-upload,
+  footer,
+  #template-upload,
+  #template-download,
+  .wrapper-claim,
+  .wrapper-bottom {
+    display: none !important;
   }
   .nobrowser {
-	display: block !important;
+    display: block !important;
   }
   .iepopup.nobrowser {
-	width: 100%;
+    width: 100%;
   }
   .iepopup .col-2 {
-	width: 90%;
-	margin: 8% 3% 5% 3%;
-	padding: 1% 2%;
-	min-height: 100px !important;
-	box-shadow: 0px 2px 3px #E9E9E9;
-	border: 1px solid #E6E6E6;
-	border-top: 3px solid #3aa9dd;
+    width: 90%;
+    margin: 8% 3% 5% 3%;
+    padding: 1% 2%;
+    min-height: 100px !important;
+    box-shadow: 0px 2px 3px #e9e9e9;
+    border: 1px solid #e6e6e6;
+    border-top: 3px solid #3aa9dd;
   }
 
   .iepopup .col-2 a {
-	font-size: 24px;
+    font-size: 24px;
   }
   .iepopup.nobrowser p {
-	line-height: 30px;
-	margin-bottom: 40px;
-	font-size: 24px;
+    line-height: 30px;
+    margin-bottom: 40px;
+    font-size: 24px;
   }
-
 
   .iepopup h3 {
-	font-size: 30px;
-	margin-bottom: 20px;
+    font-size: 30px;
+    margin-bottom: 20px;
   }
   .nobrowser .col-a img {
-	width: 100px;
+    width: 100px;
   }
   .nobrowser .col-b img {
-	width: 250px;
+    width: 250px;
   }
 
-  #template-upload, #template-download {
-	display: none;
+  #template-upload,
+  #template-download {
+    display: none;
   }
   .notifications-wrapper {
-	display: none;
+    display: none;
   }
-
 }
 
 table.left-aligned tr td {
@@ -4743,7 +4781,6 @@ table.activitylog tr:hover {
   display: none;
 }
 
-
 table.activitylog th {
   font-family: 'icomoon';
   speak: none;
@@ -4758,17 +4795,17 @@ table.activitylog th {
 }
 
 table.activitylog th.tablesorter-headerAsc .th-inner:after {
-  content: "\f0dc";
+  content: '\f0dc';
   float: right;
 }
 
 table.activitylog th.tablesorter-headerDesc .th-inner:after {
-  content: "\f0de";
+  content: '\f0de';
   float: right;
 }
 
 table.activitylog th .th-inner:after {
-  content: "\f0dd";
+  content: '\f0dd';
   float: right;
 }
 
@@ -4776,7 +4813,6 @@ table.activitylog th .th-inner:after {
   font-family: calibri, Arial, Helvetica, sans-serif;
   font-weight: bold;
 }
-
 
 /*** Share Key Popup ***/
 .share-popup-container {
@@ -4795,8 +4831,9 @@ table.activitylog th .th-inner:after {
   font-weight: normal;
 }
 
-.share-popup-top-label, .share-popup-list-title, .share-popup-bottom-label {
-
+.share-popup-top-label,
+.share-popup-list-title,
+.share-popup-bottom-label {
   float: left;
   text-align: left;
   font-size: 16px;
@@ -4876,8 +4913,8 @@ table.activitylog th .th-inner:after {
   overflow-y: auto;
   overflow-x: hidden;
   border-top: 1px solid #cacaca;
-  box-shadow: inset 0 2px 2px -1px rgba(0, 0, 0, .1);
-  -webkit-box-shadow: inset 0 2px 2px -1px rgba(0, 0, 0, .1);
+  box-shadow: inset 0 2px 2px -1px rgba(0, 0, 0, 0.1);
+  -webkit-box-shadow: inset 0 2px 2px -1px rgba(0, 0, 0, 0.1);
 }
 
 .share-popup-container-bottom {
@@ -4923,7 +4960,8 @@ input.share-popup-container-input-email {
   border-bottom: none;
 }
 
-span.share-popup-item-name, .share-popup-item-email {
+span.share-popup-item-name,
+.share-popup-item-email {
   text-align: left;
   width: 100%;
   float: left;
@@ -4937,7 +4975,6 @@ span.share-popup-item-email {
   color: #999;
   line-height: 13px;
 }
-
 
 .blink {
   -webkit-animation-name: blink;
@@ -4968,28 +5005,27 @@ span.share-popup-item-email {
   animation-iteration-count: 1;
 }
 
-
 @-webkit-keyframes blink {
   50% {
-	opacity: 0;
+    opacity: 0;
   }
 }
 
 @-moz-keyframes blink {
   50% {
-	opacity: 0;
+    opacity: 0;
   }
 }
 
 @-o-keyframes blink {
   50% {
-	opacity: 0;
+    opacity: 0;
   }
 }
 
 @keyframes blink {
   50% {
-	opacity: 0;
+    opacity: 0;
   }
 }
 
@@ -5004,7 +5040,7 @@ div.ui-user-top-image {
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
   -moz-box-sizing: border-box;
   box-sizing: border-box;
-  color: #0099CC;
+  color: #0099cc;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5025,7 +5061,7 @@ div.ui-user-top-image {
   transition: 0.3s ease;
   cursor: pointer;
   background-color: transparent;
-  border: 2px solid #0099CC;
+  border: 2px solid #0099cc;
 }
 
 .ui.user.label:hover {
@@ -5092,11 +5128,11 @@ div.ui-user-top-image {
   padding-left: 50px;
   position: relative;
   float: right;
-  font-size:16px;
+  font-size: 16px;
 }
 
 #user-menu-dropdown {
-  .menu{
+  .menu {
     width: 200px;
     margin: 0 0 0 -1px;
     padding: 12px 8px !important;
@@ -5169,8 +5205,9 @@ img.ui-user-top-image-general {
 
 /*****************************/
 
-
-.active-tm-container, .inactive-tm-container, .mgmt-container {
+.active-tm-container,
+.inactive-tm-container,
+.mgmt-container {
   margin: 0 auto;
   width: 998px;
   margin-top: 0px;
@@ -5215,7 +5252,8 @@ a.btn.pull-left.addtmx {
   margin-left: 5px;
 }
 
-a.pull-right, .btn-grey.canceladdtmx {
+a.pull-right,
+.btn-grey.canceladdtmx {
   margin-right: -6px;
 }
 
@@ -5229,7 +5267,9 @@ a#add-mt-provider-cancel {
     position: relative;
 }*/
 
-a.existingKey, .pull-right.btn-ok, .addtmxfile {
+a.existingKey,
+.pull-right.btn-ok,
+.addtmxfile {
   margin-right: 4px;
   width: 108px;
 }
@@ -5280,4 +5320,3 @@ a.pull-left.btn-ok.uploadtm {
 body svg {
   padding: 0 !important;
 }
-

--- a/public/css/sass/commons/_analyze.scss
+++ b/public/css/sass/commons/_analyze.scss
@@ -1,1312 +1,1301 @@
 // rewrite semantic CSS
 
-body.analyze{
-    min-width: 1024px;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
-    background-color: $grey5;
-    overflow: visible;
-    header {
-        z-index: 1001 !important;
-    }
-
+body.analyze {
+  min-width: 1024px;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
+  background-color: $grey5;
+  overflow: visible;
+  header {
+    z-index: 1001 !important;
+  }
 }
 
 .project-list {
-    padding-top: 102px; /* was 62px with previous header */
-    padding-bottom: 160px;
+  padding-top: 102px; /* was 62px with previous header */
+  padding-bottom: 160px;
 
+  .project {
+    .scroll {
+      background-color: $grey2;
+      width: 40px;
+      height: 40px;
+      position: fixed;
+      bottom: 35px;
+      left: 8px;
+      border-radius: 5px;
+      border: none;
+      outline: none;
+      opacity: 0.8;
+      z-index: 3;
+      &:hover {
+        opacity: 1;
+      }
+      i {
+        margin-left: -7px;
+        font-size: 22px;
+        margin-top: 11px;
+      }
+    }
 
-    .project {
-        .scroll {
-            background-color: $grey2;
-            width: 40px;
-            height: 40px;
-            position: fixed;
-            bottom: 35px;
-            left: 8px;
-            border-radius: 5px;
-            border: none;
-            outline: none;
-            opacity: .8;
-            z-index: 3;
-            &:hover {
-                opacity: 1;
-            }
-            i {
-                margin-left: -7px;
-                font-size: 22px;
-                margin-top: 11px;
-            }
+    .project-header {
+      background: $grey4;
+      padding-bottom: 10px;
+      margin-bottom: 0;
+      .left-analysis {
+        padding-top: 20px;
+        padding-left: 30px;
+        top: 14px;
+        position: relative;
+        width: 55% !important;
+        height: 205px;
+        .h1 {
+          font-size: 38px;
+          font-weight: 100;
+          color: grey;
+          margin-bottom: 0;
         }
-
-        .project-header {
-            background: $grey4;
-            padding-bottom: 10px;
-            margin-bottom: 0;
-            .left-analysis {
-                padding-top: 20px;
-                padding-left: 30px;
-                top: 14px;
-                position: relative;
-                width: 55% !important;
-                height: 205px;
-                .h1 {
-                    font-size: 38px;
-                    font-weight: 100;
-                    color: grey;
-                    margin-bottom: 0;
-                }
-                .ui.ribbon.label {
-                    position: relative;
-                    top: 0;
-                    z-index: 2;
-                    left: -45px;
-                    max-width: 100%;
-                    min-width: 0;
-                    background-color: $grey2;
-                    color: #000000;
-                    border-radius: 0 2px 2px 0;
-                    padding-right: 15px;
-                    &:after {
-                        border-right-color: $grey1 !important;
-                    }
-                    .project-id, .project-name {
-                        display: inline-block;
-                        vertical-align: text-bottom;
-                        position: relative;
-                    }
-                    .project-id {
-                        font-size: 14px;
-                        font-weight: 700;
-                        margin-right: 5px;
-                        margin-left: 15px;
-                        color: #5a5a5a;
-                        top: -2px;
-                    }
-                    .project-name {
-                        font-size: 20px;
-                        max-width: 100%;
-                        min-width: 30px;
-                        white-space: nowrap;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                        top: 1px;
-                        padding-left: 15px;
-                    }
-                }
-                .project-create {
-                    top: 10px;
-                    position: relative;
-                    font-size: 18px;
-                }
-                .analysis-create {
-                    margin-top: 35px;
-                    font-size: 16px;
-                    .search-tm-matches {
-                        .loader {
-                            margin-right: 5px;
-                        }
-                        h5 {
-                            display: inline-block;
-                            margin-bottom: 0;
-                            span {
-                                color: $greenDefault;
-                                padding: 5px 2px 5px 0;
-                                margin-left: 4px;
-                                border-radius: 15px;
-                            }
-                            i {
-                                color: $greenDefault;
-                                position: relative;
-                                top: 2px;
-                            }
-                        }
-                        .complete {
-                            display: inline-block;
-                            font-size: 18px;
-                            .number {
-                                font-weight: 700;
-                            }
-                            a {
-                                font-weight: 700;
-                                text-decoration: underline;
-                                &:hover {
-                                    text-decoration: none;
-                                }
-                            }
-
-                        }
-                        .downloadAnalysisReport {
-                            display: inline-block;
-                            border-left: 1px solid black;
-                            padding-left: 10px;
-                            color: black;
-                            text-decoration: underline;
-                            margin-left: 10px;
-                            cursor: pointer;
-                            &:hover {
-                                text-decoration: none;
-                            }
-                        }
-                        .analysisNotPerformed {
-                            margin-top: -8px !important;
-                            text-decoration: underline;
-                            display: inline-block;
-                        }
-                    }
-                }
-
-            }
-
-            .word-count {
-                .word-percent {
-                    position: relative;
-                    padding: 15px 15px 10px 20px;
-                    border: 1px solid $greenDefault;
-                    top: 27px;
-                    font-size: 16px;
-                    margin-bottom: 25px;
-                    .percent {
-                        font-size: 40px;
-                        font-weight: 700;
-                        display: inline-block;
-                        vertical-align: -webkit-baseline-middle;
-                        margin-right: 10px;
-                    }
-                    .content {
-                        font-size: 20px;
-                        .sub.header {
-                            font-size: 12px;
-                        }
-                    }
-                    a {
-                        text-decoration: underline;
-                        font-weight: 700;
-                        cursor: pointer;
-                        &:hover {
-                            text-decoration: none;
-                        }
-                        &:active {
-                            text-decoration: none;
-                        }
-                        &:focus {
-                            text-decoration: none;
-                        }
-                    }
-                    .custom {
-                        &.popup {
-                            min-width: 90%;
-                        }
-                    }
-                }
-                .word-raw, .matecat-raw {
-                    background-color: #f2f4f1;
-                    padding: 5px;
-                    border: 1px solid #7eaf3e;
-                    text-align: center;
-                    transition: 0.4s ease;
-                    h3, h4 {
-                        margin: 0;
-                    }
-                    h3 {
-                        font-size: 28px
-                    }
-                }
-                .word-raw {
-
-                }
-                .overlay {
-                    background-color: rgba(243, 243, 243, 0.6);
-                    border: 1px solid #a7c3a7;
-                    margin-top: -67px;
-                    z-index: 10;
-                    position: relative;
-                    height: 100%;
-                }
-                .updated-count {
-                    background-color: #f9ffb5;
-                }
-            }
-
-            .saving-count {
-                background-color: white;
-                position: relative;
-                top: 10px;
-                margin-bottom: 15px;
-                padding: 15px;
-                border: 1px solid green;
-                border-radius: 0;
-                .percent {
-                    vertical-align: middle;
-                    display: inline-block;
-                }
-            }
-            .progress {
-                padding: 0 15px;
-                top: 5px;
-                .progress-bar {
-                    width: 100%;
-                }
-            }
-        }
-
-
-        .project-top {
-            padding: 45px 15px 15px;
-            background-color: $grey5;
-            margin: 0 -1rem 0;
-            .compare-table {
-                background-color: $grey3;
-                margin-bottom: 1px;
-                .updated-count {
-                    background-color: #f9ffb5;
-                    transition: 0.4s ease;
-                }
-                .header-compare-table, .jobs-compare-table {
-                    h5 {
-                        margin-bottom: 0;
-                        font-weight: 100;
-                        font-size: 14px;
-                    }
-                    p {
-                        font-size: 12px;
-                    }
-                }
-                .header-compare-table {
-                    //padding-top: 15px;
-                    //padding-bottom: 15px;
-                    z-index: 1;
-                    position: relative;
-                }
-                .title-job {
-                    display: flex;
-                    flex-flow: inherit;
-                    align-items: center;
-                    justify-content: flex-start;
-                    width: 28%;
-                    /*line-height: 50px;*/
-                    /*text-align: left;*/
-                    font-size: 16px;
-                    padding: 10px 24px;
-                    /*margin-right: 0;*/
-
-                    &.splitted {
-                        width: 28%;
-                        &.heading {
-                            width: 80%;
-                            justify-content: flex-start;
-
-                        }
-                        &:not(.heading){
-                            .job-id {
-                                width:85%;
-                                margin-bottom: 12px;
-                            }
-                        }
-                    }
-                    .job-info{
-                        display: flex;
-                        justify-content: flex-start;
-                        width: 100%;
-                        margin-bottom: 12px;
-                    }
-                    &.splitted {
-                        .job-info{
-                            margin-bottom: 0;
-                        }
-                    }
-                    .translate-url {
-                        display: inline-flex;
-                        width: 100%;
-                        .copy {
-                            .icon {
-                                height: 100%;
-                                width: 100%;
-                                font-size: 18px;
-                                font-weight: 700;
-                                padding: 2px;
-                            }
-                        }
-                        span {
-                            display: flex;
-                        }
-                        input {
-                            outline: none;
-                            border: 1px solid #BBBBBB;
-                            padding: 4px;
-                            color: #0099CC;
-                            font-size: 12px;
-                            font-weight: 700;
-                            white-space: nowrap;
-                            text-overflow: ellipsis;
-                            border-radius: 2px 0 0 2px;
-                            border-right:none;
-                            min-width: 200px;
-                            height: 24px;
-                            width: 100%;
-                        }
-                        button {
-                            border: 1px solid #BBBBBB;
-                            background-color: #FFFFFF;
-                            color: #0099CC;
-                            text-align: center;
-                            text-decoration: none;
-                            border-radius: 0 2px 2px 0;
-                            height: 24px;
-                            min-width: 24px;
-                            padding: 0;
-                            margin:0;
-                            i {
-                                margin: 2px 0 0 0;
-                            }
-                        }
-                    }
-
-            }
-            .titles-compare {
-                display: flex;
-                align-items: center;
-                width: 38%;
-                text-align: center;
-                padding-left: 0;
-                padding-right: 0;
-                font-size: 16px;
-            }
-            .title-total-words, .title-standard-words, .title-matecat-words {
-                display: flex;
-                align-items: center;
-                justify-content:center;
-                width: 33.333%;
-                border-right: 1px solid #d7d8dc;
-                /*border-left: 1px solid #d7d8dc;*/
-                /*margin-left: -1px;*/
-                /*line-height: 100px;*/
-                padding-top: 15px;
-                padding-bottom: 15px;
-                height: 100%;
-                &:first-child{
-                    border-left: 1px solid #d7d8dc;
-                }
-
-            }
-            .title-standard-words {
-                h5 {
-                    span {
-                        color: #a7a7a7;
-                        font-weight: 100;
-                        position: relative;
-                        top: 2px;
-                        left: 2px;
-                    }
-                }
-            }
-            .title-matecat-words {
-                h5 {
-                    font-weight: 700;
-                }
-            }
-            &.jobs {
-                background-color: $grey5;
-                z-index: 0;
-                position: relative;
-                .job {
-                    margin-bottom: 15px;
-                    .chunks {
-                        .chunk {
-                            background-color: #ffffff;
-                            transition: 0.3s ease;
-                            cursor: pointer;
-                            /*padding: 16px 8px;*/
-                            .job-details {
-                                font-size: 15px;
-                                float: right;
-                                top: 11px;
-                                color: #4183C4;
-                                text-decoration: underline;
-                                font-weight: 700;
-                                margin-left: 5px;
-                                cursor: pointer;
-                                display: inline-block;
-                                &:hover {
-                                    text-decoration: none;
-                                }
-                            }
-                            &:hover {
-                                background-color: #f6f6f9;
-                                .title-matecat-words {
-                                    background: #f6ffe9 !important;
-                                    transition: 0.3s ease;
-                                }
-                            }
-                            .ttw, .tsw, .tmw {
-                                text-align: center;
-                                /*padding-right: 15px;*/
-                                color: #788190;
-                                padding-top: 0;
-                                padding-bottom: 0;
-                                .cell-label {
-                                    float: left;
-                                    margin-left: 15px;
-                                    font-weight: 100;
-                                    font-size: 16px;
-                                }
-                            }
-                            .tmw {
-                                font-weight: 700;
-                                font-size: 18px;
-                                margin-bottom: 1px;
-                                color: #788190;
-                                .cell-label {
-                                    text-decoration: underline;
-                                    cursor: pointer;
-                                    color: #646760;
-                                    &:hover {
-                                        text-decoration: none;
-                                    }
-                                }
-                                i {
-                                    font-size: 23px;
-                                    top: 4px;
-                                    position: relative;
-                                    float: right;
-                                    margin-left: 5px;
-                                    margin-top: 9px;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            .activity-icons {
-                width: 34%;
-                display: flex;
-                align-items: center;
-                justify-content: space-evenly;
-                text-align: center;
-                padding: 0 4px;
-
-
-                /*margin-left:8px;*/
-                .ui.primary.button,
-                .ui.basic.blue.button{
-                    min-width: 120px !important;
-                    height: 34px;
-                }
-                .activity-button {
-                    display: flex;
-                    width: 68%;
-                    padding: 0 4px;
-                    justify-content: flex-end;
-                    .button {
-                        width: 45%;
-                    }
-                    &.splitted {
-
-                    }
-                }
-                .outsource-translation {
-                    display:flex;
-                    align-items: center;
-                    justify-content: center;
-                    width: 32%;
-                    flex-flow: column;
-                    border-left: 1px solid #BBBBBB;
-                    padding: 8px;
-                    /*margin-left: 4px;*/
-                    a {
-                        color: #09beec;
-                        text-decoration:underline;
-                    }
-                    span {
-                        color: #000;
-                        font-size: 10px;
-                        display:flex;
-                        justify-content: center;
-                        align-items: end;
-                        svg {
-                            margin-left:2px;
-                        }
-                    }
-                }
-                .split, .merge {
-                    font-family: Calibri, Arial, Helvetica, sans-serif;
-                    padding: 5px 20px; //padding: 8px 16px;
-                    vertical-align: top;
-                    font-size: 19px; //font-size: 16px;
-                    border: 1px solid #09beec;
-                    border-radius: 2px;
-                    box-shadow: none !important;
-                    background-color: #ffffff !important;
-                    font-weight: 700; //font-weight: normal;
-                    /*margin-top: -3px;*/
-                    &:hover {
-                        text-decoration: none;
-                        box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                        border: 1px solid #09beec;
-                    }
-                    &:focus {
-                        box-shadow: none !important;
-                        background-color: #f2f2f2 !important;
-                    }
-                    &:active {
-                        box-shadow: none !important;
-                        background-color: #f2f2f2 !important;
-                    }
-                }
-
-                .merge {
-                    margin: -3px 0 0;
-                    padding: 5px 14px;
-                    width: 54%;
-                }
-                .open-translate,
-                .open-revise {
-                    font-family: Calibri, Arial, Helvetica, sans-serif;
-                    padding: 6px 15px; // padding: 8px 16px;
-                    vertical-align: top;
-                    font-size: 20px; //font-size: 16px;
-                    border: 1px solid #797979; //border: none;
-                    border-radius: 2px;
-                    /*margin: -3px 0 0 0;*/
-                    font-weight: 700; //font-weight: normal;
-                }
-
-                &.splitted {
-                    width: 20%;
-                    justify-content: flex-end;
-                    padding: 0 8px;
-                }
-
-                @media only screen and (max-width: 1199px) {
-                    .ui.primary.button,
-                    .ui.basic.blue.button{
-                        min-width: 100px !important;
-                        height: 34px;
-                    }
-                    .merge {
-                         padding: 5px 12px;
-                    }
-                    .split {
-                        padding: 5px 12px;
-                        i {
-                            margin: 0;
-                        }
-                    }
-
-                        .open-translate {
-                            font-family: Calibri, Arial, Helvetica, sans-serif;
-                            padding: 5px 12px;
-                        }
-                    }
-                }
-                .openOutsource {
-                    .title-job, .titles-compare, .activity-icons {
-                        display: none;
-                    }
-                }
-            }
-            .analyze-report {
-                text-align: center;
-                width: 100%;
-                background-color: $grey3;
-                margin: 0 auto;
-                position: relative;
-                top: 30px;
-                cursor: pointer;
-                z-index: 1;
-                > div {
-                    width: 140px;
-                    margin: 0 auto;
-                    position: relative;
-                    height: 48px;
-                }
-                h3 {
-                    margin-bottom: 10px;
-                    color: #000;
-                    float: left;
-                    margin-top: 10px;
-                }
-                .rounded {
-                    width: 35px;
-                    height: 35px;
-                    line-height: 0;
-                    border-radius: 17px;
-                    cursor: pointer;
-                    transition: 0.3s ease;
-                    float: left;
-                    i {
-                        font-size: 30px;
-                        margin: 0;
-                        padding: 0;
-                        top: 3px;
-                        position: relative;
-                        transition: 0.3s ease;
-                        color: $black;
-                        &.open {
-                            -webkit-transform: rotate(180deg);
-                            -moz-transform: rotate(180deg);
-                            -ms-transform: rotate(180deg);
-                            -o-transform: rotate(180deg);
-                            transform: rotate(180deg);
-                            top: 11px;
-                        }
-                    }
-                }
-            }
-        }
-        .job-id {
+        .ui.ribbon.label {
+          position: relative;
+          top: 0;
+          z-index: 2;
+          left: -45px;
+          max-width: 100%;
+          min-width: 0;
+          background-color: $grey2;
+          color: #000000;
+          border-radius: 0 2px 2px 0;
+          padding-right: 15px;
+          &:after {
+            border-right-color: $grey1 !important;
+          }
+          .project-id,
+          .project-name {
             display: inline-block;
-            color: $grey1;
-            font-size: 12px;
+            vertical-align: text-bottom;
             position: relative;
-            line-height: 35px;
-            top: 1px;
-            text-align: left;
+          }
+          .project-id {
+            font-size: 14px;
+            font-weight: 700;
             margin-right: 5px;
-            min-width: 70px;
+            margin-left: 15px;
+            color: #5a5a5a;
+            top: -2px;
+          }
+          .project-name {
+            font-size: 20px;
+            max-width: 100%;
+            min-width: 30px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            top: 1px;
+            padding-left: 15px;
+          }
         }
+        .project-create {
+          top: 10px;
+          position: relative;
+          font-size: 18px;
+        }
+        .analysis-create {
+          margin-top: 35px;
+          font-size: 16px;
+          .search-tm-matches {
+            .loader {
+              margin-right: 5px;
+            }
+            h5 {
+              display: inline-block;
+              margin-bottom: 0;
+              span {
+                color: $greenDefault;
+                padding: 5px 2px 5px 0;
+                margin-left: 4px;
+                border-radius: 15px;
+              }
+              i {
+                color: $greenDefault;
+                position: relative;
+                top: 2px;
+              }
+            }
+            .complete {
+              display: inline-block;
+              font-size: 18px;
+              .number {
+                font-weight: 700;
+              }
+              a {
+                font-weight: 700;
+                text-decoration: underline;
+                &:hover {
+                  text-decoration: none;
+                }
+              }
+            }
+            .downloadAnalysisReport {
+              display: inline-block;
+              border-left: 1px solid black;
+              padding-left: 10px;
+              color: black;
+              text-decoration: underline;
+              margin-left: 10px;
+              cursor: pointer;
+              &:hover {
+                text-decoration: none;
+              }
+            }
+            .analysisNotPerformed {
+              margin-top: -8px !important;
+              text-decoration: underline;
+              display: inline-block;
+            }
+          }
+        }
+      }
+
+      .word-count {
+        .word-percent {
+          position: relative;
+          padding: 15px 15px 10px 20px;
+          border: 1px solid $greenDefault;
+          top: 27px;
+          font-size: 16px;
+          margin-bottom: 25px;
+          .percent {
+            font-size: 40px;
+            font-weight: 700;
+            display: inline-block;
+            vertical-align: -webkit-baseline-middle;
+            margin-right: 10px;
+          }
+          .content {
+            font-size: 20px;
+            .sub.header {
+              font-size: 12px;
+            }
+          }
+          a {
+            text-decoration: underline;
+            font-weight: 700;
+            cursor: pointer;
+            &:hover {
+              text-decoration: none;
+            }
+            &:active {
+              text-decoration: none;
+            }
+            &:focus {
+              text-decoration: none;
+            }
+          }
+          .custom {
+            &.popup {
+              min-width: 90%;
+            }
+          }
+        }
+        .word-raw,
+        .matecat-raw {
+          background-color: #f2f4f1;
+          padding: 5px;
+          border: 1px solid #7eaf3e;
+          text-align: center;
+          transition: 0.4s ease;
+          h3,
+          h4 {
+            margin: 0;
+          }
+          h3 {
+            font-size: 28px;
+          }
+        }
+        .word-raw {
+        }
+        .overlay {
+          background-color: rgba(243, 243, 243, 0.6);
+          border: 1px solid #a7c3a7;
+          margin-top: -67px;
+          z-index: 10;
+          position: relative;
+          height: 100%;
+        }
+        .updated-count {
+          background-color: #f9ffb5;
+        }
+      }
+
+      .saving-count {
+        background-color: white;
+        position: relative;
+        top: 10px;
+        margin-bottom: 15px;
+        padding: 15px;
+        border: 1px solid green;
+        border-radius: 0;
+        .percent {
+          vertical-align: middle;
+          display: inline-block;
+        }
+      }
+      .progress {
+        padding: 0 15px;
+        top: 5px;
+        .progress-bar {
+          width: 100%;
+        }
+      }
+    }
+
+    .project-top {
+      padding: 45px 15px 15px;
+      background-color: $grey5;
+      margin: 0 -1rem 0;
+      .compare-table {
+        background-color: $grey3;
+        margin-bottom: 1px;
+        .updated-count {
+          background-color: #f9ffb5;
+          transition: 0.4s ease;
+        }
+        .header-compare-table,
+        .jobs-compare-table {
+          h5 {
+            margin-bottom: 0;
+            font-weight: 100;
+            font-size: 14px;
+          }
+          p {
+            font-size: 12px;
+          }
+        }
+        .header-compare-table {
+          //padding-top: 15px;
+          //padding-bottom: 15px;
+          z-index: 1;
+          position: relative;
+        }
+        .title-job {
+          display: flex;
+          flex-flow: inherit;
+          align-items: center;
+          justify-content: flex-start;
+          width: 28%;
+          /*line-height: 50px;*/
+          /*text-align: left;*/
+          font-size: 16px;
+          padding: 10px 24px;
+          /*margin-right: 0;*/
+
+          &.splitted {
+            width: 28%;
+            &.heading {
+              width: 80%;
+              justify-content: flex-start;
+            }
+            &:not(.heading) {
+              .job-id {
+                width: 85%;
+                margin-bottom: 12px;
+              }
+            }
+          }
+          .job-info {
+            display: flex;
+            justify-content: flex-start;
+            width: 100%;
+            margin-bottom: 12px;
+          }
+          &.splitted {
+            .job-info {
+              margin-bottom: 0;
+            }
+          }
+          .translate-url {
+            display: inline-flex;
+            width: 100%;
+            .copy {
+              .icon {
+                height: 100%;
+                width: 100%;
+                font-size: 18px;
+                font-weight: 700;
+                padding: 2px;
+              }
+            }
+            span {
+              display: flex;
+            }
+            input {
+              outline: none;
+              border: 1px solid #bbbbbb;
+              padding: 4px;
+              color: #0099cc;
+              font-size: 12px;
+              font-weight: 700;
+              white-space: nowrap;
+              text-overflow: ellipsis;
+              border-radius: 2px 0 0 2px;
+              border-right: none;
+              min-width: 200px;
+              height: 24px;
+              width: 100%;
+            }
+            button {
+              border: 1px solid #bbbbbb;
+              background-color: #ffffff;
+              color: #0099cc;
+              text-align: center;
+              text-decoration: none;
+              border-radius: 0 2px 2px 0;
+              height: 24px;
+              min-width: 24px;
+              padding: 0;
+              margin: 0;
+              i {
+                margin: 2px 0 0 0;
+              }
+            }
+          }
+        }
+        .titles-compare {
+          display: flex;
+          align-items: center;
+          width: 38%;
+          text-align: center;
+          padding-left: 0;
+          padding-right: 0;
+          font-size: 16px;
+        }
+        .title-total-words,
+        .title-standard-words,
+        .title-matecat-words {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 33.333%;
+          border-right: 1px solid #d7d8dc;
+          /*border-left: 1px solid #d7d8dc;*/
+          /*margin-left: -1px;*/
+          /*line-height: 100px;*/
+          padding-top: 15px;
+          padding-bottom: 15px;
+          height: 100%;
+          &:first-child {
+            border-left: 1px solid #d7d8dc;
+          }
+        }
+        .title-standard-words {
+          h5 {
+            span {
+              color: #a7a7a7;
+              font-weight: 100;
+              position: relative;
+              top: 2px;
+              left: 2px;
+            }
+          }
+        }
+        .title-matecat-words {
+          h5 {
+            font-weight: 700;
+          }
+        }
+        &.jobs {
+          background-color: $grey5;
+          z-index: 0;
+          position: relative;
+          .job {
+            margin-bottom: 15px;
+            .chunks {
+              .chunk {
+                background-color: #ffffff;
+                transition: 0.3s ease;
+                cursor: pointer;
+                /*padding: 16px 8px;*/
+                .job-details {
+                  font-size: 15px;
+                  float: right;
+                  top: 11px;
+                  color: #4183c4;
+                  text-decoration: underline;
+                  font-weight: 700;
+                  margin-left: 5px;
+                  cursor: pointer;
+                  display: inline-block;
+                  &:hover {
+                    text-decoration: none;
+                  }
+                }
+                &:hover {
+                  background-color: #f6f6f9;
+                  .title-matecat-words {
+                    background: #f6ffe9 !important;
+                    transition: 0.3s ease;
+                  }
+                }
+                .ttw,
+                .tsw,
+                .tmw {
+                  text-align: center;
+                  /*padding-right: 15px;*/
+                  color: #788190;
+                  padding-top: 0;
+                  padding-bottom: 0;
+                  .cell-label {
+                    float: left;
+                    margin-left: 15px;
+                    font-weight: 100;
+                    font-size: 16px;
+                  }
+                }
+                .tmw {
+                  font-weight: 700;
+                  font-size: 18px;
+                  margin-bottom: 1px;
+                  color: #788190;
+                  .cell-label {
+                    text-decoration: underline;
+                    cursor: pointer;
+                    color: #646760;
+                    &:hover {
+                      text-decoration: none;
+                    }
+                  }
+                  i {
+                    font-size: 23px;
+                    top: 4px;
+                    position: relative;
+                    float: right;
+                    margin-left: 5px;
+                    margin-top: 9px;
+                  }
+                }
+              }
+            }
+          }
+        }
+        .activity-icons {
+          width: 34%;
+          display: flex;
+          align-items: center;
+          justify-content: space-evenly;
+          text-align: center;
+          padding: 0 4px;
+
+          /*margin-left:8px;*/
+          .ui.primary.button,
+          .ui.basic.blue.button {
+            min-width: 120px !important;
+            height: 34px;
+          }
+          .activity-button {
+            display: flex;
+            width: 68%;
+            padding: 0 4px;
+            justify-content: flex-end;
+            .button {
+              width: 45%;
+            }
+            &.splitted {
+            }
+          }
+          .outsource-translation {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 32%;
+            flex-flow: column;
+            border-left: 1px solid #bbbbbb;
+            padding: 8px;
+            /*margin-left: 4px;*/
+            a {
+              color: #09beec;
+              text-decoration: underline;
+            }
+            span {
+              color: #000;
+              font-size: 10px;
+              display: flex;
+              justify-content: center;
+              align-items: end;
+              svg {
+                margin-left: 2px;
+              }
+            }
+          }
+          .split,
+          .merge {
+            font-family: Calibri, Arial, Helvetica, sans-serif;
+            padding: 5px 20px; //padding: 8px 16px;
+            vertical-align: top;
+            font-size: 19px; //font-size: 16px;
+            border: 1px solid #09beec;
+            border-radius: 2px;
+            box-shadow: none !important;
+            background-color: #ffffff !important;
+            font-weight: 700; //font-weight: normal;
+            /*margin-top: -3px;*/
+            &:hover {
+              text-decoration: none;
+              box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+                0 2px 4px rgba(0, 0, 0, 0.24) !important;
+              border: 1px solid #09beec;
+            }
+            &:focus {
+              box-shadow: none !important;
+              background-color: #f2f2f2 !important;
+            }
+            &:active {
+              box-shadow: none !important;
+              background-color: #f2f2f2 !important;
+            }
+          }
+
+          .merge {
+            margin: -3px 0 0;
+            padding: 5px 14px;
+            width: 54%;
+          }
+          .open-translate,
+          .open-revise {
+            font-family: Calibri, Arial, Helvetica, sans-serif;
+            padding: 6px 15px; // padding: 8px 16px;
+            vertical-align: top;
+            font-size: 20px; //font-size: 16px;
+            border: 1px solid #797979; //border: none;
+            border-radius: 2px;
+            /*margin: -3px 0 0 0;*/
+            font-weight: 700; //font-weight: normal;
+          }
+
+          &.splitted {
+            width: 20%;
+            justify-content: flex-end;
+            padding: 0 8px;
+          }
+
+          @media only screen and (max-width: 1199px) {
+            .ui.primary.button,
+            .ui.basic.blue.button {
+              min-width: 100px !important;
+              height: 34px;
+            }
+            .merge {
+              padding: 5px 12px;
+            }
+            .split {
+              padding: 5px 12px;
+              i {
+                margin: 0;
+              }
+            }
+
+            .open-translate {
+              font-family: Calibri, Arial, Helvetica, sans-serif;
+              padding: 5px 12px;
+            }
+          }
+        }
+        .openOutsource {
+          .title-job,
+          .titles-compare,
+          .activity-icons {
+            display: none;
+          }
+        }
+      }
+      .analyze-report {
+        text-align: center;
+        width: 100%;
+        background-color: $grey3;
+        margin: 0 auto;
+        position: relative;
+        top: 30px;
+        cursor: pointer;
+        z-index: 1;
+        > div {
+          width: 140px;
+          margin: 0 auto;
+          position: relative;
+          height: 48px;
+        }
+        h3 {
+          margin-bottom: 10px;
+          color: #000;
+          float: left;
+          margin-top: 10px;
+        }
+        .rounded {
+          width: 35px;
+          height: 35px;
+          line-height: 0;
+          border-radius: 17px;
+          cursor: pointer;
+          transition: 0.3s ease;
+          float: left;
+          i {
+            font-size: 30px;
+            margin: 0;
+            padding: 0;
+            top: 3px;
+            position: relative;
+            transition: 0.3s ease;
+            color: $black;
+            &.open {
+              -webkit-transform: rotate(180deg);
+              -moz-transform: rotate(180deg);
+              -ms-transform: rotate(180deg);
+              -o-transform: rotate(180deg);
+              transform: rotate(180deg);
+              top: 11px;
+            }
+          }
+        }
+      }
+    }
+    .job-id {
+      display: inline-block;
+      color: $grey1;
+      font-size: 12px;
+      position: relative;
+      line-height: 35px;
+      top: 1px;
+      text-align: left;
+      margin-right: 5px;
+      min-width: 70px;
+    }
 
     .source-target {
+      display: inline-block;
+      font-weight: bold;
+      max-width: 76%;
+      vertical-align: middle;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: 16px;
+      line-height: 32px;
+      .source-box {
+        /*line-height: 30px;*/
         display: inline-block;
-        font-weight: bold;
-        max-width: 76%;
+        max-width: 50%;
+        min-width: 60px;
         vertical-align: middle;
-        white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        font-size: 16px;
-        line-height:32px;
-        .source-box {
-            /*line-height: 30px;*/
-            display: inline-block;
-            max-width: 50%;
-            min-width: 60px;
-            vertical-align: middle;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            &.no-split {
-                max-width: 40%;
-            }
+        &.no-split {
+          max-width: 40%;
         }
-        .in-to {
-            display: inline-block;
-            top: 3px;
-            color: #5a5a5a;
-            /*line-height: 28px;*/
-            width: 24px;
-            position: relative;
-            i {
-                margin-right: 0;
-                font-size: 12px;
-                top: -2px;
-                position: relative;
-            }
+      }
+      .in-to {
+        display: inline-block;
+        top: 3px;
+        color: #5a5a5a;
+        /*line-height: 28px;*/
+        width: 24px;
+        position: relative;
+        i {
+          margin-right: 0;
+          font-size: 12px;
+          top: -2px;
+          position: relative;
         }
-        .target-box {
-            display: inline-block;
-            /*line-height: 30px;*/
-            max-width: 50%;
-            min-width: 60px;
-            vertical-align: middle;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            &.no-split {
-                max-width: 43%;
-            }
+      }
+      .target-box {
+        display: inline-block;
+        /*line-height: 30px;*/
+        max-width: 50%;
+        min-width: 60px;
+        vertical-align: middle;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        &.no-split {
+          max-width: 43%;
         }
+      }
     }
 
     @media only screen and (max-width: 1199px) and (min-width: 992px) {
-        .source-target {
-            /*max-width: 68% !important;*/
-            .source-box,
-            .target-box{
-                max-width: 50%;
-                min-width: 50px;
-                vertical-align: middle;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                /*&.no-split {
+      .source-target {
+        /*max-width: 68% !important;*/
+        .source-box,
+        .target-box {
+          max-width: 50%;
+          min-width: 50px;
+          vertical-align: middle;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          /*&.no-split {
                     max-width: 40%;
                     min-width: 50px;
                     vertical-align: middle;
                     overflow: hidden;
                     text-overflow: ellipsis;
                 }*/
-            }
         }
+      }
     }
 
     .project-body {
-        margin-top: 0;
-        background-color: $grey3;
-        margin: 0 -1rem 0;
-        margin-left: 1px;
-        margin-right: 1px;
-        .job {
-            padding: 0 15px;
-            margin-top: 35px;
-            margin-bottom: 20px;
-            .job-header {
-                background-color: #ffffff !important;
-                padding: 0 0 !important;
-            }
-            .job-body {
-                background-color: $grey5;
-                .chunks {
-                    .chunk-container {
-                        padding-top: 0;
-                        .analysis {
-                            //padding-top: 60px;
-                            margin-top: 0;
-                            &.show-details {
-                                .head-chunk, .job-table-header > div,
-                                .chunk-analyze-container > div {
-                                    background-color: #eaebef !important;
-
-                                }
-                            }
-                            &.outsource-open {
-                                margin-left: -35px;
-                                margin-right: -35px;
-                            }
-
-                                .head-chunk {
-                                    transition: 0.3s ease;
-                                    background-color: $grey5;
-                                    padding: 8px 15px;
-                                    position: relative;
-                                    z-index: 4;
-                                    text-align: left;
-                                    .job-not-payable {
-                                        display: inline-block;
-                                        padding: 0 0 0 10px !important;
-                                        line-height: 30px;
-                                        position: relative;
-                                        top: 1px;
-                                        display: inline-block;
-                                        color: $grey1;
-                                        #raw-words {
-                                            text-decoration: line-through;
-                                        }
-                                    }
-                                    .job-payable {
-                                        padding: 0 10px !important;
-                                        min-width: 105px;
-                                        line-height: 30px;
-                                        font-weight: 700;
-                                        position: relative;
-                                        top: 1px;
-                                        display: inline-block;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-            }
+      margin-top: 0;
+      background-color: $grey3;
+      margin: 0 -1rem 0;
+      margin-left: 1px;
+      margin-right: 1px;
+      .job {
+        padding: 0 15px;
+        margin-top: 35px;
+        margin-bottom: 20px;
+        .job-header {
+          background-color: #ffffff !important;
+          padding: 0 0 !important;
         }
-    }
+        .job-body {
+          background-color: $grey5;
+          .chunks {
+            .chunk-container {
+              padding-top: 0;
+              .analysis {
+                //padding-top: 60px;
+                margin-top: 0;
+                &.show-details {
+                  .head-chunk,
+                  .job-table-header > div,
+                  .chunk-analyze-container > div {
+                    background-color: #eaebef !important;
+                  }
+                }
+                &.outsource-open {
+                  margin-left: -35px;
+                  margin-right: -35px;
+                }
 
-}
+                .head-chunk {
+                  transition: 0.3s ease;
+                  background-color: $grey5;
+                  padding: 8px 15px;
+                  position: relative;
+                  z-index: 4;
+                  text-align: left;
+                  .job-not-payable {
+                    display: inline-block;
+                    padding: 0 0 0 10px !important;
+                    line-height: 30px;
+                    position: relative;
+                    top: 1px;
+                    display: inline-block;
+                    color: $grey1;
+                    #raw-words {
+                      text-decoration: line-through;
+                    }
+                  }
+                  .job-payable {
+                    padding: 0 10px !important;
+                    min-width: 105px;
+                    line-height: 30px;
+                    font-weight: 700;
+                    position: relative;
+                    top: 1px;
+                    display: inline-block;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 .analysis {
-.job-table-header {
+  .job-table-header {
     margin-top: 0 !important;
     margin-bottom: 0;
-
-}
-.chunk-analyze-container {
+  }
+  .chunk-analyze-container {
     margin-top: 0 !important;
     margin-bottom: 0;
     width: 103%;
     .ui.grid {
-        margin-top: 0;
-        width: 103%;
+      margin-top: 0;
+      width: 103%;
     }
-
-}
-.chunks-title-table, .chunks-pay-table, .chunk, .chunk-detail {
+  }
+  .chunks-title-table,
+  .chunks-pay-table,
+  .chunk,
+  .chunk-detail {
     .left-box {
-        height: 1%;
-        position: relative;
-        float: left;
-        text-align: left;
-        width: 15%;
+      height: 1%;
+      position: relative;
+      float: left;
+      text-align: left;
+      width: 15%;
     }
     .single-analysis {
+      display: inline-block;
+      margin: 0 auto;
+      width: 85%;
+      position: relative;
+      float: left;
+      text-align: right;
+      font-size: 15px;
+      line-height: 30px;
+      .single {
         display: inline-block;
-        margin: 0 auto;
-        width: 85%;
-        position: relative;
-        float: left;
-        text-align: right;
-        font-size: 15px;
-        line-height: 30px;
-        .single {
-            display: inline-block;
-            width: 8.5%;
-            margin-left: 0;
-            margin-right: -1px;
-            padding: 4px 6px 0 2px;
-            span {
-                font-size: 13px;
-                vertical-align: top;
-            }
-            &.total {
-                width: 8.5%;
-            }
-            &.payable-words {
-            }
-            &.new {
-                width: 5.5%;
-            }
-            &.repetition {
-                width: 9%;
-            }
-            &.internal-matches {
-            }
-            &.p-50-74 {
-            }
-            &.p-75-84 {
-            }
-            &.p-85-94 {
-            }
-            &.p-95-99 {
-            }
-            &.tm-100 {
-                width: 5%;
-            }
-            &.tm-public {
-                width: 6%;
-            }
-            &.tm-context {
-                width: 7%;
-            }
-            &.machine-translation {
-                position: relative;
-                width: 9%;
-                border-right: none;
-            }
+        width: 8.5%;
+        margin-left: 0;
+        margin-right: -1px;
+        padding: 4px 6px 0 2px;
+        span {
+          font-size: 13px;
+          vertical-align: top;
         }
+        &.total {
+          width: 8.5%;
+        }
+        &.payable-words {
+        }
+        &.new {
+          width: 5.5%;
+        }
+        &.repetition {
+          width: 9%;
+        }
+        &.internal-matches {
+        }
+        &.p-50-74 {
+        }
+        &.p-75-84 {
+        }
+        &.p-85-94 {
+        }
+        &.p-95-99 {
+        }
+        &.tm-100 {
+          width: 5%;
+        }
+        &.tm-public {
+          width: 6%;
+        }
+        &.tm-context {
+          width: 7%;
+        }
+        &.machine-translation {
+          position: relative;
+          width: 9%;
+          border-right: none;
+        }
+      }
     }
     .right-box {
-        width: 10%;
-        position: relative;
-        float: right;
-        top: 2px;
+      width: 10%;
+      position: relative;
+      float: right;
+      top: 2px;
     }
 
     @media only screen and (max-width: 1199px) and (min-width: 992px) {
-        .left-box {
-            padding-left: 0 !important;
-            .job-id {
-                min-width: 65px;
-
-            }
-            .file-details {
-                text-decoration: underline;
-                min-width: 25px;
-                line-height: 35px;
-                font-weight: 700;
-                position: relative;
-                top: 1px;
-                .details {
-                    display: none;
-                }
-                &:hover {
-                    text-decoration: none;
-                }
-            }
-            .f-details-number {
-                display: inline-block;
-            }
+      .left-box {
+        padding-left: 0 !important;
+        .job-id {
+          min-width: 65px;
         }
-        .single-analysis {
-            display: inline-block;
-            margin: 0 auto;
-            position: relative;
-            float: left;
-            text-align: right;
-            font-size: 14px;
-            line-height: 30px;
-            .single {
-                span {
-                    font-size: 12px;
-                    font-weight: 700;
-                }
-            }
+        .file-details {
+          text-decoration: underline;
+          min-width: 25px;
+          line-height: 35px;
+          font-weight: 700;
+          position: relative;
+          top: 1px;
+          .details {
+            display: none;
+          }
+          &:hover {
+            text-decoration: none;
+          }
         }
+        .f-details-number {
+          display: inline-block;
+        }
+      }
+      .single-analysis {
+        display: inline-block;
+        margin: 0 auto;
+        position: relative;
+        float: left;
+        text-align: right;
+        font-size: 14px;
+        line-height: 30px;
+        .single {
+          span {
+            font-size: 12px;
+            font-weight: 700;
+          }
+        }
+      }
     }
 
     @media only screen and (max-width: 991px) and (min-width: 768px) {
-        .left-box {
-            padding-left: 0 !important;
-            .job-id {
-                min-width: 65px;
-            }
-            .file-details {
-                text-decoration: underline;
-                min-width: 25px;
-                line-height: 35px;
-                font-weight: 700;
-                position: relative;
-                top: 1px;
-                .details {
-                    display: none;
-                }
-                &:hover {
-                    text-decoration: none;
-                }
-            }
+      .left-box {
+        padding-left: 0 !important;
+        .job-id {
+          min-width: 65px;
         }
-        .single-analysis {
-            display: inline-block;
-            margin: 0 auto;
-            position: relative;
-            float: left;
-            text-align: center;
-            font-size: 14px;
-            line-height: 30px;
-            .single {
-                span {
-                    font-size: 12px;
-                    font-weight: 700;
-                }
-            }
+        .file-details {
+          text-decoration: underline;
+          min-width: 25px;
+          line-height: 35px;
+          font-weight: 700;
+          position: relative;
+          top: 1px;
+          .details {
+            display: none;
+          }
+          &:hover {
+            text-decoration: none;
+          }
         }
+      }
+      .single-analysis {
+        display: inline-block;
+        margin: 0 auto;
+        position: relative;
+        float: left;
+        text-align: center;
+        font-size: 14px;
+        line-height: 30px;
+        .single {
+          span {
+            font-size: 12px;
+            font-weight: 700;
+          }
+        }
+      }
     }
 
     @media only screen and (max-width: 767px) {
-        .left-box {
-            padding-left: 0 !important;
-            .job-id {
-                min-width: 65px;
-            }
-            .file-details {
-                text-decoration: underline;
-                min-width: 25px;
-                line-height: 35px;
-                font-weight: 700;
-                position: relative;
-                top: 1px;
-                .details {
-                    display: none;
-                }
-                &:hover {
-                    text-decoration: none;
-                }
-            }
+      .left-box {
+        padding-left: 0 !important;
+        .job-id {
+          min-width: 65px;
         }
-        .single-analysis {
-            display: inline-block;
-            margin: 0 auto;
+        .file-details {
+          text-decoration: underline;
+          min-width: 25px;
+          line-height: 35px;
+          font-weight: 700;
+          position: relative;
+          top: 1px;
+          .details {
+            display: none;
+          }
+          &:hover {
+            text-decoration: none;
+          }
+        }
+      }
+      .single-analysis {
+        display: inline-block;
+        margin: 0 auto;
 
-            position: relative;
-            float: left;
-            text-align: center;
-            font-size: 14px;
-            line-height: 30px;
-            .single {
-                span {
-                    font-size: 12px;
-                    font-weight: 700;
-                }
-            }
+        position: relative;
+        float: left;
+        text-align: center;
+        font-size: 14px;
+        line-height: 30px;
+        .single {
+          span {
+            font-size: 12px;
+            font-weight: 700;
+          }
         }
+      }
     }
+  }
 
-}
-
-
-    .chunks-title-table {
-        box-shadow: none !important;
-        padding-top: 0 !important;
-        padding-bottom: 0 !important;
-        border-bottom: 1px solid $grey2;
-        .single-analysis {
-            line-height: 25px;
-            .single {
-                line-height: 18px;
-                -webkit-box-sizing: border-box;
-                -moz-box-sizing: border-box;
-                box-sizing: border-box;
-                padding-bottom: 3px;
-                height: 60px;
-                vertical-align: text-top;
-                border: 1px solid $grey1;
-                border-bottom: none;
-                border-top: none;
-                text-align: center;
-                padding-right: 6px;
-            }
-        }
+  .chunks-title-table {
+    box-shadow: none !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    border-bottom: 1px solid $grey2;
+    .single-analysis {
+      line-height: 25px;
+      .single {
+        line-height: 18px;
+        -webkit-box-sizing: border-box;
+        -moz-box-sizing: border-box;
+        box-sizing: border-box;
+        padding-bottom: 3px;
+        height: 60px;
+        vertical-align: text-top;
+        border: 1px solid $grey1;
+        border-bottom: none;
+        border-top: none;
+        text-align: center;
+        padding-right: 6px;
+      }
     }
+  }
 
-    .chunks-pay-table {
-        box-shadow: none !important;
-        padding-top: 0 !important;
-        padding-bottom: 3px !important;
-        top: -1px;
-        .single-analysis {
-            .single {
-                border: 1px solid $grey1;
-                border-bottom: none;
-                text-align: right;
-                padding-right: 6px;
-                &.total {
-                    width: 16.9%;
-                    text-decoration: none;
-                    border-left: 1px solid $grey1;
-                }
-            }
+  .chunks-pay-table {
+    box-shadow: none !important;
+    padding-top: 0 !important;
+    padding-bottom: 3px !important;
+    top: -1px;
+    .single-analysis {
+      .single {
+        border: 1px solid $grey1;
+        border-bottom: none;
+        text-align: right;
+        padding-right: 6px;
+        &.total {
+          width: 16.9%;
+          text-decoration: none;
+          border-left: 1px solid $grey1;
         }
+      }
     }
+  }
 
-.chunk, .chunk-detail {
+  .chunk,
+  .chunk-detail {
     transition: 0.3s ease;
     background-color: #ffffff;
     padding-top: 4px !important;
     padding-bottom: 4px !important;
     text-align: center;
-}
+  }
 
-    .chunk {
-        z-index: 2;
+  .chunk {
+    z-index: 2;
+    transition: 0.3s ease;
+    &:hover {
+      background-color: #f0f1f6;
+      .payable-words {
+        background: #e8fbcc !important;
+      }
+    }
+    .file-details {
+      display: inline-block;
+      text-decoration: underline;
+      min-width: 62px;
+      line-height: 35px;
+      position: relative;
+      top: 1px;
+      cursor: pointer;
+      color: $grey1;
+      &:hover {
+        text-decoration: none;
+      }
+    }
+    .f-details-number {
+      display: inline-block;
+      position: relative;
+      top: 1px;
+      color: $grey1;
+    }
+    .single-analysis {
+      .single {
+        border-right: 1px solid #e4e6e8;
+        border-left: 1px solid #e4e6e8;
+        text-align: right;
+        padding-right: 6px;
+      }
+      .payable-words {
+        font-weight: 700;
         transition: 0.3s ease;
-        &:hover {
-            background-color: #f0f1f6;
-            .payable-words {
-                background: #e8fbcc !important;
-            }
-        }
-        .file-details {
-            display: inline-block;
-            text-decoration: underline;
-            min-width: 62px;
-            line-height: 35px;
-            position: relative;
-            top: 1px;
-            cursor: pointer;
-            color: $grey1;
-            &:hover {
-                text-decoration: none;
-            }
-        }
-        .f-details-number {
-            display: inline-block;
-            position: relative;
-            top: 1px;
-            color: $grey1;
-        }
-        .single-analysis {
-            .single {
-                border-right: 1px solid #e4e6e8;
-                border-left: 1px solid #e4e6e8;
-                text-align: right;
-                padding-right: 6px;
-            }
-            .payable-words {
-                font-weight: 700;
-                transition: 0.3s ease;
-                color: #000000;
-                font-size: 18px;
-            }
-            .payable-words.updated-count {
-                background-color: $approvedGreen;
-                transition: 0.3s ease;
-            }
+        color: #000000;
+        font-size: 18px;
+      }
+      .payable-words.updated-count {
+        background-color: $approvedGreen;
+        transition: 0.3s ease;
+      }
 
-        .updated-count {
-            background-color: #f9ffb5;
-            transition: 0.4s ease;
-        }
-    }
-
-
-}
-
-    .chunk-detail {
-        padding-top: 0 !important;
-        padding-bottom: 0 !important;
-        background-color: $grey2;
-        padding-left: 12px;
-        z-index: 0;
-        .left-box {
-            padding-top: 8px;
-            i {
-                position: absolute;
-                top: 12px;
-            }
-            .file-title-details {
-                display: inline-block;
-                max-width: 82%;
-                min-width: 30px;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                position: absolute;
-                transition: 0.3s ease;
-                position: absolute;
-                left: 18px;
-                cursor: default;
-                &:hover {
-                    display: inline-block;
-                    max-width: 210%;
-                    min-width: 30px;
-                    white-space: nowrap;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    position: absolute;
-                    left: 18px;
-                    background: #c7c6c6;
-                    padding: 0 5px;
-                    z-index: 2;
-                }
-            }
-        }
-    }
-    .updated-count {
+      .updated-count {
         background-color: #f9ffb5;
         transition: 0.4s ease;
+      }
     }
+  }
+
+  .chunk-detail {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    background-color: $grey2;
+    padding-left: 12px;
+    z-index: 0;
+    .left-box {
+      padding-top: 8px;
+      i {
+        position: absolute;
+        top: 12px;
+      }
+      .file-title-details {
+        display: inline-block;
+        max-width: 82%;
+        min-width: 30px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        position: absolute;
+        transition: 0.3s ease;
+        position: absolute;
+        left: 18px;
+        cursor: default;
+        &:hover {
+          display: inline-block;
+          max-width: 210%;
+          min-width: 30px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          position: absolute;
+          left: 18px;
+          background: #c7c6c6;
+          padding: 0 5px;
+          z-index: 2;
+        }
+      }
+    }
+  }
+  .updated-count {
+    background-color: #f9ffb5;
+    transition: 0.4s ease;
+  }
 }
 
-
-
 @media only screen and (min-width: 1200px) {
-.ui.container {
+  .ui.container {
     width: 1140px;
     margin-left: auto !important;
     margin-right: auto !important;
     transition: 0.3s ease;
-}
+  }
 }
 
 @media only screen and (min-width: 1380px) {
-.ui.container {
+  .ui.container {
     width: 1280px;
     margin-left: auto !important;
     margin-right: auto !important;
     transition: 0.3s ease;
-}
+  }
 }
 
 @media only screen and (max-width: 1199px) and (min-width: 992px) {
-.ui.container {
+  .ui.container {
     width: 991px;
     margin-left: auto !important;
     margin-right: auto !important;
     transition: 0.3s ease;
-}
-
+  }
 }
 
 @media only screen and (max-width: 991px) and (min-width: 768px) {
-.ui.container {
+  .ui.container {
     min-width: 991px;
     margin-left: auto !important;
     margin-right: auto !important;
     transition: 0.3s ease;
-}
-.project-list {
+  }
+  .project-list {
     padding-top: 50px;
-
-}
-
+  }
 }
 
 @media only screen and (max-width: 767px) {
-.ui.container {
+  .ui.container {
     margin-left: 1em !important;
     margin-right: 1em !important;
     min-width: 991px;
     transition: 0.3s ease;
-}
-.project-list {
+  }
+  .project-list {
     padding-top: 50px;
-
-}
+  }
 }
 
 // Transitions
 .chunk-detail {
-width: 100%;
-height: 35px;
-position: relative;
-overflow: hidden;
-&.transition-enter {
+  width: 100%;
+  height: 35px;
+  position: relative;
+  overflow: hidden;
+  &.transition-enter {
     height: 0;
-    padding-top:0px !important;
+    padding-top: 0px !important;
     padding-bottom: 0 !important;
-}
+  }
 
-&.transition-enter.transition-enter-active {
+  &.transition-enter.transition-enter-active {
     height: 35px;
-    -webkit-transition: height .3s ease;
-}
+    -webkit-transition: height 0.3s ease;
+  }
 
-&.transition-exit.transition-exit-active {
+  &.transition-exit.transition-exit-active {
     height: 0;
-    padding-top:0px !important;
+    padding-top: 0px !important;
     padding-bottom: 0 !important;
-    -webkit-transition: height .3s ease;
-}
+    -webkit-transition: height 0.3s ease;
+  }
 }
 .progress-bar {
-height: 20px;
-position: relative;
-overflow: hidden;
-&.transition-enter {
+  height: 20px;
+  position: relative;
+  overflow: hidden;
+  &.transition-enter {
     height: 0;
-    padding-top:0px !important;
+    padding-top: 0px !important;
     padding-bottom: 0 !important;
-}
+  }
 
-&.transition-enter.transition-enter-active {
+  &.transition-enter.transition-enter-active {
     height: 20px;
-    -webkit-transition: height .3s ease;
-}
+    -webkit-transition: height 0.3s ease;
+  }
 
-&.transition-exit.transition-exit-active {
+  &.transition-exit.transition-exit-active {
     height: 0;
-    padding-top:0px !important;
+    padding-top: 0px !important;
     padding-bottom: 0 !important;
-    -webkit-transition: height .3s ease;
-}
+    -webkit-transition: height 0.3s ease;
+  }
 }
 
 .project {
-.jobs {
+  .jobs {
     position: relative;
     max-height: 2500px;
     opacity: 1;
-}
-.transitionAnalyzeMain-enter {
+  }
+  .transitionAnalyzeMain-enter {
     max-height: 0;
     opacity: 0;
-}
+  }
 
-.transitionAnalyzeMain-enter.transitionAnalyzeMain-enter-active {
+  .transitionAnalyzeMain-enter.transitionAnalyzeMain-enter-active {
     max-height: 3000px;
     opacity: 1;
-    -webkit-transition: max-height .5s ease, opacity 1s ease;
-}
+    -webkit-transition: max-height 0.5s ease, opacity 1s ease;
+  }
 
-.transitionAnalyzeMain-exit.transitionAnalyzeMain-exit-active {
+  .transitionAnalyzeMain-exit.transitionAnalyzeMain-exit-active {
     max-height: 0;
     padding-top: 0;
     padding-bottom: 0;
     opacity: 0;
-    -webkit-transition: max-height .5s ease, padding 1s ease, opacity 1s ease;
-}
+    -webkit-transition: max-height 0.5s ease, padding 1s ease, opacity 1s ease;
+  }
 }
 
 .ui.popup {
-    z-index:999;
+  z-index: 999;
 }
-
 
 /*.analyze footer {
     background: #6d6e71;
@@ -1333,85 +1322,84 @@ overflow: hidden;
 /* Header */
 
 #action-manage {
-    opacity: 0.8;
-    &:hover {
-        opacity: 1;
-    }
+  opacity: 0.8;
+  &:hover {
+    opacity: 1;
+  }
 }
 
 /* Footer */
-.normal-foo{
-    background-color: $grey4;
-    min-width: 992px;
+.normal-foo {
+  background-color: $grey4;
+  min-width: 992px;
 
-    width: 100%;
-    position: fixed;
+  width: 100%;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  .footer-body {
+    display: grid;
+    position: relative;
+    grid-column-gap: 24px;
+    grid-template-columns: 0.6fr 0.6fr 1fr;
+    align-items: center;
+    padding: 16px 64px;
+    height: 77px;
+    .info {
+      display: grid;
+      align-items: center;
+      grid-template-columns: 40px auto;
+      grid-column-gap: 8px;
+      .logo {
+        background-position: center;
+        background-size: cover;
+      }
+      .description {
+        color: $grey1;
+        font-weight: 100;
+        font-size: 12px;
+        text-align: left;
+        line-height: 14px;
+        .link {
+          color: #00aee4;
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+  .side-info {
+    padding: 0 16px;
+    position: absolute;
+    display: grid;
+    align-items: center;
     bottom: 0;
-    left: 0;
-    z-index: 2;
-    .footer-body{
-        display: grid;
-        position: relative;
-        grid-column-gap: 24px;
-        grid-template-columns: 0.6fr 0.6fr 1fr;
-        align-items: center;
-        padding: 16px 64px;
-        height: 77px;
-        .info{
-            display: grid;
-            align-items: center;
-            grid-template-columns: 40px auto;
-            grid-column-gap: 8px;
-            .logo{
-                background-position: center;
-                background-size: cover;
-            }
-            .description{
-                color: $grey1;
-                font-weight: 100;
-                font-size: 12px;
-                text-align: left;
-                line-height: 14px;
-                .link{
-                    color: #00aee4;
-                    text-decoration: underline;
-                }
-            }
+    right: 0;
+    width: 419px;
+    height: 35px;
+    box-shadow: -2px -2px 12px 0 rgba(198, 198, 198, 0.5);
+    background-color: #ffffff;
+    .side-info-body {
+      display: grid;
+      grid-template-columns: 80px 80px 80px;
+      align-items: center;
+      .item {
+        a {
+          margin: 0;
+          padding: 0;
+          color: $grey1;
+          display: block;
+          text-decoration: underline;
+          text-align: left;
         }
+      }
     }
-    .side-info{
-        padding: 0 16px;
-        position: absolute;
-        display: grid;
-        align-items: center;
-        bottom: 0;
-        right: 0;
-        width: 419px;
-        height: 35px;
-        box-shadow: -2px -2px 12px 0 rgba(198, 198, 198, 0.5);
-        background-color: #ffffff;
-        .side-info-body{
-            display: grid;
-            grid-template-columns: 80px 80px 80px;
-            align-items: center;
-            .item{
-                a{
-                    margin: 0;
-                    padding: 0;
-                    color: $grey1;
-                    display: block;
-                    text-decoration: underline;
-                    text-align: left;
-                }
-            }
-        }
-    }
+  }
 }
 
 #action-manage {
-    opacity: 0.8;
-    &:hover {
-        opacity: 1;
-    }
+  opacity: 0.8;
+  &:hover {
+    opacity: 1;
+  }
 }
-

--- a/public/css/sass/commons/_buttons.scss
+++ b/public/css/sass/commons/_buttons.scss
@@ -1,135 +1,153 @@
-
 /*SIZE*/
 .ui.buttons .button,
 .ui.buttons .or,
 .ui.button {
-    font-size: 16px;
+  font-size: 16px;
 }
 
 .ui.button-modal {
-    font-size: 18px;
-    cursor: pointer;
-    font-weight: bold;
-    padding: 0 22px;
-    display: inline-block;
-    height: 40px;
-    overflow: hidden;
-    line-height: 40px;
-    &.blue {
-        background: -webkit-gradient(linear, left top, left bottom, from($translatedBlue), to(#119ec4));
-        background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
-        background: linear-gradient(top, $translatedBlue, #119ec4);
-        color: #fff;
-        border: 1px solid #848689;
-        text-decoration: none;
-        border-radius: 2px;
-        &.disabled {
-            opacity: 0.5 !important;
-            cursor: default;
-            -moz-box-shadow: none;
-            -webkit-box-shadow: none;
-            border: 1px solid #666;
-            background: #ccc;
-        }
+  font-size: 18px;
+  cursor: pointer;
+  font-weight: bold;
+  padding: 0 22px;
+  display: inline-block;
+  height: 40px;
+  overflow: hidden;
+  line-height: 40px;
+  &.blue {
+    background: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from($translatedBlue),
+      to(#119ec4)
+    );
+    background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
+    background: linear-gradient(top, $translatedBlue, #119ec4);
+    color: #fff;
+    border: 1px solid #848689;
+    text-decoration: none;
+    border-radius: 2px;
+    &.disabled {
+      opacity: 0.5 !important;
+      cursor: default;
+      -moz-box-shadow: none;
+      -webkit-box-shadow: none;
+      border: 1px solid #666;
+      background: #ccc;
     }
-    &.grey {
-        color: #333;
-        background: #f6f6f6;
-        background: -webkit-gradient(linear, left top, left bottom, from(#f6f6f6), to(#e2e3e5));
-        background: -moz-linear-gradient(top, #f6f6f6, #e2e3e5);
-        background: linear-gradient(top, #f6f6f6, #e2e3e5);
-        border: 1px solid #848689;
-        text-decoration: none;
-        border-radius: 2px;
-    }
-    &.orange {
-        background-color: #f26522;
-        background: -webkit-gradient(linear, left top, left bottom, from(#f26522), to(#fb5d12));
-        background: -moz-linear-gradient(top, #f26522, #fb5d12);
-        background: linear-gradient(top, #f26522, #fb5d12);
-        color: #fff;
-        border: 1px solid #848689;
-        text-decoration: none;
-        border-radius: 2px;
-    }
-    &:hover {
-        box-shadow: 0 1px 2px #ccc;
-        -webkit-box-shadow: 0 1px 2px #ccc;
-        border: 1px solid #000;
-    }
-    &:active {
-        -moz-box-shadow: inset 0 0 1px 1px #888;
-        -webkit-box-shadow: inset 0 0 1px 1px #888;
-        box-shadow: inset 0 0 1px 1px #888;
-    }
+  }
+  &.grey {
+    color: #333;
+    background: #f6f6f6;
+    background: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#f6f6f6),
+      to(#e2e3e5)
+    );
+    background: -moz-linear-gradient(top, #f6f6f6, #e2e3e5);
+    background: linear-gradient(top, #f6f6f6, #e2e3e5);
+    border: 1px solid #848689;
+    text-decoration: none;
+    border-radius: 2px;
+  }
+  &.orange {
+    background-color: #f26522;
+    background: -webkit-gradient(
+      linear,
+      left top,
+      left bottom,
+      from(#f26522),
+      to(#fb5d12)
+    );
+    background: -moz-linear-gradient(top, #f26522, #fb5d12);
+    background: linear-gradient(top, #f26522, #fb5d12);
+    color: #fff;
+    border: 1px solid #848689;
+    text-decoration: none;
+    border-radius: 2px;
+  }
+  &:hover {
+    box-shadow: 0 1px 2px #ccc;
+    -webkit-box-shadow: 0 1px 2px #ccc;
+    border: 1px solid #000;
+  }
+  &:active {
+    -moz-box-shadow: inset 0 0 1px 1px #888;
+    -webkit-box-shadow: inset 0 0 1px 1px #888;
+    box-shadow: inset 0 0 1px 1px #888;
+  }
 
-    &.margin {
-        &.left-10 {
-            margin-left: 10px;
-        }
-        &.left-20 {
-            margin-left: 20px;
-        }
-        &.left-30 {
-            margin-left: 30px;
-        }
-        &.right-10 {
-            margin-right: 10px;
-        }
-        &.right-20 {
-            margin-right: 20px;
-        }
-        &.right-30 {
-            margin-right: 30px;
-        }
+  &.margin {
+    &.left-10 {
+      margin-left: 10px;
     }
-
+    &.left-20 {
+      margin-left: 20px;
+    }
+    &.left-30 {
+      margin-left: 30px;
+    }
+    &.right-10 {
+      margin-right: 10px;
+    }
+    &.right-20 {
+      margin-right: 20px;
+    }
+    &.right-30 {
+      margin-right: 30px;
+    }
+  }
 }
 
-
 .ui.button.cancel-button {
-    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    margin-top: 0;
-    border: 1px solid #797979;
-    border-radius: 2px;
-    background-color: #f6f6f6;
-    margin-right: 15px;
-    &:hover {
-        //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-    }
-    &:focus {
-        box-shadow: none;
-    }
+  font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  margin-top: 0;
+  border: 1px solid #797979;
+  border-radius: 2px;
+  background-color: #f6f6f6;
+  margin-right: 15px;
+  &:hover {
+    //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  }
+  &:focus {
+    box-shadow: none;
+  }
 }
 
 // Button TR, LR navigation through filter
-.ui.next-repetition-group, .ui.next-repetition {
-    border: 1px solid #797979;
-    position: relative;
-    top: -6px;
-    padding: 9px 12px 8px !important;
+.ui.next-repetition-group,
+.ui.next-repetition {
+  border: 1px solid #797979;
+  position: relative;
+  top: -6px;
+  padding: 9px 12px 8px !important;
 }
 
-.ui.next-review-repetition-group, .ui.next-review-repetition {
-    border: 1px solid #797979;
-    position: relative;
-    top: -6px;
-    padding: 9px 12px 8px !important;
-    background: $approvedGreen !important;
-    &.revise-button-2 {
-        background: #BC6AC9 !important;
-    }
+.ui.next-review-repetition-group,
+.ui.next-review-repetition {
+  border: 1px solid #797979;
+  position: relative;
+  top: -6px;
+  padding: 9px 12px 8px !important;
+  background: $approvedGreen !important;
+  &.revise-button-2 {
+    background: #bc6ac9 !important;
+  }
 }
 
-.ui.next-repetition-group, .ui.next-review-repetition-group {
-    margin-right: 4px;
+.ui.next-repetition-group,
+.ui.next-review-repetition-group {
+  margin-right: 4px;
 }
 
 // Button comment segment
 .ui.primary.mbc-comment-send-btn {
-    font-size: 14px;
-    padding: 8px 10px;
-    text-align: right;
-    border-radius: 2px;
-    float: right;
+  font-size: 14px;
+  padding: 8px 10px;
+  text-align: right;
+  border-radius: 2px;
+  float: right;
 }

--- a/public/css/sass/commons/_colors.scss
+++ b/public/css/sass/commons/_colors.scss
@@ -1,48 +1,47 @@
-
 $black: #000;
-$grey: #6F6F6F;
+$grey: #6f6f6f;
 $white: white;
 
 $grey1: #788190;
-$grey2: #AEBDCD;
-$grey3: #D9E0E8;
-$grey4: #EAEBEE;
-$grey5: #F5F6F7;
+$grey2: #aebdcd;
+$grey3: #d9e0e8;
+$grey4: #eaebee;
+$grey5: #f5f6f7;
 
-$darkBlue: #002B5A;
-$darkBlueHover: #00254F;
-$darkBlueTransparent: #D9E0E8;
+$darkBlue: #002b5a;
+$darkBlueHover: #00254f;
+$darkBlueTransparent: #d9e0e8;
 
-$linkBlue: #4184C4;
-$linkBlueHover: #3174B4;
-$linkBlueActive: #3174B4;
-$linkBlueTransparent: #86AACD;
+$linkBlue: #4184c4;
+$linkBlueHover: #3174b4;
+$linkBlueActive: #3174b4;
+$linkBlueTransparent: #86aacd;
 
-$translatedBlue: #0099CC;
-$translatedBlueHover: #0889B3;
-$translatedBlueActive: #0889B3;
-$translatedBlueTransparent: #63C3E3;
+$translatedBlue: #0099cc;
+$translatedBlueHover: #0889b3;
+$translatedBlueActive: #0889b3;
+$translatedBlueTransparent: #63c3e3;
 
-$approvedGreen: #2FB177;
-$approvedGreenHover: #1C9F64;
-$approvedGreenTransparent: #80D5AF;
+$approvedGreen: #2fb177;
+$approvedGreenHover: #1c9f64;
+$approvedGreenTransparent: #80d5af;
 
-$approved2Green: #9352C1;
-$approved2GreenHover: #7A3CA6;
-$approved2GreenTransparent: #B58DD2;
+$approved2Green: #9352c1;
+$approved2GreenHover: #7a3ca6;
+$approved2GreenTransparent: #b58dd2;
 
 $rebuttedRed: #ff8734;
-$rebuttedRedHover: #E9511F;
-$rebuttedRedTransparent: #FFAA8E;
+$rebuttedRedHover: #e9511f;
+$rebuttedRedTransparent: #ffaa8e;
 
-$greenDefault: #1FBD1F;
-$greenDefaultHover: #1BA61B;
-$greenDefaultTransparent: #7CC576;
+$greenDefault: #1fbd1f;
+$greenDefaultHover: #1ba61b;
+$greenDefaultTransparent: #7cc576;
 
-$redDefault: #E02020;
-$redDefaultHover: #D31D1D;
-$redDefaultTransparent: #FFC8CA;
+$redDefault: #e02020;
+$redDefaultHover: #d31d1d;
+$redDefaultTransparent: #ffc8ca;
 
-$orangeDefault: #FFCC01;
-$orangeDefaultHover: #EFBF00;
-$orangeDefaultTransparent: #FEE47A;
+$orangeDefault: #ffcc01;
+$orangeDefaultHover: #efbf00;
+$orangeDefaultTransparent: #fee47a;

--- a/public/css/sass/commons/_date-picker-translator.scss
+++ b/public/css/sass/commons/_date-picker-translator.scss
@@ -1,57 +1,62 @@
 .xdsoft_datetimepicker {
-    font-family: Calibri, Arial, Helvetica, sans-serif;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_today {
-    color: $translatedBlue;
+  color: $translatedBlue;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td.xdsoft_current {
-    background: $translatedBlue;
-    box-shadow: none;
-    color: #ffffff;
+  background: $translatedBlue;
+  box-shadow: none;
+  color: #ffffff;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td:hover {
-    color: #666 !important;
-    background: #d0d0d0 !important;
-    box-shadow: none !important;
+  color: #666 !important;
+  background: #d0d0d0 !important;
+  box-shadow: none !important;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td:active {
-    color: #ffffff !important;
-    background: $translatedBlue !important;
-    box-shadow: none !important;
+  color: #ffffff !important;
+  background: $translatedBlue !important;
+  box-shadow: none !important;
 }
 
 .xdsoft_datetimepicker .xdsoft_calendar td:focus {
-    color: #ffffff !important;
-    background: $translatedBlue !important;
-    box-shadow: none !important;
+  color: #ffffff !important;
+  background: $translatedBlue !important;
+  box-shadow: none !important;
 }
 
-.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box>div>div.xdsoft_current {
-    background: $translatedBlue;
-    box-shadow: none;
+.xdsoft_datetimepicker
+  .xdsoft_timepicker
+  .xdsoft_time_box
+  > div
+  > div.xdsoft_current {
+  background: $translatedBlue;
+  box-shadow: none;
 }
 
-.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box>div>div:hover {
-    color: #666 !important;
-    background: #d0d0d0 !important;
-    box-shadow: none !important;
+.xdsoft_datetimepicker .xdsoft_timepicker .xdsoft_time_box > div > div:hover {
+  color: #666 !important;
+  background: #d0d0d0 !important;
+  box-shadow: none !important;
 }
 
 .xdsoft_datetimepicker .blue-gradient-button {
-    background: $translatedBlue;
-    color: white;
-    font-family: Calibri;
-    border: 1px solid #797979 !important;
-    padding: 4px;
+  background: $translatedBlue;
+  color: white;
+  font-family: Calibri;
+  border: 1px solid #797979 !important;
+  padding: 4px;
 }
 
 .xdsoft_datetimepicker .blue-gradient-button:hover {
-    background: $translatedBlue;
-    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-    color: #fff;
-    border: 1px solid #797979 !important;
+  background: $translatedBlue;
+  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  color: #fff;
+  border: 1px solid #797979 !important;
 }

--- a/public/css/sass/commons/_divider.scss
+++ b/public/css/sass/commons/_divider.scss
@@ -1,28 +1,30 @@
 // Top Margin
 
-@each $divider in 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 26, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 200, 300, 400, 500 {
+@each $divider in 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+  18, 19, 20, 26, 30, 40, 50, 60, 70, 80, 90, 100, 125, 150, 200, 300, 400, 500
+{
   .top-#{$divider} {
     margin-top: $divider * 1px !important;
   }
   .bottom-#{$divider} {
-    margin-bottom: $divider *1px !important;
+    margin-bottom: $divider * 1px !important;
   }
   .left-#{$divider} {
-    margin-left: $divider *1px !important;
+    margin-left: $divider * 1px !important;
   }
   .right-#{$divider} {
-    margin-right: $divider *1px !important;
+    margin-right: $divider * 1px !important;
   }
   .pad-top-#{$divider} {
     padding-top: $divider * 1px !important;
   }
   .pad-bottom-#{$divider} {
-    padding-bottom: $divider *1px !important;
+    padding-bottom: $divider * 1px !important;
   }
   .pad-right-#{$divider} {
-    padding-right: $divider *1px !important;
+    padding-right: $divider * 1px !important;
   }
   .pad-left-#{$divider} {
-    padding-left: $divider *1px !important;
+    padding-left: $divider * 1px !important;
   }
 }

--- a/public/css/sass/commons/_icons.scss
+++ b/public/css/sass/commons/_icons.scss
@@ -1,16 +1,17 @@
 @font-face {
   font-family: 'icomoon';
-  src:  url('fonts/icomoon.eot?pz5eid');
-  src:  url('fonts/icomoon.eot?pz5eid#iefix') format('embedded-opentype'),
-  url('fonts/icomoon.ttf?pz5eid') format('truetype'),
-  url('fonts/icomoon.woff?pz5eid') format('woff'),
-  url('fonts/icomoon.svg?pz5eid#icomoon') format('svg');
+  src: url('fonts/icomoon.eot?pz5eid');
+  src: url('fonts/icomoon.eot?pz5eid#iefix') format('embedded-opentype'),
+    url('fonts/icomoon.ttf?pz5eid') format('truetype'),
+    url('fonts/icomoon.woff?pz5eid') format('woff'),
+    url('fonts/icomoon.svg?pz5eid#icomoon') format('svg');
   font-weight: normal;
   font-style: normal;
   font-display: block;
 }
 
-[class^="icon-"], [class*=" icon-"] {
+[class^='icon-'],
+[class*=' icon-'] {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'icomoon' !important;
   speak: never;
@@ -26,1400 +27,1400 @@
 }
 
 .icon-go-to-first:before {
-  content: "\ea8e";
+  content: '\ea8e';
 }
 .icon-go-to-last:before {
-  content: "\ea8f";
+  content: '\ea8f';
 }
 .icon-no-preview:before {
-  content: "\ea8d";
+  content: '\ea8d';
 }
 .icon-quote-client:before {
-  content: "\ea89";
+  content: '\ea89';
 }
 .icon-qr-matecat:before {
-  content: "\e90a";
+  content: '\e90a';
 }
 .icon-tm-matecat:before {
-  content: "\e90b";
+  content: '\e90b';
 }
 .icon-uniE96B:before {
-  content: "\e96b";
+  content: '\e96b';
 }
 .icon-uniE96D:before {
-  content: "\e96d";
+  content: '\e96d';
 }
 .icon-uniE96E:before {
-  content: "\e96e";
+  content: '\e96e';
 }
 .icon-uniE970:before {
-  content: "\e970";
+  content: '\e970';
 }
 .icon-error_outline:before {
-  content: "\e001";
+  content: '\e001';
 }
 .icon-format_color_fill:before {
-  content: "\e23a";
+  content: '\e23a';
 }
 .icon-power-cord:before {
-  content: "\e291";
+  content: '\e291';
 }
 .icon-power-cord2:before {
-  content: "\e292";
+  content: '\e292';
 }
 .icon-file_download:before {
-  content: "\e2c4";
+  content: '\e2c4';
 }
 .icon-collections_bookmark:before {
-  content: "\e431";
+  content: '\e431';
 }
 .icon-user22:before {
-  content: "\e601";
+  content: '\e601';
 }
 .icon-upload:before {
-  content: "\e602";
+  content: '\e602';
 }
 .icon-download:before {
-  content: "\e603";
+  content: '\e603';
 }
 .icon-stop:before {
-  content: "\e604";
+  content: '\e604';
 }
 .icon-info:before {
-  content: "\e605";
+  content: '\e605';
 }
 .icon-drawer:before {
-  content: "\e606";
+  content: '\e606';
 }
 .icon-minus:before {
-  content: "\e607";
+  content: '\e607';
 }
 .icon-settings:before {
-  content: "\e8b8";
+  content: '\e8b8';
 }
 .icon-download-logs:before {
-  content: "\e906";
+  content: '\e906';
 }
 .icon-zip:before {
-  content: "\e907";
+  content: '\e907';
 }
 .icon-mic:before {
-  content: "\e91e";
+  content: '\e91e';
 }
 .icon-bubble2:before {
-  content: "\e96f";
+  content: '\e96f';
 }
 .icon-cancel-circle:before {
-  content: "\ea0d";
+  content: '\ea0d';
 }
 .icon-make-group:before {
-  content: "\ea58";
+  content: '\ea58';
 }
 .icon-text-height:before {
-  content: "\ea5f";
+  content: '\ea5f';
 }
 .icon-superscript2:before {
-  content: "\ea6b";
+  content: '\ea6b';
 }
 .icon-subscript2:before {
-  content: "\ea6c";
+  content: '\ea6c';
 }
 .icon-refresh:before {
-  content: "\f021";
+  content: '\f021';
 }
 .icon-split:before {
-  content: "\f03d";
+  content: '\f03d';
 }
 .icon-edit:before {
-  content: "\f044";
+  content: '\f044';
 }
 .icon-play:before {
-  content: "\f04b";
+  content: '\f04b';
 }
 .icon-chevron-left:before {
-  content: "\f053";
+  content: '\f053';
 }
 .icon-eye2:before {
-  content: "\f06e";
+  content: '\f06e';
 }
 .icon-navicon:before {
-  content: "\f0c9";
+  content: '\f0c9';
 }
 .icon-google-plus-square2:before {
-  content: "\f0d5";
+  content: '\f0d5';
 }
 .icon-sort-up:before {
-  content: "\f0e0";
+  content: '\f0e0';
 }
 .icon-code:before {
-  content: "\f121";
+  content: '\f121';
 }
 .icon-star-half-empty:before {
-  content: "\f123";
+  content: '\f123';
 }
 .icon-play-circle:before {
-  content: "\f144";
+  content: '\f144';
 }
 .icon-notice:before {
-  content: "\e903";
+  content: '\e903';
 }
 .icon-forward:before {
-  content: "\e902";
+  content: '\e902';
 }
 .icon-file:before {
-  content: "\e904";
+  content: '\e904';
 }
 .icon-number:before {
-  content: "\e90c";
+  content: '\e90c';
 }
 .icon-number2:before {
-  content: "\e90d";
+  content: '\e90d';
 }
 .icon-number3:before {
-  content: "\e90e";
+  content: '\e90e';
 }
 .icon-number4:before {
-  content: "\e90f";
+  content: '\e90f';
 }
 .icon-number5:before {
-  content: "\e910";
+  content: '\e910';
 }
 .icon-number6:before {
-  content: "\e911";
+  content: '\e911';
 }
 .icon-number7:before {
-  content: "\e912";
+  content: '\e912';
 }
 .icon-number8:before {
-  content: "\e913";
+  content: '\e913';
 }
 .icon-number9:before {
-  content: "\e914";
+  content: '\e914';
 }
 .icon-number10:before {
-  content: "\e915";
+  content: '\e915';
 }
 .icon-number11:before {
-  content: "\e916";
+  content: '\e916';
 }
 .icon-number12:before {
-  content: "\e917";
+  content: '\e917';
 }
 .icon-number13:before {
-  content: "\e918";
+  content: '\e918';
 }
 .icon-number14:before {
-  content: "\e919";
+  content: '\e919';
 }
 .icon-number15:before {
-  content: "\e91a";
+  content: '\e91a';
 }
 .icon-number16:before {
-  content: "\e91b";
+  content: '\e91b';
 }
 .icon-number17:before {
-  content: "\e91c";
+  content: '\e91c';
 }
 .icon-number18:before {
-  content: "\e91d";
+  content: '\e91d';
 }
 .icon-number19:before {
-  content: "\e91f";
+  content: '\e91f';
 }
 .icon-number20:before {
-  content: "\e920";
+  content: '\e920';
 }
 .icon-quote:before {
-  content: "\e921";
+  content: '\e921';
 }
 .icon-quote2:before {
-  content: "\e923";
+  content: '\e923';
 }
 .icon-tag:before {
-  content: "\e924";
+  content: '\e924';
 }
 .icon-tag2:before {
-  content: "\e925";
+  content: '\e925';
 }
 .icon-link:before {
-  content: "\e926";
+  content: '\e926';
 }
 .icon-link2:before {
-  content: "\e927";
+  content: '\e927';
 }
 .icon-cabinet:before {
-  content: "\e928";
+  content: '\e928';
 }
 .icon-cabinet2:before {
-  content: "\e929";
+  content: '\e929';
 }
 .icon-calendar:before {
-  content: "\e92a";
+  content: '\e92a';
 }
 .icon-calendar2:before {
-  content: "\e92b";
+  content: '\e92b';
 }
 .icon-calendar3:before {
-  content: "\e92c";
+  content: '\e92c';
 }
 .icon-file2:before {
-  content: "\e92d";
+  content: '\e92d';
 }
 .icon-file3:before {
-  content: "\e92e";
+  content: '\e92e';
 }
 .icon-file4:before {
-  content: "\e92f";
+  content: '\e92f';
 }
 .icon-files:before {
-  content: "\e930";
+  content: '\e930';
 }
 .icon-phone:before {
-  content: "\e931";
+  content: '\e931';
 }
 .icon-tablet:before {
-  content: "\e932";
+  content: '\e932';
 }
 .icon-window:before {
-  content: "\e933";
+  content: '\e933';
 }
 .icon-monitor:before {
-  content: "\e934";
+  content: '\e934';
 }
 .icon-ipod:before {
-  content: "\e935";
+  content: '\e935';
 }
 .icon-tv:before {
-  content: "\e936";
+  content: '\e936';
 }
 .icon-camera:before {
-  content: "\e937";
+  content: '\e937';
 }
 .icon-camera2:before {
-  content: "\e938";
+  content: '\e938';
 }
 .icon-camera3:before {
-  content: "\e939";
+  content: '\e939';
 }
 .icon-film:before {
-  content: "\e93a";
+  content: '\e93a';
 }
 .icon-film2:before {
-  content: "\e93b";
+  content: '\e93b';
 }
 .icon-film3:before {
-  content: "\e93c";
+  content: '\e93c';
 }
 .icon-microphone:before {
-  content: "\e93d";
+  content: '\e93d';
 }
 .icon-microphone2:before {
-  content: "\e93e";
+  content: '\e93e';
 }
 .icon-microphone3:before {
-  content: "\e93f";
+  content: '\e93f';
 }
 .icon-drink:before {
-  content: "\e940";
+  content: '\e940';
 }
 .icon-drink2:before {
-  content: "\e941";
+  content: '\e941';
 }
 .icon-drink3:before {
-  content: "\e942";
+  content: '\e942';
 }
 .icon-drink4:before {
-  content: "\e943";
+  content: '\e943';
 }
 .icon-coffee:before {
-  content: "\e944";
+  content: '\e944';
 }
 .icon-mug:before {
-  content: "\e945";
+  content: '\e945';
 }
 .icon-icecream:before {
-  content: "\e901";
+  content: '\e901';
 }
 .icon-cake:before {
-  content: "\e946";
+  content: '\e946';
 }
 .icon-inbox:before {
-  content: "\e947";
+  content: '\e947';
 }
 .icon-download2:before {
-  content: "\e948";
+  content: '\e948';
 }
 .icon-upload2:before {
-  content: "\e949";
+  content: '\e949';
 }
 .icon-inbox2:before {
-  content: "\e94a";
+  content: '\e94a';
 }
 .icon-checkmark4:before {
-  content: "\e94b";
+  content: '\e94b';
 }
 .icon-checkmark5:before {
-  content: "\e94c";
+  content: '\e94c';
 }
 .icon-cancel:before {
-  content: "\e94d";
+  content: '\e94d';
 }
 .icon-cancel2:before {
-  content: "\e94e";
+  content: '\e94e';
 }
 .icon-plus2:before {
-  content: "\e94f";
+  content: '\e94f';
 }
 .icon-plus3:before {
-  content: "\e950";
+  content: '\e950';
 }
 .icon-minus2:before {
-  content: "\e951";
+  content: '\e951';
 }
 .icon-minus3:before {
-  content: "\e952";
+  content: '\e952';
 }
 .icon-notice3:before {
-  content: "\e953";
+  content: '\e953';
 }
 .icon-notice4:before {
-  content: "\e954";
+  content: '\e954';
 }
 .icon-cog:before {
-  content: "\e955";
+  content: '\e955';
 }
 .icon-cogs:before {
-  content: "\e956";
+  content: '\e956';
 }
 .icon-cog2:before {
-  content: "\e957";
+  content: '\e957';
 }
 .icon-warning2:before {
-  content: "\e958";
+  content: '\e958';
 }
 .icon-health:before {
-  content: "\e959";
+  content: '\e959';
 }
 .icon-suitcase:before {
-  content: "\e95a";
+  content: '\e95a';
 }
 .icon-suitcase2:before {
-  content: "\e95b";
+  content: '\e95b';
 }
 .icon-suitcase3:before {
-  content: "\e95c";
+  content: '\e95c';
 }
 .icon-picture:before {
-  content: "\e95d";
+  content: '\e95d';
 }
 .icon-pictures:before {
-  content: "\e95e";
+  content: '\e95e';
 }
 .icon-pictures2:before {
-  content: "\e95f";
+  content: '\e95f';
 }
 .icon-android:before {
-  content: "\e960";
+  content: '\e960';
 }
 .icon-marvin:before {
-  content: "\e961";
+  content: '\e961';
 }
 .icon-pacman:before {
-  content: "\e962";
+  content: '\e962';
 }
 .icon-cassette:before {
-  content: "\e963";
+  content: '\e963';
 }
 .icon-watch:before {
-  content: "\e964";
+  content: '\e964';
 }
 .icon-chronometer:before {
-  content: "\e965";
+  content: '\e965';
 }
 .icon-watch2:before {
-  content: "\e966";
+  content: '\e966';
 }
 .icon-alarmclock:before {
-  content: "\e969";
+  content: '\e969';
 }
 .icon-time:before {
-  content: "\e96a";
+  content: '\e96a';
 }
 .icon-time2:before {
-  content: "\e96c";
+  content: '\e96c';
 }
 .icon-headphones:before {
-  content: "\e971";
+  content: '\e971';
 }
 .icon-wallet:before {
-  content: "\e974";
+  content: '\e974';
 }
 .icon-cancel3:before {
-  content: "\e975";
+  content: '\e975';
 }
 .icon-eye3:before {
-  content: "\e976";
+  content: '\e976';
 }
 .icon-position:before {
-  content: "\e977";
+  content: '\e977';
 }
 .icon-sitemap:before {
-  content: "\e978";
+  content: '\e978';
 }
 .icon-sitemap2:before {
-  content: "\e979";
+  content: '\e979';
 }
 .icon-cloud:before {
-  content: "\e97a";
+  content: '\e97a';
 }
 .icon-upload3:before {
-  content: "\e97b";
+  content: '\e97b';
 }
 .icon-chart:before {
-  content: "\e97c";
+  content: '\e97c';
 }
 .icon-chart2:before {
-  content: "\e97d";
+  content: '\e97d';
 }
 .icon-chart3:before {
-  content: "\e97e";
+  content: '\e97e';
 }
 .icon-chart4:before {
-  content: "\e97f";
+  content: '\e97f';
 }
 .icon-chart5:before {
-  content: "\e980";
+  content: '\e980';
 }
 .icon-chart6:before {
-  content: "\e981";
+  content: '\e981';
 }
 .icon-location:before {
-  content: "\e982";
+  content: '\e982';
 }
 .icon-download3:before {
-  content: "\e983";
+  content: '\e983';
 }
 .icon-basket:before {
-  content: "\e984";
+  content: '\e984';
 }
 .icon-folder:before {
-  content: "\e985";
+  content: '\e985';
 }
 .icon-gamepad:before {
-  content: "\e986";
+  content: '\e986';
 }
 .icon-alarm:before {
-  content: "\e987";
+  content: '\e987';
 }
 .icon-alarm-cancel:before {
-  content: "\e988";
+  content: '\e988';
 }
 .icon-phone2:before {
-  content: "\e989";
+  content: '\e989';
 }
 .icon-phone3:before {
-  content: "\e98a";
+  content: '\e98a';
 }
 .icon-image:before {
-  content: "\e98b";
+  content: '\e98b';
 }
 .icon-open:before {
-  content: "\e98c";
+  content: '\e98c';
 }
 .icon-sale:before {
-  content: "\e98d";
+  content: '\e98d';
 }
 .icon-direction:before {
-  content: "\e98e";
+  content: '\e98e';
 }
 .icon-map:before {
-  content: "\e991";
+  content: '\e991';
 }
 .icon-trashcan:before {
-  content: "\e992";
+  content: '\e992';
 }
 .icon-vote:before {
-  content: "\e993";
+  content: '\e993';
 }
 .icon-graduate:before {
-  content: "\e994";
+  content: '\e994';
 }
 .icon-lab:before {
-  content: "\e995";
+  content: '\e995';
 }
 .icon-tie:before {
-  content: "\e996";
+  content: '\e996';
 }
 .icon-football:before {
-  content: "\e997";
+  content: '\e997';
 }
 .icon-eightball:before {
-  content: "\e998";
+  content: '\e998';
 }
 .icon-bowling:before {
-  content: "\e999";
+  content: '\e999';
 }
 .icon-bowlingpin:before {
-  content: "\e99a";
+  content: '\e99a';
 }
 .icon-baseball:before {
-  content: "\e99b";
+  content: '\e99b';
 }
 .icon-soccer:before {
-  content: "\e99c";
+  content: '\e99c';
 }
 .icon-3dglasses:before {
-  content: "\e99d";
+  content: '\e99d';
 }
 .icon-microwave:before {
-  content: "\e99e";
+  content: '\e99e';
 }
 .icon-refrigerator:before {
-  content: "\e99f";
+  content: '\e99f';
 }
 .icon-oven:before {
-  content: "\e9a0";
+  content: '\e9a0';
 }
 .icon-washingmachine:before {
-  content: "\e9a1";
+  content: '\e9a1';
 }
 .icon-mouse:before {
-  content: "\e9a2";
+  content: '\e9a2';
 }
 .icon-smiley:before {
-  content: "\e9a3";
+  content: '\e9a3';
 }
 .icon-sad:before {
-  content: "\e9a4";
+  content: '\e9a4';
 }
 .icon-mute:before {
-  content: "\e9a5";
+  content: '\e9a5';
 }
 .icon-hand:before {
-  content: "\e9a6";
+  content: '\e9a6';
 }
 .icon-radio:before {
-  content: "\e9a7";
+  content: '\e9a7';
 }
 .icon-satellite:before {
-  content: "\e9a8";
+  content: '\e9a8';
 }
 .icon-medal:before {
-  content: "\e9a9";
+  content: '\e9a9';
 }
 .icon-medal2:before {
-  content: "\e9aa";
+  content: '\e9aa';
 }
 .icon-switch:before {
-  content: "\e9ab";
+  content: '\e9ab';
 }
 .icon-key:before {
-  content: "\e9ac";
+  content: '\e9ac';
 }
 .icon-cord:before {
-  content: "\e9ad";
+  content: '\e9ad';
 }
 .icon-locked:before {
-  content: "\e9ae";
+  content: '\e9ae';
 }
 .icon-unlocked:before {
-  content: "\e9af";
+  content: '\e9af';
 }
 .icon-locked2:before {
-  content: "\e9b0";
+  content: '\e9b0';
 }
 .icon-unlocked2:before {
-  content: "\e9b1";
+  content: '\e9b1';
 }
 .icon-magnifier:before {
-  content: "\e9b2";
+  content: '\e9b2';
 }
 .icon-zoomin:before {
-  content: "\e9b3";
+  content: '\e9b3';
 }
 .icon-zoomout:before {
-  content: "\e9b4";
+  content: '\e9b4';
 }
 .icon-stack:before {
-  content: "\e9b5";
+  content: '\e9b5';
 }
 .icon-stack2:before {
-  content: "\e9b6";
+  content: '\e9b6';
 }
 .icon-stack3:before {
-  content: "\e9b7";
+  content: '\e9b7';
 }
 .icon-davidstar:before {
-  content: "\e9b8";
+  content: '\e9b8';
 }
 .icon-cross:before {
-  content: "\e9b9";
+  content: '\e9b9';
 }
 .icon-moonandstar:before {
-  content: "\e9ba";
+  content: '\e9ba';
 }
 .icon-transformers:before {
-  content: "\e9bb";
+  content: '\e9bb';
 }
 .icon-batman:before {
-  content: "\e9bc";
+  content: '\e9bc';
 }
 .icon-spaceinvaders:before {
-  content: "\e9bd";
+  content: '\e9bd';
 }
 .icon-skeletor:before {
-  content: "\e9be";
+  content: '\e9be';
 }
 .icon-lamp:before {
-  content: "\e9bf";
+  content: '\e9bf';
 }
 .icon-lamp2:before {
-  content: "\e9c0";
+  content: '\e9c0';
 }
 .icon-umbrella:before {
-  content: "\e9c1";
+  content: '\e9c1';
 }
 .icon-streetlight:before {
-  content: "\e9c2";
+  content: '\e9c2';
 }
 .icon-bomb:before {
-  content: "\e9c3";
+  content: '\e9c3';
 }
 .icon-archive:before {
-  content: "\e9c4";
+  content: '\e9c4';
 }
 .icon-battery:before {
-  content: "\e9c5";
+  content: '\e9c5';
 }
 .icon-battery2:before {
-  content: "\e9c6";
+  content: '\e9c6';
 }
 .icon-battery3:before {
-  content: "\e9c7";
+  content: '\e9c7';
 }
 .icon-battery4:before {
-  content: "\e9c8";
+  content: '\e9c8';
 }
 .icon-battery5:before {
-  content: "\e9c9";
+  content: '\e9c9';
 }
 .icon-megaphone:before {
-  content: "\e9cc";
+  content: '\e9cc';
 }
 .icon-megaphone2:before {
-  content: "\e9cd";
+  content: '\e9cd';
 }
 .icon-patch:before {
-  content: "\e9cf";
+  content: '\e9cf';
 }
 .icon-pil:before {
-  content: "\e9d0";
+  content: '\e9d0';
 }
 .icon-injection:before {
-  content: "\e9d1";
+  content: '\e9d1';
 }
 .icon-thermometer:before {
-  content: "\e9d2";
+  content: '\e9d2';
 }
 .icon-lamp3:before {
-  content: "\e9d3";
+  content: '\e9d3';
 }
 .icon-lamp4:before {
-  content: "\e9d4";
+  content: '\e9d4';
 }
 .icon-lamp5:before {
-  content: "\e9d5";
+  content: '\e9d5';
 }
 .icon-cube:before {
-  content: "\e9d6";
+  content: '\e9d6';
 }
 .icon-box:before {
-  content: "\e9d7";
+  content: '\e9d7';
 }
 .icon-box2:before {
-  content: "\e9d8";
+  content: '\e9d8';
 }
 .icon-diamond:before {
-  content: "\e9d9";
+  content: '\e9d9';
 }
 .icon-bag:before {
-  content: "\e9da";
+  content: '\e9da';
 }
 .icon-moneybag:before {
-  content: "\e9db";
+  content: '\e9db';
 }
 .icon-grid:before {
-  content: "\e9dc";
+  content: '\e9dc';
 }
 .icon-grid2:before {
-  content: "\e9dd";
+  content: '\e9dd';
 }
 .icon-list:before {
-  content: "\e9de";
+  content: '\e9de';
 }
 .icon-list2:before {
-  content: "\e9df";
+  content: '\e9df';
 }
 .icon-ruler:before {
-  content: "\e9e0";
+  content: '\e9e0';
 }
 .icon-ruler2:before {
-  content: "\e9e1";
+  content: '\e9e1';
 }
 .icon-layout:before {
-  content: "\e9e2";
+  content: '\e9e2';
 }
 .icon-layout2:before {
-  content: "\e9e3";
+  content: '\e9e3';
 }
 .icon-layout3:before {
-  content: "\e9e4";
+  content: '\e9e4';
 }
 .icon-layout4:before {
-  content: "\e9e5";
+  content: '\e9e5';
 }
 .icon-layout5:before {
-  content: "\e9e6";
+  content: '\e9e6';
 }
 .icon-layout6:before {
-  content: "\e9e7";
+  content: '\e9e7';
 }
 .icon-layout7:before {
-  content: "\e9e8";
+  content: '\e9e8';
 }
 .icon-layout8:before {
-  content: "\e9e9";
+  content: '\e9e9';
 }
 .icon-layout9:before {
-  content: "\e9ea";
+  content: '\e9ea';
 }
 .icon-layout10:before {
-  content: "\e9eb";
+  content: '\e9eb';
 }
 .icon-layout11:before {
-  content: "\e9ec";
+  content: '\e9ec';
 }
 .icon-layout12:before {
-  content: "\e9ed";
+  content: '\e9ed';
 }
 .icon-layout13:before {
-  content: "\e9ee";
+  content: '\e9ee';
 }
 .icon-layout14:before {
-  content: "\e9ef";
+  content: '\e9ef';
 }
 .icon-tools:before {
-  content: "\e9f0";
+  content: '\e9f0';
 }
 .icon-screwdriver:before {
-  content: "\e9f1";
+  content: '\e9f1';
 }
 .icon-paint:before {
-  content: "\e9f2";
+  content: '\e9f2';
 }
 .icon-hammer:before {
-  content: "\e9f3";
+  content: '\e9f3';
 }
 .icon-brush:before {
-  content: "\e9f4";
+  content: '\e9f4';
 }
 .icon-pen:before {
-  content: "\e9f5";
+  content: '\e9f5';
 }
 .icon-chat:before {
-  content: "\e9f6";
+  content: '\e9f6';
 }
 .icon-comments:before {
-  content: "\e9f7";
+  content: '\e9f7';
 }
 .icon-chat2:before {
-  content: "\e9f8";
+  content: '\e9f8';
 }
 .icon-chat3:before {
-  content: "\e9f9";
+  content: '\e9f9';
 }
 .icon-volume:before {
-  content: "\e9fa";
+  content: '\e9fa';
 }
 .icon-volume2:before {
-  content: "\e9fb";
+  content: '\e9fb';
 }
 .icon-volume3:before {
-  content: "\e9fc";
+  content: '\e9fc';
 }
 .icon-equalizer:before {
-  content: "\e9fd";
+  content: '\e9fd';
 }
 .icon-resize:before {
-  content: "\e9fe";
+  content: '\e9fe';
 }
 .icon-resize2:before {
-  content: "\e9ff";
+  content: '\e9ff';
 }
 .icon-stretch:before {
-  content: "\ea00";
+  content: '\ea00';
 }
 .icon-narrow:before {
-  content: "\ea01";
+  content: '\ea01';
 }
 .icon-resize3:before {
-  content: "\ea02";
+  content: '\ea02';
 }
 .icon-download4:before {
-  content: "\ea03";
+  content: '\ea03';
 }
 .icon-calculator:before {
-  content: "\ea04";
+  content: '\ea04';
 }
 .icon-library:before {
-  content: "\ea05";
+  content: '\ea05';
 }
 .icon-auction:before {
-  content: "\ea06";
+  content: '\ea06';
 }
 .icon-justice:before {
-  content: "\ea07";
+  content: '\ea07';
 }
 .icon-stats:before {
-  content: "\ea0a";
+  content: '\ea0a';
 }
 .icon-stats2:before {
-  content: "\ea0b";
+  content: '\ea0b';
 }
 .icon-attachment:before {
-  content: "\ea0c";
+  content: '\ea0c';
 }
 .icon-hourglass:before {
-  content: "\ea0e";
+  content: '\ea0e';
 }
 .icon-abacus:before {
-  content: "\ea0f";
+  content: '\ea0f';
 }
 .icon-pencil:before {
-  content: "\ea12";
+  content: '\ea12';
 }
 .icon-pen2:before {
-  content: "\ea13";
+  content: '\ea13';
 }
 .icon-pin:before {
-  content: "\ea14";
+  content: '\ea14';
 }
 .icon-pin2:before {
-  content: "\ea15";
+  content: '\ea15';
 }
 .icon-discout:before {
-  content: "\ea16";
+  content: '\ea16';
 }
 .icon-edit2:before {
-  content: "\ea17";
+  content: '\ea17';
 }
 .icon-scissors:before {
-  content: "\ea18";
+  content: '\ea18';
 }
 .icon-profile:before {
-  content: "\ea19";
+  content: '\ea19';
 }
 .icon-profile2:before {
-  content: "\ea1a";
+  content: '\ea1a';
 }
 .icon-profile3:before {
-  content: "\ea1b";
+  content: '\ea1b';
 }
 .icon-rotate:before {
-  content: "\ea1c";
+  content: '\ea1c';
 }
 .icon-rotate2:before {
-  content: "\ea1d";
+  content: '\ea1d';
 }
 .icon-reply:before {
-  content: "\ea1e";
+  content: '\ea1e';
 }
 .icon-forward3:before {
-  content: "\ea1f";
+  content: '\ea1f';
 }
 .icon-retweet:before {
-  content: "\ea20";
+  content: '\ea20';
 }
 .icon-shuffle:before {
-  content: "\ea21";
+  content: '\ea21';
 }
 .icon-loop:before {
-  content: "\ea22";
+  content: '\ea22';
 }
 .icon-crop:before {
-  content: "\ea23";
+  content: '\ea23';
 }
 .icon-square:before {
-  content: "\ea24";
+  content: '\ea24';
 }
 .icon-square2:before {
-  content: "\ea25";
+  content: '\ea25';
 }
 .icon-circle:before {
-  content: "\ea26";
+  content: '\ea26';
 }
 .icon-dollar:before {
-  content: "\ea27";
+  content: '\ea27';
 }
 .icon-dollar2:before {
-  content: "\ea28";
+  content: '\ea28';
 }
 .icon-coins:before {
-  content: "\ea29";
+  content: '\ea29';
 }
 .icon-pig:before {
-  content: "\ea2a";
+  content: '\ea2a';
 }
 .icon-bookmark:before {
-  content: "\ea2b";
+  content: '\ea2b';
 }
 .icon-bookmark2:before {
-  content: "\ea2c";
+  content: '\ea2c';
 }
 .icon-addressbook:before {
-  content: "\ea2d";
+  content: '\ea2d';
 }
 .icon-addressbook2:before {
-  content: "\ea2e";
+  content: '\ea2e';
 }
 .icon-safe:before {
-  content: "\ea2f";
+  content: '\ea2f';
 }
 .icon-envelope:before {
-  content: "\ea30";
+  content: '\ea30';
 }
 .icon-envelope2:before {
-  content: "\ea31";
+  content: '\ea31';
 }
 .icon-radioactive:before {
-  content: "\ea32";
+  content: '\ea32';
 }
 .icon-music:before {
-  content: "\ea33";
+  content: '\ea33';
 }
 .icon-presentation:before {
-  content: "\ea34";
+  content: '\ea34';
 }
 .icon-male:before {
-  content: "\ea35";
+  content: '\ea35';
 }
 .icon-female:before {
-  content: "\ea36";
+  content: '\ea36';
 }
 .icon-aids:before {
-  content: "\ea37";
+  content: '\ea37';
 }
 .icon-heart2:before {
-  content: "\ea38";
+  content: '\ea38';
 }
 .icon-info2:before {
-  content: "\ea39";
+  content: '\ea39';
 }
 .icon-info3:before {
-  content: "\ea3a";
+  content: '\ea3a';
 }
 .icon-piano:before {
-  content: "\ea3b";
+  content: '\ea3b';
 }
 .icon-rain:before {
-  content: "\ea3e";
+  content: '\ea3e';
 }
 .icon-snow:before {
-  content: "\ea3f";
+  content: '\ea3f';
 }
 .icon-lightning:before {
-  content: "\ea42";
+  content: '\ea42';
 }
 .icon-sun:before {
-  content: "\ea43";
+  content: '\ea43';
 }
 .icon-moon:before {
-  content: "\ea44";
+  content: '\ea44';
 }
 .icon-cloudy:before {
-  content: "\ea45";
+  content: '\ea45';
 }
 .icon-cloudy2:before {
-  content: "\ea46";
+  content: '\ea46';
 }
 .icon-car:before {
-  content: "\ea47";
+  content: '\ea47';
 }
 .icon-bike:before {
-  content: "\ea48";
+  content: '\ea48';
 }
 .icon-truck:before {
-  content: "\ea49";
+  content: '\ea49';
 }
 .icon-bus:before {
-  content: "\ea4a";
+  content: '\ea4a';
 }
 .icon-bike2:before {
-  content: "\ea4b";
+  content: '\ea4b';
 }
 .icon-plane:before {
-  content: "\ea4c";
+  content: '\ea4c';
 }
 .icon-paperplane:before {
-  content: "\ea4d";
+  content: '\ea4d';
 }
 .icon-rocket:before {
-  content: "\ea4e";
+  content: '\ea4e';
 }
 .icon-book:before {
-  content: "\ea4f";
+  content: '\ea4f';
 }
 .icon-book2:before {
-  content: "\ea50";
+  content: '\ea50';
 }
 .icon-barcode:before {
-  content: "\ea51";
+  content: '\ea51';
 }
 .icon-barcode2:before {
-  content: "\ea52";
+  content: '\ea52';
 }
 .icon-expand2:before {
-  content: "\ea53";
+  content: '\ea53';
 }
 .icon-collapse:before {
-  content: "\ea54";
+  content: '\ea54';
 }
 .icon-popout:before {
-  content: "\ea55";
+  content: '\ea55';
 }
 .icon-popin:before {
-  content: "\ea56";
+  content: '\ea56';
 }
 .icon-target:before {
-  content: "\ea57";
+  content: '\ea57';
 }
 .icon-badge:before {
-  content: "\ea59";
+  content: '\ea59';
 }
 .icon-badge2:before {
-  content: "\ea5a";
+  content: '\ea5a';
 }
 .icon-ticket:before {
-  content: "\ea5b";
+  content: '\ea5b';
 }
 .icon-ticket2:before {
-  content: "\ea5c";
+  content: '\ea5c';
 }
 .icon-ticket3:before {
-  content: "\ea5d";
+  content: '\ea5d';
 }
 .icon-microphone4:before {
-  content: "\ea5e";
+  content: '\ea5e';
 }
 .icon-cone:before {
-  content: "\ea60";
+  content: '\ea60';
 }
 .icon-blocked:before {
-  content: "\ea61";
+  content: '\ea61';
 }
 .icon-stop2:before {
-  content: "\ea62";
+  content: '\ea62';
 }
 .icon-keyboard:before {
-  content: "\ea63";
+  content: '\ea63';
 }
 .icon-keyboard2:before {
-  content: "\ea64";
+  content: '\ea64';
 }
 .icon-radio2:before {
-  content: "\ea65";
+  content: '\ea65';
 }
 .icon-printer:before {
-  content: "\ea66";
+  content: '\ea66';
 }
 .icon-checked:before {
-  content: "\ea67";
+  content: '\ea67';
 }
 .icon-error:before {
-  content: "\ea68";
+  content: '\ea68';
 }
 .icon-add:before {
-  content: "\ea69";
+  content: '\ea69';
 }
 .icon-minus4:before {
-  content: "\ea6a";
+  content: '\ea6a';
 }
 .icon-alert:before {
-  content: "\ea6d";
+  content: '\ea6d';
 }
 .icon-pictures3:before {
-  content: "\ea6e";
+  content: '\ea6e';
 }
 .icon-atom:before {
-  content: "\ea6f";
+  content: '\ea6f';
 }
 .icon-eyedropper:before {
-  content: "\ea70";
+  content: '\ea70';
 }
 .icon-globe:before {
-  content: "\ea71";
+  content: '\ea71';
 }
 .icon-globe2:before {
-  content: "\ea72";
+  content: '\ea72';
 }
 .icon-shipping:before {
-  content: "\ea73";
+  content: '\ea73';
 }
 .icon-yingyang:before {
-  content: "\ea74";
+  content: '\ea74';
 }
 .icon-compass:before {
-  content: "\ea75";
+  content: '\ea75';
 }
 .icon-zip2:before {
-  content: "\ea76";
+  content: '\ea76';
 }
 .icon-zip3:before {
-  content: "\ea77";
+  content: '\ea77';
 }
 .icon-anchor:before {
-  content: "\ea78";
+  content: '\ea78';
 }
 .icon-lockedheart:before {
-  content: "\ea79";
+  content: '\ea79';
 }
 .icon-magnet:before {
-  content: "\ea7a";
+  content: '\ea7a';
 }
 .icon-navigation:before {
-  content: "\ea7b";
+  content: '\ea7b';
 }
 .icon-tags:before {
-  content: "\ea7c";
+  content: '\ea7c';
 }
 .icon-heart3:before {
-  content: "\ea7d";
+  content: '\ea7d';
 }
 .icon-heart4:before {
-  content: "\ea7e";
+  content: '\ea7e';
 }
 .icon-usb:before {
-  content: "\ea81";
+  content: '\ea81';
 }
 .icon-clipboard:before {
-  content: "\ea84";
+  content: '\ea84';
 }
 .icon-clipboard2:before {
-  content: "\ea85";
+  content: '\ea85';
 }
 .icon-clipboard3:before {
-  content: "\ea86";
+  content: '\ea86';
 }
 .icon-switch2:before {
-  content: "\ea87";
+  content: '\ea87';
 }
 .icon-ruler3:before {
-  content: "\ea88";
+  content: '\ea88';
 }
 .icon-notice2:before {
-  content: "\e908";
+  content: '\e908';
 }
 .icon-forward2:before {
-  content: "\e909";
+  content: '\e909';
 }
 .icon-assignment_turned_in:before {
-  content: "\e862";
+  content: '\e862';
 }
 .icon-more_vert:before {
-  content: "\e5d4";
+  content: '\e5d4';
 }
 .icon-pageview:before {
-  content: "\e905";
+  content: '\e905';
 }
 .icon-preview-bottom-window:before {
-  content: "\ea8b";
+  content: '\ea8b';
 }
 .icon-preview-new-window:before {
-  content: "\ea8c";
+  content: '\ea8c';
 }
 .icon-users:before {
-  content: "\e972";
+  content: '\e972';
 }
 .icon-lock:before {
-  content: "\e98f";
+  content: '\e98f';
 }
 .icon-earth:before {
-  content: "\e9ca";
+  content: '\e9ca';
 }
 .icon-user2:before {
-  content: "\e600";
+  content: '\e600';
 }
 .icon-checkmark:before {
-  content: "\ea10";
+  content: '\ea10';
 }
 .icon-undo2:before {
-  content: "\e967";
+  content: '\e967';
 }
 .icon-notification:before {
-  content: "\ea08";
+  content: '\ea08';
 }
 .icon-embed:before {
-  content: "\ea7f";
+  content: '\ea7f';
 }
 .icon-share2:before {
-  content: "\ea82";
+  content: '\ea82';
 }
 .icon-arrow-right2:before {
-  content: "\ea3c";
+  content: '\ea3c';
 }
 .icon-arrow-left2:before {
-  content: "\ea40";
+  content: '\ea40';
 }
 .icon-file-text:before {
-  content: "\e922";
+  content: '\e922';
 }
 .icon-eye:before {
-  content: "\e9ce";
+  content: '\e9ce';
 }
 .icon-checkmark2:before {
-  content: "\e900";
+  content: '\e900';
 }
 .icon-users2:before {
-  content: "\e973";
+  content: '\e973';
 }
 .icon-lock2:before {
-  content: "\e990";
+  content: '\e990';
 }
 .icon-earth2:before {
-  content: "\e9cb";
+  content: '\e9cb';
 }
 .icon-user23:before {
-  content: "\e608";
+  content: '\e608';
 }
 .icon-checkmark3:before {
-  content: "\ea11";
+  content: '\ea11';
 }
 .icon-undo22:before {
-  content: "\e968";
+  content: '\e968';
 }
 .icon-notification2:before {
-  content: "\ea09";
+  content: '\ea09';
 }
 .icon-embed2:before {
-  content: "\ea80";
+  content: '\ea80';
 }
 .icon-share22:before {
-  content: "\ea83";
+  content: '\ea83';
 }
 .icon-arrow-right22:before {
-  content: "\ea3d";
+  content: '\ea3d';
 }
 .icon-arrow-left22:before {
-  content: "\ea41";
+  content: '\ea41';
 }
 .icon-unlocked3:before {
-  content: "\ea8a";
+  content: '\ea8a';
 }
 .icon-copy:before {
-  content: "\ea90";
+  content: '\ea90';
 }
 .icon-search:before {
-  content: "\f002";
+  content: '\f002';
 }
 .icon-envelope-o:before {
-  content: "\f003";
+  content: '\f003';
 }
 .icon-heart:before {
-  content: "\f004";
+  content: '\f004';
 }
 .icon-star:before {
-  content: "\f005";
+  content: '\f005';
 }
 .icon-user:before {
-  content: "\f007";
+  content: '\f007';
 }
 .icon-check:before {
-  content: "\f00c";
+  content: '\f00c';
 }
 .icon-times:before {
-  content: "\f00d";
+  content: '\f00d';
 }
 .icon-power-off:before {
-  content: "\f011";
+  content: '\f011';
 }
 .icon-gear:before {
-  content: "\f013";
+  content: '\f013';
 }
 .icon-trash-o:before {
-  content: "\f014";
+  content: '\f014';
 }
 .icon-share-square-o:before {
-  content: "\f045";
+  content: '\f045';
 }
 .icon-chevron-right:before {
-  content: "\f054";
+  content: '\f054';
 }
 .icon-plus-circle:before {
-  content: "\f055";
+  content: '\f055';
 }
 .icon-times-circle:before {
-  content: "\f057";
+  content: '\f057';
 }
 .icon-check-circle:before {
-  content: "\f058";
+  content: '\f058';
 }
 .icon-times-circle-o:before {
-  content: "\f05c";
+  content: '\f05c';
 }
 .icon-check-circle-o:before {
-  content: "\f05d";
+  content: '\f05d';
 }
 .icon-expand:before {
-  content: "\f065";
+  content: '\f065';
 }
 .icon-compress:before {
-  content: "\f066";
+  content: '\f066';
 }
 .icon-plus:before {
-  content: "\f067";
+  content: '\f067';
 }
 .icon-warning:before {
-  content: "\f071";
+  content: '\f071';
 }
 .icon-sign-in:before {
-  content: "\f090";
+  content: '\f090';
 }
 .icon-wrench:before {
-  content: "\f0ad";
+  content: '\f0ad';
 }
 .icon-tasks:before {
-  content: "\f0ae";
+  content: '\f0ae';
 }
 .icon-filter:before {
-  content: "\f0b0";
+  content: '\f0b0';
 }
 .icon-google-plus-square:before {
-  content: "\f0d4";
+  content: '\f0d4';
 }
 .icon-unsorted:before {
-  content: "\f0dc";
+  content: '\f0dc';
 }
 .icon-sort-down:before {
-  content: "\f0dd";
+  content: '\f0dd';
 }
 .icon-exchange:before {
-  content: "\f0ec";
+  content: '\f0ec';
 }
 .icon-mail-reply:before {
-  content: "\f112";
+  content: '\f112';
 }
 .icon-minus-square-o:before {
-  content: "\f147";
+  content: '\f147';
 }
 .icon-stack-exchange:before {
-  content: "\f18d";
+  content: '\f18d';
 }
 .icon-plus-square-o:before {
-  content: "\f196";
+  content: '\f196';
 }
 .icon-language:before {
-  content: "\f1ab";
+  content: '\f1ab';
 }
 .icon-paw:before {
-  content: "\f1b0";
+  content: '\f1b0';
 }

--- a/public/css/sass/commons/_manage.scss
+++ b/public/css/sass/commons/_manage.scss
@@ -1,1005 +1,994 @@
 // rewrite semantic CSS
 
 body.manage {
-    min-width: 1024px;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
-    background-color: $grey5;
-    overflow: visible;
+  min-width: 1024px;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
+  background-color: $grey5;
+  overflow: visible;
 }
 
 .ui.icon.button {
-    padding: 0px;
-    font-size: 18px;
-    margin: 0px;
-    width: 30px;
-    height: 30px;
-    line-height: 30px;
-    text-align: center;
+  padding: 0px;
+  font-size: 18px;
+  margin: 0px;
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  text-align: center;
 }
 
 .ui.icon.button > .icon {
-    opacity: 0.9;
-    margin: 0em;
-    vertical-align: inherit;
+  opacity: 0.9;
+  margin: 0em;
+  vertical-align: inherit;
 }
 
 .ui.top.right.pointing.dropdown > .menu:after {
-    right: .5em;
-    z-index: -1;
+  right: 0.5em;
+  z-index: -1;
 }
 
 .item.cancel-item {
-    position: absolute !important;
-    left: -99999px;
+  position: absolute !important;
+  left: -99999px;
 }
-
-
 
 // Closing Shadow - Transitions for buttons
 
 .project-list {
-    padding-top: 100px;
-    padding-bottom: 160px;
-    .ui.inverted.dimmer {
-        background-color: $grey5;
+  padding-top: 100px;
+  padding-bottom: 160px;
+  .ui.inverted.dimmer {
+    background-color: $grey5;
+  }
+
+  .project {
+    margin-bottom: 30px !important;
+    //border: 1px solid $grey2;
+    .project-title {
+      padding-bottom: 0 !important;
     }
+    .ui.ribbon.label {
+      z-index: 2;
+      left: -28px;
+      max-width: 535px;
+      min-width: 0px;
+      line-height: 17px;
+      background-color: $grey2;
+      color: $black;
+      height: 30px;
+      border-radius: 0 2px 2px 0;
+      display: inline-block;
+    }
+    .project-header {
+      background-color: $grey4;
+      padding-bottom: 10px !important;
+      //border-bottom: 1px solid #ccc;
+      margin-bottom: -25px;
+      position: relative;
 
-    .project {
-        margin-bottom: 30px !important;
-        //border: 1px solid $grey2;
-        .project-title {
-            padding-bottom: 0 !important;
+      .project-name {
+        font-size: 17px;
+        max-width: 400px;
+        min-width: 30px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: inline-block;
+        vertical-align: text-bottom;
+      }
+      .project-id {
+        font-size: 14px;
+        font-weight: normal;
+        margin-left: 17px;
+        display: inline-block;
+        vertical-align: text-bottom;
+        min-width: 72px;
+        color: #5a5a5a;
+      }
+      .ui.form .field :disabled {
+        opacity: 1 !important;
+      }
+      .project-payable {
+        padding: 23px 0;
+        float: left;
+        a {
+          text-decoration: underline;
+          &:hover {
+            text-decoration: none;
+          }
         }
-        .ui.ribbon.label {
-            z-index: 2;
-            left: -28px;
-            max-width: 535px;
-            min-width: 0px;
-            line-height: 17px;
-            background-color: $grey2;
-            color: $black;
+      }
+      .project-activity-icon {
+        padding: 2px 12px 0px !important;
+        font-family: Calibri, Arial, Helvetica, sans-serif;
+        position: relative;
+        top: 4px;
+
+        .ui.dropdown {
+          text-align: center;
+          border-radius: 30px;
+          .scrolling.menu {
+            max-height: 21.7em;
+          }
+          .ui.icon.input input {
+            font-family: Calibri, Arial, Helvetica, sans-serif;
+            padding-right: 2.67142857em !important;
+            box-shadow: inset 0 1px 3px #ddd;
+          }
+          &.project-menu.ui.button {
+            box-shadow: none;
+          }
+          &.project-personal-assignee {
+            margin-right: 8px;
+            background-color: $white;
+            vertical-align: top;
+            border: 1px solid #bdbdbd;
+            cursor: default;
+            .text {
+              border-radius: 15px;
+              padding: 2px 14px 2px 3px;
+              color: black;
+              transition: 0.3s ease;
+              .ui.circular.label {
+                background-color: #cecece;
+                color: #888888;
+              }
+            }
+          }
+          &.project-team {
+            margin-right: 8px;
+            background-color: $white;
+            vertical-align: top;
             height: 30px;
-            border-radius: 0 2px 2px 0;
-            display: inline-block;
-        }
-        .project-header {
-
-            background-color: $grey4;
-            padding-bottom: 10px !important;
-            //border-bottom: 1px solid #ccc;
-            margin-bottom: -25px;
-            position: relative;
-
-            .project-name {
-                font-size: 17px;
-                max-width: 400px;
-                min-width: 30px;
+            .text {
+              max-width: 170px;
+              min-width: 30px;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              border-radius: 15px;
+              padding: 5px 15px;
+              color: $black;
+              transition: 0.3s ease;
+            }
+            .menu {
+              z-index: 1;
+              .divider {
+                margin: 0;
+              }
+              .item {
+                max-width: 200px;
+                min-width: 170px;
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
-                display: inline-block;
-                vertical-align: text-bottom;
-            }
-            .project-id {
+              }
+              .header {
                 font-size: 14px;
-                font-weight: normal;
-                margin-left: 17px;
-                display: inline-block;
-                vertical-align: text-bottom;
-                min-width: 72px;
-                color: #5a5a5a;
-            }
-            .ui.form .field :disabled {
-                opacity: 1 !important;
-            }
-            .project-payable {
-                padding: 23px 0;
-                float: left;
-                a {
-                    text-decoration: underline;
-                    &:hover {
-                        text-decoration: none;
-                    }
+                margin: 0px;
+                padding: 15px;
+                cursor: pointer;
+
+                &:hover {
+                  background-color: $grey3;
                 }
+              }
             }
-            .project-activity-icon {
-                padding: 2px 12px 0px !important;
-                font-family: Calibri, Arial, Helvetica, sans-serif;
+            &:hover .text {
+              background-color: $grey5 !important;
+            }
+          }
+          &.project-assignee {
+            margin-right: 8px;
+            background-color: #ffffff !important;
+            vertical-align: top;
+            /*height: 30px !important;*/
+            .text {
+              display: flex;
+              max-width: 170px;
+              min-width: 30px;
+              border-radius: 15px;
+              padding: 3px 15px 3px 3px;
+              color: #000000;
+              transition: 0.3s ease;
+              height: 30px;
+              img {
+                max-height: 24px;
+                margin-top: 0;
+                margin-bottom: 0;
+              }
+              span {
                 position: relative;
-                top: 4px;
-
-                .ui.dropdown {
-                    text-align: center;
-                    border-radius: 30px;
-                    .scrolling.menu {
-                        max-height: 21.7em;
-                    }
-                    .ui.icon.input input {
-                        font-family: Calibri, Arial, Helvetica, sans-serif;
-                        padding-right: 2.67142857em !important;
-                        box-shadow: inset 0 1px 3px #ddd;
-                    }
-                    &.project-menu.ui.button {
-                        box-shadow: none;
-                    }
-                    &.project-personal-assignee {
-                        margin-right: 8px;
-                        background-color: $white;
-                        vertical-align: top;
-                        border: 1px solid #bdbdbd;
-                        cursor: default;
-                        .text {
-                            border-radius: 15px;
-                            padding: 2px 14px 2px 3px;
-                            color: black;
-                            transition: 0.3s ease;
-                            .ui.circular.label {
-                                background-color: #cecece;
-                                color: #888888;
-                            }
-                        }
-                    }
-                    &.project-team {
-                        margin-right: 8px;
-                        background-color: $white;
-                        vertical-align: top;
-                        height: 30px;
-                        .text {
-                            max-width: 170px;
-                            min-width: 30px;
-                            white-space: nowrap;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            border-radius: 15px;
-                            padding: 5px 15px;
-                            color: $black;
-                            transition: 0.3s ease;
-                        }
-                        .menu {
-                            z-index: 1;
-                            .divider {
-                                margin: 0;
-                            }
-                            .item {
-                                max-width: 200px;
-                                min-width: 170px;
-                                white-space: nowrap;
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                            }
-                            .header {
-                                font-size: 14px;
-                                margin: 0px;
-                                padding: 15px;
-                                cursor: pointer;
-
-                                &:hover {
-                                    background-color: $grey3;
-                                }
-                            }
-                        }
-                        &:hover .text {
-                            background-color: $grey5 !important;
-                        }
-                    }
-                    &.project-assignee {
-                        margin-right: 8px;
-                        background-color: #ffffff !important;
-                        vertical-align: top;
-                        /*height: 30px !important;*/
-                        .text {
-                            display: flex;
-                            max-width: 170px;
-                            min-width: 30px;
-                            border-radius: 15px;
-                            padding: 3px 15px 3px 3px;
-                            color: #000000;
-                            transition: 0.3s ease;
-                            height: 30px;
-                            img {
-                                max-height: 24px;
-                                margin-top: 0;
-                                margin-bottom: 0;
-                            }
-                            span {
-                                position: relative;
-                                top: 2px;
-                                white-space: nowrap;
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                            }
-                        }
-                        .menu {
-                            z-index: 1;
-                            .divider {
-                                margin: 0;
-                            }
-                            .header {
-                                font-size: 14px;
-                                margin: 0px;
-                                padding: 15px;
-                                cursor: pointer;
-                                a {
-                                    color: $translatedBlue;
-                                }
-                                i {
-                                    float: right;
-                                    font-size: 18px;
-                                    color: $translatedBlue;
-                                }
-                                &:hover {
-                                    background-color: $grey3;
-                                }
-                            }
-                            .scrolling {
-                                .item {
-                                    display: flex;
-                                    align-items: center;
-                                    img {
-                                        margin-top: 0;
-                                        margin-bottom: 0;
-                                    }
-                                }
-                            }
-                        }
-                        .item .ui.cancel.label {
-                            display: none;
-                        }
-                        &:hover .text {
-                            background-color: #ffffff !important;
-                            padding-right: 5px;
-                            padding-right: 30px;
-                        }
-                        &.disabled {
-                            background-color: #f4f4f4!important;
-                            box-shadow: 0px 0px 1px #666!important;
-                            opacity: 1;
-                            &.text {
-                                color: #666!important;
-                            }
-                        }
-                    }
-
-                    &.project-not-assigned {
-                        border: 1px solid #868686;
-                        padding: 0px 15px 0px 3px;
-                        trans\ition: 0.3s ease;
-                        color: rgba(0, 0, 0, 0.6);
-                        margin-right: 5px;
-                        vertical-align: top;
-                        i {
-                            transition: 0.3s ease;
-                        }
-                        &:hover {
-                            border: 1px solid $translatedBlue;
-                            color: $translatedBlue;
-                            .icon-user22 {
-                                color: $translatedBlue;
-                            }
-                        }
-                        .not-assigned {
-                            line-height: 13px;
-                            margin-right: 0px;
-                            padding-left: 10px;
-                            background-color: transparent;
-                        }
-                        .menu {
-                            .header {
-                                font-size: 14px;
-                                margin: 0px;
-                                padding: 15px;
-                                cursor: pointer;
-                                a {
-                                    color: $translatedBlue;
-                                }
-                                i {
-                                    float: right;
-                                    font-size: 18px;
-                                    color: $translatedBlue;
-                                }
-                                &:hover {
-                                    background-color: $grey3;
-                                }
-                            }
-                        }
-                        .ui.cancel.label {
-                            display: none;
-                        }
-                    }
-                    &.project-assignee {
-                        .ui.cancel.label {
-                            padding: 4px;
-                            background-color: #d6d6d6;
-                            margin: 0px;
-                            border-radius: 15px;
-                            position: absolute;
-                            bottom: 3px;
-                            line-height: 0px;
-                            right: 3px;
-                            visibility: hidden;
-                            i {
-                                font-size: 15px;
-                                color: #ffffff;
-                            }
-                            &:hover {
-                                background-color: #cccccc !important;
-                            }
-                        }
-
-                        &:hover .ui.cancel.label {
-                            visibility: visible;
-                            z-index: 2;
-                        }
-                    }
-                }
+                top: 2px;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
             }
-        }
-
-        .project-body {
-            background-color: $grey4;
-
-            .jobs {
-
-                margin-top: 0px;
-            }
-            .job {
-                padding: 0 15px;
-                margin-bottom: 15px;
-                .job-header {
-                    background-color: #ffffff !important;
-                    padding: 0 0 !important;
-
-                    .split-merge {
-                        padding: 10px 15px;
-                        .merge {
-                            font-family: Calibri, Arial, Helvetica, sans-serif;
-                            padding: 5px 17px;
-                            border: 1px solid #797979;
-                            font-size: 16px;
-                            transition: 0.3s ease !important;
-                        }
-                    }
-                }
-                .job-body {
-                    .chunks {
-                        .chunk-container {
-                        }
-                        .chunk {
-                            transition: 0.3s ease;
-                            background-color: #ffffff;
-                            padding: 8px 15px;
-                            &.outsource-container.no-outsource {
-                                overflow: unset;
-                            }
-                            .outsource.modal .popup {
-                                box-shadow: none;
-                            }
-                            .job-id {
-                                float: left;
-                                min-width: 70px;
-                                color: #969696;
-                                font-size: 12px;
-                                position: relative;
-                                line-height: 28px;
-                                top: 2px;
-                                margin-right: 5px;
-                            }
-                            .source-target {
-                                min-width: 140px;
-                                float: left;
-                                font-weight: bold;
-                                position: relative;
-                                top: 1px;
-                                .source-box {
-                                    float: left;
-                                    max-width: 60px;
-                                    min-width: 60px;
-                                    white-space: nowrap;
-                                    overflow: hidden;
-                                    text-overflow: ellipsis;
-                                    line-height: 30px;
-                                }
-                                .in-to {
-                                    float: left;
-                                    top: 4px;
-                                    color: #5a5a5a;
-                                    line-height: 26px;
-                                    position: relative;
-                                    font-size: 12px;
-                                    i {
-                                        margin-right: 0;
-                                    }
-                                }
-                                .target-box {
-                                    float: left;
-                                    width: 60px;
-                                    white-space: nowrap;
-                                    overflow: hidden;
-                                    text-overflow: ellipsis;
-                                    line-height: 30px;
-                                }
-                            }
-                            .progress-bar {
-
-                            }
-                            .tm-job,
-                            .activity-icon-single{
-                                float: left;
-                                width: 30px;
-                                height: 30px;
-
-                            }
-                            .job-activity-icons {
-                                float: left;
-                                width: 30px;
-                                height: 30px;
-                                margin-left: 5px;
-                                .comments {
-
-                                }
-                                .group-activity-icons {
-                                    .item {
-                                        margin: 0;
-                                        padding: 1px !important;
-                                        a {
-                                            padding: 0;
-                                            width: 100%;
-                                            border-radius: 0px;
-                                            font-size: 15px;
-                                            font-weight: normal;
-                                            font-family: Calibri, Arial, Helvetica, sans-serif;
-                                            text-align: left;
-                                            margin: 0 15px 0 10px;
-                                            background: transparent !important;
-                                            box-shadow: none !important;
-                                            i {
-                                                margin-right: 10px !important;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            .tm-job.job-activity-icons {
-                                a {
-                                    i {
-                                        vertical-align: inherit;
-                                    }
-                                }
-                            }
-                            .outsource-job {
-                                display: inline-block;
-                                min-width: 30%;
-                                padding-left: 5px;
-                                .translated-outsourced {
-                                    top: 1px;
-                                    bottom: 6px;
-                                    vertical-align: text-bottom;
-                                    display: inline-block;
-                                    position: relative;
-                                    text-align: left;
-                                    .outsource-logo-box {
-                                        min-width: 123px;
-                                        display: inherit;
-                                        margin-left: 10px;
-                                        img.outsource-logo {
-                                            width: 108px;
-                                            margin: -9px 10px 0 0;
-                                            vertical-align: middle;
-                                        }
-                                        @media only screen and (max-width: 1199px) and (min-width: 992px) {
-                                            width: 180px;
-                                        }
-                                    }
-                                    &.outsource {
-                                        margin-top: 6px;
-                                    }
-                                }
-                                .job-to-translator {
-                                    display: inline-block;
-                                    margin-right: 5px;
-                                    margin-left: 5px;
-                                    vertical-align: text-bottom;
-                                    color: #969696;
-                                    max-width: 150px;
-                                    white-space: nowrap;
-                                    overflow: hidden;
-                                    text-overflow: ellipsis;
-                                    line-height: 20px;
-                                    margin-top: 5px;
-                                    transition: 0.3s ease;
-
-                                    @media only screen and (max-width: 1199px) and (min-width: 992px) {
-                                        width: fit-content;
-                                        max-width: 190px;
-                                        &:hover {
-
-                                        }
-                                    }
-                                    a {
-                                        text-decoration: underline;
-                                        font-weight: 700;
-
-                                    }
-                                    &.not-assigned {
-                                        width: fit-content;
-                                    }
-                                }
-                                &:hover .job-to-translator{
-
-                                }
-
-                                .job-delivery {
-                                    display: inline-block;
-                                    margin-right: 5px;
-                                    margin-left: 5px;
-                                    vertical-align: text-bottom;
-                                    line-height: 20px;
-                                    .outsource-day-text {
-                                        font-weight: 700;
-                                        display: inherit;
-                                        margin-right: 3px;
-                                    }
-                                    .outsource-month-text {
-                                        display: inherit;
-                                        font-weight: 700;
-                                        margin-right: 5px;
-                                    }
-                                    .outsource-time-text {
-                                        display: inherit;
-                                        font-weight: 700;
-                                    }
-                                    .outsource-gmt-text {
-                                        color: #969696;
-                                        display: inherit;
-                                        margin-left: 5px;
-                                        font-size: 13px;
-                                    }
-
-                                    @media only screen and (max-width: 1199px) and (min-width: 992px) {
-                                        display: none;
-                                    }
-                                    @media only screen and (max-width: 991px) and (min-width: 768px) {
-                                        display: none;
-                                    }
-                                    @media only screen and (max-width: 767px) {
-                                        display: none;
-                                    }
-                                }
-                                &:hover .translator .job-delivery {
-                                    display: none;
-                                }
-                                .item {
-                                    margin-left: 10px;
-                                    display: none;
-                                    float: right;
-                                    cursor: pointer;
-                                    @media only screen and (max-width: 1200px) {
-                                        margin-left: 5px;
-                                    }
-                                    .ui.cancel{
-                                        padding: 4px;
-                                        background-color: #d6d6d6;
-                                        margin-top: 3px;
-                                        margin-bottom: 2px;
-                                        position: relative;
-                                        line-height: 0;
-                                        right: 3px;
-                                        font-size: 15px;
-                                        color: #ffffff;
-                                    }
-                                    &:hover .ui.cancel {
-                                        background-color: #cccccc !important;
-                                    }
-
-                                }
-                                &:hover .item {
-                                    display: inline-block;
-                                }
-                                &:hover {
-                                    .translator {
-                                        //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                                        transition: 0.3s ease;
-                                        cursor: pointer;
-                                        border-radius: 2px;
-                                        a {
-                                            text-decoration: none;
-                                        }
-                                    }
-                                }
-                            }
-                            .job-payable {
-                                padding: 0 5px 0 5px !important;
-                                float: left;
-                                text-decoration: underline;
-                                min-width: 106px;
-                                line-height: 30px;
-                                font-weight: 700;
-                                position: relative;
-                                top: 1px;
-                                &:hover {
-                                    text-decoration: none;
-                                }
-                            }
-                            .open-translate {
-                                font-family: Calibri, Arial, Helvetica, sans-serif;
-                                padding: 6px 15px;
-                                vertical-align: top;
-                                font-size: 16px;
-                                //border: 1px solid #797979;
-                                border-radius: 2px;
-                                float: right;
-                            }
-                            .open-vendor {
-                                font-family: Calibri, Arial, Helvetica, sans-serif;
-                                padding: 6px 7px;
-                                vertical-align: top;
-                                font-size: 16px;
-                                //border: 1px solid #7eaf3e;
-                                border-radius: 2px;
-                                float: right;
-                                font-weight: bold;
-                                box-shadow: none !important;
-                                color: #7eaf3e !important;
-                                &:hover {
-                                    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                                }
-                                &:active {
-                                    box-shadow: none !important;
-                                }
-                                &:focus {
-                                    box-shadow: none !important;
-                                }
-                            }
-                            .open-outsource {
-                                font-family: Calibri, Arial, Helvetica, sans-serif;
-                                padding: 6px 22px;
-                                vertical-align: top;
-                                font-size: 16px;
-                                //border: 1px solid #797979;
-                                border-radius: 2px;
-                                float: right;
-
-                                &.buy-translation {
-                                    display: flex;
-                                    align-items: center;
-                                    background: #fff;
-                                    color: $black;
-                                    font-weight:normal;
-                                    padding: 5px 8px;
-                                    border: none; // border: 1px solid #979797;
-                                    font-size: 14px;
-                                    .buy-translation-span:hover {
-                                        text-decoration: none;
-                                    }
-                                    .buy-translation-span {
-                                        text-decoration: underline;
-                                        font-size: 14px;
-                                    }
-                                    span {
-                                        color:#000;
-                                        font-size: 12px;
-                                        margin-left:4px;
-                                        line-height: 1.6;
-                                    }
-                                    img {
-                                        margin-left:3px;
-                                        width: 20px;
-                                        height: 20px;
-                                    }
-                                }
-                            }
-                            .open-outsourced {
-                                font-family: Calibri, Arial, Helvetica, sans-serif;
-                                padding: 6px 19px;
-                                vertical-align: top;
-                                font-size: 16px;
-                                //border: 1px solid #797979;
-                                border-radius: 2px;
-                                float: right;
-                                &:hover {
-                                    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                                }
-                                &:focus {
-                                    box-shadow: none !important;
-                                }
-                                &:active {
-                                    box-shadow: none !important;
-                                }
-                            }
-                            .job-menu {
-                                i {
-                                    vertical-align: inherit;
-                                }
-                                &.ui.button {
-                                    background-color: transparent;
-                                    border-radius: 2px;
-                                    float: right;
-                                    .divider {
-                                        margin: 0;
-                                    }
-                                    .item {
-                                        padding: 10px 15px !important;
-                                    }
-                                    &:hover {
-                                        background-color: #ececec;
-                                    }
-                                    &:active {
-                                        background-color: #e2e2e2;
-                                    }
-                                    &:focus {
-                                        background-color: #e2e2e2;
-                                    }
-                                }
-                            }
-
-                            .chunk-download-progress {
-                                height: 2px;
-                                background-color: #ffffff;
-                                position: absolute;
-                                bottom: 0px;
-                                width: 100%;
-                                left: 0;
-                                &:after {
-                                    content: '';
-                                    opacity: 1;
-                                    position: absolute;
-                                    top: 0;
-                                    left: 0;
-                                    right: 0;
-                                    bottom: 0;
-                                    background: #000000;
-                                    border-radius: .28571429rem;
-                                    -webkit-animation: progress-active 1s ease infinite;
-                                    animation: progress-active 1s ease infinite;
-                                }
-                            }
-                            &.updated-job {
-                                background-color: #f9ffb5;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        .project-footer {
-            padding: 0 30px 5px !important;
-            text-align: right;
-            background-color: $grey4;
-            .activity-log {
-                margin-top: -10px;
-                margin-right: -15px;
+            .menu {
+              z-index: 1;
+              .divider {
+                margin: 0;
+              }
+              .header {
+                font-size: 14px;
+                margin: 0px;
+                padding: 15px;
+                cursor: pointer;
                 a {
-                    text-decoration: underline;
-                    color: $grey1;
-                    font-size: 13px;
-                    &:hover {
-                        text-decoration: none;
-                    }
+                  color: $translatedBlue;
                 }
+                i {
+                  float: right;
+                  font-size: 18px;
+                  color: $translatedBlue;
+                }
+                &:hover {
+                  background-color: $grey3;
+                }
+              }
+              .scrolling {
+                .item {
+                  display: flex;
+                  align-items: center;
+                  img {
+                    margin-top: 0;
+                    margin-bottom: 0;
+                  }
+                }
+              }
             }
-            .project-due-date {
-                margin-top: -10px;
-                margin-left: -15px;
-                color: $grey1;
-                font-size: 13px;
+            .item .ui.cancel.label {
+              display: none;
             }
+            &:hover .text {
+              background-color: #ffffff !important;
+              padding-right: 5px;
+              padding-right: 30px;
+            }
+            &.disabled {
+              background-color: #f4f4f4 !important;
+              box-shadow: 0px 0px 1px #666 !important;
+              opacity: 1;
+              &.text {
+                color: #666 !important;
+              }
+            }
+          }
+
+          &.project-not-assigned {
+            border: 1px solid #868686;
+            padding: 0px 15px 0px 3px;
+            trans\ition: 0.3s ease;
+            color: rgba(0, 0, 0, 0.6);
+            margin-right: 5px;
+            vertical-align: top;
+            i {
+              transition: 0.3s ease;
+            }
+            &:hover {
+              border: 1px solid $translatedBlue;
+              color: $translatedBlue;
+              .icon-user22 {
+                color: $translatedBlue;
+              }
+            }
+            .not-assigned {
+              line-height: 13px;
+              margin-right: 0px;
+              padding-left: 10px;
+              background-color: transparent;
+            }
+            .menu {
+              .header {
+                font-size: 14px;
+                margin: 0px;
+                padding: 15px;
+                cursor: pointer;
+                a {
+                  color: $translatedBlue;
+                }
+                i {
+                  float: right;
+                  font-size: 18px;
+                  color: $translatedBlue;
+                }
+                &:hover {
+                  background-color: $grey3;
+                }
+              }
+            }
+            .ui.cancel.label {
+              display: none;
+            }
+          }
+          &.project-assignee {
+            .ui.cancel.label {
+              padding: 4px;
+              background-color: #d6d6d6;
+              margin: 0px;
+              border-radius: 15px;
+              position: absolute;
+              bottom: 3px;
+              line-height: 0px;
+              right: 3px;
+              visibility: hidden;
+              i {
+                font-size: 15px;
+                color: #ffffff;
+              }
+              &:hover {
+                background-color: #cccccc !important;
+              }
+            }
+
+            &:hover .ui.cancel.label {
+              visibility: visible;
+              z-index: 2;
+            }
+          }
         }
+      }
     }
+
+    .project-body {
+      background-color: $grey4;
+
+      .jobs {
+        margin-top: 0px;
+      }
+      .job {
+        padding: 0 15px;
+        margin-bottom: 15px;
+        .job-header {
+          background-color: #ffffff !important;
+          padding: 0 0 !important;
+
+          .split-merge {
+            padding: 10px 15px;
+            .merge {
+              font-family: Calibri, Arial, Helvetica, sans-serif;
+              padding: 5px 17px;
+              border: 1px solid #797979;
+              font-size: 16px;
+              transition: 0.3s ease !important;
+            }
+          }
+        }
+        .job-body {
+          .chunks {
+            .chunk-container {
+            }
+            .chunk {
+              transition: 0.3s ease;
+              background-color: #ffffff;
+              padding: 8px 15px;
+              &.outsource-container.no-outsource {
+                overflow: unset;
+              }
+              .outsource.modal .popup {
+                box-shadow: none;
+              }
+              .job-id {
+                float: left;
+                min-width: 70px;
+                color: #969696;
+                font-size: 12px;
+                position: relative;
+                line-height: 28px;
+                top: 2px;
+                margin-right: 5px;
+              }
+              .source-target {
+                min-width: 140px;
+                float: left;
+                font-weight: bold;
+                position: relative;
+                top: 1px;
+                .source-box {
+                  float: left;
+                  max-width: 60px;
+                  min-width: 60px;
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  line-height: 30px;
+                }
+                .in-to {
+                  float: left;
+                  top: 4px;
+                  color: #5a5a5a;
+                  line-height: 26px;
+                  position: relative;
+                  font-size: 12px;
+                  i {
+                    margin-right: 0;
+                  }
+                }
+                .target-box {
+                  float: left;
+                  width: 60px;
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  line-height: 30px;
+                }
+              }
+              .progress-bar {
+              }
+              .tm-job,
+              .activity-icon-single {
+                float: left;
+                width: 30px;
+                height: 30px;
+              }
+              .job-activity-icons {
+                float: left;
+                width: 30px;
+                height: 30px;
+                margin-left: 5px;
+                .comments {
+                }
+                .group-activity-icons {
+                  .item {
+                    margin: 0;
+                    padding: 1px !important;
+                    a {
+                      padding: 0;
+                      width: 100%;
+                      border-radius: 0px;
+                      font-size: 15px;
+                      font-weight: normal;
+                      font-family: Calibri, Arial, Helvetica, sans-serif;
+                      text-align: left;
+                      margin: 0 15px 0 10px;
+                      background: transparent !important;
+                      box-shadow: none !important;
+                      i {
+                        margin-right: 10px !important;
+                      }
+                    }
+                  }
+                }
+              }
+              .tm-job.job-activity-icons {
+                a {
+                  i {
+                    vertical-align: inherit;
+                  }
+                }
+              }
+              .outsource-job {
+                display: inline-block;
+                min-width: 30%;
+                padding-left: 5px;
+                .translated-outsourced {
+                  top: 1px;
+                  bottom: 6px;
+                  vertical-align: text-bottom;
+                  display: inline-block;
+                  position: relative;
+                  text-align: left;
+                  .outsource-logo-box {
+                    min-width: 123px;
+                    display: inherit;
+                    margin-left: 10px;
+                    img.outsource-logo {
+                      width: 108px;
+                      margin: -9px 10px 0 0;
+                      vertical-align: middle;
+                    }
+                    @media only screen and (max-width: 1199px) and (min-width: 992px) {
+                      width: 180px;
+                    }
+                  }
+                  &.outsource {
+                    margin-top: 6px;
+                  }
+                }
+                .job-to-translator {
+                  display: inline-block;
+                  margin-right: 5px;
+                  margin-left: 5px;
+                  vertical-align: text-bottom;
+                  color: #969696;
+                  max-width: 150px;
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  line-height: 20px;
+                  margin-top: 5px;
+                  transition: 0.3s ease;
+
+                  @media only screen and (max-width: 1199px) and (min-width: 992px) {
+                    width: fit-content;
+                    max-width: 190px;
+                    &:hover {
+                    }
+                  }
+                  a {
+                    text-decoration: underline;
+                    font-weight: 700;
+                  }
+                  &.not-assigned {
+                    width: fit-content;
+                  }
+                }
+                &:hover .job-to-translator {
+                }
+
+                .job-delivery {
+                  display: inline-block;
+                  margin-right: 5px;
+                  margin-left: 5px;
+                  vertical-align: text-bottom;
+                  line-height: 20px;
+                  .outsource-day-text {
+                    font-weight: 700;
+                    display: inherit;
+                    margin-right: 3px;
+                  }
+                  .outsource-month-text {
+                    display: inherit;
+                    font-weight: 700;
+                    margin-right: 5px;
+                  }
+                  .outsource-time-text {
+                    display: inherit;
+                    font-weight: 700;
+                  }
+                  .outsource-gmt-text {
+                    color: #969696;
+                    display: inherit;
+                    margin-left: 5px;
+                    font-size: 13px;
+                  }
+
+                  @media only screen and (max-width: 1199px) and (min-width: 992px) {
+                    display: none;
+                  }
+                  @media only screen and (max-width: 991px) and (min-width: 768px) {
+                    display: none;
+                  }
+                  @media only screen and (max-width: 767px) {
+                    display: none;
+                  }
+                }
+                &:hover .translator .job-delivery {
+                  display: none;
+                }
+                .item {
+                  margin-left: 10px;
+                  display: none;
+                  float: right;
+                  cursor: pointer;
+                  @media only screen and (max-width: 1200px) {
+                    margin-left: 5px;
+                  }
+                  .ui.cancel {
+                    padding: 4px;
+                    background-color: #d6d6d6;
+                    margin-top: 3px;
+                    margin-bottom: 2px;
+                    position: relative;
+                    line-height: 0;
+                    right: 3px;
+                    font-size: 15px;
+                    color: #ffffff;
+                  }
+                  &:hover .ui.cancel {
+                    background-color: #cccccc !important;
+                  }
+                }
+                &:hover .item {
+                  display: inline-block;
+                }
+                &:hover {
+                  .translator {
+                    //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+                    transition: 0.3s ease;
+                    cursor: pointer;
+                    border-radius: 2px;
+                    a {
+                      text-decoration: none;
+                    }
+                  }
+                }
+              }
+              .job-payable {
+                padding: 0 5px 0 5px !important;
+                float: left;
+                text-decoration: underline;
+                min-width: 106px;
+                line-height: 30px;
+                font-weight: 700;
+                position: relative;
+                top: 1px;
+                &:hover {
+                  text-decoration: none;
+                }
+              }
+              .open-translate {
+                font-family: Calibri, Arial, Helvetica, sans-serif;
+                padding: 6px 15px;
+                vertical-align: top;
+                font-size: 16px;
+                //border: 1px solid #797979;
+                border-radius: 2px;
+                float: right;
+              }
+              .open-vendor {
+                font-family: Calibri, Arial, Helvetica, sans-serif;
+                padding: 6px 7px;
+                vertical-align: top;
+                font-size: 16px;
+                //border: 1px solid #7eaf3e;
+                border-radius: 2px;
+                float: right;
+                font-weight: bold;
+                box-shadow: none !important;
+                color: #7eaf3e !important;
+                &:hover {
+                  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+                    0 2px 4px rgba(0, 0, 0, 0.24) !important;
+                }
+                &:active {
+                  box-shadow: none !important;
+                }
+                &:focus {
+                  box-shadow: none !important;
+                }
+              }
+              .open-outsource {
+                font-family: Calibri, Arial, Helvetica, sans-serif;
+                padding: 6px 22px;
+                vertical-align: top;
+                font-size: 16px;
+                //border: 1px solid #797979;
+                border-radius: 2px;
+                float: right;
+
+                &.buy-translation {
+                  display: flex;
+                  align-items: center;
+                  background: #fff;
+                  color: $black;
+                  font-weight: normal;
+                  padding: 5px 8px;
+                  border: none; // border: 1px solid #979797;
+                  font-size: 14px;
+                  .buy-translation-span:hover {
+                    text-decoration: none;
+                  }
+                  .buy-translation-span {
+                    text-decoration: underline;
+                    font-size: 14px;
+                  }
+                  span {
+                    color: #000;
+                    font-size: 12px;
+                    margin-left: 4px;
+                    line-height: 1.6;
+                  }
+                  img {
+                    margin-left: 3px;
+                    width: 20px;
+                    height: 20px;
+                  }
+                }
+              }
+              .open-outsourced {
+                font-family: Calibri, Arial, Helvetica, sans-serif;
+                padding: 6px 19px;
+                vertical-align: top;
+                font-size: 16px;
+                //border: 1px solid #797979;
+                border-radius: 2px;
+                float: right;
+                &:hover {
+                  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+                    0 2px 4px rgba(0, 0, 0, 0.24) !important;
+                }
+                &:focus {
+                  box-shadow: none !important;
+                }
+                &:active {
+                  box-shadow: none !important;
+                }
+              }
+              .job-menu {
+                i {
+                  vertical-align: inherit;
+                }
+                &.ui.button {
+                  background-color: transparent;
+                  border-radius: 2px;
+                  float: right;
+                  .divider {
+                    margin: 0;
+                  }
+                  .item {
+                    padding: 10px 15px !important;
+                  }
+                  &:hover {
+                    background-color: #ececec;
+                  }
+                  &:active {
+                    background-color: #e2e2e2;
+                  }
+                  &:focus {
+                    background-color: #e2e2e2;
+                  }
+                }
+              }
+
+              .chunk-download-progress {
+                height: 2px;
+                background-color: #ffffff;
+                position: absolute;
+                bottom: 0px;
+                width: 100%;
+                left: 0;
+                &:after {
+                  content: '';
+                  opacity: 1;
+                  position: absolute;
+                  top: 0;
+                  left: 0;
+                  right: 0;
+                  bottom: 0;
+                  background: #000000;
+                  border-radius: 0.28571429rem;
+                  -webkit-animation: progress-active 1s ease infinite;
+                  animation: progress-active 1s ease infinite;
+                }
+              }
+              &.updated-job {
+                background-color: #f9ffb5;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    .project-footer {
+      padding: 0 30px 5px !important;
+      text-align: right;
+      background-color: $grey4;
+      .activity-log {
+        margin-top: -10px;
+        margin-right: -15px;
+        a {
+          text-decoration: underline;
+          color: $grey1;
+          font-size: 13px;
+          &:hover {
+            text-decoration: none;
+          }
+        }
+      }
+      .project-due-date {
+        margin-top: -10px;
+        margin-left: -15px;
+        color: $grey1;
+        font-size: 13px;
+      }
+    }
+  }
 }
 
 .no-results-teams .no-results-found {
-    background: url(/public/img/matecat_teams.svg) no-repeat!important;
-    background-position: center center!important;
-    background-size: 420px!important;
+  background: url(/public/img/matecat_teams.svg) no-repeat !important;
+  background-position: center center !important;
+  background-size: 420px !important;
 }
 
 // closing rewrite semantic CSS
 .notify-notfound {
-    .no-results-found {
-        background: url(/public/img/jobnotfound.png) no-repeat;
-        background-position: center center;
-        height: 320px;
-    }
-    .welcome-to-matecat {
-        background: url(/public/img/welcome-to-matecat.png) no-repeat;
-        background-position: center center;
-        height: 320px;
-        background-size: 420px !important;
-    }
-    .message-nofound {
-        text-align: center;
-        display: block;
-        font-size: 34px;
-        margin-top: 100px;
-        line-height: 40px;
-    }
+  .no-results-found {
+    background: url(/public/img/jobnotfound.png) no-repeat;
+    background-position: center center;
+    height: 320px;
+  }
+  .welcome-to-matecat {
+    background: url(/public/img/welcome-to-matecat.png) no-repeat;
+    background-position: center center;
+    height: 320px;
+    background-size: 420px !important;
+  }
+  .message-nofound {
+    text-align: center;
+    display: block;
+    font-size: 34px;
+    margin-top: 100px;
+    line-height: 40px;
+  }
 
-    .message-create {
+  .message-create {
+    text-align: center;
+    display: block;
+    font-size: 25px;
+    margin-top: 0px;
+    line-height: 40px;
+    p {
+      padding: 20px;
+      a {
         text-align: center;
-        display: block;
-        font-size: 25px;
-        margin-top: 0px;
-        line-height: 40px;
-        p {
-            padding: 20px;
-            a {
-                text-align: center;
-                font-family: Calibri, Arial, Helvetica, sans-serif;
-                padding: 16px 25px;
-                vertical-align: top;
-                font-size: 20px;
-                border: 1px solid #797979;
-                border-radius: 2px;
-                margin: 10px;
-            }
-        }
+        font-family: Calibri, Arial, Helvetica, sans-serif;
+        padding: 16px 25px;
+        vertical-align: top;
+        font-size: 20px;
+        border: 1px solid #797979;
+        border-radius: 2px;
+        margin: 10px;
+      }
     }
+  }
 }
 
-.normal-foo{
-    background-color: $grey4;
-    min-width: 992px;
-    width: 100%;
-    position: fixed;
+.normal-foo {
+  background-color: $grey4;
+  min-width: 992px;
+  width: 100%;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  .footer-body {
+    display: grid;
+    position: relative;
+    grid-column-gap: 24px;
+    grid-template-columns: 0.6fr 0.6fr 1fr;
+    align-items: center;
+    padding: 16px 64px;
+    height: 77px;
+    .info {
+      display: grid;
+      align-items: center;
+      grid-template-columns: 40px auto;
+      grid-column-gap: 8px;
+      .logo {
+        background-position: center;
+        background-size: cover;
+      }
+      .description {
+        color: $grey1;
+        font-weight: 100;
+        font-size: 12px;
+        text-align: left;
+        line-height: 14px;
+        .link {
+          color: #00aee4;
+          text-decoration: underline;
+        }
+      }
+    }
+  }
+  .side-info {
+    padding: 0 16px;
+    position: absolute;
+    display: grid;
+    align-items: center;
     bottom: 0;
-    left: 0;
-    z-index: 2;
-    .footer-body{
-        display: grid;
-        position: relative;
-        grid-column-gap: 24px;
-        grid-template-columns: 0.6fr 0.6fr 1fr;
-        align-items: center;
-        padding: 16px 64px;
-        height: 77px;
-        .info{
-            display: grid;
-            align-items: center;
-            grid-template-columns: 40px auto;
-            grid-column-gap: 8px;
-            .logo{
-                background-position: center;
-                background-size: cover;
-            }
-            .description{
-                color: $grey1;
-                font-weight: 100;
-                font-size: 12px;
-                text-align: left;
-                line-height: 14px;
-                .link{
-                    color: #00aee4;
-                    text-decoration: underline;
-                }
-            }
+    right: 0;
+    width: 419px;
+    height: 35px;
+    box-shadow: -2px -2px 12px 0 rgba(198, 198, 198, 0.5);
+    background-color: #ffffff;
+    .side-info-body {
+      display: grid;
+      grid-template-columns: 80px 80px 80px;
+      align-items: center;
+      .item {
+        a {
+          margin: 0;
+          padding: 0;
+          color: $grey1;
+          display: block;
+          text-decoration: underline;
+          text-align: left;
         }
+      }
     }
-    .side-info{
-        padding: 0 16px;
-        position: absolute;
-        display: grid;
-        align-items: center;
-        bottom: 0;
-        right: 0;
-        width: 419px;
-        height: 35px;
-        box-shadow: -2px -2px 12px 0 rgba(198, 198, 198, 0.5);
-        background-color: #ffffff;
-        .side-info-body{
-            display: grid;
-            grid-template-columns: 80px 80px 80px;
-            align-items: center;
-            .item{
-                a{
-                    margin: 0;
-                    padding: 0;
-                    color: $grey1;
-                    display: block;
-                    text-decoration: underline;
-                    text-align: left;
-                }
-            }
-        }
-    }
+  }
 }
 
-.modal[data-type=view] {
-    display: none;
+.modal[data-type='view'] {
+  display: none;
 }
 
 /* fix di daniele */
 
 .ui.pointing.dropdown > .menu:after {
-    box-shadow: -1px -1px 0px 0px rgb(222, 222, 223);
+  box-shadow: -1px -1px 0px 0px rgb(222, 222, 223);
 }
 
 @media only screen and (min-width: 1200px) {
-    .ui.container {
-        width: 1140px;
-        margin-left: auto !important;
-        margin-right: auto !important;
-        transition: 0.3s ease;
-    }
-
+  .ui.container {
+    width: 1140px;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    transition: 0.3s ease;
+  }
 }
 
 @media only screen and (min-width: 1380px) {
-    .ui.container {
-        width: 1280px;
-        margin-left: auto !important;
-        margin-right: auto !important;
-        transition: 0.3s ease;
-    }
+  .ui.container {
+    width: 1280px;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    transition: 0.3s ease;
+  }
 }
 
 @media only screen and (max-width: 1199px) and (min-width: 992px) {
-    .ui.container {
-        width: 991px;
-        margin-left: auto !important;
-        margin-right: auto !important;
-        transition: 0.3s ease;
-        .outsource-container {
-            width: 105%;
-        }
-        .outsource-job {
-            min-width: 20% !important;
-        }
+  .ui.container {
+    width: 991px;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    transition: 0.3s ease;
+    .outsource-container {
+      width: 105%;
     }
-
+    .outsource-job {
+      min-width: 20% !important;
+    }
+  }
 }
 
 @media only screen and (max-width: 991px) and (min-width: 768px) {
-    .ui.container {
-        min-width: 991px;
-        margin-left: auto !important;
-        margin-right: auto !important;
-        transition: 0.3s ease;
+  .ui.container {
+    min-width: 991px;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    transition: 0.3s ease;
+  }
+  .project-list {
+    padding-top: 50px;
+    .job-to-translator {
+      margin-right: 5px;
+      margin-left: 15px;
+      min-width: 0px;
+      max-width: 210px !important;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
-    .project-list {
-        padding-top: 50px;
-        .job-to-translator {
-            margin-right: 5px;
-            margin-left: 15px;
-            min-width: 0px;
-            max-width: 210px !important;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
-    }
-    .outsource-job {
-        min-width: 20% !important;
-    }
+  }
+  .outsource-job {
+    min-width: 20% !important;
+  }
 }
 
 @media only screen and (max-width: 767px) {
-    .ui.container {
-        margin-left: 1em !important;
-        margin-right: 1em !important;
-        min-width: 961px;
-        transition: 0.3s ease;
-    }
-    .project-list {
-        padding-top: 50px;
-    }
-    .outsource-job {
-        min-width: 20% !important;
-    }
+  .ui.container {
+    margin-left: 1em !important;
+    margin-right: 1em !important;
+    min-width: 961px;
+    transition: 0.3s ease;
+  }
+  .project-list {
+    padding-top: 50px;
+  }
+  .outsource-job {
+    min-width: 20% !important;
+  }
 }
 
 .status-filter {
-    display: inline-block;
-    position: absolute;
-    right: -70px;
-    background: #d8d8d8;
-    padding: 4px 5px 4px;
-    top: 3px;
-    border-radius: 2px;
-    color: #5d5d5d;
-    font-weight: 100;
+  display: inline-block;
+  position: absolute;
+  right: -70px;
+  background: #d8d8d8;
+  padding: 4px 5px 4px;
+  top: 3px;
+  border-radius: 2px;
+  color: #5d5d5d;
+  font-weight: 100;
 }
 
 .ui.dropdown .scrolling.menu {
-    border-top:none;
+  border-top: none;
 }

--- a/public/css/sass/commons/_matecat_fonts.scss
+++ b/public/css/sass/commons/_matecat_fonts.scss
@@ -1,8 +1,17 @@
 @font-face {
   font-family: Calibri;
-  src: local(Calibri), url("../fonts/calibri-webfont.woff") format("woff"), url("../fonts/calibri-webfont.ttf") format("truetype"), url("../fonts/calibri-webfont.eot"), url("../fonts/calibri-webfont.eot?#iefix") format("embedded-opentype"); }
+  src: local(Calibri), url('../fonts/calibri-webfont.woff') format('woff'),
+    url('../fonts/calibri-webfont.ttf') format('truetype'),
+    url('../fonts/calibri-webfont.eot'),
+    url('../fonts/calibri-webfont.eot?#iefix') format('embedded-opentype');
+}
 
 @font-face {
   font-family: Calibri;
   font-weight: bold;
-  src: local("Calibri Bold"), url("../fonts/calibri_bold-webfont.woff") format("woff"), url("../fonts/calibri_bold-webfont.ttf") format("truetype"), url("../fonts/calibri_bold-webfont.eot"), url("../fonts/calibri_bold-webfont.eot?#iefix") format("embedded-opentype"); }
+  src: local('Calibri Bold'),
+    url('../fonts/calibri_bold-webfont.woff') format('woff'),
+    url('../fonts/calibri_bold-webfont.ttf') format('truetype'),
+    url('../fonts/calibri_bold-webfont.eot'),
+    url('../fonts/calibri_bold-webfont.eot?#iefix') format('embedded-opentype');
+}

--- a/public/css/sass/commons/_nav-bar.scss
+++ b/public/css/sass/commons/_nav-bar.scss
@@ -1,501 +1,495 @@
 header {
-    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    position: fixed;
-    width: 100%;
-    z-index: 12;
-    margin: 0;
-    background: #002b5c;
-    height: 60px;
-    @media only screen and (max-width: 992px) {
-        min-width: 992px;
-        position: relative;
-    }
-    .nav-mc-bar {
-        margin: 0px !important;
-        //min-width: 992px;
-        .navigation {
-            padding: 10px!important;
-            /*padding: 5px 15px 5px 0px !important;
+  font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  position: fixed;
+  width: 100%;
+  z-index: 12;
+  margin: 0;
+  background: #002b5c;
+  height: 60px;
+  @media only screen and (max-width: 992px) {
+    min-width: 992px;
+    position: relative;
+  }
+  .nav-mc-bar {
+    margin: 0px !important;
+    //min-width: 992px;
+    .navigation {
+      padding: 10px !important;
+      /*padding: 5px 15px 5px 0px !important;
             background-color: #4d4d4d;
             height: 48px !important;*/
-            .ui.grid {
-                margin-right: 0;
-            }
-
+      .ui.grid {
+        margin-right: 0;
+      }
+    }
+    .ui.selection.dropdown,
+    .ui.select-org.dropdown {
+      font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+      font-weight: 600;
+      &.org {
+        float: right;
+      }
+      i {
+        float: right;
+      }
+      .menu {
+        .header {
+          font-size: 14px;
+          display: grid;
+          grid-template-columns: 1fr 40px;
+          grid-template-rows: 28px;
+          align-items: center;
+          margin: 0;
+          padding: 8px 16px;
+          cursor: pointer;
+          color: $translatedBlue;
+          &:hover {
+            background-color: #f3f3f3;
+          }
+          i {
+            float: right;
+            font-size: 24px;
+            margin-top: -3px;
+            margin-right: -3px;
+            color: $translatedBlue;
+          }
         }
-        .ui.selection.dropdown,
-        .ui.select-org.dropdown {
-            font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-            font-weight: 600;
-            &.org {
-                float: right;
-            }
-            i {
-                float: right;
-            }
-            .menu {
-                .header {
-                    font-size: 14px;
-                    display: grid;
-                    grid-template-columns: 1fr 40px;
-                    grid-template-rows: 28px;
-                    align-items: center;
-                    margin: 0;
-                    padding: 8px 16px;
-                    cursor: pointer;
-                    color: $translatedBlue;
-                    &:hover {
-                        background-color: #f3f3f3;
-                    }
-                    i {
-                        float: right;
-                        font-size: 24px;
-                        margin-top: -3px;
-                        margin-right: -3px;
-                        color: $translatedBlue;
-                    }
-                }
-                .item > a > i {
-                    position: absolute;
-                    width: 24px;
-                    height: 24px;
-                    line-height: 24px;
-                    border-radius: 50%;
-                    top: 16%;
-                    right: 10px;
-                    bottom: 20%;
-                    background-color: transparent;
-                    color: $translatedBlue;
-                    font-size: 18px;
-                    padding-left: 1px;
-                    &:hover {
-                        background-color: #dededc;
-                        transition: 0.3s ease;
-                    }
-                }
-                .item:first-child {
-                    a > i {
-                        display: none;
-                    }
-                }
-                .divider {
-                    margin: 0;
-                }
-            }
-            .scrolling {
-                .item.item.item {
-                    padding: 8px !important;
-                    width: 230px;
-                    min-width: 150px;
-                    white-space: nowrap;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
+        .item > a > i {
+          position: absolute;
+          width: 24px;
+          height: 24px;
+          line-height: 24px;
+          border-radius: 50%;
+          top: 16%;
+          right: 10px;
+          bottom: 20%;
+          background-color: transparent;
+          color: $translatedBlue;
+          font-size: 18px;
+          padding-left: 1px;
+          &:hover {
+            background-color: #dededc;
+            transition: 0.3s ease;
+          }
+        }
+        .item:first-child {
+          a > i {
+            display: none;
+          }
+        }
+        .divider {
+          margin: 0;
+        }
+      }
+      .scrolling {
+        .item.item.item {
+          padding: 8px !important;
+          width: 230px;
+          min-width: 150px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
 
-                    /*&:hover .team-filter,
+          /*&:hover .team-filter,
                     &.active.selected .team-filter{
                         background: #fff;
                         border-radius: 50px;
                     }*/
-                }
-                .team-filter {
-                    visibility: visible;
-                }
-
-            }
         }
-        .ui.selection.visible.dropdown > .text:not(.default),
-        .ui.select-org.visible.dropdown > .text:not(.default) {
-            /*font-weight: 600;*/
-            //color: white;
+        .team-filter {
+          visibility: visible;
         }
-        div.ui-user-top-image {
-            -webkit-box-align: center;
-            -webkit-align-items: center;
-            -ms-flex-align: center;
-            align-items: center;
-            /*background: center/cover #9c9c9c;*/
-            border-radius: 50%;
-            box-shadow: inset 0 0 0 1px rgba(0,0,0,0.2);
-            -moz-box-sizing: border-box;
-            box-sizing: border-box;
-            color: $translatedBlue;
-            display: -webkit-inline-box;
-            display: -webkit-inline-flex;
-            display: -ms-inline-flexbox;
-            display: inline-flex;
-            -webkit-box-pack: center;
-            -webkit-justify-content: center;
-            -ms-flex-pack: center;
-            justify-content: center;
-            position: relative;
-            vertical-align: top;
-            float: right;
-            font-size: 14px;
-            height: 36px;
-            width: 36px;
-            margin-left: 10px;
-            margin-right: 10px;
-            text-decoration: none;
-            transition: 0.3s ease;
-            cursor: pointer;
-            background-color: transparent;
-            border: 2px solid $translatedBlue;
-            /*opacity: 0.8;
+      }
+    }
+    .ui.selection.visible.dropdown > .text:not(.default),
+    .ui.select-org.visible.dropdown > .text:not(.default) {
+      /*font-weight: 600;*/
+      //color: white;
+    }
+    div.ui-user-top-image {
+      -webkit-box-align: center;
+      -webkit-align-items: center;
+      -ms-flex-align: center;
+      align-items: center;
+      /*background: center/cover #9c9c9c;*/
+      border-radius: 50%;
+      box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      color: $translatedBlue;
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-box-pack: center;
+      -webkit-justify-content: center;
+      -ms-flex-pack: center;
+      justify-content: center;
+      position: relative;
+      vertical-align: top;
+      float: right;
+      font-size: 14px;
+      height: 36px;
+      width: 36px;
+      margin-left: 10px;
+      margin-right: 10px;
+      text-decoration: none;
+      transition: 0.3s ease;
+      cursor: pointer;
+      background-color: transparent;
+      border: 2px solid $translatedBlue;
+      /*opacity: 0.8;
             &:hover {
                 opacity: 1;
             }*/
-        }
-        .ui.user-nolog.label {
-            -webkit-box-align: center;
-            -webkit-align-items: center;
-            -ms-flex-align: center;
-            align-items: center;
-            background: center/cover transparent;
-            /*border-radius: 50%;*/
-            -moz-box-sizing: border-box;
-            box-sizing: border-box;
-            /*color: #fff;*/
-            display: -webkit-inline-box;
-            display: -webkit-inline-flex;
-            display: -ms-inline-flexbox;
-            display: inline-flex;
-            -webkit-box-pack: center;
-            -webkit-justify-content: center;
-            -ms-flex-pack: center;
-            justify-content: center;
-            position: relative;
-            vertical-align: top;
-            float: right;
-            /*font-size: 14px;*/
-            /*height: 36px;
+    }
+    .ui.user-nolog.label {
+      -webkit-box-align: center;
+      -webkit-align-items: center;
+      -ms-flex-align: center;
+      align-items: center;
+      background: center/cover transparent;
+      /*border-radius: 50%;*/
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      /*color: #fff;*/
+      display: -webkit-inline-box;
+      display: -webkit-inline-flex;
+      display: -ms-inline-flexbox;
+      display: inline-flex;
+      -webkit-box-pack: center;
+      -webkit-justify-content: center;
+      -ms-flex-pack: center;
+      justify-content: center;
+      position: relative;
+      vertical-align: top;
+      float: right;
+      /*font-size: 14px;*/
+      /*height: 36px;
             width: 36px;*/
-            /*margin-left: 10px;
+      /*margin-left: 10px;
             margin-right: 10px;*/
-            text-decoration: none;
-            cursor: pointer;
-            /*border: 1px dashed;*/
-            top: 2px;
-            padding:0;
-            width: 40px;
-            /*&:hover {
+      text-decoration: none;
+      cursor: pointer;
+      /*border: 1px dashed;*/
+      top: 2px;
+      padding: 0;
+      width: 40px;
+      /*&:hover {
                 border: 1px dashed $translatedBlue !important;
                 i {
                     color: $translatedBlue;
                 }
             }*/
-        }
+    }
 
-        .dropdown.select-org {
-            background-color: #ffffff;
-            border-radius: 30px;
-            min-width: 105px;
-            color: #000000;
-            font-size: 14px;
-            padding: 3px 15px;
-            float: left;
-            margin-left: 10px;
-            display: grid;
-            grid-template-columns: auto 13px;
-            column-gap: 6px;
-            align-items: center;
-            grid-template-rows: 28px;
+    .dropdown.select-org {
+      background-color: #ffffff;
+      border-radius: 30px;
+      min-width: 105px;
+      color: #000000;
+      font-size: 14px;
+      padding: 3px 15px;
+      float: left;
+      margin-left: 10px;
+      display: grid;
+      grid-template-columns: auto 13px;
+      column-gap: 6px;
+      align-items: center;
+      grid-template-rows: 28px;
 
-            /*opacity:0.8;
+      /*opacity:0.8;
             &:hover, &.active {
                 opacity:1;
             }*/
 
-            .item {
-                display: grid;
-                grid-template-columns: auto;
-                align-items: center;
-                grid-template-rows: 28px;
+      .item {
+        display: grid;
+        grid-template-columns: auto;
+        align-items: center;
+        grid-template-rows: 28px;
 
-                .item-info {
-                    display: grid;
-                    grid-template-columns: 1fr 40px;
-                    align-items: center;
-                    grid-template-rows: 32px;
-                    padding: 0 0 0 8px;
-                    .icon {
-                        margin:0 !important;
-                        padding: 0px 8px;
-                        a {
-                            display: grid;
-                            padding: 0 4px;
-                            height: 24px;
-                            justify-content: center;
-                            align-items: center;
-                            visibility: hidden;
-                            &:hover {
-                                background: rgba(0, 0, 0, 0.03);
-                                border-radius: 50px;
-                            }
-                            svg {
-                                path {
-                                  fill: #0099cc;
-                                }
-                            }
-                        }
-                    }
+        .item-info {
+          display: grid;
+          grid-template-columns: 1fr 40px;
+          align-items: center;
+          grid-template-rows: 32px;
+          padding: 0 0 0 8px;
+          .icon {
+            margin: 0 !important;
+            padding: 0px 8px;
+            a {
+              display: grid;
+              padding: 0 4px;
+              height: 24px;
+              justify-content: center;
+              align-items: center;
+              visibility: hidden;
+              &:hover {
+                background: rgba(0, 0, 0, 0.03);
+                border-radius: 50px;
+              }
+              svg {
+                path {
+                  fill: #0099cc;
                 }
-                &:hover .icon a {
-                    visibility: visible;
-                }
-
-                &.selected {
-                    .item-info {
-                        color: #fff;
-                        border-radius: 2px;
-                        background: #002b5c;
-                        a {
-                            svg {
-                                path {
-                                    fill: #fff;
-                                }
-                            }
-                            &:hover {
-                                svg {
-                                    path {
-                                        fill: $translatedBlue;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+              }
             }
-
-            i.dropdown.icon {
-                top: 12px;
-                margin-left: 5px !important;
-            }
-
-            span.text {
-                text-align: left;
-                /*line-height: 32px;*/
-                text-decoration: none;
-                min-width: 0;
-                /*max-width: 74px;*/
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                font-weight: 100;
-            }
-
-            div.icon{
-                padding: 6px 0 0 0;
-            }
-
-            &:hover span.text {
-                text-decoration: none;
-                transition: 0.3s ease;
-            }
-            &.only-one-team .scrolling.menu {
-                display: none;
-            }
-            &.disable-dropdown-team {
-                pointer-events: none;
-                cursor: default;
-                .text {
-                    text-decoration: none;
-                }
-            }
+          }
         }
-    }
-}
-
-.user-menu-tooltip {
-    right: 30px !important;
-
-    h4.header {
-        box-shadow: none !important;
-        background: transparent;
-        text-decoration: none;
-        border-bottom: none;
-        color: black;
-        margin-bottom: 10px !important;
-    }
-
-    .content p {
-        font-size: 15px;
-        text-align: left;
-        min-width: 180px;
-    }
-
-    a.close-popup-teams {
-        float: right;
-        cursor: pointer;
-        text-decoration: underline;
-        &:hover {
-            text-decoration: none;
+        &:hover .icon a {
+          visibility: visible;
         }
-    }
-}
 
-.user-teams {
-    //padding-right: 52px !important;
-    display: grid !important;
-    grid-template-columns: auto auto auto auto;
-    justify-content: right;
-    align-items: center;
-    padding-right: 24px;
-
-    #profile-menu {
-        .menu{
-            width: 200px;
-            margin: 0 0 0 -1px;
-            padding: 12px 8px !important;
-            top: 52px !important;
+        &.selected {
+          .item-info {
+            color: #fff;
             border-radius: 2px;
-            border: solid 1px #cdd4de;
-            right: 18px !important;
-            &::after {
-                content: "";
-                width: 0;
-                height: 0;
-                border-left: 6px solid transparent;
-                border-right: 6px solid transparent;
-                border-bottom: 6px solid #ffffff;
-                bottom: 100%;
-                left: auto;
-                right: 12%;
-                transform: translate(90%, 0) !important;
-                position: absolute;
-                pointer-events: none;
-            }
-            .item {
-                border-radius: 2px;
-                padding: 8px !important;
-                font-size: 16px !important;
-
-                &:hover {
-                    background-color: #f2f5f7 !important;
-                    color: #0055b8 !important;
+            background: #002b5c;
+            a {
+              svg {
+                path {
+                  fill: #fff;
                 }
-                &.selected {
-                    background-color: transparent !important;
-                    font-weight: normal !important;
+              }
+              &:hover {
+                svg {
+                  path {
+                    fill: $translatedBlue;
+                  }
                 }
+              }
             }
+          }
         }
-    }
+      }
 
-    .ui-user-top-image {
-        float: right;
-        margin: 0 10px;
-        cursor: pointer;
-        min-width: 35px;
-        @media only screen and (max-width: 1040px) {
-            margin: 0 -7px;
-        }
-    }
+      i.dropdown.icon {
+        top: 12px;
+        margin-left: 5px !important;
+      }
 
-    .organization-name {
-        color: #fff;
-        font-size: 15px;
-        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        font-weight: 600;
+      span.text {
+        text-align: left;
+        /*line-height: 32px;*/
         text-decoration: none;
-        float: right;
-        line-height: 37px;
-        min-width: 0px;
-        max-width: 110px;
+        min-width: 0;
+        /*max-width: 74px;*/
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-    }
+        font-weight: 100;
+      }
 
-    .separator {
-        width: 1px;
-        height: 30px;
-        background: white;
-        float: right;
-        margin-right: 14px;
-        margin-left: 14px;
+      div.icon {
+        padding: 6px 0 0 0;
+      }
+
+      &:hover span.text {
+        text-decoration: none;
+        transition: 0.3s ease;
+      }
+      &.only-one-team .scrolling.menu {
+        display: none;
+      }
+      &.disable-dropdown-team {
+        pointer-events: none;
+        cursor: default;
+        .text {
+          text-decoration: none;
+        }
+      }
     }
+  }
 }
 
+.user-menu-tooltip {
+  right: 30px !important;
+
+  h4.header {
+    box-shadow: none !important;
+    background: transparent;
+    text-decoration: none;
+    border-bottom: none;
+    color: black;
+    margin-bottom: 10px !important;
+  }
+
+  .content p {
+    font-size: 15px;
+    text-align: left;
+    min-width: 180px;
+  }
+
+  a.close-popup-teams {
+    float: right;
+    cursor: pointer;
+    text-decoration: underline;
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
+.user-teams {
+  //padding-right: 52px !important;
+  display: grid !important;
+  grid-template-columns: auto auto auto auto;
+  justify-content: right;
+  align-items: center;
+  padding-right: 24px;
+
+  #profile-menu {
+    .menu {
+      width: 200px;
+      margin: 0 0 0 -1px;
+      padding: 12px 8px !important;
+      top: 52px !important;
+      border-radius: 2px;
+      border: solid 1px #cdd4de;
+      right: 18px !important;
+      &::after {
+        content: '';
+        width: 0;
+        height: 0;
+        border-left: 6px solid transparent;
+        border-right: 6px solid transparent;
+        border-bottom: 6px solid #ffffff;
+        bottom: 100%;
+        left: auto;
+        right: 12%;
+        transform: translate(90%, 0) !important;
+        position: absolute;
+        pointer-events: none;
+      }
+      .item {
+        border-radius: 2px;
+        padding: 8px !important;
+        font-size: 16px !important;
+
+        &:hover {
+          background-color: #f2f5f7 !important;
+          color: #0055b8 !important;
+        }
+        &.selected {
+          background-color: transparent !important;
+          font-weight: normal !important;
+        }
+      }
+    }
+  }
+
+  .ui-user-top-image {
+    float: right;
+    margin: 0 10px;
+    cursor: pointer;
+    min-width: 35px;
+    @media only screen and (max-width: 1040px) {
+      margin: 0 -7px;
+    }
+  }
+
+  .organization-name {
+    color: #fff;
+    font-size: 15px;
+    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    font-weight: 600;
+    text-decoration: none;
+    float: right;
+    line-height: 37px;
+    min-width: 0px;
+    max-width: 110px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .separator {
+    width: 1px;
+    height: 30px;
+    background: white;
+    float: right;
+    margin-right: 14px;
+    margin-left: 14px;
+  }
+}
 
 .logo {
-    position: relative;
-    float: left;
-    border: 0;
-    //margin-top: 5px;
-    background: url(../../img/logo_matecat.png) 0px 0px no-repeat;
-    width: 180px;
-    height: 38px;
-    background-size: cover;
-    left: 20px;
-    top: 3px;
+  position: relative;
+  float: left;
+  border: 0;
+  //margin-top: 5px;
+  background: url(../../img/logo_matecat.png) 0px 0px no-repeat;
+  width: 180px;
+  height: 38px;
+  background-size: cover;
+  left: 20px;
+  top: 3px;
 }
 
-
 #menu-site {
-
-    /*margin-top: 8px !important;*/
-    /*float: right !important;*/
-    margin-right: 6px;
-    text-align: right;
-    /*
+  /*margin-top: 8px !important;*/
+  /*float: right !important;*/
+  margin-right: 6px;
+  text-align: right;
+  /*
     border-right: 1px solid #8a8a8a;
     */
-    /*height: 22px;*/
-    .btn {
-        background: #fff;
-        color: #002b5c;
-        font-size: 16px;
-        width:140px;
-        text-align: center;
-        max-height: 40px;
-        border-radius: 5px;
-        line-height: 1.25;
-        margin-left: 24px;
-        border: none;
-    }
+  /*height: 22px;*/
+  .btn {
+    background: #fff;
+    color: #002b5c;
+    font-size: 16px;
+    width: 140px;
+    text-align: center;
+    max-height: 40px;
+    border-radius: 5px;
+    line-height: 1.25;
+    margin-left: 24px;
+    border: none;
+  }
 
-    li {
-        a {
-            font-size: 16px !important;
-        }
+  li {
+    a {
+      font-size: 16px !important;
     }
+  }
 }
 
 .menu-site-right {
-    float: right !important;
+  float: right !important;
 }
 
 .upload-page-header {
-    .dropdown span {
-        margin-right: 0 !important;
-    }
+  .dropdown span {
+    margin-right: 0 !important;
+  }
 }
 
-
 .cta-create-team {
-    position: fixed !important;
-    .ui.primary.button {
-        border: 1px solid #797979;
-        float: right;
-        border-radius: 2px;
-        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;;
+  position: fixed !important;
+  .ui.primary.button {
+    border: 1px solid #797979;
+    float: right;
+    border-radius: 2px;
+    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  }
+  .content {
+    p {
+      font-size: 15px;
     }
-    .content {
-        p {
-            font-size: 15px;
-        }
-        a {
-            float: right;
-            text-decoration: underline;
-            color: #39699a;
-            cursor: pointer;
-            &:hover {
-                text-decoration: none;
-            }
-        }
+    a {
+      float: right;
+      text-decoration: underline;
+      color: #39699a;
+      cursor: pointer;
+      &:hover {
+        text-decoration: none;
+      }
     }
+  }
 }
 
 .ui.dropdown > .left.menu .menu {
-    margin: 0 !important;
+  margin: 0 !important;
 }

--- a/public/css/sass/commons/_outsource.scss
+++ b/public/css/sass/commons/_outsource.scss
@@ -1,1253 +1,1256 @@
 .after-open-outsource {
-    border-left: 2px solid $translatedBlue;
-    padding-left: 13px !important;
+  border-left: 2px solid $translatedBlue;
+  padding-left: 13px !important;
 }
 .outsource-container {
-    padding: 0px !important;
-    margin-top: 30px !important;
-    margin-bottom: 30px !important;
-    width: 107%;
-    margin-left: -3.0% !important;
-    //margin-right: -2% !important;
-    //box-shadow: 0 1px 20px rgba(0, 0, 0, 0.67);
-    overflow: hidden;
-    .outsource-header {
-        padding: 5px 35px 5px 40px !important;
-        z-index: 1;
-        .job-id {}
-        .source-target {
-            .source-box, .target-box {
-                width: unset !important;
-                max-width: unset !important;
-                font-size: 18px;
-            }
+  padding: 0px !important;
+  margin-top: 30px !important;
+  margin-bottom: 30px !important;
+  width: 107%;
+  margin-left: -3% !important;
+  //margin-right: -2% !important;
+  //box-shadow: 0 1px 20px rgba(0, 0, 0, 0.67);
+  overflow: hidden;
+  .outsource-header {
+    padding: 5px 35px 5px 40px !important;
+    z-index: 1;
+    .job-id {
+    }
+    .source-target {
+      .source-box,
+      .target-box {
+        width: unset !important;
+        max-width: unset !important;
+        font-size: 18px;
+      }
+    }
+    .job-payable {
+      display: inline-block;
+      padding: 0 0 0 10px !important;
+      line-height: 30px;
+      position: relative;
+      top: 2px;
+      text-decoration: none !important;
+      font-weight: 700;
+      font-size: 16px;
+    }
+    .project-subject {
+      display: inline-block;
+      line-height: 30px;
+      position: relative;
+      top: 2px;
+      font-size: 16px;
+      float: right;
+    }
+  }
+  &.transitionOutsource-enter {
+    height: 0;
+  }
+
+  &.showTranslator.transitionOutsource-enter.transitionOutsource-enter-active {
+    height: 339px;
+    -webkit-transition: all 0.3s ease;
+  }
+
+  &.no-outsource.transitionOutsource-enter.transitionOutsource-enter-active {
+    height: 140px;
+    -webkit-transition: all 0.3s ease;
+  }
+
+  &.showOutsource.transitionOutsource-enter.transitionOutsource-enter-active {
+    height: 505px;
+    -webkit-transition: all 0.3s ease;
+  }
+
+  &.showOpenBox.transitionOutsource-enter.transitionOutsource-enter-active {
+    height: 612px;
+    -webkit-transition: all 0.3s ease;
+  }
+
+  &.transitionOutsource-exit.transitionOutsource-exit-active {
+    height: 0 !important;
+    margin: 0 !important;
+    -webkit-transition: all 0.3s ease;
+  }
+
+  a {
+    text-decoration: underline;
+    font-weight: 700;
+    cursor: pointer;
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .gmt {
+    .gmt-outsourced {
+      display: inline-block;
+      margin-bottom: 10px;
+    }
+  }
+
+  .gmt {
+    font-size: 14px;
+    font-weight: normal;
+    float: right;
+    clear: both;
+    position: relative;
+    top: 4px;
+    .gmt-select {
+      min-width: 107px !important;
+      width: auto;
+      background: transparent;
+      padding: 12px 8px 10px;
+      .dropdown.icon {
+        padding: 10px 3px 0 0;
+      }
+      .text {
+        .gmt-description {
+          display: none;
         }
-        .job-payable {
+      }
+      .menu {
+        min-width: 330px;
+        height: 205px;
+        .item {
+          border-top: 1px solid #fafafa;
+          padding: 15px 5px 15px 10px !important;
+          white-space: normal;
+          word-wrap: normal;
+          .gmt-value {
             display: inline-block;
-            padding: 0 0 0 10px !important;
-            line-height: 30px;
+            margin-right: 5px;
+          }
+          .gmt-description {
+            display: inline-block;
+          }
+        }
+      }
+    }
+  }
+
+  .delivery-order,
+  .container-reduced {
+    .confirm-delivery-input {
+      margin-top: 31px;
+      .back,
+      .email-confirm,
+      .input {
+        display: inline-block;
+      }
+      .back {
+        float: left;
+        margin-top: 12px;
+        a {
+          i {
             position: relative;
             top: 2px;
-            text-decoration: none !important;
-            font-weight: 700;
-            font-size: 16px;
+          }
         }
-        .project-subject {
-            display: inline-block;
-            line-height: 30px;
-            position: relative;
-            top: 2px;
-            font-size: 16px;
-            float: right;
+      }
+      .email-confirm {
+        padding-right: 15px;
+      }
+      input {
+        min-width: 235px;
+      }
+    }
+  }
+  .confirm-delivery-box {
+    background: #daeddf;
+    padding: 9px 15px 3px;
+    text-align: right;
+    line-height: 20px;
+    .confirm-title {
+      font-size: 18px;
+      font-weight: 700;
+    }
+    p {
+      line-height: 16px;
+    }
+  }
+
+  .assign-job-translator {
+    background-color: #d7d8dc;
+    padding: 10px 15px 35px;
+    width: 100%;
+    .title {
+      display: inline-block;
+      padding: 15px 15px 15px 25px;
+      font-size: 20px;
+      font-weight: 700;
+      width: 25%;
+      vertical-align: top;
+      position: relative;
+      top: 24px;
+    }
+    .title-url {
+      padding: 10px 0;
+      width: 75%;
+      display: inline-block;
+      .job-url {
+        display: inline-block;
+        a {
+          font-size: 16px;
         }
-    }
-    &.transitionOutsource-enter {
-        height: 0;
-    }
-
-    &.showTranslator.transitionOutsource-enter.transitionOutsource-enter-active {
-        height: 339px;
-        -webkit-transition: all .3s ease;
-    }
-
-    &.no-outsource.transitionOutsource-enter.transitionOutsource-enter-active {
-        height: 140px;
-        -webkit-transition: all .3s ease;
-    }
-
-    &.showOutsource.transitionOutsource-enter.transitionOutsource-enter-active {
-        height: 505px;
-        -webkit-transition: all .3s ease;
-    }
-
-    &.showOpenBox.transitionOutsource-enter.transitionOutsource-enter-active {
-        height: 612px;
-        -webkit-transition: all .3s ease;
-    }
-
-    &.transitionOutsource-exit.transitionOutsource-exit-active {
-        height: 0 !important;
-        margin: 0 !important;
-        -webkit-transition: all .3s ease;
-    }
-
-    a {
-        text-decoration: underline;
-        font-weight: 700;
-        cursor: pointer;
-        &:hover {
-            text-decoration: none;
-        }
-    }
-
-    .gmt {
-        .gmt-outsourced {
-            display: inline-block;
-            margin-bottom: 10px;
-        }
-    }
-
-    .gmt {
-        font-size: 14px;
-        font-weight: normal;
-        float: right;
-        clear: both;
-        position: relative;
-        top: 4px;
-        .gmt-select {
-            min-width: 107px !important;
-            width: auto;
-            background: transparent;
-            padding: 12px 8px 10px;
-            .dropdown.icon {
-                padding: 10px 3px 0 0;
-            }
-            .text {
-                .gmt-description {
-                    display: none;
-                }
-            }
-            .menu {
-                min-width: 330px;
-                height: 205px;
-                .item {
-                    border-top: 1px solid #FAFAFA;
-                    padding: 15px 5px 15px 10px !important;
-                    white-space: normal;
-                    word-wrap: normal;
-                    .gmt-value {
-                        display: inline-block;
-                        margin-right: 5px;
-                    }
-                    .gmt-description {
-                        display: inline-block;
-                    }
-                }
-            }
-        }
-    }
-
-
-    .delivery-order, .container-reduced {
-        .confirm-delivery-input {
-            margin-top: 31px;
-            .back, .email-confirm, .input {
-                display: inline-block;
-            }
-            .back {
-                float: left;
-                margin-top: 12px;
-                a {
-                    i {
-                        position: relative;
-                        top: 2px;
-                    }
-                }
-            }
-            .email-confirm {
-                padding-right: 15px;
-            }
-            input {
-                min-width: 235px;
-            }
-        }
-    }
-    .confirm-delivery-box {
-        background: #daeddf;
-        padding: 9px 15px 3px;
-        text-align: right;
-        line-height: 20px;
-        .confirm-title {
-            font-size: 18px;
-            font-weight: 700;
-        }
-        p {
-            line-height: 16px;
-        }
-    }
-
-    .assign-job-translator {
-        background-color: #d7d8dc;
-        padding: 10px 15px 35px;
+      }
+      .translator-assignee {
         width: 100%;
-        .title {
-            display: inline-block;
-            padding: 15px 15px 15px 25px;
-            font-size: 20px;
-            font-weight: 700;
-            width: 25%;
-            vertical-align: top;
-            position: relative;
-            top: 24px;
-        }
-        .title-url {
-            padding: 10px 0;
-            width: 75%;
-            display: inline-block;
-            .job-url {
-                display: inline-block;
-                a {
-                    font-size: 16px;
-                }
-            }
-            .translator-assignee {
-                width: 100%;
-                .ui.form {
-                    /*width: 100%;*/
-                    .fields {
-                        margin: 0;
-                        .field {
-                            label {
-                                padding-left: 15px;
-                            }
-                            input[type="text"], input[type="email"] {
-                                box-shadow: inset 0 1px 3px #ddd;
-                                border: 1px solid #ccc;
-                                font-family: Calibri, Arial, Helvetica, sans-serif;
-                                &:focus {
-                                    border-color: #85B7D9;
-                                }
-                                &:active {
-                                    border-color: #85B7D9;
-                                }
-                            }
-                            &.send-job-box {
-                                padding: 0 15px 0 10px;
-                                padding-top: 22px;
-                                width: 28%;
-                                .send-job {
-                                    font-family: Calibri, Arial, Helvetica, sans-serif;
-                                    font-size: 16px;
-                                    border-radius: 2px;
-                                    padding: 10px 17px;
-                                    margin: 0;
-                                    float: right;
-                                    width: 97%;
-                                    min-width: 199px;
-                                    top: 1px;
-                                    position: relative;
-                                }
-                            }
-                            &.translator-email {
-                                width: 31%;
-                            }
-                            &.translator-delivery {
-                                width: 21%;
-                            }
-                            &.translator-time {
-                                 width: 202px;
-                                 .selection.dropdown {
-                                     width: 100%;
-                                     min-width: 91px !important;
-                                     border: 1px solid #ccc;
-                                     box-shadow: inset 0 1px 3px #ddd;
-                                     .menu {
-                                         height:205px;
-                                     }
-                                 }
-                             }
-                            &.gmt {
-                                position: relative;
-                                top: 23px;
-                                width: 100px;
-                                margin-right: 29px;
-                            }
-
-                        }
-                    }
-                }
-            }
-        }
-    }
-    .open-job-box {
-        background-color: $grey2;
-        padding: 35px 30px 25px 40px;
-        width: 100%;
-        cursor: auto;
-        .title {
-            display: inline-block;
-            font-size: 26px;
-            font-weight: 700;
-            width: 12%;
-            position: relative;
-            top: -4px;
-        }
-        .title-url {
-            width: 88%;
-            display: inline-block;
-            .job-url {
-                display: inline-block;
-                max-width: 80%;
-                min-width: 0;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                font-size: 15px;
-                a {
-                    font-size: 16px;
-                }
-            }
-            .button {
-                font-family: Calibri, Arial, Helvetica, sans-serif;
-                font-size: 16px;
-                //border: 1px solid #797979;
-                border-radius: 2px;
-                padding: 9px 15px;
-                margin: 0;
-                float: right;
-                margin-top: -10px;
-                width: 20%;
-            }
-        }
-    }
-
-    .divider-or {
-        padding-top: 0 !important;
-        padding-bottom: 0 !important;
-        z-index: 1;
-        padding-left: 35px !important;
-        height: 0;
-        .or {
-            width: 25px;
-            height: 25px;
-            background-color: grey;
-            text-align: center;
-            line-height: 25px;
-            border-radius: 50%;
-            color: #ffffff;
-            position: absolute;
-            top: -14px;
-            left: 90px;
-        }
-    }
-
-    .background-outsource-vendor {
-        background: $grey3;
-        width: 100%;
-        padding-bottom: 15px;
-        padding-top: 15px;
-        cursor: auto;
-        .outsource-not-available {
-            font-size: 20px;
-        }
-        .translated-loader {
-            position: absolute;
-            top: 50%;
-            left: 50%;
+        .ui.form {
+          /*width: 100%;*/
+          .fields {
             margin: 0;
-            text-align: center;
-            z-index: 1;
-            -webkit-transform: translateX(-50%) translateY(-50%);
-            transform: translateX(-50%) translateY(-50%);
-            img {
-                width: 40px
-            }
-            .text-loader-outsource {
-                font-size: 28px;
-                margin-top: 10px;
-                font-weight: 700;
-            }
-        }
-        .outsource-to-vendor {
-            .payment-service {
-                padding: 5px 10px 15px;
-                .service-box {
-                    display: inline-block;
-                    padding: 0 10px 0 15px;
-                    font-size: 26px;
-                    font-weight: 700;
-                    .service {
-                        display: inline-block;
-                        &.project-management {  }
-                        &.translation, &.revision {
-                            margin-left: 8px;
-                        }
-                    }
+            .field {
+              label {
+                padding-left: 15px;
+              }
+              input[type='text'],
+              input[type='email'] {
+                box-shadow: inset 0 1px 3px #ddd;
+                border: 1px solid #ccc;
+                font-family: Calibri, Arial, Helvetica, sans-serif;
+                &:focus {
+                  border-color: #85b7d9;
                 }
-                .fiducial-logo {
-                    display: inline-block;
-                    padding: 0;
-                    vertical-align: text-bottom;
-                    .translated-logo {
-                        display: inline-block;
-                        .logo-t {
-                            width: 100px;
-                            position: relative;
-                            top: 6px;
-                            padding: 0;
-                            margin: 0 0 0 5px;
-                        }
-                    }
+                &:active {
+                  border-color: #85b7d9;
                 }
-            }
-            .payment-details-box {
-                background-color: #ffffff;
-                padding: 15px;
+              }
+              &.send-job-box {
+                padding: 0 15px 0 10px;
+                padding-top: 22px;
+                width: 28%;
+                .send-job {
+                  font-family: Calibri, Arial, Helvetica, sans-serif;
+                  font-size: 16px;
+                  border-radius: 2px;
+                  padding: 10px 17px;
+                  margin: 0;
+                  float: right;
+                  width: 97%;
+                  min-width: 199px;
+                  top: 1px;
+                  position: relative;
+                }
+              }
+              &.translator-email {
+                width: 31%;
+              }
+              &.translator-delivery {
+                width: 21%;
+              }
+              &.translator-time {
+                width: 202px;
+                .selection.dropdown {
+                  width: 100%;
+                  min-width: 91px !important;
+                  border: 1px solid #ccc;
+                  box-shadow: inset 0 1px 3px #ddd;
+                  .menu {
+                    height: 205px;
+                  }
+                }
+              }
+              &.gmt {
                 position: relative;
-                min-height: 232px;
-                .translator-job-details {
-                    padding-bottom: 10px;
-                    .translator-details-box {
-                        width: 38%;
-                        border-right: 1px solid black;
-                        display: inline-block;
-                        vertical-align: middle;
-                        padding: 0 0 0 10px;
-                        .left, .right {
-                            display: inline-block;
-                            margin: 0;
-                        }
-                        .left {
-                            width: 42%;
-                            .star {
-                                position: relative;
-                                left: -2px;
-                                .icon {
-                                    &.active {
-                                        background: transparent !important;
-                                        color: #7eaf3e !important;
-                                        text-shadow: none !important;
-                                    }
-                                }
-                            }
-                        }
-                        .right {
-                            float: right;
-                            width: 58%;
-                            text-align: right;
-                            padding-right: 15px;
-                        }
-                        .translator-no-found {
-                            p {
-                            }
-                        }
-                    }
-                    .job-details-box {
-                        display: inline-block;
-                        width: 44% !important;
-                        vertical-align: middle;
-                        padding: 0 0 0 15px;
-                        position: relative;
-                        .source-target-outsource {
-                            display: inline-block;
-                            width: 68%;
-                            font-size: 18px;
-                            .source-box {
-                                display: inline-block;
-                            }
-                            .in-to {
-                                display: inline-block;
-                                font-size: 16px;
-                                i {
-                                    position: relative;
-                                    top: 1px;
-                                    margin: 0;
-                                    font-weight: 100;
-                                    font-size: 13px;
-                                    color: #545353;
-                                }
-                            }
-                            .target-box {
-                                display: inline-block;
-                            }
-                            @media only screen and (max-width: 1199px) and (min-width: 992px) {
-                                font-size: 16px;
-                                .in-to {
-                                    font-size: 13px
-                                }
-                            }
-                        }
-                        .job-payment {
-                            display: inline-block;
-                            width: 32%;
-                            text-align: right;
-                            padding-right: 28px;
-                            .not-payable {
-                                text-decoration: line-through;
-                                font-size: 16px;
-                                position: absolute;
-                                top: -17px;
-                                width: 30%;
-                                padding-right: 28px;
-                            }
-                            .payable {
-                                font-size: 18px;
-                            }
-                        }
-                    }
-                    .job-price {
-                        display: inline-block;
-                        vertical-align: middle;
-                        width: 18%;
-                        font-size: 20px;
-                        text-align: center;
-                    }
-                }
-                .revision-box {
-                    padding: 4px 0px;
-                    background-color: $grey2;
-                    margin-bottom: 10px;
-                    height: 28px;
-                    .add-revision {
-                        display: inline-block;
-                        width: 82%;
-                        text-align: right;
-                        padding-right: 28px;
-                        .checkbox {
-
-                        }
-                    }
-                    .job-price {
-                        display: inline-block;
-                        font-size: 20px;
-                        text-align: center;
-                        width: 18%;
-                    }
-
-                }
-                .delivery-order {
-                    width: 82%;
-                    text-align: right;
-                    display: inline-block;
-                    vertical-align: top;
-                    margin-top: 15px;
-                    padding-right: 25px;
-                    .delivery-box {
-                        text-align: right;
-                        display: inline-block;
-                        font-size: 23px;
-                        font-weight: 700;
-                        label {
-                            font-size: 16px;
-                            display: inline-block;
-                            vertical-align: middle;
-                            font-weight: 100;
-                            padding: 5px;
-                        }
-                        .atdd {
-                            display: inline-block;
-                            font-weight: 100;
-                        }
-                        .delivery-date {
-                            display: inline-block;
-                            padding: 5px;
-                        }
-                        .delivery-time {
-                            display: inline-block;
-                            padding: 5px 15px 5px 5px;
-                        }
-
-                        .need-it-faster {
-                            font-size: 16px;
-                            margin-top: 5px;
-                            padding-right: 5px;
-                        }
-                        .need-it-faster-message {
-                            font-size: 15px;
-                            font-weight: normal;
-                            width: 600px;
-                            margin-top: 9px;
-                        }
-                        .errors-date {
-                            font-weight: 100;
-                            font-size: 14px;
-                            display: inline-block;
-                            margin-right: 6px;
-                            text-align: right;
-                            &.past-date {
-                                color: red;
-                            }
-                            &.too-far-date {
-                                color: #ffa038;
-                                .tip {
-                                    display: inline-block;
-                                    width: 5px;
-                                    margin-right: 20px;
-                                    i {
-                                        position: relative;
-                                        color: #a7a7a7;
-                                        font-size: 16px;
-                                        top: 2px;
-                                    }
-                                }
-                            }
-                            &.generic-error {
-                                color: red;
-                            }
-                        }
-                    }
-                    @media only screen and (max-width: 1199px) and (min-width: 992px) {
-                        width: 79%;
-                    }
-                    @media only screen and (max-width: 991px) and (min-width: 768px) {
-                        width: 79%;
-                    }
-                }
-                .need-it-faster-box {
-                    margin-top: 0 !important;
-                    .need-it-faster-close {
-                        position: relative;
-                        top: -29px;
-                        left: 12px;
-                        text-align: center;
-                        padding: 5px 4px;
-                        margin: 0;
-                        width: 115px;
-                        height: 115px;
-                        border-radius: 15px;
-                        background: white;
-                        i {
-                            margin: 0;
-                            position: relative;
-                            top: 2px;
-                            font-size: 15px;
-                            background: $grey2;
-                            color: #000000;
-                        }
-                    }
-                    .delivery-box {
-                        padding: 14px 15px;
-                        text-align: left;
-                        border: 1px solid $grey2;
-                        .fields {
-                            .field {
-                                label {
-                                    font-weight: unset;
-                                    font-size: unset;
-                                }
-                                input[type="text"], input[type="email"] {
-                                    box-shadow: inset 0 1px 3px #ddd;
-                                    border: 1px solid #ccc;
-                                    font-family: Calibri, Arial, Helvetica, sans-serif;
-                                    border-radius: 2px;
-                                    &:focus {
-                                        border-color: #85B7D9;
-                                    }
-                                    &:active {
-                                        border-color: #85B7D9;
-                                    }
-                                }
-                                &.input-time {
-                                    width: 120px;
-                                    .selection.dropdown {
-                                        width: 100%;
-                                        min-width: 101px !important;
-                                        border: 1px solid #ccc;
-                                        box-shadow: inset 0 1px 3px #ddd;
-                                        border-radius: 2px;
-                                        .text {
-                                            font-weight: 100 !important;
-                                        }
-                                        .menu {
-                                            height: 210px;
-                                        }
-                                    }
-                                }
-                                &.gmt {
-                                    position: relative;
-                                    top: 33px;
-                                    width: 100px;
-                                    margin-right: 20px;
-                                }
-                                .get-price {
-                                    font-family: Calibri, Arial, Helvetica, sans-serif;
-                                    padding: 9px 11px;
-                                    vertical-align: top;
-                                    font-size: 18px;
-                                    border: 1px solid $translatedBlue;
-                                    border-radius: 2px;
-                                    box-shadow: none !important;
-                                    background-color: #ffffff !important;
-                                    font-weight: 700;
-                                    margin-top: 33px;
-                                    &:hover {
-                                        text-decoration: none;
-                                        //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                                        border: 1px solid $translatedBlue;
-                                        background-color: $grey3;
-                                    }
-                                    &:focus {
-                                        box-shadow: none !important;
-                                        background-color: $grey3 !important;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                .delivery-order-not-available {
-                    margin-top: 24px;
-                    width: 45%;
-                    float: right;
-                    .quote-not-available-message {
-                        float: right;
-                        text-align: right;
-                        font-size: 20px;
-                        margin-right: 57px;
-                        line-height: 30px;
-                    }
-                }
-                .order-box-outsource {
-                    display: inline-block;
-                    width: 18%;
-                    min-width: 199px;
-                    .order-box {
-                        background-color: #a7d7916b;
-                        height: 70px;
-                        text-align: center;
-                        margin-bottom: 5px;
-                        .outsource-price {
-                            font-size: 26px;
-                            font-weight: 700;
-                            padding: 17px 0 10px;
-                        }
-                        .select-value {
-                            .content {
-                                font-family: Calibri, Arial, Helvetica, sans-serif;
-                                a {
-                                    color: #000000;
-                                    font-weight: 100;
-                                    margin-left: 10px;
-                                }
-                                i {
-                                    margin-left: 5px;
-                                }
-                                .menu {
-                                    height: 236px;
-                                    left: -10px;
-                                }
-                            }
-                        }
-                    }
-                    @media only screen and (max-width: 1199px) and (min-width: 992px) {
-                        width: 21%;
-                    }
-                    @media only screen and (max-width: 991px) and (min-width: 768px) {
-                        width: 21%;
-                    }
-                }
+                top: 23px;
+                width: 100px;
+                margin-right: 29px;
+              }
             }
-            .easy-pay-box {
-                width: 100%;
-                padding: 5px 20px 15px;
-                text-align: right;
-                .easy-pay {
-                    font-weight: 700;
-                    margin-bottom: 0;
-                    span {
-                        font-weight: 100;
-                    }
-                }
+          }
+        }
+      }
+    }
+  }
+  .open-job-box {
+    background-color: $grey2;
+    padding: 35px 30px 25px 40px;
+    width: 100%;
+    cursor: auto;
+    .title {
+      display: inline-block;
+      font-size: 26px;
+      font-weight: 700;
+      width: 12%;
+      position: relative;
+      top: -4px;
+    }
+    .title-url {
+      width: 88%;
+      display: inline-block;
+      .job-url {
+        display: inline-block;
+        max-width: 80%;
+        min-width: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 15px;
+        a {
+          font-size: 16px;
+        }
+      }
+      .button {
+        font-family: Calibri, Arial, Helvetica, sans-serif;
+        font-size: 16px;
+        //border: 1px solid #797979;
+        border-radius: 2px;
+        padding: 9px 15px;
+        margin: 0;
+        float: right;
+        margin-top: -10px;
+        width: 20%;
+      }
+    }
+  }
+
+  .divider-or {
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    z-index: 1;
+    padding-left: 35px !important;
+    height: 0;
+    .or {
+      width: 25px;
+      height: 25px;
+      background-color: grey;
+      text-align: center;
+      line-height: 25px;
+      border-radius: 50%;
+      color: #ffffff;
+      position: absolute;
+      top: -14px;
+      left: 90px;
+    }
+  }
+
+  .background-outsource-vendor {
+    background: $grey3;
+    width: 100%;
+    padding-bottom: 15px;
+    padding-top: 15px;
+    cursor: auto;
+    .outsource-not-available {
+      font-size: 20px;
+    }
+    .translated-loader {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      margin: 0;
+      text-align: center;
+      z-index: 1;
+      -webkit-transform: translateX(-50%) translateY(-50%);
+      transform: translateX(-50%) translateY(-50%);
+      img {
+        width: 40px;
+      }
+      .text-loader-outsource {
+        font-size: 28px;
+        margin-top: 10px;
+        font-weight: 700;
+      }
+    }
+    .outsource-to-vendor {
+      .payment-service {
+        padding: 5px 10px 15px;
+        .service-box {
+          display: inline-block;
+          padding: 0 10px 0 15px;
+          font-size: 26px;
+          font-weight: 700;
+          .service {
+            display: inline-block;
+            &.project-management {
             }
-            .customer-request {
-                .customer-box {
-                    padding: 0 15px 15px;
+            &.translation,
+            &.revision {
+              margin-left: 8px;
+            }
+          }
+        }
+        .fiducial-logo {
+          display: inline-block;
+          padding: 0;
+          vertical-align: text-bottom;
+          .translated-logo {
+            display: inline-block;
+            .logo-t {
+              width: 100px;
+              position: relative;
+              top: 6px;
+              padding: 0;
+              margin: 0 0 0 5px;
+            }
+          }
+        }
+      }
+      .payment-details-box {
+        background-color: #ffffff;
+        padding: 15px;
+        position: relative;
+        min-height: 232px;
+        .translator-job-details {
+          padding-bottom: 10px;
+          .translator-details-box {
+            width: 38%;
+            border-right: 1px solid black;
+            display: inline-block;
+            vertical-align: middle;
+            padding: 0 0 0 10px;
+            .left,
+            .right {
+              display: inline-block;
+              margin: 0;
+            }
+            .left {
+              width: 42%;
+              .star {
+                position: relative;
+                left: -2px;
+                .icon {
+                  &.active {
+                    background: transparent !important;
+                    color: #7eaf3e !important;
+                    text-shadow: none !important;
+                  }
+                }
+              }
+            }
+            .right {
+              float: right;
+              width: 58%;
+              text-align: right;
+              padding-right: 15px;
+            }
+            .translator-no-found {
+              p {
+              }
+            }
+          }
+          .job-details-box {
+            display: inline-block;
+            width: 44% !important;
+            vertical-align: middle;
+            padding: 0 0 0 15px;
+            position: relative;
+            .source-target-outsource {
+              display: inline-block;
+              width: 68%;
+              font-size: 18px;
+              .source-box {
+                display: inline-block;
+              }
+              .in-to {
+                display: inline-block;
+                font-size: 16px;
+                i {
+                  position: relative;
+                  top: 1px;
+                  margin: 0;
+                  font-weight: 100;
+                  font-size: 13px;
+                  color: #545353;
+                }
+              }
+              .target-box {
+                display: inline-block;
+              }
+              @media only screen and (max-width: 1199px) and (min-width: 992px) {
+                font-size: 16px;
+                .in-to {
+                  font-size: 13px;
+                }
+              }
+            }
+            .job-payment {
+              display: inline-block;
+              width: 32%;
+              text-align: right;
+              padding-right: 28px;
+              .not-payable {
+                text-decoration: line-through;
+                font-size: 16px;
+                position: absolute;
+                top: -17px;
+                width: 30%;
+                padding-right: 28px;
+              }
+              .payable {
+                font-size: 18px;
+              }
+            }
+          }
+          .job-price {
+            display: inline-block;
+            vertical-align: middle;
+            width: 18%;
+            font-size: 20px;
+            text-align: center;
+          }
+        }
+        .revision-box {
+          padding: 4px 0px;
+          background-color: $grey2;
+          margin-bottom: 10px;
+          height: 28px;
+          .add-revision {
+            display: inline-block;
+            width: 82%;
+            text-align: right;
+            padding-right: 28px;
+            .checkbox {
+            }
+          }
+          .job-price {
+            display: inline-block;
+            font-size: 20px;
+            text-align: center;
+            width: 18%;
+          }
+        }
+        .delivery-order {
+          width: 82%;
+          text-align: right;
+          display: inline-block;
+          vertical-align: top;
+          margin-top: 15px;
+          padding-right: 25px;
+          .delivery-box {
+            text-align: right;
+            display: inline-block;
+            font-size: 23px;
+            font-weight: 700;
+            label {
+              font-size: 16px;
+              display: inline-block;
+              vertical-align: middle;
+              font-weight: 100;
+              padding: 5px;
+            }
+            .atdd {
+              display: inline-block;
+              font-weight: 100;
+            }
+            .delivery-date {
+              display: inline-block;
+              padding: 5px;
+            }
+            .delivery-time {
+              display: inline-block;
+              padding: 5px 15px 5px 5px;
+            }
+
+            .need-it-faster {
+              font-size: 16px;
+              margin-top: 5px;
+              padding-right: 5px;
+            }
+            .need-it-faster-message {
+              font-size: 15px;
+              font-weight: normal;
+              width: 600px;
+              margin-top: 9px;
+            }
+            .errors-date {
+              font-weight: 100;
+              font-size: 14px;
+              display: inline-block;
+              margin-right: 6px;
+              text-align: right;
+              &.past-date {
+                color: red;
+              }
+              &.too-far-date {
+                color: #ffa038;
+                .tip {
+                  display: inline-block;
+                  width: 5px;
+                  margin-right: 20px;
+                  i {
                     position: relative;
-                    overflow: hidden;
-                    width: 55%;
-                    .title-pointer {
-                        h3 {
-                            display: inline-block;
-                            width: 50%;
-                            padding-left: 30px;
-                            margin-bottom: 5px;
-                        }
-                        .pointers {
-                            /*display: inline-block;
+                    color: #a7a7a7;
+                    font-size: 16px;
+                    top: 2px;
+                  }
+                }
+              }
+              &.generic-error {
+                color: red;
+              }
+            }
+          }
+          @media only screen and (max-width: 1199px) and (min-width: 992px) {
+            width: 79%;
+          }
+          @media only screen and (max-width: 991px) and (min-width: 768px) {
+            width: 79%;
+          }
+        }
+        .need-it-faster-box {
+          margin-top: 0 !important;
+          .need-it-faster-close {
+            position: relative;
+            top: -29px;
+            left: 12px;
+            text-align: center;
+            padding: 5px 4px;
+            margin: 0;
+            width: 115px;
+            height: 115px;
+            border-radius: 15px;
+            background: white;
+            i {
+              margin: 0;
+              position: relative;
+              top: 2px;
+              font-size: 15px;
+              background: $grey2;
+              color: #000000;
+            }
+          }
+          .delivery-box {
+            padding: 14px 15px;
+            text-align: left;
+            border: 1px solid $grey2;
+            .fields {
+              .field {
+                label {
+                  font-weight: unset;
+                  font-size: unset;
+                }
+                input[type='text'],
+                input[type='email'] {
+                  box-shadow: inset 0 1px 3px #ddd;
+                  border: 1px solid #ccc;
+                  font-family: Calibri, Arial, Helvetica, sans-serif;
+                  border-radius: 2px;
+                  &:focus {
+                    border-color: #85b7d9;
+                  }
+                  &:active {
+                    border-color: #85b7d9;
+                  }
+                }
+                &.input-time {
+                  width: 120px;
+                  .selection.dropdown {
+                    width: 100%;
+                    min-width: 101px !important;
+                    border: 1px solid #ccc;
+                    box-shadow: inset 0 1px 3px #ddd;
+                    border-radius: 2px;
+                    .text {
+                      font-weight: 100 !important;
+                    }
+                    .menu {
+                      height: 210px;
+                    }
+                  }
+                }
+                &.gmt {
+                  position: relative;
+                  top: 33px;
+                  width: 100px;
+                  margin-right: 20px;
+                }
+                .get-price {
+                  font-family: Calibri, Arial, Helvetica, sans-serif;
+                  padding: 9px 11px;
+                  vertical-align: top;
+                  font-size: 18px;
+                  border: 1px solid $translatedBlue;
+                  border-radius: 2px;
+                  box-shadow: none !important;
+                  background-color: #ffffff !important;
+                  font-weight: 700;
+                  margin-top: 33px;
+                  &:hover {
+                    text-decoration: none;
+                    //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+                    border: 1px solid $translatedBlue;
+                    background-color: $grey3;
+                  }
+                  &:focus {
+                    box-shadow: none !important;
+                    background-color: $grey3 !important;
+                  }
+                }
+              }
+            }
+          }
+        }
+        .delivery-order-not-available {
+          margin-top: 24px;
+          width: 45%;
+          float: right;
+          .quote-not-available-message {
+            float: right;
+            text-align: right;
+            font-size: 20px;
+            margin-right: 57px;
+            line-height: 30px;
+          }
+        }
+        .order-box-outsource {
+          display: inline-block;
+          width: 18%;
+          min-width: 199px;
+          .order-box {
+            background-color: #a7d7916b;
+            height: 70px;
+            text-align: center;
+            margin-bottom: 5px;
+            .outsource-price {
+              font-size: 26px;
+              font-weight: 700;
+              padding: 17px 0 10px;
+            }
+            .select-value {
+              .content {
+                font-family: Calibri, Arial, Helvetica, sans-serif;
+                a {
+                  color: #000000;
+                  font-weight: 100;
+                  margin-left: 10px;
+                }
+                i {
+                  margin-left: 5px;
+                }
+                .menu {
+                  height: 236px;
+                  left: -10px;
+                }
+              }
+            }
+          }
+          @media only screen and (max-width: 1199px) and (min-width: 992px) {
+            width: 21%;
+          }
+          @media only screen and (max-width: 991px) and (min-width: 768px) {
+            width: 21%;
+          }
+        }
+      }
+      .easy-pay-box {
+        width: 100%;
+        padding: 5px 20px 15px;
+        text-align: right;
+        .easy-pay {
+          font-weight: 700;
+          margin-bottom: 0;
+          span {
+            font-weight: 100;
+          }
+        }
+      }
+      .customer-request {
+        .customer-box {
+          padding: 0 15px 15px;
+          position: relative;
+          overflow: hidden;
+          width: 55%;
+          .title-pointer {
+            h3 {
+              display: inline-block;
+              width: 50%;
+              padding-left: 30px;
+              margin-bottom: 5px;
+            }
+            .pointers {
+              /*display: inline-block;
                             text-align: right;
                             width: 50%;*/
-                            text-align: right;
-                            .pointer {
-                                width: 12px;
-                                height: 12px;
-                                background: #d5d8dc;
-                                display: inline-block;
-                                border-radius: 50%;
-                                margin-right: 5px;
-                                cursor: pointer;
-                                transition: 0.3s ease;
-                                &.active {
-                                    background: $greenDefault;
-                                }
-                            }
-                        }
-                    }
-                    .slider-box {
-                        min-height: 110px;
-                        position: relative;
-                        border: 1px solid #a8bbb2;
-                        padding: 15px 0px;
-                        .appendix {
-                            display: inline-block;
-                            width: 8%;
-                            vertical-align: top;
-                            font-size: 28px;
-                            position: relative;
-                            top: -3px;
-                            color: #a8bbb2;
-                            right: 13px;
-                            background: #f1f3f2;
-                            padding: 6px 2px;
-                            text-align: center;
-                        }
-                        .customer-box-info {
-                            width: 90%;
-                            display: inline-block;
-                            position: absolute;
-                            opacity: 0;
-                            &.fade-in {
-                                transition: 1.5s;
-                                opacity: 1;
-                            }
-                            .customer-text {
-                                padding-bottom: 10px;
-                                font-size: 14px;
-                                line-height: 18px;
-                            }
-                            .customer-info {
-                                width: 55%;
-                                display: inline-block;
-                                .customer-photo {
-                                    display: inline-block;
-                                    width: 30px;
-                                    height: 30px;
-                                    border-radius: 50%;
-                                    vertical-align: middle;
-                                }
-                                .customer-name {
-                                    display: inline-block;
-                                    margin-left: 10px;
-                                }
-                                .customer-role {
-                                    display: inline-block;
-                                    margin-left: 3px;
-                                    font-weight: 700;
-                                }
-                            }
-                            .customer-corporate-logo {
-                                display: inline-block;
-                                width: 45%;
-                                text-align: right;
-                                vertical-align: middle;
-                                img {
-                                    width: auto;
-                                    vertical-align: middle;
-                                    padding: 6px;
-                                    height: 40px;
-                                }
-                                .c-export {
-                                    height: 30px !important;
-                                }
-                            }
-                        }
-                    }
+              text-align: right;
+              .pointer {
+                width: 12px;
+                height: 12px;
+                background: #d5d8dc;
+                display: inline-block;
+                border-radius: 50%;
+                margin-right: 5px;
+                cursor: pointer;
+                transition: 0.3s ease;
+                &.active {
+                  background: $greenDefault;
                 }
-                .request-box {
-                    width: 45%;
-                    .title-request {
-                        position: absolute;
-                        right: 30px;
-                        bottom: 60px;
-                        h3 {
-                            margin-bottom: 5px;
-                            padding-left: 30px;
-                        }
-                    }
-                    .request-info-box {
-                        color: #909894;
-                        position: absolute;
-                        bottom: 20px;
-                        right: 30px;
-                        .mobile-mail-box, .account-box {
-                            .item {
-                                padding: 0;
-                                .icon {
-                                    padding-right: 0;
-                                    margin-right: 5px;
-                                }
-                                .content {
-                                    padding-left: 0;
-                                    .header, .description {
-                                        font-family: Calibri, Arial, Helvetica, sans-serif;
-                                        color: inherit;
-                                    }
-                                    a {
-                                        color: #000000 !important;
-                                    }
-                                }
-                            }
-                            .call {
-                                .icon {
-                                    margin-right: 0;
-                                }
-                            }
-                            .send-email {
-
-                            }
-                            .open-chat {
-                                i {
-                                    position: relative;
-                                    font-size: 16px;
-                                }
-                                .content {
-                                    .button {
-                                        font-family: Calibri, Arial, Helvetica, sans-serif;
-                                        border: 1px solid #c1c1c1;
-                                        background: #f3f3f3;
-                                        position: relative;
-                                        top: 5px;
-                                        width: 100%;
-                                        margin-right: 0;
-                                        padding: 9px 10px;
-                                        .sign {
-                                            width: 10px;
-                                            height: 10px;
-                                            display: inline-block;
-                                            vertical-align: baseline;
-                                            margin-right: 5px;
-                                            border-radius: 50%;
-                                            position: relative;
-                                            top: 1px;
-                                            &.online-item {
-                                                background-color: $translatedBlue;
-                                            }
-                                            &.offline-item {
-                                                background-color: gray;
-                                            }
-                                        }
-                                    }
-                                }
-
-                            }
-                        }
-                    }
-                }
+              }
             }
-        }
-
-        .outsource-to-vendor-reduced {
-            padding-top: 30px !important;
-            padding-left: 15px !important;
-            padding-right: 15px !important;
+          }
+          .slider-box {
+            min-height: 110px;
             position: relative;
-            min-height: 145px;
-            .reduced-boxes {
-                .container-reduced {
-                    padding: 0 10px;
-                    width: 81%;
-                    display: inline-block;
-                    vertical-align: top;
-                    .job-menu, .open-translate {
-                        display: none;
-                    }
-                    .title-reduced {
-                        font-size: 24px;
-                        font-weight: 100;
-                    }
-                    .payment-service {
-                        display: inline-block;
-                        width: 63%;
-                        vertical-align: top;
-                        position: relative;
-                        top: 10px;
-                        .service-box {
-                            display: inline-block;
-                            font-size: 22px;
-                            font-weight: 700;
-                            .service {
-                                display: inline-block;
-                                &.project-management {
-
-                                }
-                                &.translation {
-                                    margin-left: 6px;
-                                    margin-right: 6px;
-                                }
-                                &.revision {
-                                    margin-right: 6px;
-                                }
-                            }
-                        }
-                        .fiducial-logo {
-                            display: inline-block;
-                            img {
-                                width: 100px;
-                                position: relative;
-                                top: 9px;
-                                margin-left: 4px;
-                            }
-                        }
-                        .view-more {
-                            z-index: 1;
-                            position: relative;
-                        }
-                    }
-                    .delivery-order {
-                        display: inline-block;
-                        width: 37%;
-                        text-align: right;
-                        position: relative;
-                        top: -15px;
-                        .need-it-faster-box {
-                            .delivery-box {
-                                border: 1px solid $grey2;
-                            }
-                        }
-                        .delivery-box {
-                            display: inline-block;
-                            font-size: 18px;
-                            font-weight: 700;
-                            label {
-                                padding: 5px;
-                                font-size: 16px;
-                                color: gray;
-                                font-weight: 100;
-                                display: flex;
-                            }
-                            .delivery-date, .delivery-time{
-                                display: inline-block;
-                                padding: 5px;
-                            }
-                            .atdd {
-                                display: inline-block;
-                                font-weight: 100;
-                            }
-                            .delivery-time {
-                                padding-right: 15px !important;
-                            }
-                            .gmt {
-
-                            }
-                        }
-                    }
-                    .delivery-order-not-available {
-                        width: 40%;
-                        float: right;
-                        position: absolute;
-                        right: -10px;
-                        top: 20px;
-                        .quote-not-available-message {
-                            float: right;
-                            text-align: right;
-                            font-size: 20px;
-                            margin-right: 57px;
-                            line-height: 30px;
-                        }
-                    }
-
-                    .errors-date {
-                        font-weight: 100;
-                        font-size: 14px;
-                        display: inline-block;
-                        margin-right: 6px;
-                        text-align: right;
-                        width: 100%;
-                        position: relative;
-                        top: -10px;
-                        &.generic-error {
-                            color: red;
-                        }
-                    }
-                    .confirm-delivery-input {
-                        text-align: right;
-                        margin-top: 8px;
-                    }
+            border: 1px solid #a8bbb2;
+            padding: 15px 0px;
+            .appendix {
+              display: inline-block;
+              width: 8%;
+              vertical-align: top;
+              font-size: 28px;
+              position: relative;
+              top: -3px;
+              color: #a8bbb2;
+              right: 13px;
+              background: #f1f3f2;
+              padding: 6px 2px;
+              text-align: center;
+            }
+            .customer-box-info {
+              width: 90%;
+              display: inline-block;
+              position: absolute;
+              opacity: 0;
+              &.fade-in {
+                transition: 1.5s;
+                opacity: 1;
+              }
+              .customer-text {
+                padding-bottom: 10px;
+                font-size: 14px;
+                line-height: 18px;
+              }
+              .customer-info {
+                width: 55%;
+                display: inline-block;
+                .customer-photo {
+                  display: inline-block;
+                  width: 30px;
+                  height: 30px;
+                  border-radius: 50%;
+                  vertical-align: middle;
                 }
-                .order-box-outsource {
-                    display: inline-block;
-                    float: right;
-                    text-align: center;
-                    margin-top: -17px;
-                    width: 18%;
-                    min-width: 200px;
-                    .order-box {
-                        background-color: #a7d7916b;
-                        padding: 25px 5px 15px;
-                        margin-bottom: 5px;
-                        .outsource-price {
-                            font-size: 28px;
-                            font-weight: 700;
-                            margin-bottom: 10px;
-                        }
-                        .select-value {
-                            .content {
-                                font-family: Calibri, Arial, Helvetica, sans-serif;
-                                a {
-                                    color: #000000;
-                                    font-weight: 100;
-                                    font-size: 14px;
-                                }
-                                i {
-                                    margin-left: 5px !important;
-                                }
-                                .menu {
-                                    top: -5px;
-                                    left: -23px;
-                                    height: 95px;
-                                }
-                            }
-                        }
-                    }
-                    .order-button-outsource {
-                        .open-order, .confirm-order {
-                            width: 100%;
-                            font-family: Calibri, Arial, Helvetica, sans-serif;
-                            padding: 10px 22px;
-                            vertical-align: top;
-                            font-size: 16px;
-                            border-radius: 2px;
-                            margin: 0px;
-                        }
-                    }
+                .customer-name {
+                  display: inline-block;
+                  margin-left: 10px;
                 }
-                .confirm-delivery-box {
-                    text-align: right;
-                    display: inline-block;
+                .customer-role {
+                  display: inline-block;
+                  margin-left: 3px;
+                  font-weight: 700;
+                }
+              }
+              .customer-corporate-logo {
+                display: inline-block;
+                width: 45%;
+                text-align: right;
+                vertical-align: middle;
+                img {
+                  width: auto;
+                  vertical-align: middle;
+                  padding: 6px;
+                  height: 40px;
+                }
+                .c-export {
+                  height: 30px !important;
+                }
+              }
+            }
+          }
+        }
+        .request-box {
+          width: 45%;
+          .title-request {
+            position: absolute;
+            right: 30px;
+            bottom: 60px;
+            h3 {
+              margin-bottom: 5px;
+              padding-left: 30px;
+            }
+          }
+          .request-info-box {
+            color: #909894;
+            position: absolute;
+            bottom: 20px;
+            right: 30px;
+            .mobile-mail-box,
+            .account-box {
+              .item {
+                padding: 0;
+                .icon {
+                  padding-right: 0;
+                  margin-right: 5px;
+                }
+                .content {
+                  padding-left: 0;
+                  .header,
+                  .description {
+                    font-family: Calibri, Arial, Helvetica, sans-serif;
+                    color: inherit;
+                  }
+                  a {
+                    color: #000000 !important;
+                  }
+                }
+              }
+              .call {
+                .icon {
+                  margin-right: 0;
+                }
+              }
+              .send-email {
+              }
+              .open-chat {
+                i {
+                  position: relative;
+                  font-size: 16px;
+                }
+                .content {
+                  .button {
+                    font-family: Calibri, Arial, Helvetica, sans-serif;
+                    border: 1px solid #c1c1c1;
+                    background: #f3f3f3;
+                    position: relative;
+                    top: 5px;
                     width: 100%;
-                    margin-top: 10px;
-                }
-                @media only screen and (max-width: 1199px) and (min-width: 992px) {
-                    .container-reduced {
-                        width: 79%;
-                        .payment-service {
-                            width: 60%;
-                            top: 18px !important;
-                        }
-                        .delivery-order {
-                            width: 35%;
-                            top: -15px;
-                            .delivery-box {
-                                label {
-                                    padding: 5px;
-                                    font-size: 16px;
-                                    color: gray;
-                                    font-weight: 100;
-                                    display: grid;
-                                }
-                                .gmt {
-                                    position: relative;
-                                    top: 15px;
-                                }
-                            }
-                        }
+                    margin-right: 0;
+                    padding: 9px 10px;
+                    .sign {
+                      width: 10px;
+                      height: 10px;
+                      display: inline-block;
+                      vertical-align: baseline;
+                      margin-right: 5px;
+                      border-radius: 50%;
+                      position: relative;
+                      top: 1px;
+                      &.online-item {
+                        background-color: $translatedBlue;
+                      }
+                      &.offline-item {
+                        background-color: gray;
+                      }
                     }
+                  }
                 }
-                @media only screen and (max-width: 991px) and (min-width: 768px) {
-                    .container-reduced {
-                        width: 79%;
-                        .payment-service {
-                            width: 60%;
-                            top: 18px !important;
-                        }
-                        .delivery-order {
-                            width: 35%;
-                            top: -15px;
-                            .delivery-box {
-                                label {
-                                    padding: 5px;
-                                    font-size: 16px;
-                                    color: gray;
-                                    font-weight: 100;
-                                    display: grid;
-                                }
-                                .gmt {
-                                    position: relative;
-                                    top: 15px;
-                                }
-                            }
-                        }
-                    }
-                }
-                @media only screen and (max-width: 767px) {
-                    .container-reduced {
-                        width: 79%;
-                        .payment-service {
-                            width: 60%;
-                            top: 18px !important;
-                        }
-                        .delivery-order {
-                            width: 35%;
-                            top: -15px;
-                            .delivery-box {
-                                label {
-                                    padding: 5px;
-                                    font-size: 16px;
-                                    color: gray;
-                                    font-weight: 100;
-                                    display: grid;
-                                }
-                                .gmt {
-                                    position: relative;
-                                    top: 15px;
-                                }
-                            }
-                        }
-                    }
-                }
+              }
             }
+          }
         }
-        &.compact-background {
-            background: #ffffff;
-            padding-bottom: 25px;
-            padding-top: 25px;
-        }
+      }
     }
 
-    .order-button-outsource {
-        margin: 0;
-        .open-order, .confirm-order {
-            font-family: Calibri, Arial, Helvetica, sans-serif;
-            padding: 10px;
-            margin: 0;
-            font-size: 18px;
-            border-radius: 2px;
-            width: 100%;
-
-        }
-        .open-outsourced {
-            font-family: Calibri, Arial, Helvetica, sans-serif;
-            padding: 11px 0 !important;
+    .outsource-to-vendor-reduced {
+      padding-top: 30px !important;
+      padding-left: 15px !important;
+      padding-right: 15px !important;
+      position: relative;
+      min-height: 145px;
+      .reduced-boxes {
+        .container-reduced {
+          padding: 0 10px;
+          width: 81%;
+          display: inline-block;
+          vertical-align: top;
+          .job-menu,
+          .open-translate {
+            display: none;
+          }
+          .title-reduced {
+            font-size: 24px;
+            font-weight: 100;
+          }
+          .payment-service {
+            display: inline-block;
+            width: 63%;
             vertical-align: top;
-            font-size: 16px;
-            border-radius: 2px;
-            width: 100%;
+            position: relative;
+            top: 10px;
+            .service-box {
+              display: inline-block;
+              font-size: 22px;
+              font-weight: 700;
+              .service {
+                display: inline-block;
+                &.project-management {
+                }
+                &.translation {
+                  margin-left: 6px;
+                  margin-right: 6px;
+                }
+                &.revision {
+                  margin-right: 6px;
+                }
+              }
+            }
+            .fiducial-logo {
+              display: inline-block;
+              img {
+                width: 100px;
+                position: relative;
+                top: 9px;
+                margin-left: 4px;
+              }
+            }
+            .view-more {
+              z-index: 1;
+              position: relative;
+            }
+          }
+          .delivery-order {
+            display: inline-block;
+            width: 37%;
+            text-align: right;
+            position: relative;
+            top: -15px;
+            .need-it-faster-box {
+              .delivery-box {
+                border: 1px solid $grey2;
+              }
+            }
+            .delivery-box {
+              display: inline-block;
+              font-size: 18px;
+              font-weight: 700;
+              label {
+                padding: 5px;
+                font-size: 16px;
+                color: gray;
+                font-weight: 100;
+                display: flex;
+              }
+              .delivery-date,
+              .delivery-time {
+                display: inline-block;
+                padding: 5px;
+              }
+              .atdd {
+                display: inline-block;
+                font-weight: 100;
+              }
+              .delivery-time {
+                padding-right: 15px !important;
+              }
+              .gmt {
+              }
+            }
+          }
+          .delivery-order-not-available {
+            width: 40%;
             float: right;
-            margin-right: 0 !important;
-            &:hover {
-                box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+            position: absolute;
+            right: -10px;
+            top: 20px;
+            .quote-not-available-message {
+              float: right;
+              text-align: right;
+              font-size: 20px;
+              margin-right: 57px;
+              line-height: 30px;
             }
-            &:focus {
-                box-shadow: none !important;
+          }
+
+          .errors-date {
+            font-weight: 100;
+            font-size: 14px;
+            display: inline-block;
+            margin-right: 6px;
+            text-align: right;
+            width: 100%;
+            position: relative;
+            top: -10px;
+            &.generic-error {
+              color: red;
             }
-            &:active {
-                box-shadow: none !important;
-            }
+          }
+          .confirm-delivery-input {
+            text-align: right;
+            margin-top: 8px;
+          }
         }
-    }
-
-
-    @media only screen and (min-width: 1200px) {
-
-    }
-
-    @media only screen and (min-width: 1380px) {
-
-    }
-
-    @media only screen and (max-width: 1199px) and (min-width: 992px) {
-        .outsource-container {
-            width: 105%;
-            .container-reduced {
-                width: 79%;
+        .order-box-outsource {
+          display: inline-block;
+          float: right;
+          text-align: center;
+          margin-top: -17px;
+          width: 18%;
+          min-width: 200px;
+          .order-box {
+            background-color: #a7d7916b;
+            padding: 25px 5px 15px;
+            margin-bottom: 5px;
+            .outsource-price {
+              font-size: 28px;
+              font-weight: 700;
+              margin-bottom: 10px;
             }
+            .select-value {
+              .content {
+                font-family: Calibri, Arial, Helvetica, sans-serif;
+                a {
+                  color: #000000;
+                  font-weight: 100;
+                  font-size: 14px;
+                }
+                i {
+                  margin-left: 5px !important;
+                }
+                .menu {
+                  top: -5px;
+                  left: -23px;
+                  height: 95px;
+                }
+              }
+            }
+          }
+          .order-button-outsource {
+            .open-order,
+            .confirm-order {
+              width: 100%;
+              font-family: Calibri, Arial, Helvetica, sans-serif;
+              padding: 10px 22px;
+              vertical-align: top;
+              font-size: 16px;
+              border-radius: 2px;
+              margin: 0px;
+            }
+          }
         }
+        .confirm-delivery-box {
+          text-align: right;
+          display: inline-block;
+          width: 100%;
+          margin-top: 10px;
+        }
+        @media only screen and (max-width: 1199px) and (min-width: 992px) {
+          .container-reduced {
+            width: 79%;
+            .payment-service {
+              width: 60%;
+              top: 18px !important;
+            }
+            .delivery-order {
+              width: 35%;
+              top: -15px;
+              .delivery-box {
+                label {
+                  padding: 5px;
+                  font-size: 16px;
+                  color: gray;
+                  font-weight: 100;
+                  display: grid;
+                }
+                .gmt {
+                  position: relative;
+                  top: 15px;
+                }
+              }
+            }
+          }
+        }
+        @media only screen and (max-width: 991px) and (min-width: 768px) {
+          .container-reduced {
+            width: 79%;
+            .payment-service {
+              width: 60%;
+              top: 18px !important;
+            }
+            .delivery-order {
+              width: 35%;
+              top: -15px;
+              .delivery-box {
+                label {
+                  padding: 5px;
+                  font-size: 16px;
+                  color: gray;
+                  font-weight: 100;
+                  display: grid;
+                }
+                .gmt {
+                  position: relative;
+                  top: 15px;
+                }
+              }
+            }
+          }
+        }
+        @media only screen and (max-width: 767px) {
+          .container-reduced {
+            width: 79%;
+            .payment-service {
+              width: 60%;
+              top: 18px !important;
+            }
+            .delivery-order {
+              width: 35%;
+              top: -15px;
+              .delivery-box {
+                label {
+                  padding: 5px;
+                  font-size: 16px;
+                  color: gray;
+                  font-weight: 100;
+                  display: grid;
+                }
+                .gmt {
+                  position: relative;
+                  top: 15px;
+                }
+              }
+            }
+          }
+        }
+      }
     }
-
-    @media only screen and (max-width: 991px) and (min-width: 768px) {
-
+    &.compact-background {
+      background: #ffffff;
+      padding-bottom: 25px;
+      padding-top: 25px;
     }
+  }
 
-    @media only screen and (max-width: 767px) {
-
+  .order-button-outsource {
+    margin: 0;
+    .open-order,
+    .confirm-order {
+      font-family: Calibri, Arial, Helvetica, sans-serif;
+      padding: 10px;
+      margin: 0;
+      font-size: 18px;
+      border-radius: 2px;
+      width: 100%;
     }
+    .open-outsourced {
+      font-family: Calibri, Arial, Helvetica, sans-serif;
+      padding: 11px 0 !important;
+      vertical-align: top;
+      font-size: 16px;
+      border-radius: 2px;
+      width: 100%;
+      float: right;
+      margin-right: 0 !important;
+      &:hover {
+        box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+          0 2px 4px rgba(0, 0, 0, 0.24) !important;
+      }
+      &:focus {
+        box-shadow: none !important;
+      }
+      &:active {
+        box-shadow: none !important;
+      }
+    }
+  }
+
+  @media only screen and (min-width: 1200px) {
+  }
+
+  @media only screen and (min-width: 1380px) {
+  }
+
+  @media only screen and (max-width: 1199px) and (min-width: 992px) {
+    .outsource-container {
+      width: 105%;
+      .container-reduced {
+        width: 79%;
+      }
+    }
+  }
+
+  @media only screen and (max-width: 991px) and (min-width: 768px) {
+  }
+
+  @media only screen and (max-width: 767px) {
+  }
 }

--- a/public/css/sass/commons/_progress-mc-bar.scss
+++ b/public/css/sass/commons/_progress-mc-bar.scss
@@ -1,107 +1,115 @@
 #manage-container .progress-bar {
-	height: 20px;
-	top: 15px;
-	float: left;
-	min-width: 115px;
-	border-radius: 10px;
-	/* margin-bottom: 10px; */
-	padding-top: 7px;
+  height: 20px;
+  top: 15px;
+  float: left;
+  min-width: 115px;
+  border-radius: 10px;
+  /* margin-bottom: 10px; */
+  padding-top: 7px;
 }
 
 .analyze .progress-bar {
-	height: 20px;
-	margin-top: -8px;
-	float: left;
-	min-width: 115px;
-	border-radius: 10px;
-	margin-bottom: 10px;
+  height: 20px;
+  margin-top: -8px;
+  float: left;
+  min-width: 115px;
+  border-radius: 10px;
+  margin-bottom: 10px;
 }
 .progress-bar {
-	.progr {
-		background-color: inherit;
-	    //min-width: 120px;
-	    position: relative;
-		.meter {
-		    height: 18px;
-		    width: 100%;
-		    float: left;
-		    margin: 0px 15px 0px 0 !important;
-		    background-color: #d0d1d1;
-		    overflow: hidden;
-			border-radius: 10px;
-			a {
-			    display: block;
-				height: 100%;
-				max-width: 100%;
-				float: left;
-				overflow: hidden;
-				-webkit-transition: all 200ms ease-in;
-				transition: all 200ms ease-in;
-			}
-		    a:after {
-				content: "";
-			    position: absolute;
-			    top: 0px;
-			    left: 0;
-			    bottom: 0;
-			    right: 0;
-			    background-image: -webkit-linear-gradient(-45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%, transparent);
-			    z-index: 0;
-			    -webkit-background-size: 50px 50px;
-			    -moz-background-size: 50px 50px;
-			    background-size: 50px 50px;
-			    -webkit-animation: move 2s linear infinite;
-			    overflow: hidden;
-			    height: 18px;
-				opacity: 0.3;
-				pointer-events: none;
-		    }
-		}
-		.translated-bar {
-			background-color: $translatedBlue;
-		}
-		.approved-bar {
-			background-color: $approvedGreen;
-		}
-		.approved-bar-2nd-pass {
-			background-color: $approved2Green;
-		}
-		.warning-bar {
-			background-color: $rebuttedRed;
-		}
-		.draft-bar {
-			background-color: $grey4;
-		}
-	}
+  .progr {
+    background-color: inherit;
+    //min-width: 120px;
+    position: relative;
+    .meter {
+      height: 18px;
+      width: 100%;
+      float: left;
+      margin: 0px 15px 0px 0 !important;
+      background-color: #d0d1d1;
+      overflow: hidden;
+      border-radius: 10px;
+      a {
+        display: block;
+        height: 100%;
+        max-width: 100%;
+        float: left;
+        overflow: hidden;
+        -webkit-transition: all 200ms ease-in;
+        transition: all 200ms ease-in;
+      }
+      a:after {
+        content: '';
+        position: absolute;
+        top: 0px;
+        left: 0;
+        bottom: 0;
+        right: 0;
+        background-image: -webkit-linear-gradient(
+          -45deg,
+          rgba(255, 255, 255, 0.2) 25%,
+          transparent 25%,
+          transparent 50%,
+          rgba(255, 255, 255, 0.2) 50%,
+          rgba(255, 255, 255, 0.2) 75%,
+          transparent 75%,
+          transparent
+        );
+        z-index: 0;
+        -webkit-background-size: 50px 50px;
+        -moz-background-size: 50px 50px;
+        background-size: 50px 50px;
+        -webkit-animation: move 2s linear infinite;
+        overflow: hidden;
+        height: 18px;
+        opacity: 0.3;
+        pointer-events: none;
+      }
+    }
+    .translated-bar {
+      background-color: $translatedBlue;
+    }
+    .approved-bar {
+      background-color: $approvedGreen;
+    }
+    .approved-bar-2nd-pass {
+      background-color: $approved2Green;
+    }
+    .warning-bar {
+      background-color: $rebuttedRed;
+    }
+    .draft-bar {
+      background-color: $grey4;
+    }
+  }
 }
 
 .multiple {
-	.btn {
-		.progress-bar {
-		    border: 0px;
-		    height: 6px;
-		    margin-top: 0px;
-	   
-			.progr {
-				height: 23px;
-				width: 100%;
-				min-width: 1px;
-				.meter {
-			      	height: 8px;
-				    margin: -5px 0 0 0 !important;
-				    border: 0px;
-					border-radius: 8px;
-					a {
-					    height: 8px;
-					    border-radius: 0px;
-						&:after {
-						    top: -5px;
-						    height: 8px;	
-						}
-					}
-				}
-			}
-		}
-	}
-}
+  .btn {
+    .progress-bar {
+      border: 0px;
+      height: 6px;
+      margin-top: 0px;
 
+      .progr {
+        height: 23px;
+        width: 100%;
+        min-width: 1px;
+        .meter {
+          height: 8px;
+          margin: -5px 0 0 0 !important;
+          border: 0px;
+          border-radius: 8px;
+          a {
+            height: 8px;
+            border-radius: 0px;
+            &:after {
+              top: -5px;
+              height: 8px;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/public/css/sass/commons/_shadows.scss
+++ b/public/css/sass/commons/_shadows.scss
@@ -1,11 +1,9 @@
 //boxes
 .shadow-1 {
-     box-shadow: 0 0 0 #e0e0e0,
-                 0 0 2px rgba(0,0,0,.12),
-                 0 2px 4px rgba(0,0,0,.24) !important;
+  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.24) !important;
 }
 //header example navbar
 .shadow-2 {
-  box-shadow: 0 0 4px rgba(0,0,0,.14),
-              0 4px 8px rgba(0,0,0,.28)
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.14), 0 4px 8px rgba(0, 0, 0, 0.28);
 }

--- a/public/css/sass/commons/_sub-header.scss
+++ b/public/css/sass/commons/_sub-header.scss
@@ -1,332 +1,325 @@
 .sub-head {
-	color: white;
-	 .ui.container.equal.width.grid {
-        width: 1335px !important;
+  color: white;
+  .ui.container.equal.width.grid {
+    width: 1335px !important;
+  }
+  .projects-state {
+    width: 40px !important;
+  }
+  .assigned-list {
+    margin-right: 8px;
+    margin-top: 1px;
+    .switch {
+      margin-top: 12px;
     }
-	.projects-state {
-		width: 40px !important;
-	}
-	.assigned-list {
-		margin-right: 8px;
-		margin-top: 1px;
-		.switch {
-			margin-top: 12px;
-		}
-	}
-	.ws-settings {
-		padding: 0px;
-		width: 38px;
-		height: 38px;
-		margin: 0px;
-		line-height: 19px;
-		vertical-align: top;
-		margin-left: 10px;
-		i {
-			line-height: 25px;
-		}
-	}
-	.users-filter {
-		background-color: #fff;
-		color: #002b5c;
-		font-weight: 500;
-		padding: 3px 5px;
-		line-height: 1.21;
-		border-radius: 30px;
-		font-size: 14px;
-		min-width: 170px;
-		float: left;
-		display: grid;
-		width: 168px;
-		grid-template-columns: auto 23px;
-		align-items: center;
-		margin-top: 4px;
+  }
+  .ws-settings {
+    padding: 0px;
+    width: 38px;
+    height: 38px;
+    margin: 0px;
+    line-height: 19px;
+    vertical-align: top;
+    margin-left: 10px;
+    i {
+      line-height: 25px;
+    }
+  }
+  .users-filter {
+    background-color: #fff;
+    color: #002b5c;
+    font-weight: 500;
+    padding: 3px 5px;
+    line-height: 1.21;
+    border-radius: 30px;
+    font-size: 14px;
+    min-width: 170px;
+    float: left;
+    display: grid;
+    width: 168px;
+    grid-template-columns: auto 23px;
+    align-items: center;
+    margin-top: 4px;
 
-		/*opacity:0.8;
+    /*opacity:0.8;
 		&:hover, &.active {
 			opacity: 1;
 		}*/
 
-		.icon {
-			padding-top: 6px;
-		}
-		.text{
-			display: grid;
-			grid-template-columns: 28px 100px;
-			align-items: center;
-			column-gap: 8px;
-			margin-right: 4px;
+    .icon {
+      padding-top: 6px;
+    }
+    .text {
+      display: grid;
+      grid-template-columns: 28px 100px;
+      align-items: center;
+      column-gap: 8px;
+      margin-right: 4px;
 
-			img{
-				margin: 0!important;
-			}
-			.label{
-				font-size: 12px;
-				line-height: 12px;
-				margin-right: 0;
-				border: 2px solid #0099cc;
-				color: #0099cc;
-				border-radius: 100%;
-				padding: 6px 4px;
+      img {
+        margin: 0 !important;
+      }
+      .label {
+        font-size: 12px;
+        line-height: 12px;
+        margin-right: 0;
+        border: 2px solid #0099cc;
+        color: #0099cc;
+        border-radius: 100%;
+        padding: 6px 4px;
 
-				&.all {
-					font-size: 10px;
-				}
-			}
+        &.all {
+          font-size: 10px;
+        }
+      }
 
-			.user-name-filter {
-				white-space: nowrap;
-				overflow: hidden;
-				text-overflow: ellipsis;
-			}
+      .user-name-filter {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-			.box-number-project {
-				display: none;
-			}
-		}
-		.menu{
-			width: 350px;
-			left: -70%!important;
-			&::after{
-				left: 50%!important;
-			}
-			.item{
-				display: grid;
-				grid-template-columns: 28px auto;
-				grid-column-gap: 8px;
-				padding: 0 12px!important;
-				align-items: center;
-				grid-template-rows: 40px;
+      .box-number-project {
+        display: none;
+      }
+    }
+    .menu {
+      width: 350px;
+      left: -70% !important;
+      &::after {
+        left: 50% !important;
+      }
+      .item {
+        display: grid;
+        grid-template-columns: 28px auto;
+        grid-column-gap: 8px;
+        padding: 0 12px !important;
+        align-items: center;
+        grid-template-rows: 40px;
 
-				.label {
-					margin: 0;
-					padding: 1px 0 !important;
-					text-align: center;
-					border: 2px solid #0099cc;
-					color: #0099cc;
-					border-radius: 100%;
-					line-height: 22px;
+        .label {
+          margin: 0;
+          padding: 1px 0 !important;
+          text-align: center;
+          border: 2px solid #0099cc;
+          color: #0099cc;
+          border-radius: 100%;
+          line-height: 22px;
 
-					&.all {
-						font-size: 10px;
-					}
-				}
-				.box-number-project{
-					border-radius: 50%;
-					padding: 4px;
-					text-align: center;
-					color: #0099cc;
-					font-size: 12px;
-					font-weight: bold;
-				}
-				img{
-					margin: 0!important;
-				}
+          &.all {
+            font-size: 10px;
+          }
+        }
+        .box-number-project {
+          border-radius: 50%;
+          padding: 4px;
+          text-align: center;
+          color: #0099cc;
+          font-size: 12px;
+          font-weight: bold;
+        }
+        img {
+          margin: 0 !important;
+        }
 
-				.user-projects {
-					display: grid;
-					grid-template-columns: auto 0.13fr;
-					align-items: center;
-					padding: 4px 8px;
-				}
+        .user-projects {
+          display: grid;
+          grid-template-columns: auto 0.13fr;
+          align-items: center;
+          padding: 4px 8px;
+        }
 
-				&:hover {
-					color: #0055b8;
-					background: #f2f5f7;
-				}
+        &:hover {
+          color: #0055b8;
+          background: #f2f5f7;
+        }
 
-				&.active {
-					&.selected {
-
-						.user-projects {
-							background: #002b5c;
-							color: #fff;
-							font-weight: normal;
-							border-radius: 2px;
-							display: grid;
-							grid-template-rows: 18px;
-						}
-						.box-number-project{
-							color: #fff;
-						}
-
-						.user-name-filter{
-							font-weight: normal;
-						}
-					}
-				}
-
-			}
-
-		}
-		.input-field {
-			margin-left: 10px;
-			margin-top: -2px;
-		}
-		.list-team{
-			.ui.dropdown {
-
-				.all {
-					padding: 0px;
-					width: 24px;
-					height: 24px;
-					line-height: 24px;
-					border-radius: 50%;
-					text-align: center;
-					font-size: 12px;
-					font-weight: 600;
-				}
-                .ui.icon.input input {
-                    box-shadow: inset 0 1px 3px #ddd;
-                }
-				.text {
-					text-decoration: underline;
-					transition: 0.3s ease;
-					&:hover {
-						text-decoration: none;
-					}
-                    img {
-                        width: 24px;
-                        height: 24px;
-                    }
-                    .box-number-project {
-                        position: absolute ;
-                        width: 35px;
-                        height: 22px;
-                        line-height: 22px;
-                        border-radius: 2px;
-                        right: -40px;
-                        background-color: #676666;
-                        color: #bdbdbd;
-                        font-size: 12px;
-                        padding-left: 1px;
-                        text-align: center;
-                        display: inline-block;
-                    }
-				}
-                i {
-                    margin-left: 5px;
-                }
-                .scrolling.menu {
-                    .item{
-                        img {
-							width: 24px;
-							height: 24px;
-							margin-top: 0;
-							margin-bottom: 0;
-							vertical-align: middle;
-                        }
-                        .user-name-filter {
-                            top: 2px;
-                            position: relative;
-
-                        }
-						.box-number-project {
-                            position: absolute;
-							width: 35px;
-							height: 22px;
-							line-height: 22px;
-							border-radius: 2px;
-							top: 12px;
-							right: 10px;
-							background-color: #d8d8d8;
-							color: #636363;
-							font-size: 12px;
-							padding-left: 1px;
-							text-align: center;
-						}
-                    }
-                }
-			}
-		}
-	}
-	.search-state-filters {
-		input.search-projects {
-			height: 40px;
-			border-radius: 2px;
-			background-color: #fff;
-			color: #002b5c;
-			transition: 0.2s ease-in;
-			font-size: 14px;
-			max-width: 320px;
-			width: 100%;
-			padding: 12px 16px;
-			box-shadow: none;
-			border: none;
-			opacity: 0.4;
-			&::placeholder{
-				color: #002b5c;
-			}
-
-			&:focus {
-                border: none!important;
-				opacity: 1;
-				& + .dropdown{
-					background-color: #ffffff;
-				}
-			}
-		}
-		.ui.dropdown {
-            background-color: #fff;
-			border-left: 1px solid #002b5c;
-			/*transition: 0.2s ease-in;*/
-			color: #002b5c;
-			font-weight: 500;
-			padding: 2px 16px 2px 8px;
-			line-height: 1.21;
-			border-radius: 0px 2px 2px 0px;
-			font-size: 1em;
-			min-width: 110px;
-			display: grid;
-			grid-template-columns: 36px auto;
-			align-items: center;
-			opacity: 0.4;
-            &:hover,
-			&:active,
-			&:focus {
-                opacity:1;
+        &.active {
+          &.selected {
+            .user-projects {
+              background: #002b5c;
+              color: #fff;
+              font-weight: normal;
+              border-radius: 2px;
+              display: grid;
+              grid-template-rows: 18px;
             }
-			.text{
-				svg{
-					display: none;
-				}
-			}
-			.menu {
-				min-width: 144px;
-				padding: 8px 8px 12px 8px;
-				border-radius: 2px;
-				border: solid 1px #cdd4de;
-				right: 0 !important;
-				left: auto !important;
-				box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.2);
+            .box-number-project {
+              color: #fff;
+            }
 
-				&::after{
-					left: 50%!important;
-				}
+            .user-name-filter {
+              font-weight: normal;
+            }
+          }
+        }
+      }
+    }
+    .input-field {
+      margin-left: 10px;
+      margin-top: -2px;
+    }
+    .list-team {
+      .ui.dropdown {
+        .all {
+          padding: 0px;
+          width: 24px;
+          height: 24px;
+          line-height: 24px;
+          border-radius: 50%;
+          text-align: center;
+          font-size: 12px;
+          font-weight: 600;
+        }
+        .ui.icon.input input {
+          box-shadow: inset 0 1px 3px #ddd;
+        }
+        .text {
+          text-decoration: underline;
+          transition: 0.3s ease;
+          &:hover {
+            text-decoration: none;
+          }
+          img {
+            width: 24px;
+            height: 24px;
+          }
+          .box-number-project {
+            position: absolute;
+            width: 35px;
+            height: 22px;
+            line-height: 22px;
+            border-radius: 2px;
+            right: -40px;
+            background-color: #676666;
+            color: #bdbdbd;
+            font-size: 12px;
+            padding-left: 1px;
+            text-align: center;
+            display: inline-block;
+          }
+        }
+        i {
+          margin-left: 5px;
+        }
+        .scrolling.menu {
+          .item {
+            img {
+              width: 24px;
+              height: 24px;
+              margin-top: 0;
+              margin-bottom: 0;
+              vertical-align: middle;
+            }
+            .user-name-filter {
+              top: 2px;
+              position: relative;
+            }
+            .box-number-project {
+              position: absolute;
+              width: 35px;
+              height: 22px;
+              line-height: 22px;
+              border-radius: 2px;
+              top: 12px;
+              right: 10px;
+              background-color: #d8d8d8;
+              color: #636363;
+              font-size: 12px;
+              padding-left: 1px;
+              text-align: center;
+            }
+          }
+        }
+      }
+    }
+  }
+  .search-state-filters {
+    input.search-projects {
+      height: 40px;
+      border-radius: 2px;
+      background-color: #fff;
+      color: #002b5c;
+      transition: 0.2s ease-in;
+      font-size: 14px;
+      max-width: 320px;
+      width: 100%;
+      padding: 12px 16px;
+      box-shadow: none;
+      border: none;
+      opacity: 0.4;
+      &::placeholder {
+        color: #002b5c;
+      }
 
-				.item {
-					border-radius: 2px;
-					color: #002b5c;
-					font-size: 15px;
-					padding: 8px !important;
-					font-weight: normal;
-					display:grid;
-					grid-template-columns: auto 16px;
-					align-items: center;
-					margin: 4px 0 0 0 ;
+      &:focus {
+        border: none !important;
+        opacity: 1;
+        & + .dropdown {
+          background-color: #ffffff;
+        }
+      }
+    }
+    .ui.dropdown {
+      background-color: #fff;
+      border-left: 1px solid #002b5c;
+      /*transition: 0.2s ease-in;*/
+      color: #002b5c;
+      font-weight: 500;
+      padding: 2px 16px 2px 8px;
+      line-height: 1.21;
+      border-radius: 0px 2px 2px 0px;
+      font-size: 1em;
+      min-width: 110px;
+      display: grid;
+      grid-template-columns: 36px auto;
+      align-items: center;
+      opacity: 0.4;
+      &:hover,
+      &:active,
+      &:focus {
+        opacity: 1;
+      }
+      .text {
+        svg {
+          display: none;
+        }
+      }
+      .menu {
+        min-width: 144px;
+        padding: 8px 8px 12px 8px;
+        border-radius: 2px;
+        border: solid 1px #cdd4de;
+        right: 0 !important;
+        left: auto !important;
+        box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.2);
 
-					&:hover {
-						background-color: rgba(0, 0, 0, 0.03);
-					}
-					&.selected {
-						background-color: #002b5c;
-						color: #ffffff;
-					}
+        &::after {
+          left: 50% !important;
+        }
 
-				}
-			}
-		}
+        .item {
+          border-radius: 2px;
+          color: #002b5c;
+          font-size: 15px;
+          padding: 8px !important;
+          font-weight: normal;
+          display: grid;
+          grid-template-columns: auto 16px;
+          align-items: center;
+          margin: 4px 0 0 0;
 
-	}
+          &:hover {
+            background-color: rgba(0, 0, 0, 0.03);
+          }
+          &.selected {
+            background-color: #002b5c;
+            color: #ffffff;
+          }
+        }
+      }
+    }
+  }
 }
 
 /*.cta-create-team {

--- a/public/css/sass/commons/_team-member.scss
+++ b/public/css/sass/commons/_team-member.scss
@@ -1,6 +1,6 @@
 .ui-user-top-image {
-    float: right;
-    margin-left: 10px;
-    margin-right: 20px;
-    cursor: pointer;
+  float: right;
+  margin-left: 10px;
+  margin-right: 20px;
+  cursor: pointer;
 }

--- a/public/css/sass/commons/_tooltip.scss
+++ b/public/css/sass/commons/_tooltip.scss
@@ -1,4 +1,3 @@
-
 #powerTip {
   cursor: default;
   background-color: #fff;
@@ -9,9 +8,10 @@
   position: absolute;
   white-space: nowrap;
   z-index: 2147483647;
-  border: 1px solid #D4D4D5;
+  border: 1px solid #d4d4d5;
   border-radius: 0.28571429rem;
-  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
 }
 
 #powerTip:before {
@@ -19,15 +19,16 @@
   content: '';
   width: 0.71428571em;
   height: 0.71428571em;
-  background: #FFFFFF;
+  background: #ffffff;
   -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
   z-index: 2;
-  box-shadow: -1px -1px 0px 0px #D4D4D5;
+  box-shadow: -1px -1px 0px 0px #d4d4d5;
   top: -4px;
 }
 
-#powerTip.n:before, #powerTip.s:before {
+#powerTip.n:before,
+#powerTip.s:before {
   left: 50%;
   margin-left: -5px;
   top: -5px;
@@ -44,30 +45,36 @@
   bottom: -6px !important;
   top: initial;
   transform: rotate(225deg);
-
 }
 #powerTip.e:before {
   right: -5px;
   transform: rotate(135deg);
-
 }
 
-#powerTip.ne-alt:before, #powerTip.se-alt:before ,
-#powerTip.ne:before, #powerTip.se:before {
+#powerTip.ne-alt:before,
+#powerTip.se-alt:before,
+#powerTip.ne:before,
+#powerTip.se:before {
   left: 10px;
 }
-#powerTip.nw-alt:before, #powerTip.sw-alt:before ,
-#powerTip.nw:before, #powerTip.sw:before {
+#powerTip.nw-alt:before,
+#powerTip.sw-alt:before,
+#powerTip.nw:before,
+#powerTip.sw:before {
   right: 10px;
 }
-#powerTip.ne-alt:before, #powerTip.nw-alt:before,
-#powerTip.ne:before, #powerTip.nw:before {
+#powerTip.ne-alt:before,
+#powerTip.nw-alt:before,
+#powerTip.ne:before,
+#powerTip.nw:before {
   bottom: -5px;
   transform: rotate(225deg);
   top: initial;
 }
-#powerTip.se-alt:before, #powerTip.sw-alt:before ,
-#powerTip.se:before, #powerTip.sw:before {
+#powerTip.se-alt:before,
+#powerTip.sw-alt:before,
+#powerTip.se:before,
+#powerTip.sw:before {
   top: -5px;
   transform: rotate(45deg);
 }

--- a/public/css/sass/commons/icons_main.scss
+++ b/public/css/sass/commons/icons_main.scss
@@ -1,1 +1,1 @@
-@import "icons";
+@import 'icons';

--- a/public/css/sass/components/bulk-approve-bar/bulk_approve_bar.scss
+++ b/public/css/sass/components/bulk-approve-bar/bulk_approve_bar.scss
@@ -1,97 +1,101 @@
 .bulk-approve-bar {
-    position: relative;
-    z-index: 2;
-    background: #edf4fd;
-    padding: 8px 10px;
-    box-shadow: 0 0 4px rgba(0, 0, 0, 0.43);
-    float: left;
-    width: 100%;
-    box-sizing: border-box;
-    min-width: 1008px;
-    min-height: 48px;
-    .bulk-back-info, .bulk-activity-icons, .bulk-back, .bulk-info {
-        display: inline-block;
-        vertical-align: middle;
+  position: relative;
+  z-index: 2;
+  background: #edf4fd;
+  padding: 8px 10px;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.43);
+  float: left;
+  width: 100%;
+  box-sizing: border-box;
+  min-width: 1008px;
+  min-height: 48px;
+  .bulk-back-info,
+  .bulk-activity-icons,
+  .bulk-back,
+  .bulk-info {
+    display: inline-block;
+    vertical-align: middle;
+  }
+  .bulk-back-info {
+    width: 50%;
+    text-align: left;
+    .bulk-back {
+      .back-bulk {
+        background: transparent;
+        padding: 0;
+        margin-left: 6px;
+        position: relative;
+        top: 2px;
+        i {
+          position: relative;
+          top: 1px;
+        }
+      }
     }
-    .bulk-back-info {
-        width: 50%;
-        text-align: left;
-        .bulk-back {
-            .back-bulk {
-                background: transparent;
-                padding: 0;
-                margin-left: 6px;
-                position: relative;
-                top: 2px;
-                i {
-                    position: relative;
-                    top: 1px;
-                }
-            }
-        }
-        .bulk-info {
-            padding-left: 53px;
-            font-size: 18px;
-            position: relative;
-            top: 2px;
-        }
+    .bulk-info {
+      padding-left: 53px;
+      font-size: 18px;
+      position: relative;
+      top: 2px;
     }
-    .bulk-activity-icons {
-        width: 50%;
-        text-align: right;
-        padding-right: 6.3%;
-        .approve-all-segments {
-            line-height: 18px;
-            background: transparent;
-            font-weight: 100;
-            padding: 6px 10px;
-            border-radius: 2px;
-            transition: 0.3s ease;
-            width: auto;
-            vertical-align: bottom;
-            margin-right: 0;
-            &:hover {
-                box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-            }
-            &.translated-all-bulked {
-                border: 1px solid $translatedBlue;
-                color: $translatedBlue;
-            }
-            &.approved-all-bulked {
-                border: 1px solid $approvedGreen;
-                color: $approvedGreen;
-                &.approved-2nd-pass {
-                    border: 1px solid $approved2Green;
-                    color: $approved2Green;
-                }
-            }
-            i {
-                top: 3px;
-                margin-right: 0 !important;
-                position: relative;
-                &:before {
-                    font-size: 19px;
-                    line-height: 1px;
-                }
-            }
+  }
+  .bulk-activity-icons {
+    width: 50%;
+    text-align: right;
+    padding-right: 6.3%;
+    .approve-all-segments {
+      line-height: 18px;
+      background: transparent;
+      font-weight: 100;
+      padding: 6px 10px;
+      border-radius: 2px;
+      transition: 0.3s ease;
+      width: auto;
+      vertical-align: bottom;
+      margin-right: 0;
+      &:hover {
+        box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+          0 2px 4px rgba(0, 0, 0, 0.24) !important;
+      }
+      &.translated-all-bulked {
+        border: 1px solid $translatedBlue;
+        color: $translatedBlue;
+      }
+      &.approved-all-bulked {
+        border: 1px solid $approvedGreen;
+        color: $approvedGreen;
+        &.approved-2nd-pass {
+          border: 1px solid $approved2Green;
+          color: $approved2Green;
         }
+      }
+      i {
+        top: 3px;
+        margin-right: 0 !important;
+        position: relative;
+        &:before {
+          font-size: 19px;
+          line-height: 1px;
+        }
+      }
     }
-    .label-filters {
-        display: inline-block;
-        &.labl {
-            margin-right: 10px;
-            position: relative;
-            line-height: 32px;
-        }
-        .loader {
-            width: 20px;
-            height: 20px;
-            background: url(../../img/loading.gif) 0 0 no-repeat !important;
-            position: absolute;
-            bottom: 6px;
-            display: block;
-            left: 105px;
-            background-size: 20px 20px !important;
-        }
+  }
+  .label-filters {
+    display: inline-block;
+    &.labl {
+      margin-right: 10px;
+      position: relative;
+      line-height: 32px;
     }
+    .loader {
+      width: 20px;
+      height: 20px;
+      background: url(../../img/loading.gif) 0 0 no-repeat !important;
+      position: absolute;
+      bottom: 6px;
+      display: block;
+      left: 105px;
+      background-size: 20px 20px !important;
+    }
+  }
 }

--- a/public/css/sass/components/header/header.scss
+++ b/public/css/sass/components/header/header.scss
@@ -1,30 +1,30 @@
 header {
-    .revision-mark {
-      /*float: left;
+  .revision-mark {
+    /*float: left;
       position: relative;*/
-      width: 24px;
-      height: 24px;
-      left: -7px;
-      top: 11px;
+    width: 24px;
+    height: 24px;
+    left: -7px;
+    top: 11px;
 
-      font-weight: bold;
-      font-size: 16px;
-      line-height: 23px;
-      color: white;
-      text-align: center;
-      border-radius: 2px;
-      margin-top: 7px;
-      border: 1px solid #ffffff;
+    font-weight: bold;
+    font-size: 16px;
+    line-height: 23px;
+    color: white;
+    text-align: center;
+    border-radius: 2px;
+    margin-top: 7px;
+    border: 1px solid #ffffff;
 
-      &.revision-r1 {
-          background: $approvedGreen;
-      }
-      &.revision-r2 {
-          background: $approved2Green;
-      }
+    &.revision-r1 {
+      background: $approvedGreen;
     }
-
-    #files-instructions svg {
-        display: block;
+    &.revision-r2 {
+      background: $approved2Green;
     }
+  }
+
+  #files-instructions svg {
+    display: block;
+  }
 }

--- a/public/css/sass/components/header/qaComponent.scss
+++ b/public/css/sass/components/header/qaComponent.scss
@@ -22,7 +22,8 @@
   justify-content: flex-start;
 }
 
-.qa-issues-container, .qa-lexiqa-container {
+.qa-issues-container,
+.qa-lexiqa-container {
   width: 150px;
   height: 50px;
   align-items: center;
@@ -40,11 +41,13 @@
   width: 190px;
 }
 
-.qa-issues-container:hover, .qa-lexiqa-container:hover {
+.qa-issues-container:hover,
+.qa-lexiqa-container:hover {
   background-color: #d0d0d0;
 }
 
-.qa-issues-container.selected, .qa-lexiqa-container.selected {
+.qa-issues-container.selected,
+.qa-lexiqa-container.selected {
   box-shadow: inset 0px -3px 0px #4d4d4d;
 }
 
@@ -71,27 +74,27 @@
 }
 
 .icon-qa-total-issues:before {
-  content: "\e903";
+  content: '\e903';
   font-size: 25px;
 }
 
 .icon-qa-glossary:before {
-  content: "\ea4f";
+  content: '\ea4f';
   font-size: 25px;
 }
 
 .icon-conflicts:before {
-  content: "\f071";
+  content: '\f071';
   font-size: 25px;
 }
 
 .icon-qa-issues:before {
-  content: "\ea7f";
+  content: '\ea7f';
   font-size: 25px;
 }
 
 .icon-qa-lexiqa:before {
-  content: "\f044";
+  content: '\f044';
   font-size: 25px;
   margin-top: 0px;
   display: block;
@@ -123,16 +126,17 @@
 }
 
 .icon-qa-right-arrow:before {
-  content: "\ea3c";
+  content: '\ea3c';
   font-size: 18px;
 }
 
 .icon-qa-left-arrow:before {
-  content: "\ea40";
+  content: '\ea40';
   font-size: 18px;
 }
 
-.qa-move-up, .qa-move-down {
+.qa-move-up,
+.qa-move-down {
   color: #797979;
 }
 
@@ -175,7 +179,7 @@
       font-weight: 700;
       margin-right: 5px;
       &.labl {
-        margin-left: 70px
+        margin-left: 70px;
       }
     }
     @media (max-width: 1230px) {
@@ -199,10 +203,10 @@
       .qa-issue {
       }
       .icon-cancel-circle {
-        color: #E1565A;
+        color: #e1565a;
       }
       .icon-warning2 {
-        color: #EA862C;
+        color: #ea862c;
       }
       .ui.basic.buttons {
         button {

--- a/public/css/sass/components/header/search.scss
+++ b/public/css/sass/components/header/search.scss
@@ -1,432 +1,434 @@
 .searchbox {
-    position: relative;
-    float: left;
-    width: 100%;
-    font-size: 12px;
-    background: #ffffff;
-    box-shadow: 0 0 4px rgba(0, 0, 0, 0.45);
-    .block.buttons {
-        margin-top: -6px !important;
+  position: relative;
+  float: left;
+  width: 100%;
+  font-size: 12px;
+  background: #ffffff;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.45);
+  .block.buttons {
+    margin-top: -6px !important;
+  }
+  .search-inputs {
+    height: 74px;
+  }
+  #exec-filter {
+    float: right;
+  }
+  .block.right {
+    margin-right: 0 !important;
+  }
+  .btn {
+    float: right;
+    font-weight: bold;
+    margin: 4px 0px 3px 10px;
+    padding: 2px 10px;
+    height: 28px;
+    background: #eeeeef;
+    cursor: pointer;
+    font-size: 14px;
+    width: fit-content;
+    text-transform: uppercase;
+    &:disabled {
+      cursor: not-allowed;
+      background: #ffffff;
+      color: #d0d0d0;
+      color: #d0d0d0;
+      border: 1px solid #d0d0d0;
+      font-weight: 100;
     }
-    .search-inputs {
-        height: 74px;
-    }
-    #exec-filter {
-        float: right;
-    }
-    .block.right {
-        margin-right: 0 !important;
-    }
-    .btn {
-        float: right;
-        font-weight: bold;
-        margin: 4px 0px 3px 10px;
-        padding: 2px 10px;
-        height: 28px;
-        background: #eeeeef;
-        cursor: pointer;
-        font-size: 14px;
-        width: fit-content;
-        text-transform: uppercase;
-        &:disabled {
-            cursor: not-allowed;
-            background: #ffffff;
-            color: #d0d0d0;
-            color: #d0d0d0;
-            border: 1px solid #d0d0d0;
-            font-weight: 100;
-        }
-    }
+  }
 
-    input[type=button]:hover {
-        border-width: 1px;
-    }
+  input[type='button']:hover {
+    border-width: 1px;
+  }
+  .search-input {
+    width: 200px;
+    font-size: 12px !important;
+    height: 23px;
+    padding: 0 5px;
+    border: 1px solid #abadb3;
+    -webkit-transition: all 100ms ease-in;
+    -moz-transition: all 100ms ease-in;
+  }
+
+  .search-input:hover,
+  .search-editarea:hover {
+    -moz-box-shadow: inset 0 1px 1px #e6e7e8;
+    -webkit-box-shadow: inset 0 1px 1px #e6e7e8;
+  }
+
+  .search-input:focus,
+  .search-editarea:focus {
+    -moz-box-shadow: inset 0 1px 2px #ccc;
+    -webkit-box-shadow: inset 0 1px 2px #ccc;
+    color: #000;
+  }
+
+  @media only screen and (max-width: 1200px) {
     .search-input {
-        width: 200px;
-        font-size: 12px !important;
-        height: 23px;
-        padding: 0 5px;
-        border: 1px solid #abadb3;
-        -webkit-transition: all 100ms ease-in;
-        -moz-transition: all 100ms ease-in;
+      width: 160px;
     }
-
-    .search-input:hover, .search-editarea:hover {
-        -moz-box-shadow: inset 0 1px 1px #e6e7e8;
-        -webkit-box-shadow: inset 0 1px 1px #e6e7e8;
+  }
+  @media only screen and (max-width: 1100px) {
+    .search-input {
+      width: 140px;
     }
-
-    .search-input:focus, .search-editarea:focus {
-        -moz-box-shadow: inset 0 1px 2px #ccc;
-        -webkit-box-shadow: inset 0 1px 2px #ccc;
-        color: #000
+  }
+  @media only screen and (max-width: 1050px) {
+    .search-input {
+      width: 132px;
     }
-
-    @media only screen and (max-width: 1200px) {
-        .search-input {
-            width: 160px;
-        }
-    }
-    @media only screen and (max-width: 1100px) {
-        .search-input {
-            width: 140px;
-        }
-    }
-    @media only screen and (max-width: 1050px) {
-        .search-input {
-            width: 132px;
-        }
-    }
-    label {
-        display: inline;
-        width: auto !important;
-        margin-right: 5px;
-        text-transform: uppercase;
-    }
-    input[type=button],
-    input[type=submit] {
-        text-transform: uppercase;
-        -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        box-sizing: border-box;
-    }
-    .block {
-        float: left;
-        margin-right: 10px;
-        text-align: left;
-        -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        box-sizing: border-box;
-    }
-    .block .field {
-        width: 100%;
-        text-align: right;
-        margin-bottom: 5px;
-    }
-    .block.right {
-        float: right !important;
-        margin-top: -5px !important;
-    }
-    .block.right .block {
-        margin-right: 0px;
-        margin-left: 20px;
-    }
-    .block.right .block .btn {
-        margin-right: 0px;
-        margin-left: 10px;
-    }
-    .block.vcentered {
-        padding-top: 7px !important;
-    }
-    .search-options label {
-        text-transform: capitalize;
-    }
+  }
+  label {
+    display: inline;
+    width: auto !important;
+    margin-right: 5px;
+    text-transform: uppercase;
+  }
+  input[type='button'],
+  input[type='submit'] {
+    text-transform: uppercase;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+  .block {
+    float: left;
+    margin-right: 10px;
+    text-align: left;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+  .block .field {
+    width: 100%;
+    text-align: right;
+    margin-bottom: 5px;
+  }
+  .block.right {
+    float: right !important;
+    margin-top: -5px !important;
+  }
+  .block.right .block {
+    margin-right: 0px;
+    margin-left: 20px;
+  }
+  .block.right .block .btn {
+    margin-right: 0px;
+    margin-left: 10px;
+  }
+  .block.vcentered {
+    padding-top: 7px !important;
+  }
+  .search-options label {
+    text-transform: capitalize;
+  }
 }
 
-input#exec-cancel, input#exec-find, input#exec-find, button#exec-replace {
-    width: 95px;
+input#exec-cancel,
+input#exec-find,
+input#exec-find,
+button#exec-replace {
+  width: 95px;
 }
-
-
 
 /////////// New Find
 .ui.form {
-    box-sizing: border-box;
-    //TODO: Transform in SCSS Component for all INPUT TYPES
-    input {
-        border-radius: 2px !important;
-        border: 1px solid rgba(34, 36, 38, 0.15) !important;
-        box-shadow: inset 0 1px 3px #ddd !important;
-        font-size: 1.2em !important;
-        padding: 8px 16px 7px !important;
-        &::-webkit-input-placeholder {
-            color: #929292;
-        }
-        &:hover {
-            border-color: rgba(34, 36, 38, 0.35) !important;
-        }
-        &:focus {
-            border-color: #85B7D9 !important;
-            background: #FFFFFF !important;
-            color: rgba(0, 0, 0, 0.8) !important;
-            /*outline: none;*/
-        }
+  box-sizing: border-box;
+  //TODO: Transform in SCSS Component for all INPUT TYPES
+  input {
+    border-radius: 2px !important;
+    border: 1px solid rgba(34, 36, 38, 0.15) !important;
+    box-shadow: inset 0 1px 3px #ddd !important;
+    font-size: 1.2em !important;
+    padding: 8px 16px 7px !important;
+    &::-webkit-input-placeholder {
+      color: #929292;
     }
-    .find-wrapper {
-        .find-container {
-            background-color: #fff;
-            padding: 10px 0 0;
-            margin-bottom: 0;
-            box-shadow: 0 1px 3px #666;
-            border-radius: 0 0 0 0;
+    &:hover {
+      border-color: rgba(34, 36, 38, 0.35) !important;
+    }
+    &:focus {
+      border-color: #85b7d9 !important;
+      background: #ffffff !important;
+      color: rgba(0, 0, 0, 0.8) !important;
+      /*outline: none;*/
+    }
+  }
+  .find-wrapper {
+    .find-container {
+      background-color: #fff;
+      padding: 10px 0 0;
+      margin-bottom: 0;
+      box-shadow: 0 1px 3px #666;
+      border-radius: 0 0 0 0;
+      display: block;
+      color: #4d4d4d;
+      .find-container-inside {
+        height: 100%;
+        padding: 0 6.5% 0 5%;
+        text-align: left;
+        display: flex;
+        .find-list {
+          display: flex;
+          width: 100%;
+          padding-bottom: 10px;
+        }
+        .find-element {
+          display: inline-block;
+          width: 29%;
+          margin-right: 10px;
+          &.find-dropdown-status {
+            width: fit-content;
+            margin-right: 0;
+            //TODO: Transform in SCSS Component for all DROPDOWN BUTTON
+            .find-dropdown {
+              display: flex;
+              align-items: center;
+              .ui.basic.button {
+                font-family: 'calibri', Arial, Helvetica, sans-serif;
+                font-size: 16px !important;
+                padding: 11px 20px;
+                border-radius: 2px;
+                /*transition: 0.3s ease;*/
+                box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.25) inset;
+
+                &:hover,
+                &.active {
+                  box-shadow: 0 0 0 1px #0055b8 inset;
+                  color: #0055b8 !important;
+                  background: #fff !important;
+                }
+
+                .text {
+                  /*transition: 0.3s ease;*/
+                  display: flex;
+                }
+                .ui.cancel.label {
+                  position: absolute;
+                  padding: 4px;
+                  background-color: #d6d6d6;
+                  border-radius: 15px;
+                  top: 8px;
+                  line-height: 0px;
+                  right: 0px;
+                  visibility: hidden;
+                  &:hover {
+                    background-color: #cccccc !important;
+                  }
+                }
+              }
+              .ui.input input {
+                box-shadow: inset 0 1px 3px #ddd;
+              }
+              &.not-filtered {
+                .ui.basic.button {
+                  &.disabled {
+                    box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.25) inset !important;
+                  }
+                }
+              }
+              &.filtered {
+                .ui.basic.button {
+                  background-color: #ffffff !important;
+                  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+                    0 2px 4px rgba(0, 0, 0, 0.24) !important;
+                  color: #000000 !important;
+                  padding: 9px 20px;
+                  &:hover {
+                    width: fit-content;
+                    .text {
+                      margin-right: 15px;
+                    }
+                    .ui.cancel.label {
+                      visibility: unset;
+                      right: 5px;
+                    }
+                  }
+                }
+              }
+              &.disabled {
+                background: unset;
+                opacity: 0.5 !important;
+                border: none;
+                pointer-events: none;
+                box-shadow: inherit !important;
+                .active .menu.transition {
+                  visibility: hidden !important;
+                  &:after {
+                    display: none;
+                  }
+                }
+              }
+              .circular.label {
+                &.new-color {
+                  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
+                  background: #ffffff;
+                }
+                &.draft-color {
+                  background: #e8e8e8;
+                }
+                &.translated-color {
+                  background: $translatedBlue;
+                }
+                &.approved-color {
+                  background: $approvedGreen;
+                }
+                &.approved-2ndpass-color {
+                  background: $approved2Green;
+                }
+                &.rejected-color {
+                  background: #dc2e34;
+                }
+              }
+            }
+          }
+          &.find-clear-all {
+            width: fit-content;
+            margin-right: 0;
+          }
+          .find-in-source {
+            margin-bottom: 5px;
+          }
+          .find-exact-match {
+            display: flex;
+            .exact-match {
+              &:first-child {
+                margin-right: 13px;
+              }
+            }
+          }
+          .find-in-target {
+            input {
+              margin-bottom: 5px;
+            }
+            .enable-replace-check.disable {
+              opacity: 0.5;
+            }
+          }
+          .find-in-replace {
+            input {
+              margin-bottom: 5px;
+            }
+            button {
+              padding: 5px 10px;
+            }
+          }
+
+          .find-clear {
+            margin-left: 13px;
+            border-left: 1px solid #d6d6d7;
+            padding-left: 15px;
+            position: relative;
+            top: 9px;
+            button {
+              color: grey;
+              text-decoration: underline;
+              border: none;
+              background: none;
+              outline: none;
+              &:hover {
+                text-decoration: none;
+              }
+            }
+          }
+        }
+        .find-element-container {
+          display: inline-block;
+          width: 29%;
+          margin-left: 15px;
+          margin-right: 10px;
+          .find-element {
+            width: unset;
             display: block;
-            color: #4d4d4d;
-            .find-container-inside {
-                height: 100%;
-                padding: 0 6.5% 0 5%;
-                text-align: left;
-                display: flex;
-                .find-list {
-                    display: flex;
-                    width: 100%;
-                    padding-bottom: 10px;
-                }
-                .find-element {
-                    display: inline-block;
-                    width: 29%;
-                    margin-right: 10px;
-                    &.find-dropdown-status{
-                        width: fit-content;
-                        margin-right: 0;
-                        //TODO: Transform in SCSS Component for all DROPDOWN BUTTON
-                        .find-dropdown {
-                            display: flex;
-                            align-items: center;
-                            .ui.basic.button {
-                                font-family: "calibri", Arial, Helvetica, sans-serif;
-                                font-size: 16px !important;
-                                padding: 11px 20px;
-                                border-radius: 2px;
-                                /*transition: 0.3s ease;*/
-                                box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.25) inset;
-
-                                &:hover,
-                                &.active {
-                                    box-shadow: 0 0 0 1px #0055b8 inset;
-                                    color:#0055b8 !important;
-                                    background: #fff !important;
-                                }
-
-                                .text {
-                                    /*transition: 0.3s ease;*/
-                                    display: flex
-                                }
-                                .ui.cancel.label {
-                                    position: absolute;
-                                    padding: 4px;
-                                    background-color: #d6d6d6;
-                                    border-radius: 15px;
-                                    top: 8px;
-                                    line-height: 0px;
-                                    right: 0px;
-                                    visibility: hidden;
-                                    &:hover {
-                                        background-color: #cccccc !important;
-                                    }
-                                }
-                            }
-                            .ui.input input {
-                                box-shadow: inset 0 1px 3px #ddd;
-                            }
-                            &.not-filtered {
-                                .ui.basic.button {
-
-                                    &.disabled {
-                                        box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.25) inset !important;
-                                    }
-                                }
-                            }
-                            &.filtered {
-                                .ui.basic.button {
-                                    background-color: #ffffff !important;
-                                    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                                    color: #000000 !important;
-                                    padding: 9px 20px;
-                                    &:hover {
-                                        width: fit-content;
-                                        .text {
-                                            margin-right: 15px;
-                                        }
-                                        .ui.cancel.label {
-                                            visibility: unset;
-                                            right: 5px;
-                                        }
-                                    }
-                                }
-                            }
-                            &.disabled {
-                                background: unset;
-                                opacity: 0.5 !important;
-                                border: none;
-                                pointer-events: none;
-                                box-shadow: inherit !important;
-                                .active .menu.transition {
-                                    visibility: hidden !important;
-                                    &:after {
-                                        display: none;
-                                    }
-                                }
-                            }
-                            .circular.label {
-                                &.new-color {
-                                    box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
-                                    background: #FFFFFF
-                                }
-                                &.draft-color {
-                                    background: #E8E8E8;;
-                                }
-                                &.translated-color {
-                                    background: $translatedBlue;
-                                }
-                                &.approved-color {
-                                    background: $approvedGreen;
-                                }
-                                &.approved-2ndpass-color {
-                                    background: $approved2Green;
-                                }
-                                &.rejected-color {
-                                    background: #dc2e34;
-                                }
-                            }
-                        }
-                    }
-                    &.find-clear-all {
-                        width: fit-content;
-                        margin-right: 0;
-                    }
-                    .find-in-source {
-                        margin-bottom: 5px;
-                    }
-                    .find-exact-match {
-                        display: flex;
-                        .exact-match {
-                            &:first-child {
-                                margin-right: 13px;
-                            }
-                        }
-                    }
-                    .find-in-target {
-                        input {
-                            margin-bottom: 5px;
-                        }
-                        .enable-replace-check.disable {
-                            opacity: .5;
-                        }
-                    }
-                    .find-in-replace {
-                        input {
-                            margin-bottom: 5px;
-                        }
-                        button {
-                            padding: 5px 10px;
-                        }
-                    }
-
-                    .find-clear {
-                        margin-left: 13px;
-                        border-left: 1px solid #d6d6d7;
-                        padding-left: 15px;
-                        position: relative;
-                        top: 9px;
-                        button {
-                            color: grey;
-                            text-decoration: underline;
-                            border: none;
-                            background: none;
-                            outline: none;
-                            &:hover {
-                                text-decoration: none;
-                            }
-                        }
-                    }
-                }
-                .find-element-container {
-                    display: inline-block;
-                    width: 29%;
-                    margin-left: 15px;
-                    margin-right: 10px;
-                    .find-element {
-                        width: unset;
-                        display: block;
-                    }
-                }
-                .find-actions {
-                    display: flex;
-                    justify-content: flex-end;
-                    align-items: flex-start;
-                    margin-top: 4px;
-
-                    button {
-                        border-radius: 2px;
-                        &:hover,
-                        &.active {
-                            box-shadow: 0 0 0 1px #0055b8 inset;
-                            color:#0055b8 !important;
-                            background: #fff !important;
-                        }
-
-                        &:last-child {
-                            width: max-content;
-                        }
-                        &.disabled {
-                            box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset !important;
-
-                        }
-                    }
-                }
-            }
-            .search-display {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                height: 100%;
-                font-size: 1.2em;
-                padding: 15px 6.5% 15px 5%;
-                text-align: left;
-                background: #f2f4f7;
-                .found {
-                    margin: 0;
-                    margin-right: 20px;
-                    span {
-                        .param {
-                            font-weight: 700;
-                            color: black;
-                            background: yellow;
-                            margin: 0 3px;
-                            padding: 3px 3px;
-                            border-radius: 2px;
-                        }
-                    }
-                }
-                .search-result-buttons {
-                    display: flex;
-                    p {
-                        padding: 8px 5px;
-                        margin-bottom: 0;
-                    }
-                    .ui.basic.button {
-                        width: 36px;
-                        height: 36px;
-                        padding: 0;
-                        margin: 0;
-                        line-height: 36px;
-                        margin-left: 10px;
-                        position: relative;
-                        span {
-                            position: absolute;
-                            font-size: 12px;
-                            color: #878788;
-                            -webkit-transition: all 100ms ease-in;
-                            -moz-transition: all 100ms ease-in;
-                            visibility: hidden;
-                            width: 160px;
-                            left: -50px;
-                            top: 26px;
-                        }
-                        &.disabled {
-                            box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset !important;
-                            span {
-                                display: none;
-                            }
-                        }
-                        &:hover {
-                            span {
-                                visibility: visible;
-                            }
-                        }
-                    }
-                }
-            }
+          }
         }
+        .find-actions {
+          display: flex;
+          justify-content: flex-end;
+          align-items: flex-start;
+          margin-top: 4px;
+
+          button {
+            border-radius: 2px;
+            &:hover,
+            &.active {
+              box-shadow: 0 0 0 1px #0055b8 inset;
+              color: #0055b8 !important;
+              background: #fff !important;
+            }
+
+            &:last-child {
+              width: max-content;
+            }
+            &.disabled {
+              box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset !important;
+            }
+          }
+        }
+      }
+      .search-display {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        height: 100%;
+        font-size: 1.2em;
+        padding: 15px 6.5% 15px 5%;
+        text-align: left;
+        background: #f2f4f7;
+        .found {
+          margin: 0;
+          margin-right: 20px;
+          span {
+            .param {
+              font-weight: 700;
+              color: black;
+              background: yellow;
+              margin: 0 3px;
+              padding: 3px 3px;
+              border-radius: 2px;
+            }
+          }
+        }
+        .search-result-buttons {
+          display: flex;
+          p {
+            padding: 8px 5px;
+            margin-bottom: 0;
+          }
+          .ui.basic.button {
+            width: 36px;
+            height: 36px;
+            padding: 0;
+            margin: 0;
+            line-height: 36px;
+            margin-left: 10px;
+            position: relative;
+            span {
+              position: absolute;
+              font-size: 12px;
+              color: #878788;
+              -webkit-transition: all 100ms ease-in;
+              -moz-transition: all 100ms ease-in;
+              visibility: hidden;
+              width: 160px;
+              left: -50px;
+              top: 26px;
+            }
+            &.disabled {
+              box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset !important;
+              span {
+                display: none;
+              }
+            }
+            &:hover {
+              span {
+                visibility: visible;
+              }
+            }
+          }
+        }
+      }
     }
+  }
 }

--- a/public/css/sass/components/header/segmentsFilter.scss
+++ b/public/css/sass/components/header/segmentsFilter.scss
@@ -1,67 +1,69 @@
 body section.muted {
-    background: #f2f4f7;
-    cursor: not-allowed;
-    .body{
-        .text {
-            opacity: 0.5;
-            .wrap {
-                .source {}
-                .target {
-                    .editarea {
-                        border: none !important;
-                        &:hover {
-                            border: none !important;
-                        }
-                    }
-                }
-            }
-            .status-container {
-                .status {
-                    opacity: 0.2;
-                }
-            }
+  background: #f2f4f7;
+  cursor: not-allowed;
+  .body {
+    .text {
+      opacity: 0.5;
+      .wrap {
+        .source {
         }
+        .target {
+          .editarea {
+            border: none !important;
+            &:hover {
+              border: none !important;
+            }
+          }
+        }
+      }
+      .status-container {
+        .status {
+          opacity: 0.2;
+        }
+      }
     }
-    .segment-side-buttons {}
+  }
+  .segment-side-buttons {
+  }
 }
 
 .search-settings-panel {
-    background: #efefef;
-    padding: 10px;
-    position: absolute;
-    width: 205px;
-    border: 1px solid #666;
-    top: 48px;
+  background: #efefef;
+  padding: 10px;
+  position: absolute;
+  width: 205px;
+  border: 1px solid #666;
+  top: 48px;
 }
 
 /* advanced filtering */
 
 header .filter:before {
-    content: "\f0b0";
+  content: '\f0b0';
 }
 
 header .filter {
-    display: block !important;
-    text-decoration: none;
-    color: #eee;
-    box-shadow: none;
-    border: 0;
-    padding: 12px;
-    font-size: 20px;
-    text-align: center;
+  display: block !important;
+  text-decoration: none;
+  color: #eee;
+  box-shadow: none;
+  border: 0;
+  padding: 12px;
+  font-size: 20px;
+  text-align: center;
 }
 
 .advanced-filter-searchbox {
-    display: none;
+  display: none;
 }
 
 .advanced-filter-searchbox .search-select {
-    margin-left: 5px;
+  margin-left: 5px;
 }
 
 .advanced-filter-searchbox {
-    display: block;
-    height: 48px;
+  display: block;
+  height: 48px;
 }
 /*.searchbox form {
     width: auto;
@@ -73,7 +75,7 @@ header .filter {
 }*/
 
 .advanced-filter-searchbox {
-    z-index: 1 !important;
+  z-index: 1 !important;
 }
 
 /*.searchbox .search-settings {
@@ -84,356 +86,359 @@ header .filter {
 
 body.cattool .filter,
 body.cattool .filter:hover {
-    background: transparent !important;
-    cursor: pointer;
+  background: transparent !important;
+  cursor: pointer;
 }
 body.cattool .filter:hover {
-    color: #ccc;
+  color: #ccc;
 }
 
 .cattool header .filter {
-    font-size: 25px;
-    padding: 10px;
-    padding: 0;
-    padding-top: 5px;
-    width: 45px;
-    margin: 0;
+  font-size: 25px;
+  padding: 10px;
+  padding: 0;
+  padding-top: 5px;
+  width: 45px;
+  margin: 0;
 }
 
 .mbc-history-balloon-outer {
-    display: none;
+  display: none;
 }
 
 #review-side-panel {
-    top: 48px;
+  top: 48px;
 }
 
 .search-settings-info {
-    float: left;
-    margin-right: 10px;
-    color: #666;
+  float: left;
+  margin-right: 10px;
+  color: #666;
 }
 
 .filter-segments-count {
-    float: right !important;
-    font-weight: bold;
-    font-size: 14px;
+  float: right !important;
+  font-weight: bold;
+  font-size: 14px;
 }
 
 #setStatus-filter {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 section.muted .segment-side-buttons {
-    zoom: 0.8;
+  zoom: 0.8;
 }
 
 .sf-segment-navigation-arrows {
-    float: right;
-    margin-right: 20px;
-    margin-top: -3px;
+  float: right;
+  margin-right: 20px;
+  margin-top: -3px;
 }
-
-
 
 ///////////// New Filter Segments
 
 #header-bars-wrapper {
-    .filter-wrapper {
-        position: relative;
-        width: 100%;
-        float: left;
-        margin-top: 1px;
-        .filter-container {
-            background-color: #fff;
-            height: 50px;
-            box-shadow: 0 1px 3px #666;
-            border-radius: 0 0 2px 2px;
-            display: block;
-            color: #4d4d4d;
-            //TODO: Transform in SCSS Component for all INPUT TYPES
-            input {
-                border-radius: 2px !important;
-                border: 1px solid rgba(34, 36, 38, 0.15) !important;
-                box-shadow: inset 0 1px 3px #ddd !important;
-                font-size: 1.2em !important;
-                padding: 8px 16px 7px !important;
-                &::-webkit-input-placeholder {
-                    color: rgba(0, 0, 0, 0.87);
-                }
-                &:hover {
-                    border-color: rgba(34, 36, 38, 0.35) !important;
-                }
-                &:focus {
-                    border-color: #85B7D9 !important;
-                    background: #FFFFFF !important;
-                    color: rgba(0, 0, 0, 0.8) !important;
-                    outline: none;
-                }
+  .filter-wrapper {
+    position: relative;
+    width: 100%;
+    float: left;
+    margin-top: 1px;
+    .filter-container {
+      background-color: #fff;
+      height: 50px;
+      box-shadow: 0 1px 3px #666;
+      border-radius: 0 0 2px 2px;
+      display: block;
+      color: #4d4d4d;
+      //TODO: Transform in SCSS Component for all INPUT TYPES
+      input {
+        border-radius: 2px !important;
+        border: 1px solid rgba(34, 36, 38, 0.15) !important;
+        box-shadow: inset 0 1px 3px #ddd !important;
+        font-size: 1.2em !important;
+        padding: 8px 16px 7px !important;
+        &::-webkit-input-placeholder {
+          color: rgba(0, 0, 0, 0.87);
+        }
+        &:hover {
+          border-color: rgba(34, 36, 38, 0.35) !important;
+        }
+        &:focus {
+          border-color: #85b7d9 !important;
+          background: #ffffff !important;
+          color: rgba(0, 0, 0, 0.8) !important;
+          outline: none;
+        }
+      }
+      .filter-container-inside {
+        height: 100%;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding: 0 6.5% 0 5%;
+        align-items: center;
+        .filter-list {
+          display: flex;
+          flex-grow: 3;
+          align-items: center;
+          box-sizing: border-box;
+          .filter-dropdown {
+            display: flex;
+            align-items: center;
+            &:nth-child(2) {
+              margin-left: 15px;
             }
-            .filter-container-inside {
-                height: 100%;
+            .ui.basic.button {
+              font-family: 'calibri', Arial, Helvetica, sans-serif;
+              font-size: 16px !important;
+              padding: 10px 20px;
+              border-radius: 2px;
+              /*transition: 0.3s ease;*/
+              box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
+
+              &:hover,
+              &.active {
+                box-shadow: 0 0 0 1px #0055b8 inset;
+                color: #0055b8 !important;
+                background: #fff !important;
+              }
+
+              .text {
+                /*transition: 0.3s ease;*/
                 display: flex;
-                flex-direction: row;
-                justify-content: space-between;
-                padding: 0 6.5% 0 5%;
                 align-items: center;
-                .filter-list {
-                    display: flex;
-                    flex-grow: 3;
-                    align-items: center;
-                    box-sizing: border-box;
-                    .filter-dropdown {
-                        display: flex;
-                        align-items: center;
-                        &:nth-child(2){
-                        margin-left: 15px;
-                        }
-                        .ui.basic.button{
-                            font-family: "calibri", Arial, Helvetica, sans-serif;
-                            font-size: 16px !important;
-                            padding: 10px 20px;
-                            border-radius: 2px;
-                            /*transition: 0.3s ease;*/
-                            box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
-
-                            &:hover,
-                            &.active {
-                                box-shadow: 0 0 0 1px #0055b8 inset;
-                                color:#0055b8 !important;
-                                background: #fff !important;
-                            }
-
-                            .text {
-                                /*transition: 0.3s ease;*/
-                                display: flex;
-                                align-items: center;
-                            }
-                            .ui.cancel.label {
-                                position: absolute;
-                                padding: 4px;
-                                background-color: #d6d6d6;
-                                border-radius: 15px;
-                                top: 8px;
-                                line-height: 0px;
-                                right: 0px;
-                                visibility: hidden;
-                                &:hover {
-                                    background-color: #cccccc !important;
-                                }
-                            }
-                        }
-                        .filter-status, .filter-activities, .filter-data-sample {
-                            &.not-filtered {
-                                .ui.basic.button {
-                                    /*&:hover, &.active {
+              }
+              .ui.cancel.label {
+                position: absolute;
+                padding: 4px;
+                background-color: #d6d6d6;
+                border-radius: 15px;
+                top: 8px;
+                line-height: 0px;
+                right: 0px;
+                visibility: hidden;
+                &:hover {
+                  background-color: #cccccc !important;
+                }
+              }
+            }
+            .filter-status,
+            .filter-activities,
+            .filter-data-sample {
+              &.not-filtered {
+                .ui.basic.button {
+                  /*&:hover, &.active {
                                         box-shadow: none;
                                         color: #0055b8 !important;
                                         border: 1px solid #0055b8;
                                         background: #fff !important;
                                     }*/
-                                    &.disabled {
-                                        box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.25) inset !important;
-                                        pointer-events: none;
-                                    }
-                                }
-                            }
-                            &.filtered {
-                                .ui.basic.button {
-                                    background-color: #ffffff !important;
-                                    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                                    color: #000000 !important;
-                                    padding: 9px 20px 9px 15px;
-                                    &:hover {
-                                        width: fit-content;
-                                        .text {
-                                            margin-right: 15px;
-                                        }
-                                        .ui.cancel.label {
-                                            visibility: unset;
-                                            right: 5px;
-                                        }
-                                    }
-                                }
-                            }
-                            &.disabled {
-                                background: unset;
-                                opacity: 0.5 !important;
-                                box-shadow: unset;
-                                border: none;
-                                pointer-events: none;
-                            }
-                        }
-                        .filter-status {
-                            .circular.label {
-                                &.new-color {
-                                    box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
-                                    background: #FFFFFF
-                                }
-                                &.draft-color {
-                                    background: $grey1;
-                                }
-                                &.translated-color, &.post-edited-color {
-                                    background: $translatedBlue;
-                                }
-                                &.approved-color {
-                                    background: $approvedGreen
-                                }
-                                &.approved-2ndpass-color {
-                                    background: $approved2Green;
-                                }
-                                &.rejected-color {
-                                    background: $rebuttedRed;
-                                }
-                            }
-                        }
-                        .filter-activities {
-
-                        }
-                        .filter-toggle {
-                            .checkbox {
-                                left: 5px;
-                                top: 4px;
-                                margin: 0 !important;
-                                float: none;
-                                label {
-                                    &:before {
-                                        background: #dcdfe4 !important;
-                                    }
-                                    &:after {
-                                        box-shadow: inset 0 0 0 1px rgba(34, 36, 38, 0.25);
-                                        background: #FFFFFF;
-                                    }
-                                }
-                            }
-                        }
-                        .filter-data-sample {
-                            display: flex;
-                            align-items: center;
-                            .percent-item {
-                                margin-left: 5px;
-                            }
-                            .menu {
-                                width: 220px;
-                                .head-dropdown {
-                                    label {
-                                        display: inline-block;
-                                        width: 60%;
-                                        position: relative;
-                                        font-size: 12px;
-                                        top: 16px;
-                                    }
-                                    input {
-                                        width: 40%;
-                                        display: inline-block;
-                                        right: 0;
-                                        padding: 5px 10px;
-                                        margin-top: 10px;
-                                    }
-                                }
-                            }
-                            .item, .text {
-                                .type-item, .order-item {
-                                    display: inline-block;
-                                }
-                                .order-item {
-                                    float: right;
-                                }
-                            }
-                            .text {
-                                .order-item {
-                                    margin-left: 2px;
-                                }
-                            }
-                        }
-                    }
-                    .clear-filter-element {
-                        margin-left: 13px;
-                        border-left: 1px solid #d6d6d7;
-                        padding-left: 13px;
-                        color: black;
-                        display: flex;
-                        justify-content: space-between;
-                        .clear-filter, .select-all-filter {
-                            display: inline;
-                            min-width: 65px;
-                            button {
-                                background: none;
-                                color: grey;
-                                text-decoration: underline;
-                                cursor: pointer;
-                                border: none;
-                                padding: 0;
-                                outline: none;
-                                &:hover {
-                                    text-decoration: none;
-                                }
-                            }
-                        }
-                    }
+                  &.disabled {
+                    box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.25) inset !important;
+                    pointer-events: none;
+                  }
                 }
-                .filter-navigator {
-                    display: flex;
-                    flex-grow: 1;
-                    align-items: center;
-                    .filter-actions {
-                        display: flex;
-                        flex-grow: 1;
-                        flex-direction: row;
-                        justify-content: flex-end;
-                        align-items: center;
-                        .info-navigation-filters {
-                            display: inline-block;
-                            margin: 0 15px 0 10px;
-                        }
-                        .label-filters {
-                            display: inline-block;
-                            &.labl {
-                                margin-right: 10px;
-                                position: relative;
-                            }
-                            .loader {
-                                width: 20px;
-                                height: 20px;
-                                background: url(../../img/loading.gif) 0 0 no-repeat !important;
-                                position: absolute;
-                                bottom: 0px;
-                                display: block;
-                                left: 85px;
-                                background-size: 20px 20px !important;
-                            }
-                        }
+              }
+              &.filtered {
+                .ui.basic.button {
+                  background-color: #ffffff !important;
+                  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+                    0 2px 4px rgba(0, 0, 0, 0.24) !important;
+                  color: #000000 !important;
+                  padding: 9px 20px 9px 15px;
+                  &:hover {
+                    width: fit-content;
+                    .text {
+                      margin-right: 15px;
                     }
+                    .ui.cancel.label {
+                      visibility: unset;
+                      right: 5px;
+                    }
+                  }
                 }
+              }
+              &.disabled {
+                background: unset;
+                opacity: 0.5 !important;
+                box-shadow: unset;
+                border: none;
+                pointer-events: none;
+              }
             }
+            .filter-status {
+              .circular.label {
+                &.new-color {
+                  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
+                  background: #ffffff;
+                }
+                &.draft-color {
+                  background: $grey1;
+                }
+                &.translated-color,
+                &.post-edited-color {
+                  background: $translatedBlue;
+                }
+                &.approved-color {
+                  background: $approvedGreen;
+                }
+                &.approved-2ndpass-color {
+                  background: $approved2Green;
+                }
+                &.rejected-color {
+                  background: $rebuttedRed;
+                }
+              }
+            }
+            .filter-activities {
+            }
+            .filter-toggle {
+              .checkbox {
+                left: 5px;
+                top: 4px;
+                margin: 0 !important;
+                float: none;
+                label {
+                  &:before {
+                    background: #dcdfe4 !important;
+                  }
+                  &:after {
+                    box-shadow: inset 0 0 0 1px rgba(34, 36, 38, 0.25);
+                    background: #ffffff;
+                  }
+                }
+              }
+            }
+            .filter-data-sample {
+              display: flex;
+              align-items: center;
+              .percent-item {
+                margin-left: 5px;
+              }
+              .menu {
+                width: 220px;
+                .head-dropdown {
+                  label {
+                    display: inline-block;
+                    width: 60%;
+                    position: relative;
+                    font-size: 12px;
+                    top: 16px;
+                  }
+                  input {
+                    width: 40%;
+                    display: inline-block;
+                    right: 0;
+                    padding: 5px 10px;
+                    margin-top: 10px;
+                  }
+                }
+              }
+              .item,
+              .text {
+                .type-item,
+                .order-item {
+                  display: inline-block;
+                }
+                .order-item {
+                  float: right;
+                }
+              }
+              .text {
+                .order-item {
+                  margin-left: 2px;
+                }
+              }
+            }
+          }
+          .clear-filter-element {
+            margin-left: 13px;
+            border-left: 1px solid #d6d6d7;
+            padding-left: 13px;
+            color: black;
+            display: flex;
+            justify-content: space-between;
+            .clear-filter,
+            .select-all-filter {
+              display: inline;
+              min-width: 65px;
+              button {
+                background: none;
+                color: grey;
+                text-decoration: underline;
+                cursor: pointer;
+                border: none;
+                padding: 0;
+                outline: none;
+                &:hover {
+                  text-decoration: none;
+                }
+              }
+            }
+          }
         }
-    }
-    .filter-arrows {
-        .button {
-            padding: 10px 13px;
-            display: inline-block;
-            width: 11px;
+        .filter-navigator {
+          display: flex;
+          flex-grow: 1;
+          align-items: center;
+          .filter-actions {
+            display: flex;
+            flex-grow: 1;
+            flex-direction: row;
+            justify-content: flex-end;
+            align-items: center;
+            .info-navigation-filters {
+              display: inline-block;
+              margin: 0 15px 0 10px;
+            }
+            .label-filters {
+              display: inline-block;
+              &.labl {
+                margin-right: 10px;
+                position: relative;
+              }
+              .loader {
+                width: 20px;
+                height: 20px;
+                background: url(../../img/loading.gif) 0 0 no-repeat !important;
+                position: absolute;
+                bottom: 0px;
+                display: block;
+                left: 85px;
+                background-size: 20px 20px !important;
+              }
+            }
+          }
         }
+      }
     }
-    .ui.dropdown .menu > .head-dropdown {
-        padding: 0em 1.14285714rem;
-        color: rgba(0, 0, 0, 0.85);
-        font-size: 0.78571429em;
-        font-weight: bold;
-        text-transform: uppercase;
+  }
+  .filter-arrows {
+    .button {
+      padding: 10px 13px;
+      display: inline-block;
+      width: 11px;
     }
+  }
+  .ui.dropdown .menu > .head-dropdown {
+    padding: 0em 1.14285714rem;
+    color: rgba(0, 0, 0, 0.85);
+    font-size: 0.78571429em;
+    font-weight: bold;
+    text-transform: uppercase;
+  }
 
-    .ui.dropdown .menu {
-        width: 200px;
-        padding: 8px;
-        .item {
-            font-size: 16px;
-            border-radius: 2px;
-            padding: 8px !important;
-            &:hover {
-                color: #0055b8;
-            }
-        }
+  .ui.dropdown .menu {
+    width: 200px;
+    padding: 8px;
+    .item {
+      font-size: 16px;
+      border-radius: 2px;
+      padding: 8px !important;
+      &:hover {
+        color: #0055b8;
+      }
     }
+  }
 }
-

--- a/public/css/sass/components/segment/Glossary.scss
+++ b/public/css/sass/components/segment/Glossary.scss
@@ -1,13 +1,13 @@
 .qaCheckGlossaryItem {
-    display: inline-block;
-    position: relative;
-    background-color: #ff8734;
-    cursor: pointer;
+  display: inline-block;
+  position: relative;
+  background-color: #ff8734;
+  cursor: pointer;
 }
 
 .blacklistItem {
-    background-color: #FFFA8B;
-    border-bottom: 2px solid purple;
-    display: inline-block;
-    position: relative;
+  background-color: #fffa8b;
+  border-bottom: 2px solid purple;
+  display: inline-block;
+  position: relative;
 }

--- a/public/css/sass/components/segment/Tag.scss
+++ b/public/css/sass/components/segment/Tag.scss
@@ -1,16 +1,15 @@
-.DraftEditor-root{
-  .public-DraftEditor-content > div > div{
-
+.DraftEditor-root {
+  .public-DraftEditor-content > div > div {
     // everything
     &:not(:last-child) {
       .public-DraftStyleDefault-block {
         & > * {
           &:last-child {
             &:after {
-              content:'\21B5'; //↵
+              content: '\21B5'; //↵
               padding: 0 4px;
               font-size: 14px;
-              color: #08BEEC;
+              color: #08beec;
             }
           }
         }
@@ -20,7 +19,7 @@
     &:not(:last-child) {
       .public-DraftStyleDefault-block {
         & > span {
-          &:only-child[data-offset-key]{
+          &:only-child[data-offset-key] {
             br {
               display: none;
             }
@@ -28,11 +27,10 @@
         }
       }
     }
-
   }
 }
 
-.tag-container{
+.tag-container {
   position: relative;
   display: inline-block;
 }
@@ -72,7 +70,7 @@
     //}
   }
 
-  &:not(.tag-focused){
+  &:not(.tag-focused) {
     opacity: 0.75;
     &:hover {
       cursor: pointer;
@@ -81,8 +79,8 @@
     }
   }
 
-  span{
-    &::selection{
+  span {
+    &::selection {
       color: #fff;
       background: transparent;
     }
@@ -91,7 +89,7 @@
   &.tag-open {
     margin: 0 8px 0 1px;
     &:before {
-      content: "";
+      content: '';
       position: absolute;
       right: -8px;
       bottom: 0;
@@ -106,7 +104,7 @@
   &.tag-close {
     margin: 0 1px 0 8px;
     &:after {
-      content: "";
+      content: '';
       position: absolute;
       left: -8px;
       top: 0;
@@ -121,7 +119,7 @@
   &.tag-selfclosed {
     margin: 0 8px 0 8px;
     &:after {
-      content: "";
+      content: '';
       position: absolute;
       left: -8px;
       top: 0;
@@ -132,7 +130,7 @@
       border-bottom: 8px solid transparent;
     }
     &:before {
-      content: "";
+      content: '';
       position: absolute;
       right: -8px;
       bottom: 0;
@@ -144,24 +142,24 @@
     }
   }
 
-  &.tag-ph{
+  &.tag-ph {
     border-radius: 8px;
     background: #788190;
     margin: 0 1px;
     padding: 0 4px;
     max-width: unset;
     &:before {
-      border:none;
+      border: none;
     }
-    &:after{
-      border:none;
+    &:after {
+      border: none;
     }
   }
 
   span {
     all: revert;
   }
-  span[data-text="true"]{
+  span[data-text='true'] {
     display: flow-root;
     white-space: nowrap;
     overflow: hidden;
@@ -175,7 +173,7 @@
     line-height: 1.3;
     display: inline-block;
     /*opacity: 1;*/
-    &:hover{
+    &:hover {
       cursor: default !important;
     }
 
@@ -191,24 +189,24 @@
       border-top-width: 7.5px;
       border-bottom-width: 7.5px;
     }
-    &.tag-nbsp{
+    &.tag-nbsp {
       font-size: 14px;
     }
     &.tag-lf {
-      &:after{
+      &:after {
         font-size: 12px;
       }
     }
 
     &.tag-cr {
-      &:after{
+      &:after {
         font-size: 12px;
       }
     }
-    &.tag-tab{
+    &.tag-tab {
       font-size: 12px;
     }
-    &.tag-ph{
+    &.tag-ph {
       display: inline-block;
       white-space: nowrap;
       overflow: hidden;
@@ -221,74 +219,72 @@
   /* Tag states */
   &.tag-inactive {
     color: #788190;
-    background: #F5F6F7;
+    background: #f5f6f7;
     &:before {
-      border-left-color: #F5F6F7;
+      border-left-color: #f5f6f7;
     }
     &:after {
-      border-right-color: #F5F6F7;
+      border-right-color: #f5f6f7;
     }
   }
 
-
   &.tag-clicked {
-    background-color: #2FB177;
+    background-color: #2fb177;
     opacity: 1;
     &:before {
-      border-left-color: #2FB177;
+      border-left-color: #2fb177;
     }
     &:after {
-      border-right-color: #2FB177;
+      border-right-color: #2fb177;
     }
 
     &.tag-focused {
       cursor: grab;
       opacity: 1;
-      background-color: #0099CC;
+      background-color: #0099cc;
       &:before {
-        border-left-color: #0099CC;
+        border-left-color: #0099cc;
       }
       &:after {
-        border-right-color: #0099CC;
+        border-right-color: #0099cc;
       }
       &:active {
         cursor: grabbing;
       }
     }
-
   }
   &.tag-selected {
     cursor: grab;
     opacity: 1;
-    background-color: #0099CC;
+    background-color: #0099cc;
     box-shadow: 2px 0px 5px 2px #02c0ffa3;
     &:before {
-      border-left-color: #0099CC;
+      border-left-color: #0099cc;
     }
     &:after {
-      border-right-color: #0099CC;
+      border-right-color: #0099cc;
     }
     &:active {
       cursor: grabbing;
     }
   }
   &.tag-mismatch-error {
-    background-color: #E02020;
+    background-color: #e02020;
     &:before {
-      border-left-color: #E02020;
+      border-left-color: #e02020;
     }
     &:after {
-      border-right-color: #E02020;
+      border-right-color: #e02020;
     }
   }
 
   &.tag-mismatch-warning {
-    background-color: #FFCC01;
+    background-color: #ffcc01;
     &:before {
-      border-left-color: #FFCC01;
+      border-left-color: #ffcc01;
     }
     &:after {
-      border-right-color: #FFCC01;
+      border-right-color: #ffcc01;
     }
   }
 
@@ -297,19 +293,19 @@
   }*/
 
   /* Inline tag */
-  &.tag-nbsp{
+  &.tag-nbsp {
     font-size: 18px;
     margin: 0 2px;
-    color: #08BEEC;
+    color: #08beec;
     background: transparent;
     &:before {
-      border:none;
+      border: none;
     }
     &:after {
-      border:none;
+      border: none;
     }
-    span{
-      &::selection{
+    span {
+      &::selection {
         color: #002b5c;
       }
     }
@@ -317,70 +313,70 @@
 
   &.tag-lf {
     &:before {
-      border:none;
+      border: none;
     }
-    &:after{
-      content:'\21B5';
+    &:after {
+      content: '\21B5';
       top: -7px;
       padding: 0 4px;
       font-size: 14px;
-      color: #08BEEC;
-      border:none;
+      color: #08beec;
+      border: none;
     }
   }
 
   &.tag-cr {
     &:before {
-      border:none;
+      border: none;
     }
-    &:after{
-      content:'\21B5';
+    &:after {
+      content: '\21B5';
       top: -7px;
       padding: 0 4px;
       font-size: 14px;
-      color: #08BEEC;
-      border:none;
+      color: #08beec;
+      border: none;
     }
   }
 
-  &.tag-tab{
+  &.tag-tab {
     font-size: 14px;
     margin: 0 2px;
-    color: #08BEEC;
+    color: #08beec;
     background: transparent;
     &:before {
-      border:none;
+      border: none;
     }
     &:after {
-      border:none;
+      border: none;
     }
-    span{
-      &::selection{
+    span {
+      &::selection {
         color: #002b5c;
       }
     }
   }
 
-  &.tag-split{
+  &.tag-split {
     font-size: 14px;
     font-family: 'icomoon';
     margin: 0 2px;
-    color: #08BEEC;
+    color: #08beec;
     background: transparent;
     &:before {
-      border:none;
+      border: none;
     }
     &:after {
-      border:none;
+      border: none;
     }
-    span{
-      &::selection{
+    span {
+      &::selection {
         color: #002b5c;
       }
     }
-    &:hover{
+    &:hover {
       &:after {
-        content: "\00d7";
+        content: '\00d7';
         color: red;
         position: absolute;
         font-size: 18px;
@@ -391,7 +387,7 @@
   }
 }
 
-.tag-tooltip{
+.tag-tooltip {
   position: absolute;
   width: 140px;
   height: 32px;
@@ -402,8 +398,7 @@
   justify-content: center;
   align-items: center;
   font-size: 12px;
-  .tooltip-txt{
-
+  .tooltip-txt {
   }
 }
 
@@ -412,7 +407,7 @@
   z-index: 1001;
   padding: 8px;
   bottom: 32px;
-  left:50%;
+  left: 50%;
   transform: translateX(-50%);
   width: max-content; //240px;
   background-color: #fff;
@@ -430,15 +425,19 @@
   -ms-flex-align: center;
   align-items: center;
   font-size: 12px;
-  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  -moz-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  -moz-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
   &:after {
     content: '';
     position: absolute;
     left: 50%;
     bottom: -10px;
-    box-shadow: 4px 4px 4px 0px rgba(34, 36, 38, 0.12), 8px 8px 10px 0px rgba(34, 36, 38, 0.15); //1px 1px 2px 0px rgba(34, 36, 38, 0.12)
+    box-shadow: 4px 4px 4px 0px rgba(34, 36, 38, 0.12),
+      8px 8px 10px 0px rgba(34, 36, 38, 0.15); //1px 1px 2px 0px rgba(34, 36, 38, 0.12)
     width: 14px;
     height: 14px;
     transform: rotate(45deg) translateX(-50%);
@@ -517,20 +516,17 @@
     &:not(:first-child) {
       border-top: 1px solid rgba(255, 255, 255, 0.36);
     }
-
   }
 }
 
-
 .tag-box {
-
   .tag-box-inner {
     overflow-y: scroll;
     overflow-x: hidden;
     max-height: 240px;
     padding: 0 8px 8px 8px;
     &::-webkit-scrollbar {
-      width: 4px
+      width: 4px;
     }
     &::-webkit-scrollbar-track {
       -webkit-border-radius: 10px;
@@ -555,7 +551,6 @@
     }
   }
 
-
   .tag-box-heading {
     width: 100%;
     padding: 1rem 0;
@@ -566,7 +561,7 @@
     align-items: center;
     cursor: default;
     .tag {
-      &.tag-heading{
+      &.tag-heading {
         opacity: 1;
       }
     }
@@ -590,7 +585,8 @@
     font-size: 14px;
     white-space: nowrap;
     cursor: pointer;
-    &:hover, &.active {
+    &:hover,
+    &.active {
       background-color: #f2f5f7;
       font-weight: 700;
       .tag-placeholder {
@@ -624,8 +620,8 @@
       }
 
       .place-here-tips {
-        border: 1px solid #08BEEC;
-        color: #08BEEC;
+        border: 1px solid #08beec;
+        color: #08beec;
         border-radius: 2px;
         padding: 1px 2px;
         line-height: 1.1;
@@ -634,5 +630,3 @@
     }
   }
 }
-
-

--- a/public/css/sass/components/segment/TooltipInfo.scss
+++ b/public/css/sass/components/segment/TooltipInfo.scss
@@ -1,4 +1,4 @@
-.tooltip{
+.tooltip {
   position: absolute;
   width: 140px;
   height: 32px;
@@ -9,7 +9,7 @@
   justify-content: center;
   align-items: center;
   font-size: 12px;
-  .tooltip-txt{
+  .tooltip-txt {
     background-color: unset;
   }
 }

--- a/public/css/sass/components/segment/issuesContainer.scss
+++ b/public/css/sass/components/segment/issuesContainer.scss
@@ -1,240 +1,248 @@
-section  {
-   .issues-container {
-        display: none;
-   }
+section {
+  .issues-container {
+    display: none;
+  }
 }
 section.readonly .issues-container {
-    display: none;
+  display: none;
 }
 
 .editor {
-    &.loaded {
-        .issues-container {
-            display: inline-block !important;
-            width: 100%;
-            margin-bottom: 0px;
-            border-bottom: 1px solid #ffffff;
-            position: relative;
-            z-index: 3;
-            top: 0px;
-            border-top: 1px solid #ccc;
-            background: #ffffff !important;
-            .border-box-issue {
-                width: 50%;
+  &.loaded {
+    .issues-container {
+      display: inline-block !important;
+      width: 100%;
+      margin-bottom: 0px;
+      border-bottom: 1px solid #ffffff;
+      position: relative;
+      z-index: 3;
+      top: 0px;
+      border-top: 1px solid #ccc;
+      background: #ffffff !important;
+      .border-box-issue {
+        width: 50%;
+        display: inline-block;
+        vertical-align: top;
+        .creation-issue-container {
+          padding: 1em;
+          box-sizing: border-box;
+          .field {
+            margin: 1em 0em 1em;
+            display: inline-block;
+            width: 50%;
+            .ui.dropdown {
+              border: 1px solid #888;
+              border-radius: 2px !important;
+              &:hover {
+                border: 1px solid #96c8da;
+              }
+              .text {
+                background: none;
+                font-weight: 700;
+              }
+            }
+          }
+          .select-category {
+            .category {
+              padding: 8px 15px 4px 17px;
+              .ellipsis-messages {
+                max-width: 95%;
+                min-width: 30px;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                background: yellow;
+                &.other-class {
+                  max-width: 100%;
+                }
+                &.example-class {
+                  max-width: 50%;
+                }
+              }
+              i {
+                float: right;
+                font-size: 12px;
+              }
+              .sub-category {
+                width: 100%;
+                box-sizing: content-box;
+                margin-left: -1px;
+                margin-top: -1px;
+                border-top: 0 !important;
+                border-radius: 0 0 2px 2px;
+                &.visible {
+                  border: 1px solid #96c8da;
+                  box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
+                }
+                .item {
+                  padding: 15px 10px 15px 15px !important;
+                  i {
+                    margin-left: 2em;
+                  }
+                }
+              }
+            }
+          }
+          .select-severity {
+            .item:first-child {
+              display: none;
+            }
+          }
+        }
+        .issues-list {
+          display: inline-block;
+          width: 100%;
+          margin-top: 15px;
+          margin-bottom: 0px;
+          text-align: left;
+          .issue-item {
+            display: inline-block;
+            width: 47.3%;
+            min-width: 250px;
+            margin: 0 5px 10px;
+            vertical-align: top;
+            transition: 0.3s ease;
+            .issue {
+              background: #ffffff;
+              padding: 5px 5px 5px 10px;
+              box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+                0 2px 4px rgba(0, 0, 0, 0.24) !important;
+              .issue-head,
+              .issue-activity-icon {
                 display: inline-block;
                 vertical-align: top;
-                .creation-issue-container {
-                    padding: 1em;
-                    box-sizing: border-box;
-                    .field {
-                        margin: 1em 0em 1em;
-                        display: inline-block;
-                        width: 50%;
-                        .ui.dropdown {
-                            border: 1px solid #888;
-                            border-radius: 2px !important;
-                            &:hover {
-                                border: 1px solid #96C8DA;
-                            }
-                            .text {
-                                background: none;
-                                font-weight: 700;
-                            }
-                        }
-                    }
-                    .select-category {
-                        .category {
-                            padding: 8px 15px 4px 17px;
-                            .ellipsis-messages {
-                                max-width: 95%;
-                                min-width: 30px;
-                                white-space: nowrap;
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                                background: yellow;
-                                &.other-class {
-                                    max-width: 100%;
-                                }
-                                &.example-class {
-                                    max-width: 50%;
-                                }
-                            }
-                            i {
-                                float: right;
-                                font-size: 12px;
-                            }
-                            .sub-category {
-                                width: 100%;
-                                box-sizing: content-box;
-                                margin-left: -1px;
-                                margin-top: -1px;
-                                border-top: 0 !important;
-                                border-radius: 0 0 2px 2px;
-                                &.visible {
-                                    border: 1px solid #96C8DA;
-                                    box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
-                                }
-                                .item {
-                                    padding: 15px 10px 15px 15px !important;
-                                    i {
-                                        margin-left: 2em;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    .select-severity {
-                        .item:first-child {
-                            display: none;
-                        }
-                    }
+              }
+              .issue-head {
+                width: 75%;
+                .type_issue_name,
+                .sub_type_issue_name,
+                .severity_issue_name {
+                  display: inline-block;
+                  vertical-align: top;
+                  position: relative;
+                  top: 3px;
+                  font-weight: 700;
+                  margin-right: 4px;
                 }
-                .issues-list {
-                    display: inline-block;
-                    width: 100%;
-                    margin-top: 15px;
-                    margin-bottom: 0px;
-                    text-align: left;
-                    .issue-item {
-                        display: inline-block;
-                        width: 47.3%;
-                        min-width: 250px;
-                        margin: 0 5px 10px;
-                        vertical-align: top;
-                        transition: 0.3s ease;
-                        .issue {
-                            background: #FFFFFF;
-                            padding: 5px 5px 5px 10px;
-                            box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                            .issue-head, .issue-activity-icon {
-                                display: inline-block;
-                                vertical-align: top;
-                            }
-                            .issue-head {
-                                width: 75%;
-                                .type_issue_name, .sub_type_issue_name, .severity_issue_name {
-                                    display: inline-block;
-                                    vertical-align: top;
-                                    position: relative;
-                                    top: 3px;
-                                    font-weight: 700;
-                                    margin-right: 4px;
-                                }
-                                .type_issue_name {}
-                                .sub_type_issue_name {
-                                    max-width: 65%;
-                                    min-width: 30px;
-                                    white-space: nowrap;
-                                    overflow: hidden;
-                                    text-overflow: ellipsis;
-                                    font-weight: 100;
-                                }
-                                .severity_issue_name {
-                                }
-                            }
-                            .issue-activity-icon {
-                                width: 25%;
-                                text-align: right;
-                                button {
-                                    padding: 3px;
-                                    text-align: center;
-                                    margin-right: 5px;
-                                    background: transparent;
-                                    box-shadow: 0 0 0 1px #BCBCBC inset;
-                                    border: none;
-                                    outline: none;
-                                    &.re-active {
-                                        background: #e9e9e9;
-                                        i {
-                                            color: #333333;
-                                        }
-                                    }
-                                    &:hover {
-                                        box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.35) inset;
-                                        i {
-                                            color: #333333;
-                                        }
-                                    }
-                                    &:active {
-                                        background: #e3e3e3;
-                                    }
-                                    &:focus {
-                                        box-shadow: 0 0 0 1px #96C8DA inset;
-                                    }
-                                    &:last-child {
-                                        margin-right: 0;
-                                    }
-                                    i {
-                                        margin-right: 0;
-                                        color: grey;
-                                        position: relative;
-                                        top: 1px;
-                                    }
-                                    &.re-message {
-                                        i {
-                                            color: $approvedGreen;
-                                        }
-                                        &:hover {
-                                            i {
-                                                color: #65a060;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        .comments-view {
-                            .re-add-comment, .re-comment-list {
-                                padding: 5px 10px;
-                                font-size: 18px;
-                                background: #f0f2f5;
-                                color: #787878;
-                                box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                            }
-                            .re-add-comment {
-                                input {
-                                    height: 30px;
-                                    border-radius: 30px;
-                                    box-sizing: border-box;
-                                }
-                            }
-                            .re-comment-list {
-                                font-size: 14px;
-                                background: #ffffff;
-                                .re-comment {
-                                    margin-bottom: 0;
-                                    .re-revisor {
-                                        color: $approvedGreen;
-                                    }
-                                    .re-revisor2 {
-                                        color: $approved2Green;
-                                    }
-                                    .re-translator {
-                                        color: $translatedBlue;
-                                    }
-                                    .re-comment-date{
-                                        font-size: 13px;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    @media only screen and (max-width: 1180px) {
-                        .issue-item {
-                            width: 95%;
-                            .sub_type_issue_name {
-                                max-width: 57% !important;
-                            }
-                        }
-                    }
+                .type_issue_name {
                 }
+                .sub_type_issue_name {
+                  max-width: 65%;
+                  min-width: 30px;
+                  white-space: nowrap;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  font-weight: 100;
+                }
+                .severity_issue_name {
+                }
+              }
+              .issue-activity-icon {
+                width: 25%;
+                text-align: right;
+                button {
+                  padding: 3px;
+                  text-align: center;
+                  margin-right: 5px;
+                  background: transparent;
+                  box-shadow: 0 0 0 1px #bcbcbc inset;
+                  border: none;
+                  outline: none;
+                  &.re-active {
+                    background: #e9e9e9;
+                    i {
+                      color: #333333;
+                    }
+                  }
+                  &:hover {
+                    box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.35) inset;
+                    i {
+                      color: #333333;
+                    }
+                  }
+                  &:active {
+                    background: #e3e3e3;
+                  }
+                  &:focus {
+                    box-shadow: 0 0 0 1px #96c8da inset;
+                  }
+                  &:last-child {
+                    margin-right: 0;
+                  }
+                  i {
+                    margin-right: 0;
+                    color: grey;
+                    position: relative;
+                    top: 1px;
+                  }
+                  &.re-message {
+                    i {
+                      color: $approvedGreen;
+                    }
+                    &:hover {
+                      i {
+                        color: #65a060;
+                      }
+                    }
+                  }
+                }
+              }
             }
-            &.add-issue-segment {
-                .category, .category-selected .severity {
-                    border: 1px solid $approvedGreen !important;
-                    box-shadow: inset 0 0 3px $approvedGreen;
+            .comments-view {
+              .re-add-comment,
+              .re-comment-list {
+                padding: 5px 10px;
+                font-size: 18px;
+                background: #f0f2f5;
+                color: #787878;
+                box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+                  0 2px 4px rgba(0, 0, 0, 0.24) !important;
+              }
+              .re-add-comment {
+                input {
+                  height: 30px;
+                  border-radius: 30px;
+                  box-sizing: border-box;
                 }
+              }
+              .re-comment-list {
+                font-size: 14px;
+                background: #ffffff;
+                .re-comment {
+                  margin-bottom: 0;
+                  .re-revisor {
+                    color: $approvedGreen;
+                  }
+                  .re-revisor2 {
+                    color: $approved2Green;
+                  }
+                  .re-translator {
+                    color: $translatedBlue;
+                  }
+                  .re-comment-date {
+                    font-size: 13px;
+                  }
+                }
+              }
             }
+          }
+          @media only screen and (max-width: 1180px) {
+            .issue-item {
+              width: 95%;
+              .sub_type_issue_name {
+                max-width: 57% !important;
+              }
+            }
+          }
         }
+      }
+      &.add-issue-segment {
+        .category,
+        .category-selected .severity {
+          border: 1px solid $approvedGreen !important;
+          box-shadow: inset 0 0 3px $approvedGreen;
+        }
+      }
     }
+  }
 }

--- a/public/css/sass/components/segment/segment.scss
+++ b/public/css/sass/components/segment/segment.scss
@@ -1,192 +1,189 @@
 .segment-selected-inBulk:not(.opened) {
-    .body > .text {
-        background-color: #edf4fd !important;
-    }
-    .segment-add-inBulk {
-        display: block;
-    }
-    &:hover .body > .text {
-        background-color: #edf4fd !important;
-    }
+  .body > .text {
+    background-color: #edf4fd !important;
+  }
+  .segment-add-inBulk {
+    display: block;
+  }
+  &:hover .body > .text {
+    background-color: #edf4fd !important;
+  }
 }
 
 #file section {
-    &:not(.readonly):not(.muted):hover .segment-add-inBulk {
-        display: block;
-    }
+  &:not(.readonly):not(.muted):hover .segment-add-inBulk {
+    display: block;
+  }
 
-    .segment-add-inBulk,
-    &.muted .segment-add-inBulk,
-    .muted:hover .segment-add-inBulk,
-    .readonly:hover .segment-add-inBulk{
-        display: none;
-    }
-    &:not(.editor):not(.muted):hover {
-        background: $grey4;
-        color: #000;
-    }
-    &.segment-selected {
-        background: #c8cbd5 !important;
-        border: 1px solid #989898;
-    }
+  .segment-add-inBulk,
+  &.muted .segment-add-inBulk,
+  .muted:hover .segment-add-inBulk,
+  .readonly:hover .segment-add-inBulk {
+    display: none;
+  }
+  &:not(.editor):not(.muted):hover {
+    background: $grey4;
+    color: #000;
+  }
+  &.segment-selected {
+    background: #c8cbd5 !important;
+    border: 1px solid #989898;
+  }
 }
 
 body.cattool {
-    #file section {
-        &:not(.editor) {
-            .buttons {
-                display: none;
-            }
-            &.segment-selected-inBulk :hover {
-                background: #edf4fd !important;
-            }
-        }
-
-        .editor.segment-selected-inBulk {
-            background: #edf4fd;
-            &:hover {
-                background: #edf4fd !important;
-            }
-        }
+  #file section {
+    &:not(.editor) {
+      .buttons {
+        display: none;
+      }
+      &.segment-selected-inBulk :hover {
+        background: #edf4fd !important;
+      }
     }
+
+    .editor.segment-selected-inBulk {
+      background: #edf4fd;
+      &:hover {
+        background: #edf4fd !important;
+      }
+    }
+  }
 }
 
-section{
-    &.opened{
-        .buttons {
-            display: inline-block;
-            margin-right: 0;
-            text-align: right;
-            z-index: 0;
-            position: relative;
+section {
+  &.opened {
+    .buttons {
+      display: inline-block;
+      margin-right: 0;
+      text-align: right;
+      z-index: 0;
+      position: relative;
+    }
+    .segment-body-content {
+      .warnings-block {
+        display: inline-block;
+      }
+    }
+  }
+  .actions {
+    visibility: hidden;
+  }
+  &.split-action .actions {
+    visibility: visible;
+  }
+  &:hover .actions {
+    visibility: visible;
+  }
+  .segment-body-content {
+    .warnings-block {
+      display: none;
+      width: 103%;
+      box-sizing: content-box;
+      margin-top: 10px;
+      margin-left: -20px;
+      font-size: 14px;
+      .alert-block {
+        display: inline-block;
+        width: 48%;
+        margin: 0 1%;
+        color: #6a6a69;
+        min-height: 41px;
+        &.error-alert {
+          background: #fdeae2;
+          .icon-column {
+            background-color: $redDefaultTransparent;
+            color: $redDefault;
+          }
         }
-        .segment-body-content{
-            .warnings-block{
-                display: inline-block;
-            }
+        &.warning-alert {
+          background: #fff4e3;
+          .icon-column {
+            background-color: $orangeDefaultTransparent;
+            color: $orangeDefault;
+          }
         }
-    }
-    .actions {
-        visibility: hidden;
-    }
-    &.split-action .actions {
-        visibility: visible;
-    }
-    &:hover .actions {
-        visibility: visible;
-    }
-    .segment-body-content{
-        .warnings-block{
-            display: none;
-            width: 103%;
-            box-sizing: content-box;
-            margin-top: 10px;
-            margin-left: -20px;
-            font-size: 14px;
-            .alert-block{
-                display: inline-block;
-                width: 48%;
-                margin: 0 1%;
-                color: #6A6A69;
-                min-height: 41px;
-                &.error-alert{
-                    background: #FDEAE2;
-                    .icon-column{
-                        background-color: $redDefaultTransparent;
-                        color: $redDefault;
-                    }
-                }
-                &.warning-alert{
-                    background: #FFF4E3;
-                    .icon-column{
-                        background-color: $orangeDefaultTransparent;
-                        color: $orangeDefault;
-                    }
-                }
-                &.info-alert{
-                    background: $grey3;
-                    .icon-column{
-                        background-color: $grey2;
-                        color: $grey1;
-                    }
-                }
-                .icon{
-                    padding: 8px 8px 10px 8px;
-                    font-size: 18px;
-                    margin: 0;
-                }
-            }
-            ul{
-                width: 100%;
-                display: table;
-                min-height: 41px;
-                li{
-                    display: table-cell;
-                    height: 100%;
-                }
-                .icon-column{
-                    width: 10%;
-                    position: relative;
-                    vertical-align: middle;
-                    text-align: center;
-                }
-                .content-column{
-                    width: 90%;
-                    position: relative;
-                    padding: 5px 8px;
-                    vertical-align: middle;
-                    p:first-child {
-                        margin-top: 0em;
-                        margin-bottom: 0;
-                        line-height: 13px;
-                    }
-                    p:last-child {
-                        margin-bottom: 0em;
-                        line-height: 13px;
-                    }
-                    .error-solution{
-                        margin-top: 5px;
-                        font-size: 96%;
-                    }
-                }
-            }
-
+        &.info-alert {
+          background: $grey3;
+          .icon-column {
+            background-color: $grey2;
+            color: $grey1;
+          }
         }
+        .icon {
+          padding: 8px 8px 10px 8px;
+          font-size: 18px;
+          margin: 0;
+        }
+      }
+      ul {
+        width: 100%;
+        display: table;
+        min-height: 41px;
+        li {
+          display: table-cell;
+          height: 100%;
+        }
+        .icon-column {
+          width: 10%;
+          position: relative;
+          vertical-align: middle;
+          text-align: center;
+        }
+        .content-column {
+          width: 90%;
+          position: relative;
+          padding: 5px 8px;
+          vertical-align: middle;
+          p:first-child {
+            margin-top: 0em;
+            margin-bottom: 0;
+            line-height: 13px;
+          }
+          p:last-child {
+            margin-bottom: 0em;
+            line-height: 13px;
+          }
+          .error-solution {
+            margin-top: 5px;
+            font-size: 96%;
+          }
+        }
+      }
     }
-    &.slide-right {
-        width: 70%;
-    }
-    &.editor.slide-right {
-        width: 71%;
-    }
+  }
+  &.slide-right {
+    width: 70%;
+  }
+  &.editor.slide-right {
+    width: 71%;
+  }
 }
 
 .segment-side-container {
-    position: absolute;
-    text-align: left;
-    width: 31%;
-    left: 102%;
-    display: flex;
-    flex-direction: column;
-
+  position: absolute;
+  text-align: left;
+  width: 31%;
+  left: 102%;
+  display: flex;
+  flex-direction: column;
 }
 .collection-type-separator {
-    color: #777;
-    font-size: 16px;
-    float: left;
-    width: 100%;
-    box-shadow: none !important;
-    padding: 20px 116px 10px 5%;
-    text-align: left;
-    &.first-segment {
-        padding-top: 5px;
-    }
-    &.slide-right {
-        width: 75%;
-    }
-
+  color: #777;
+  font-size: 16px;
+  float: left;
+  width: 100%;
+  box-shadow: none !important;
+  padding: 20px 116px 10px 5%;
+  text-align: left;
+  &.first-segment {
+    padding-top: 5px;
+  }
+  &.slide-right {
+    width: 75%;
+  }
 }
 
 .projectbar.slide-right {
-    width: 70%;
+  width: 70%;
 }

--- a/public/css/sass/components/segment/segmentFooter.scss
+++ b/public/css/sass/components/segment/segmentFooter.scss
@@ -1,36 +1,36 @@
 .tm-match-note-tooltip-content {
-    text-align: left;
+  text-align: left;
 }
 
-.sub-editor{
-    &.concordances {
-        &.extended.have-results{
-            .overflow{
-                max-height: 280px;
-            }
-        }
-        .cc-search{
-            form{
-                display: inline-block;
-                width: 100%;
-                .input-group{
-                    box-sizing: border-box;
-                    display: inline-block;
-                    width: 50%;
-                    padding: 20px;
-                }
-                input{
-                    display: inline-block;
-                    width: 100%;
-                    border: 1px solid #aaa;
-                    padding: 2px 0.4%;
-                    border-radius: 2px;
-                    box-shadow: inset 0 1px 2px #ddd;
-                    -webkit-box-shadow: inset 0 1px 2px #ddd;
-                    text-align: left;
-                    min-height: 20px;
-                }
-            }
-        }
+.sub-editor {
+  &.concordances {
+    &.extended.have-results {
+      .overflow {
+        max-height: 280px;
+      }
     }
+    .cc-search {
+      form {
+        display: inline-block;
+        width: 100%;
+        .input-group {
+          box-sizing: border-box;
+          display: inline-block;
+          width: 50%;
+          padding: 20px;
+        }
+        input {
+          display: inline-block;
+          width: 100%;
+          border: 1px solid #aaa;
+          padding: 2px 0.4%;
+          border-radius: 2px;
+          box-shadow: inset 0 1px 2px #ddd;
+          -webkit-box-shadow: inset 0 1px 2px #ddd;
+          text-align: left;
+          min-height: 20px;
+        }
+      }
+    }
+  }
 }

--- a/public/css/sass/components/segment/tagsMenu.scss
+++ b/public/css/sass/components/segment/tagsMenu.scss
@@ -1,353 +1,346 @@
 .target {
-    .tags-auto-complete-menu {
-        background: #FFF;
-        box-sizing: border-box;
-        max-width: 300px;
-        border-radius: 2px;
-        box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
-        border: 1px solid #dadada;
-        .ui.vertical.menu {
-            -webkit-box-shadow: none;
-            -moz-box-shadow: none;
-            box-shadow: none;
-            border: none;
-            width: 18rem;
-            .menu-container {
-
-            }
-            .head-tag-list {
-                position: -webkit-sticky;
-                position: sticky;
-                top: 0;
-                padding: 1rem 1.14rem;
-                font-weight: bold;
-                line-height: 17px;
-                border-top: 1px solid #e9e3e8;
-                border-bottom: 1px solid #e0e3e8;
-                z-index: 1;
-                background: #FFF;
-                pointer-events: none;
-                display: flex;
-                align-items: center;
-                .style-tag {
-                    padding: 4px 7px;
-                    margin: 0 5px;
-                    &.mismatch {
-                        color: #E1565A;
-                    }
-                }
-            }
-            .item {
-                text-overflow: ellipsis;
-                overflow: hidden;
-                padding: 0.78rem 1.14rem;
-                width: 100% !important;
-                font-size: 14px;
-                white-space: nowrap;
-                cursor: pointer;
-
-                &:before {
-                    background: #FFF;
-                }
-                &:hover {
-                    background: rgba(0, 0, 0, 0.05) !important;
-                }
-                &.added-tag {
-                    color: #767676 !important;
-
-                    & a {
-                        color: #767676 !important;
-                    }
-                }
-                &.missing-tag {
-                    color: #000 !important;
-                    font-size: 16px;
-                    & a {
-                        color: #000 !important;
-                    }
-                }
-                mark {
-                    background: #FFFF00;
-                }
-                &.no-results {
-                    cursor: default;
-                    pointer-events: none;
-                    height: 100%;
-                    padding: 13px !important;
-                }
-            }
-
+  .tags-auto-complete-menu {
+    background: #fff;
+    box-sizing: border-box;
+    max-width: 300px;
+    border-radius: 2px;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+    border: 1px solid #dadada;
+    .ui.vertical.menu {
+      -webkit-box-shadow: none;
+      -moz-box-shadow: none;
+      box-shadow: none;
+      border: none;
+      width: 18rem;
+      .menu-container {
+      }
+      .head-tag-list {
+        position: -webkit-sticky;
+        position: sticky;
+        top: 0;
+        padding: 1rem 1.14rem;
+        font-weight: bold;
+        line-height: 17px;
+        border-top: 1px solid #e9e3e8;
+        border-bottom: 1px solid #e0e3e8;
+        z-index: 1;
+        background: #fff;
+        pointer-events: none;
+        display: flex;
+        align-items: center;
+        .style-tag {
+          padding: 4px 7px;
+          margin: 0 5px;
+          &.mismatch {
+            color: #e1565a;
+          }
         }
+      }
+      .item {
+        text-overflow: ellipsis;
+        overflow: hidden;
+        padding: 0.78rem 1.14rem;
+        width: 100% !important;
+        font-size: 14px;
+        white-space: nowrap;
+        cursor: pointer;
+
+        &:before {
+          background: #fff;
+        }
+        &:hover {
+          background: rgba(0, 0, 0, 0.05) !important;
+        }
+        &.added-tag {
+          color: #767676 !important;
+
+          & a {
+            color: #767676 !important;
+          }
+        }
+        &.missing-tag {
+          color: #000 !important;
+          font-size: 16px;
+          & a {
+            color: #000 !important;
+          }
+        }
+        mark {
+          background: #ffff00;
+        }
+        &.no-results {
+          cursor: default;
+          pointer-events: none;
+          height: 100%;
+          padding: 13px !important;
+        }
+      }
     }
-    .head-tag-list .locked.mismatch {
-        background-color: #fdeae2;
-        color: #e1595d;
-        box-shadow: inset 0 0px 0 2px #e1565a;
-        font-weight: 100;
-        padding: 4px 6px;
-        position: relative;
-        top: -1px;
-    }
+  }
+  .head-tag-list .locked.mismatch {
+    background-color: #fdeae2;
+    color: #e1595d;
+    box-shadow: inset 0 0px 0 2px #e1565a;
+    font-weight: 100;
+    padding: 4px 6px;
+    position: relative;
+    top: -1px;
+  }
 }
 
 .style-tag {
-    display: inline-flex;
-    background: #F2F4F7;
-    box-shadow: inset 0 0 0 2px #E5E9F1;
-    border-radius: 7px;
-    font-size: 15px;
-    color: #767676;
-    font-style: italic;
-    padding: 0 6px 0 3px;
-    vertical-align: middle;
-    margin: 1px;
+  display: inline-flex;
+  background: #f2f4f7;
+  box-shadow: inset 0 0 0 2px #e5e9f1;
+  border-radius: 7px;
+  font-size: 15px;
+  color: #767676;
+  font-style: italic;
+  padding: 0 6px 0 3px;
+  vertical-align: middle;
+  margin: 1px;
+  cursor: pointer;
+  word-break: break-all;
+  &::selection {
+    background: transparent !important;
+  }
+  &:hover {
+    background: #e5e9f1;
     cursor: pointer;
-    word-break: break-all;
-    &::selection {
-        background: transparent !important;
-    }
+  }
+  a {
+    color: #3b4a5c;
+    font-weight: 700;
+  }
+  &.mismatch {
+    background-color: #fdeae2;
+    box-shadow: inset 0 0 0 2px #f9dcd1;
     &:hover {
-        background: #E5E9F1;
-        cursor: pointer;
-    }
-    a {
-        color: #3B4A5C;
-        font-weight: 700;
-    }
-    &.mismatch {
-        background-color: #fdeae2;
-        box-shadow: inset 0 0 0 2px #f9dcd1;
-        &:hover {
-            background-color: #f9dcd1;
-        }
-        &.selected {
-            box-shadow: inset 0 0 0 2px #e1565a;
-            background: #f9d7ca;
-        }
-        &, a {
-            color: #E1565A;
-        }
-    }
-    &.highlight {
-        box-shadow: inset 0 0 0 2px #3b4a5c96;
-        color: #424242;
+      background-color: #f9dcd1;
     }
     &.selected {
-        cursor: grab;
-        &:active {
-            cursor: grabbing;
-            position: relative;
-            -moz-transform: scale(1.1, 1.1);
-            -ms-transform: scale(1.1, 1.1);
-            -webkit-transform: scale(1.1, 1.1);
-            transform: scale(1.1, 1.1);
-            transition: 0.1s ease;
-        }
+      box-shadow: inset 0 0 0 2px #e1565a;
+      background: #f9d7ca;
     }
-    .tag-html-container-open,
-    .tag-html-container-close {
-        display: none !important;
+    &,
+    a {
+      color: #e1565a;
     }
-    &::selection, & a::selection {
-        background-color: transparent;
-        color: inherit;
+  }
+  &.highlight {
+    box-shadow: inset 0 0 0 2px #3b4a5c96;
+    color: #424242;
+  }
+  &.selected {
+    cursor: grab;
+    &:active {
+      cursor: grabbing;
+      position: relative;
+      -moz-transform: scale(1.1, 1.1);
+      -ms-transform: scale(1.1, 1.1);
+      -webkit-transform: scale(1.1, 1.1);
+      transform: scale(1.1, 1.1);
+      transition: 0.1s ease;
     }
+  }
+  .tag-html-container-open,
+  .tag-html-container-close {
+    display: none !important;
+  }
+  &::selection,
+  & a::selection {
+    background-color: transparent;
+    color: inherit;
+  }
 }
-body.rtl-target{
-    .targetarea .locked,
-    .spliArea .locked,
-    .translation .locked {
-        direction: ltr;
-        display: inline-block;
-    }
+body.rtl-target {
+  .targetarea .locked,
+  .spliArea .locked,
+  .translation .locked {
+    direction: ltr;
+    display: inline-block;
+  }
 }
-body.rtl-source{
-    .suggestion_source .locked,
-    .source .locked {
-        direction: ltr;
-        display: inline-block;
-    }
+body.rtl-source {
+  .suggestion_source .locked,
+  .source .locked {
+    direction: ltr;
+    display: inline-block;
+  }
 }
 .tagmode-default-compressed {
-    .targetarea .locked.startTag:before,
-    .editarea .locked.startTag:before,
-    .source .locked.startTag:before,
-    .splitArea .locked.startTag:before,
-    .editarea .locked.selfClosingTag:before,
-    .targetarea .locked.selfClosingTag:before,
-    .source .locked.selfClosingTag:before,
-    .splitArea .locked.selfClosingTag:before,
-    .editarea .locked.endTag:before,
-    .targetarea .locked.endTag:before,
-    .source .locked.endTag:before,
-    .splitArea .locked.endTag:before,
-    .suggestion_source .locked.startTag:before,
-    .suggestion_source .locked.selfClosingTag:before,
-    .suggestion_source .locked.endTag:before,
-    .translation .locked.startTag:before,
-    .translation .locked.selfClosingTag:before,
-    .translation .locked.endTag:before
-    {
-        font-family: 'icomoon';
-        speak: none;
-        font-style: normal;
-        font-weight: normal;
-        font-variant: normal;
-        text-transform: none;
-        line-height: 1;
+  .targetarea .locked.startTag:before,
+  .editarea .locked.startTag:before,
+  .source .locked.startTag:before,
+  .splitArea .locked.startTag:before,
+  .editarea .locked.selfClosingTag:before,
+  .targetarea .locked.selfClosingTag:before,
+  .source .locked.selfClosingTag:before,
+  .splitArea .locked.selfClosingTag:before,
+  .editarea .locked.endTag:before,
+  .targetarea .locked.endTag:before,
+  .source .locked.endTag:before,
+  .splitArea .locked.endTag:before,
+  .suggestion_source .locked.startTag:before,
+  .suggestion_source .locked.selfClosingTag:before,
+  .suggestion_source .locked.endTag:before,
+  .translation .locked.startTag:before,
+  .translation .locked.selfClosingTag:before,
+  .translation .locked.endTag:before {
+    font-family: 'icomoon';
+    speak: none;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
 
-        /* Better Font Rendering =========== */
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-    }
-    .targetarea .locked.startTag:before,
-    .source .locked.startTag:before,
-    .splitArea .locked.startTag:before,
-    .targetarea .locked.endTag:before,
-    .source .locked.endTag:before,
-    .splitArea .locked.endTag:before,
-    .suggestion_source .locked.startTag:before,
-    .translation .locked.startTag:before,
-    .suggestion_source .locked.endTag:before,
-    .translation .locked.endTag:before
-    {
-        content: "\f04b";
-        visibility: visible;
-        position: absolute;
-        font-size: 7px;
-        transform: scaleY(1.4);
-        -webkit-transform: scaleY(1.4);
-        -ms-transform: scaleY(1.4);
-        left: 10000px;
-    }
-    .editarea .locked.selfClosingTag:before,
-    .source .locked.selfClosingTag:before,
-    .splitArea .locked.selfClosingTag:before,
-    .suggestion_source .locked.selfClosingTag:before,
-    .translation .locked.selfClosingTag:before
-    {
-        content: "\e604";
-        visibility: visible;
-        position: absolute;
-        font-size: 10px;
-        top: -2px;
-        left: 9999px;
-    }
-    .targetarea .locked.startTag,
-    .source .locked.startTag,
-    .suggestion_source .locked.startTag,
+    /* Better Font Rendering =========== */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  .targetarea .locked.startTag:before,
+  .source .locked.startTag:before,
+  .splitArea .locked.startTag:before,
+  .targetarea .locked.endTag:before,
+  .source .locked.endTag:before,
+  .splitArea .locked.endTag:before,
+  .suggestion_source .locked.startTag:before,
+  .translation .locked.startTag:before,
+  .suggestion_source .locked.endTag:before,
+  .translation .locked.endTag:before {
+    content: '\f04b';
+    visibility: visible;
+    position: absolute;
+    font-size: 7px;
+    transform: scaleY(1.4);
+    -webkit-transform: scaleY(1.4);
+    -ms-transform: scaleY(1.4);
+    left: 10000px;
+  }
+  .editarea .locked.selfClosingTag:before,
+  .source .locked.selfClosingTag:before,
+  .splitArea .locked.selfClosingTag:before,
+  .suggestion_source .locked.selfClosingTag:before,
+  .translation .locked.selfClosingTag:before {
+    content: '\e604';
+    visibility: visible;
+    position: absolute;
+    font-size: 10px;
+    top: -2px;
+    left: 9999px;
+  }
+  .targetarea .locked.startTag,
+  .source .locked.startTag,
+  .suggestion_source .locked.startTag,
+  .translation .locked.startTag,
+  .splitArea .locked.startTag,
+  .targetarea .locked.selfClosingTag,
+  .source .locked.selfClosingTag,
+  .suggestion_source .locked.selfClosingTag,
+  .translation .locked.selfClosingTag,
+  .splitArea .locked.selfClosingTag,
+  .targetarea .locked.endTag,
+  .source .locked.endTag,
+  .suggestion_source .locked.endTag,
+  .translation .locked.endTag,
+  .endTag {
+    visibility: hidden;
+    text-indent: -9998px;
+    display: inline-block;
+    overflow: hidden;
+    position: relative;
+    margin: 0px 4px;
+    width: 7px;
+    height: 8px;
+    padding-top: 0px;
+  }
+
+  .targetarea .locked.endTag,
+  .source .locked.endTag,
+  .suggestion_source .locked.endTag,
+  .translation .locked.endTag,
+  .splitArea .locked.endTag {
+    -ms-transform: rotate(-180deg); /* IE 9 */
+    -webkit-transform: rotate(-180deg); /* Chrome, Safari, Opera */
+    transform: rotate(-180deg);
+  }
+  &.rtl-target {
+    .editarea .locked.startTag,
     .translation .locked.startTag,
-    .splitArea .locked.startTag,
-    .targetarea .locked.selfClosingTag,
-    .source .locked.selfClosingTag,
-    .suggestion_source .locked.selfClosingTag,
-    .translation .locked.selfClosingTag,
-    .splitArea .locked.selfClosingTag,
-    .targetarea .locked.endTag,
-    .source .locked.endTag,
+    .splitArea .locked.startTag {
+      -ms-transform: rotate(-180deg); /* IE 9 */
+      -webkit-transform: rotate(-180deg); /* Chrome, Safari, Opera */
+      transform: rotate(-180deg);
+    }
+    .editarea .locked.endTag,
+    .spliArea .locked.endTag,
+    .translation .locked.endTag {
+      -ms-transform: rotate(0deg); /* IE 9 */
+      -webkit-transform: rotate(0deg); /* Chrome, Safari, Opera */
+      transform: rotate(0deg);
+    }
+    .editarea .locked.startTag:before,
+    .editarea .locked.endTag:before,
+    .translation .locked.startTag:before,
+    .translation .locked.endTag:before {
+      left: auto !important;
+      right: 10000px !important;
+    }
+    .editarea .locked.selfClosingTag:before,
+    .translation .locked.selfClosingTag:before {
+      left: auto !important;
+      right: 9998px !important;
+    }
+  }
+  &.rtl-source {
+    .source .locked.startTag,
+    .suggestion_source .locked.startTag {
+      -ms-transform: rotate(-180deg); /* IE 9 */
+      -webkit-transform: rotate(-180deg); /* Chrome, Safari, Opera */
+      transform: rotate(-180deg);
+    }
     .suggestion_source .locked.endTag,
-    .translation .locked.endTag,
-    .endTag {
-        visibility: hidden;
-        text-indent: -9998px;
-        display: inline-block;
-        overflow: hidden;
-        position: relative;
-        margin: 0px 4px;
-        width: 7px;
-        height: 8px;
-        padding-top: 0px;
+    .source .locked.endTag {
+      -ms-transform: rotate(0deg); /* IE 9 */
+      -webkit-transform: rotate(0deg); /* Chrome, Safari, Opera */
+      transform: rotate(0deg);
     }
-
-    .targetarea .locked.endTag,
-    .source .locked.endTag,
-    .suggestion_source .locked.endTag,
-    .translation .locked.endTag,
-    .splitArea .locked.endTag {
-        -ms-transform: rotate(-180deg); /* IE 9 */
-        -webkit-transform: rotate(-180deg); /* Chrome, Safari, Opera */
-        transform: rotate(-180deg);
+    .source .locked.startTag:before,
+    .source .locked.endTag:before,
+    .splitArea .locked.startTag:before,
+    .splitArea .locked.endTag:before,
+    .suggestion_source .locked.startTag:before,
+    .suggestion_source .locked.endTag:before {
+      left: auto !important;
+      right: 10000px !important;
     }
-    &.rtl-target {
-        .editarea .locked.startTag,
-        .translation .locked.startTag,
-        .splitArea .locked.startTag {
-            -ms-transform: rotate(-180deg); /* IE 9 */
-            -webkit-transform: rotate(-180deg); /* Chrome, Safari, Opera */
-            transform: rotate(-180deg);
-        }
-        .editarea .locked.endTag,
-        .spliArea .locked.endTag,
-        .translation .locked.endTag {
-            -ms-transform: rotate(0deg); /* IE 9 */
-            -webkit-transform: rotate(0deg); /* Chrome, Safari, Opera */
-            transform: rotate(0deg);
-        }
-        .editarea .locked.startTag:before,
-        .editarea .locked.endTag:before,
-        .translation .locked.startTag:before,
-        .translation .locked.endTag:before {
-            left: auto !important;
-            right: 10000px !important;
-        }
-        .editarea .locked.selfClosingTag:before,
-        .translation .locked.selfClosingTag:before {
-            left: auto !important;
-            right: 9998px !important;
-        }
-
+    .source .locked.selfClosingTag:before,
+    .splitArea .locked.selfClosingTag:before,
+    .suggestion_source .locked.selfClosingTag:before {
+      left: auto !important;
+      right: 9998px !important;
     }
-    &.rtl-source {
-        .source .locked.startTag,
-        .suggestion_source .locked.startTag {
-            -ms-transform: rotate(-180deg); /* IE 9 */
-            -webkit-transform: rotate(-180deg); /* Chrome, Safari, Opera */
-            transform: rotate(-180deg);
-        }
-        .suggestion_source .locked.endTag,
-        .source .locked.endTag {
-            -ms-transform: rotate(0deg); /* IE 9 */
-            -webkit-transform: rotate(0deg); /* Chrome, Safari, Opera */
-            transform: rotate(0deg);
-        }
-        .source .locked.startTag:before,
-        .source .locked.endTag:before,
-        .splitArea .locked.startTag:before,
-        .splitArea .locked.endTag:before,
-        .suggestion_source .locked.startTag:before,
-        .suggestion_source .locked.endTag:before
-        {
-            left: auto !important;
-            right: 10000px !important;
-        }
-        .source .locked.selfClosingTag:before,
-        .splitArea .locked.selfClosingTag:before,
-        .suggestion_source .locked.selfClosingTag:before
-        {
-            left: auto !important;
-            right: 9998px !important;
-        }
-    }
+  }
 }
-
 
 //Quality report
 .qr-wrapper {
-    .style-tag {
-        cursor: default;
+  .style-tag {
+    cursor: default;
+  }
+  .added {
+    background: rgba(158, 255, 0, 0.2);
+    span.locked {
+      background: rgba(158, 255, 0, 0.2) !important;
     }
-    .added {
-        background: rgba(158, 255, 0, 0.2);
-        span.locked {
-            background: rgba(158, 255, 0, 0.2) !important;
-        }
+  }
+  .deleted {
+    background: rgba(255, 46, 0, 0.1);
+    text-decoration: line-through;
+    span.locked {
+      background: rgba(255, 46, 0, 0.1) !important;
+      text-decoration: line-through !important;
     }
-    .deleted {
-        background: rgba(255, 46, 0, 0.1) ;
-        text-decoration: line-through ;
-        span.locked{
-            background: rgba(255, 46, 0, 0.1) !important;
-            text-decoration: line-through !important;
-        }
-    }
+  }
 }

--- a/public/css/sass/editlog.scss
+++ b/public/css/sass/editlog.scss
@@ -1,71 +1,72 @@
 #current_page {
-    font-weight: bold;
-    font-size: 1.1em;
+  font-weight: bold;
+  font-size: 1.1em;
 }
 
 #pagination_box {
-    position: absolute;
-    left: 35%;
-    width: 30%;
+  position: absolute;
+  left: 35%;
+  width: 30%;
 }
 
 #pagination_box nav {
-    float: none;
-    text-align: center;
+  float: none;
+  text-align: center;
 }
 
 #pagination_box nav ul {
-    position: relative;
-    width: 100%;
-    margin: 0 auto;
-    overflow: hidden;
+  position: relative;
+  width: 100%;
+  margin: 0 auto;
+  overflow: hidden;
 }
 
 #pagination_box nav li {
-    border: 0;
-    text-align: center;
-    display: inline-block;
-    float: none;
-    margin: 0 auto;
-    overflow: hidden;
-    text-align: center;
+  border: 0;
+  text-align: center;
+  display: inline-block;
+  float: none;
+  margin: 0 auto;
+  overflow: hidden;
+  text-align: center;
 }
 
 #pagination_box nav li a {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 #sort_box {
-    padding: 20px 10px 30px 10px;
+  padding: 20px 10px 30px 10px;
 }
 
 #sort_box label {
-    padding-right: 20px;
-    font-size: 18px;
+  padding-right: 20px;
+  font-size: 18px;
 }
 
-.translate-box select, .mgmt-table-mt select {
-    width: 257px;
-    height: 37px;
-    padding: 5px;
-    font-size: 18px;
-    border: 1px solid #ccc;
-    margin: 0 0 5px 0;
+.translate-box select,
+.mgmt-table-mt select {
+  width: 257px;
+  height: 37px;
+  padding: 5px;
+  font-size: 18px;
+  border: 1px solid #ccc;
+  margin: 0 0 5px 0;
 }
 
 .article.msg {
-    width: 100%;
-    margin: 20px auto;
-    font-size: 26px;
-    font-style: italic;
-    color: #999;
+  width: 100%;
+  margin: 20px auto;
+  font-size: 26px;
+  font-style: italic;
+  color: #999;
 }
 
 .invalid_td {
-    background-color: #ee6633;
-    border:2px solid #EE6633;
+  background-color: #ee6633;
+  border: 2px solid #ee6633;
 }
 
 .ui.user.label {
-    top: 1px;
+  top: 1px;
 }

--- a/public/css/sass/legacy-misc.scss
+++ b/public/css/sass/legacy-misc.scss
@@ -1,412 +1,417 @@
 ﻿body {
-    padding-top: 30px;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
-    text-align: center
+  padding-top: 30px;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
+  text-align: center;
 }
 
 header {
-    top: 0;
-    left: 0;
-    text-align: left;
-    width: 100%;
-    position: fixed;
-    z-index: 999999999;
-    /*border-bottom: 1px solid #5F5F5F;
+  top: 0;
+  left: 0;
+  text-align: left;
+  width: 100%;
+  position: fixed;
+  z-index: 999999999;
+  /*border-bottom: 1px solid #5F5F5F;
     padding: 4px 0 5px 0;*/
-    height: 77px; /* was 38px for previous header*/
-    margin-top: 0;
+  height: 77px; /* was 38px for previous header*/
+  margin-top: 0;
 }
 
 h1 {
-    font-size: 40px
+  font-size: 40px;
 }
 
 h2 {
-    font-size: 30px;
-    margin: 0;
+  font-size: 30px;
+  margin: 0;
 }
 
 h3 {
-    margin: 0px 0 0 0;
-    padding: 0;
-    font-size: 18px;
-    color: #999999 !important;
-    font-weight: normal !important;
+  margin: 0px 0 0 0;
+  padding: 0;
+  font-size: 18px;
+  color: #999999 !important;
+  font-weight: normal !important;
 }
 
 .tablestats {
-    border-right: 1px solid #ccc;
+  border-right: 1px solid #ccc;
 }
 
 .tablestats th {
-    background-color: #efefef;
+  background-color: #efefef;
 }
 
-.tablestats td, .tablestats th {
-    border-bottom: 1px solid #ccc;
-    border-left: 1px solid #ccc;
-    padding: 6px 8px;
-    margin: 1px 0;
-    text-align: center
+.tablestats td,
+.tablestats th {
+  border-bottom: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  padding: 6px 8px;
+  margin: 1px 0;
+  text-align: center;
 }
 
 .tablestats tr:hover {
-    background: #f7f8f9
+  background: #f7f8f9;
 }
 
 .tablestats {
-    border-top: 1px solid #ccc;
-    margin-bottom: 40px;
-    -moz-box-shadow: 0 1px 2px #ccc;
-    background: #fff
+  border-top: 1px solid #ccc;
+  margin-bottom: 40px;
+  -moz-box-shadow: 0 1px 2px #ccc;
+  background: #fff;
 }
 
 .tablestats.continue {
-    margin-bottom: 4px !important;
+  margin-bottom: 4px !important;
 }
 
 .error-symbol {
-    position: absolute;
-    margin: 42px 0 0 -30px;
-    display: block;
-    width: 23px;
-    height: 23px;
+  position: absolute;
+  margin: 42px 0 0 -30px;
+  display: block;
+  width: 23px;
+  height: 23px;
 }
 
 .field {
-    float: left;
-    width: 35%;
-    margin: 10px 0 20px 0;
+  float: left;
+  width: 35%;
+  margin: 10px 0 20px 0;
 }
 
 .field h3 {
-    float: left;
-    width: auto;
-    margin-right: 40px;
-    font-weight: bold !important;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
-    font-size: 18px;
-    color: #000 !important;
+  float: left;
+  width: auto;
+  margin-right: 40px;
+  font-weight: bold !important;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
+  font-size: 18px;
+  color: #000 !important;
 }
 
 table .btn {
-    width: auto !important;
-    padding: 0px 20px 0 20px !important;
+  width: auto !important;
+  padding: 0px 20px 0 20px !important;
 }
 
 th.header {
-    background: #efefef url(../../img/bg.gif) right center no-repeat !important;
+  background: #efefef url(../../img/bg.gif) right center no-repeat !important;
 }
 
-th.headerSortUp, th.tablesorter-headerAsc {
-    background: #efefef url(../../img/asc.gif) right center no-repeat !important;
+th.headerSortUp,
+th.tablesorter-headerAsc {
+  background: #efefef url(../../img/asc.gif) right center no-repeat !important;
 }
 
-th.headerSortDown, th.tablesorter-headerDesc {
-    background: #efefef url(../../img/desc.gif) right center no-repeat !important;
+th.headerSortDown,
+th.tablesorter-headerDesc {
+  background: #efefef url(../../img/desc.gif) right center no-repeat !important;
 }
 
 .searchbox {
-    margin-top: 18px !important;
+  margin-top: 18px !important;
 }
 
 .searchbox .block {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
 
 .api .block-swagger {
-    margin-top: -20px;
-    background: #fafafa;
+  margin-top: -20px;
+  background: #fafafa;
 }
 
 /* Bruteforce Override style.css and legacy.min.css */
 section {
-    float: none !important;
-    -webkit-box-shadow: none !important;
-    -moz-box-shadow: none !important;
-    box-shadow: none !important;
+  float: none !important;
+  -webkit-box-shadow: none !important;
+  -moz-box-shadow: none !important;
+  box-shadow: none !important;
 }
 .swagger-ui .wrapper {
-    padding: 20px !important;
+  padding: 20px !important;
 }
 .scheme-container {
-    padding: 12px 0 !important;
+  padding: 12px 0 !important;
 }
 /* Bruteforce Override style.css and legacy.min.css */
 
 .api a {
-    color: #39699a;
+  color: #39699a;
 }
 
 .api .menu {
-    line-height: 26px;
+  line-height: 26px;
 }
 
 .api a:hover {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 #contentBox pre.literal-block {
-    word-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .apidesc td {
-    padding: 8px;
-    text-align: center;
+  padding: 8px;
+  text-align: center;
 }
 
 .api dt {
-    float: left;
-    text-align: left;
-    color: #666666;
-    width: 100px;
-    padding-right: 20px;
+  float: left;
+  text-align: left;
+  color: #666666;
+  width: 100px;
+  padding-right: 20px;
 }
 
 .api .menu ul {
-    padding-left: 30px;
+  padding-left: 30px;
 }
 
 .api .menu a {
-    text-decoration: underline;
-    cursor: pointer;
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 .api dd {
-    margin-left: 120px;
+  margin-left: 120px;
 }
 
 .api dl {
-    margin-left: 40px;
-    line-height: 30px;
+  margin-left: 40px;
+  line-height: 30px;
 }
 
 .api {
-    padding-top: 0;
+  padding-top: 0;
 }
 
 .api header {
-    position: relative;
+  position: relative;
 }
 
-.api h1, .api h2 {
-    color: #000 !important;
-    margin-top: 20px;
+.api h1,
+.api h2 {
+  color: #000 !important;
+  margin-top: 20px;
 }
 
 .api h3 {
-    color: #000 !important;
-    font-weight: bold !important;
-    font-size: 22px !important;
-    margin-bottom: 20px;
-    padding-top: 20px;
+  color: #000 !important;
+  font-weight: bold !important;
+  font-size: 22px !important;
+  margin-bottom: 20px;
+  padding-top: 20px;
 }
 
 .gototop {
-    text-align: right;
-    margin: 10px 0;
-    display: block;
-    padding-bottom: 20px;
-    border-bottom: 1px dashed #ccc;
+  text-align: right;
+  margin: 10px 0;
+  display: block;
+  padding-bottom: 20px;
+  border-bottom: 1px dashed #ccc;
 }
 
 .api .gototop.last {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 .api .fileformat {
-    -webkit-column-count: 2;
-    column-count: 2;
-    -moz-column-count: 2;
+  -webkit-column-count: 2;
+  column-count: 2;
+  -moz-column-count: 2;
 }
 
 .api .tablestats tr:hover {
-    background: none;
+  background: none;
 }
 
 /*.api .fileformat li:nth-child(2n+1) {
 background: #efefef;
 }*/
 ul.office {
-    -webkit-column-count: 3;
-    column-count: 3;
-    -moz-column-count: 3;
+  -webkit-column-count: 3;
+  column-count: 3;
+  -moz-column-count: 3;
 }
 
 .api table ul.lang-list {
-    -webkit-column-count: 5;
-    column-count: 5;
-    -moz-column-count: 5;
-    text-align: left;
-    line-height: 30px;
+  -webkit-column-count: 5;
+  column-count: 5;
+  -moz-column-count: 5;
+  text-align: left;
+  line-height: 30px;
 }
 
 .fileformat th {
-    padding-left: 15px;
+  padding-left: 15px;
 }
 
-.api .tablestats th, .api .tablestats td {
-    text-align: left;
-    vertical-align: top;
+.api .tablestats th,
+.api .tablestats td {
+  text-align: left;
+  vertical-align: top;
 }
 
 table {
-    table-layout: fixed;
-    width: 100%;
+  table-layout: fixed;
+  width: 100%;
 }
 
 .api .colsx {
-    float: left;
-    position: fixed;
-    padding-right: 1%;
-    width: 13%;
+  float: left;
+  position: fixed;
+  padding-right: 1%;
+  width: 13%;
 }
 
 .api .coldx {
-    float: right;
-    width: 80%;
-    margin: 20px 2% 2%;
+  float: right;
+  width: 80%;
+  margin: 20px 2% 2%;
 }
 
 .menuscroll {
-    margin-top: -30px;
+  margin-top: -30px;
 }
 
 .logosmall {
-    display: none;
+  display: none;
 }
 
 .menuscroll .logosmall {
-    display: block
+  display: block;
 }
 
 .logosmall {
-    background: url(../../img/logo-ico.png) no-repeat;
-    padding-top: 30px;
-    background-size: 45px;
+  background: url(../../img/logo-ico.png) no-repeat;
+  padding-top: 30px;
+  background-size: 45px;
 }
 
 .block {
-    height: auto;
+  height: auto;
 }
 
 .menu a.active {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .api dd {
-    margin-left: 120px;
-    margin-bottom: 10px;
+  margin-left: 120px;
+  margin-bottom: 10px;
 }
 
 .api .top {
-    display: block;
+  display: block;
 }
 
 .param {
-    font-weight: 600;
+  font-weight: 600;
 }
 
 code {
-    padding: 2px 4px;
-    font-size: 90%;
-    color: #39699a;
-    background-color: #f4f4f4;
-    white-space: nowrap;
-    border-radius: 4px;
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #39699a;
+  background-color: #f4f4f4;
+  white-space: nowrap;
+  border-radius: 4px;
 }
 
-.req, .opt {
-    font-family: inherit;
-    color: #c7254e;
-    background-color: #f9f2f4;
-    white-space: nowrap;
-    padding: 2px 4px;
-    border-left: 2px solid #c7254e;
-    border-radius: 4px;
+.req,
+.opt {
+  font-family: inherit;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  white-space: nowrap;
+  padding: 2px 4px;
+  border-left: 2px solid #c7254e;
+  border-radius: 4px;
 }
 
 .opt {
-    background-color: #dff0d8;
-    border-left: 2px solid #3c763d;
-    color: #3c763d;
+  background-color: #dff0d8;
+  border-left: 2px solid #3c763d;
+  color: #3c763d;
 }
 
 .api p {
-    margin: 0;
-    font-size: 16px;
-    line-height: 1.6em;
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.6em;
 }
 
 .missing-outsource-data {
-    background: url(../../img/loading-black.gif) 40px 10px no-repeat;
-    background-size: 20px;
-    background-position: center;
+  background: url(../../img/loading-black.gif) 40px 10px no-repeat;
+  background-size: 20px;
+  background-position: center;
 }
 
 .outsource-btn {
-    border: 1px solid #666;
-    border-radius: 4px;
-    color: white;
-    outline: 0;
-    opacity: 0.9;
-    padding: 0px !important;
-    border: 1px solid #ccc;
-    cursor: pointer;
+  border: 1px solid #666;
+  border-radius: 4px;
+  color: white;
+  outline: 0;
+  opacity: 0.9;
+  padding: 0px !important;
+  border: 1px solid #ccc;
+  cursor: pointer;
 }
 
 .outsource-btn:hover {
-    -moz-box-shadow: 0 0px 2px #666;
-    -webkit-box-shadow: 0 0px 2px #666;
-    box-shadow: 0 0px 2px #666;
+  -moz-box-shadow: 0 0px 2px #666;
+  -webkit-box-shadow: 0 0px 2px #666;
+  box-shadow: 0 0px 2px #666;
 }
 
 .outsource-btn:active .outsource-price {
-    -moz-box-shadow: inset 0 0 5px 2px #888;
-    -webkit-box-shadow: inset 0 0 5px 2px #888;
-    box-shadow: inset 0 0 5px 2px #888;
+  -moz-box-shadow: inset 0 0 5px 2px #888;
+  -webkit-box-shadow: inset 0 0 5px 2px #888;
+  box-shadow: inset 0 0 5px 2px #888;
 }
 
 .outsource-btn:active .outsource-delivery {
-    -moz-box-shadow: inset 0 -1px 2px 1px #888;
-    -webkit-box-shadow: inset 0 -1px 2px 1px #888;
-    box-shadow: inset 0 -1px 2px 1px #888;
+  -moz-box-shadow: inset 0 -1px 2px 1px #888;
+  -webkit-box-shadow: inset 0 -1px 2px 1px #888;
+  box-shadow: inset 0 -1px 2px 1px #888;
 }
 
 .outsource-price {
-    text-align: center;
-    display: block;
-    font-size: 18px;
-    background: #7eaf3e;
-    font-weight: bold;
-    padding: 10px;
+  text-align: center;
+  display: block;
+  font-size: 18px;
+  background: #7eaf3e;
+  font-weight: bold;
+  padding: 10px;
 }
 
 .outsource-delivery {
-    background: #f4f4f4;
-    display: block;
-    padding: 5px;
-    margin-top: -5px;
-    line-height: 18px;
-    font-size: 12px;
-    border-radius: 4px;
-    color: #333;
+  background: #f4f4f4;
+  display: block;
+  padding: 5px;
+  margin-top: -5px;
+  line-height: 18px;
+  font-size: 12px;
+  border-radius: 4px;
+  color: #333;
 
-    border-top: 1px solid #ccc;
-
+  border-top: 1px solid #ccc;
 }
 
 .outsource-delivery strong {
-    font-size: 14px;
+  font-size: 14px;
 }
 
 /* revise page */
 
 .lang-info {
-    margin-top: 40px;
-    margin-left: 10px;
-    color: #666;
-    font-size: 20px;
+  margin-top: 40px;
+  margin-left: 10px;
+  color: #666;
+  font-size: 20px;
 }
 
 .revision-info tr[data-vote='Excellent'],
@@ -415,359 +420,358 @@ code {
 td[data-vote='Excellent'],
 td[data-vote='Verygood'],
 td[data-vote='Good'] {
-    background: #d8ead3;
+  background: #d8ead3;
 }
 
 .revision-info tr[data-vote='Poor'],
 td[data-vote='Poor'] {
-    background: #FDD7A4;
+  background: #fdd7a4;
 }
 
 .revision-info tr[data-vote='Acceptable'],
 td[data-vote='Acceptable'] {
-    background: #fff3cd;
+  background: #fff3cd;
 }
 
 .revision-info tr[data-vote='Fail'],
 td[data-vote='Fail'] {
-    background: #f4cdcc;
+  background: #f4cdcc;
 }
 
 .tablestats.revision {
-    font-size: 18px;
+  font-size: 18px;
 }
 
 .tablestats.revision td,
 .tablestats.revision th {
-    padding: 20px;
+  padding: 20px;
 }
 
 .vote-howto p {
-    font-size: 18px;
-    line-height: 30px;
+  font-size: 18px;
+  line-height: 30px;
 }
 
 .reviselog .percent {
-    font-size: 14px;
+  font-size: 14px;
 }
 
 .details-anchor {
-    display: block;
-    position: relative;
-    top: -60px;
-    visibility: hidden;
+  display: block;
+  position: relative;
+  top: -60px;
+  visibility: hidden;
 }
 
 #details-link {
-    font-size: 16px;
-    color: #999;
-    text-shadow: none;
-    margin-top: 15px;
-    display: block;
-    clear: both;
-    cursor: pointer;
+  font-size: 16px;
+  color: #999;
+  text-shadow: none;
+  margin-top: 15px;
+  display: block;
+  clear: both;
+  cursor: pointer;
 }
 
 #ribbon {
-    padding: .34em 2em;
-    margin: 5% -7px 0;
-    position: relative;
-    color: black;
-    font-size: 24px;
-    z-index: 100000000;
-    font-weight: bold;
-    text-align: center;
-    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
-    /*box-shadow: inset 0px 1px 0px rgba(255,255,255,.3),
+  padding: 0.34em 2em;
+  margin: 5% -7px 0;
+  position: relative;
+  color: black;
+  font-size: 24px;
+  z-index: 100000000;
+  font-weight: bold;
+  text-align: center;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.3);
+  /*box-shadow: inset 0px 1px 0px rgba(255,255,255,.3),
        inset 0px 0px 20px rgba(0,0,0,0.0),
        0px 1px 1px rgba(0, 0, 0, 0.65); */
-    /* background: #09beec; */
-    display: inline-block;
+  /* background: #09beec; */
+  display: inline-block;
 }
 
 #vote-box {
-    width: 217px;
-    background: #f7f7f7;
-    height: 85px;
-    position: absolute;
-    right: 0px;
-    top: 30px;
-    text-align: center;
-    font-size: 45px;
-    font-weight: bold;
-    text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.3);
-    padding: 50px 5px 10px;
-    z-index: 100000000;
-    border-radius: 4px;
-    border: 1px solid #ECECEC;
-    box-shadow: 1px 1px 0px #E6E6E6;
+  width: 217px;
+  background: #f7f7f7;
+  height: 85px;
+  position: absolute;
+  right: 0px;
+  top: 30px;
+  text-align: center;
+  font-size: 45px;
+  font-weight: bold;
+  text-shadow: 0px 1px 0px rgba(0, 0, 0, 0.3);
+  padding: 50px 5px 10px;
+  z-index: 100000000;
+  border-radius: 4px;
+  border: 1px solid #ececec;
+  box-shadow: 1px 1px 0px #e6e6e6;
 }
 
 .vote-area {
-    margin: 0 auto;
-    width: 100%;
-    float: left;
-    padding: 20px 0 30px 0;
+  margin: 0 auto;
+  width: 100%;
+  float: left;
+  padding: 20px 0 30px 0;
 }
 
 .vote-area h3 {
-    clear: both;
+  clear: both;
 }
 
 .blueline {
-    width: 100%;
-    height: 1px;
-    background: #09beec;
-    float: left;
-    box-shadow: 0px 1px 0px #ccc;
+  width: 100%;
+  height: 1px;
+  background: #09beec;
+  float: left;
+  box-shadow: 0px 1px 0px #ccc;
 }
 
 #vote-box[data-vote='Excellent'],
 #vote-box[data-vote='Verygood'],
 #vote-box[data-vote='Good'] {
-    color: #3C9423;
+  color: #3c9423;
 }
 
 #vote-box[data-vote='Acceptable'] {
-    color: #EABA22;
+  color: #eaba22;
 }
 
 #vote-box[data-vote='Poor'] {
-    color: #FFA935;;
+  color: #ffa935;
 }
 
 #vote-box[data-vote='Fail'] {
-    color: #E7504D;
+  color: #e7504d;
 }
 
 table.tablestats.revision-info td,
 table.tablestats.revision-info th {
-    padding: 15px;
-    font-size: 16px;
+  padding: 15px;
+  font-size: 16px;
 }
 
 /* Table Equivalent Translated Score Highlight */
 .qa_eq_tr[data-vote='Excellent'] td,
 .qa_eq_tr[data-vote='Verygood'] td,
 .qa_eq_tr[data-vote='Good'] td {
-    border-color: #3C9423 !important;
+  border-color: #3c9423 !important;
 }
 
 .qa_eq_tr[data-vote='Acceptable'] td {
-    border-color: #E5B007 !important;
+  border-color: #e5b007 !important;
 }
 
 .qa_eq_tr[data-vote='Poor'] td {
-    border-color: #FFA935 !important;
+  border-color: #ffa935 !important;
 }
 
 .qa_eq_tr[data-vote='Fail'] td {
-    border-color: #E7504D !important;
+  border-color: #e7504d !important;
 }
 
 .qa_eq_tr {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .qa_eq_td {
-    font-size: 18px !important;
-    border-top: 1px solid;
-    border-bottom: 1px solid !important;
-    border-left: 0 !important;
+  font-size: 18px !important;
+  border-top: 1px solid;
+  border-bottom: 1px solid !important;
+  border-left: 0 !important;
 }
 
 .qa_eq_td_first {
-    border-left: 4px solid !important;
+  border-left: 4px solid !important;
 }
 
 .qa_eq_td_last {
-    border-right: 4px solid !important;
+  border-right: 4px solid !important;
 }
 
 /* Table Equivalent Translated Score Highlight */
 
 .vote-howto h3 {
-    font-size: 22px;
-    margin-bottom: 20px;
-    font-weight: bold !important;
-    color: #333 !important;
+  font-size: 22px;
+  margin-bottom: 20px;
+  font-weight: bold !important;
+  color: #333 !important;
 }
 
 .vote-howto h2 {
-    margin-top: 20px;
-    margin-bottom: 20px
+  margin-top: 20px;
+  margin-bottom: 20px;
 }
 
 blockquote {
-    padding: 10px 20px;
-    margin: 20px 30px 30px 30px;
-    background: #eee;
-    font-size: 16px;
-    border-left: 5px solid #aaa;
-    width: 700px;
+  padding: 10px 20px;
+  margin: 20px 30px 30px 30px;
+  background: #eee;
+  font-size: 16px;
+  border-left: 5px solid #aaa;
+  width: 700px;
 }
 
 /**
 	QUALITY REPORT
 **/
 .qa-job-title {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .weight-normal {
-    font-weight: normal;
+  font-weight: normal;
 }
 
 .tablestats.revision th.issue {
-    width: 440px;
+  width: 440px;
 }
 
 .tablestats.revision th.score {
-    width: 200px;
+  width: 200px;
 }
 
-.tablestats.revision td, .tablestats.revision-info td {
-    text-align: left;
+.tablestats.revision td,
+.tablestats.revision-info td {
+  text-align: left;
 }
 
 /********* PEE Page ***************/
 .pee-page {
-    min-width: 1000px;
-    overflow: scroll;
+  min-width: 1000px;
+  overflow: scroll;
 }
 .pee-page header {
-    border-bottom: 1px solid #5C5C5C;
-    background-color: #4D4D4D;
-    padding: 0px 0 2px 0;
-    margin-bottom: 20px;
-    height: 45px;
+  border-bottom: 1px solid #5c5c5c;
+  background-color: #4d4d4d;
+  padding: 0px 0 2px 0;
+  margin-bottom: 20px;
+  height: 45px;
 }
 #tablePEE {
-    width: 92%;
-    margin: 0 auto;
-    margin-bottom: 50px;
-    clear: both;
+  width: 92%;
+  margin: 0 auto;
+  margin-bottom: 50px;
+  clear: both;
 }
-.pee-page h1{
-    margin-bottom: 30px;
-    margin-top: 60px;
-    font-size: 40px;
+.pee-page h1 {
+  margin-bottom: 30px;
+  margin-top: 60px;
+  font-size: 40px;
 }
-.pee-page h2{
-    margin-bottom: 30px;
+.pee-page h2 {
+  margin-bottom: 30px;
 }
 .pee.progressbar {
-    height: 20px;
-    position: relative;
-    width: 80%;
-    float: right;
-    padding-left: 20px;
+  height: 20px;
+  position: relative;
+  width: 80%;
+  float: right;
+  padding-left: 20px;
 }
 .pee .progress {
-    background: url(https://www.matecat.com/public/img/progressbar.gif);
-    display: block;
-    height: 20px;
+  background: url(https://www.matecat.com/public/img/progressbar.gif);
+  display: block;
+  height: 20px;
 }
 .labelpee {
-    position: relative;
-    float: left;
-    width: 4%;
-    text-shadow: 0px 0px 2px #fff;
-    text-align: left;
+  position: relative;
+  float: left;
+  width: 4%;
+  text-shadow: 0px 0px 2px #fff;
+  text-align: left;
 }
 
-.pee-page .tablestats.revision td, .tablestats.revision th {
-    padding: 15px 20px;
-    text-overflow: ellipsis;
-    overflow: hidden;
+.pee-page .tablestats.revision td,
+.tablestats.revision th {
+  padding: 15px 20px;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .pee-page .tablesorter-filter-row input {
-    width: 100%;
+  width: 100%;
 }
 .pee-page tr.tablesorter-headerRow th {
-    padding: 15px 0 !important;
+  padding: 15px 0 !important;
 }
 .pee-page th.tablesorter-headerUnSorted {
-    background: #efefef url(https://www.matecat.com/public/img/bg.gif) right center no-repeat !important;
+  background: #efefef url(https://www.matecat.com/public/img/bg.gif) right
+    center no-repeat !important;
 }
 
 .pee-page .tablesorter-filter-row {
-    background: #f4f4f4;
+  background: #f4f4f4;
 }
 
 .pee-page select {
-    width: 100%;
-    height: 23px;
-    background: #fff;
+  width: 100%;
+  height: 23px;
+  background: #fff;
 }
 
 .pee-page div.selectContainer {
-    width: 92%;
-    margin: 0 auto;
+  width: 92%;
+  margin: 0 auto;
 }
 
 .pee-page div.selectContainer .dropdown {
-    width: 200px !important;
+  width: 200px !important;
 }
 
-
-
 .pee-page .notfound {
-    width: 100%;
-    margin: 20px auto;
-    font-size: 26px;
-    font-style: italic;
-    color: #999;
+  width: 100%;
+  margin: 20px auto;
+  font-size: 26px;
+  font-style: italic;
+  color: #999;
 }
 
 .chart-container {
-    width: 1200px;
-    margin: 0 auto;
-    /*height: 500px;*/
-    margin-bottom: 40px;
-    text-align: center;
+  width: 1200px;
+  margin: 0 auto;
+  /*height: 500px;*/
+  margin-bottom: 40px;
+  text-align: center;
 }
 
 .chart-container .ui.segment {
-    /*height: 500px;*/
-    border: none;
-    box-shadow: none;
+  /*height: 500px;*/
+  border: none;
+  box-shadow: none;
 }
 
 .chart-container span {
-    font-size: 18px;
+  font-size: 18px;
 }
 
 .chart-container text {
-    font-size: 12px;
+  font-size: 12px;
 }
 
 .filter-chart-container {
-    width: 1000px;
-    margin: 0 auto;
-    margin-bottom: 40px;
-    /*background: #eee;*/
-    /*border: 1px solid #ccc;*/
-    /*padding: 20px;*/
+  width: 1000px;
+  margin: 0 auto;
+  margin-bottom: 40px;
+  /*background: #eee;*/
+  /*border: 1px solid #ccc;*/
+  /*padding: 20px;*/
 }
 .pee-page .dropdown input {
-    display: inline-block;
+  display: inline-block;
 }
- .filter-chart-container .ui.grid {
-     width: 100%;
-     height: 100%;
-     margin: 0;
- }
+.filter-chart-container .ui.grid {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}
 .pee-page .ui.styled.accordion {
-    width: 100%;
-    background: #eee;
+  width: 100%;
+  background: #eee;
 }
 .pee-page .accordion .title {
-    text-align: right;
+  text-align: right;
 }
 .pee-page .error {
-    float: none;
+  float: none;
 }
 /**********************************/
-
-

--- a/public/css/sass/lexiqa.scss
+++ b/public/css/sass/lexiqa.scss
@@ -1,121 +1,122 @@
-
-
 /*
  ==============================
         Tooltip STYLING
  ==============================
  */
 .lexiqa-tooltip {
+  position: absolute;
+  z-index: 1001;
+  padding: 0 4px;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content; //240px;
+  background-color: #fff;
+  border-radius: 4px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -moz-box-pack: justify;
+  -ms-flex-pack: justify;
+  justify-content: flex-end;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 12px;
+  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  -moz-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  &:after {
+    content: '';
     position: absolute;
-    z-index: 1001;
-    padding: 0 4px;
-    bottom: 32px;
-    left:50%;
-    transform: translateX(-50%);
-    width: max-content; //240px;
-    background-color: #fff;
-    border-radius: 4px;
+    left: 50%;
+    bottom: -10px;
+    box-shadow: 4px 4px 4px 0px rgba(34, 36, 38, 0.12),
+      8px 8px 10px 0px rgba(34, 36, 38, 0.15); //1px 1px 2px 0px rgba(34, 36, 38, 0.12)
+    width: 14px;
+    height: 14px;
+    transform: rotate(45deg) translateX(-50%);
+    background: #ffffff;
+  }
+
+  .tooltip-error-wrapper {
     display: -webkit-box;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
-    -webkit-box-pack: justify;
-    -moz-box-pack: justify;
-    -ms-flex-pack: justify;
-    justify-content: flex-end;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+  .tooltip-error-container {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
     -webkit-box-align: center;
     -webkit-align-items: center;
     -ms-flex-align: center;
     align-items: center;
-    font-size: 12px;
-    -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-    -moz-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-    box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-    &:after {
-        content: '';
-        position: absolute;
-        left: 50%;
-        bottom: -10px;
-        box-shadow: 4px 4px 4px 0px rgba(34, 36, 38, 0.12), 8px 8px 10px 0px rgba(34, 36, 38, 0.15); //1px 1px 2px 0px rgba(34, 36, 38, 0.12)
-        width: 14px;
-        height: 14px;
-        transform: rotate(45deg) translateX(-50%);
-        background: #ffffff;
+    -webkit-box-pack: justify;
+    -moz-box-pack: justify;
+    -ms-flex-pack: justify;
+    justify-content: space-between;
+    width: 100%;
+    line-height: 1.45;
+    /*border-bottom: 1px solid #fff;*/
+    .tooltip-error-category {
+      padding: 0.5rem;
+      max-width: 148px;
+      &::first-letter {
+        text-transform: capitalize;
+      }
     }
-
-    .tooltip-error-wrapper {
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-box-orient: vertical;
-        -webkit-box-direction: normal;
-        -webkit-flex-direction: column;
-        -ms-flex-direction: column;
-        flex-direction: column;
-        -webkit-flex-wrap: wrap;
-        -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
-        width: 100%;
+    .tooltip-error-ignore {
+      color: #757575;
+      text-decoration: none;
+      cursor: pointer;
+      border-radius: 0 4px 4px 0;
+      padding-left: 10px;
+      height: 40px;
+      &:hover {
+        color: #525252;
+      }
+      .icon-cancel-circle:before {
+        line-height: 40px;
+        float: left;
+        font-size: 18px;
+      }
+      .tooltip-error-ignore-text {
+        margin-left: 5px;
+        margin-right: 10px;
+        float: left;
+        line-height: 40px;
+      }
     }
-    .tooltip-error-container {
-        display: -webkit-box;
-        display: -webkit-flex;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-box-orient: horizontal;
-        -webkit-box-direction: normal;
-        -webkit-flex-direction: row;
-        -ms-flex-direction: row;
-        flex-direction: row;
-        -webkit-flex-wrap: wrap;
-        -ms-flex-wrap: wrap;
-        flex-wrap: wrap;
-        -webkit-box-align: center;
-        -webkit-align-items: center;
-        -ms-flex-align: center;
-        align-items: center;
-        -webkit-box-pack: justify;
-        -moz-box-pack: justify;
-        -ms-flex-pack: justify;
-        justify-content: space-between;
-        width: 100%;
-        line-height: 1.45;
-        /*border-bottom: 1px solid #fff;*/
-        .tooltip-error-category {
-            padding: 0.5rem;
-            max-width: 148px;
-            &::first-letter {
-                text-transform: capitalize;
-            }
-        }
-        .tooltip-error-ignore {
-            color: #757575;
-            text-decoration: none;
-            cursor: pointer;
-            border-radius: 0 4px 4px 0;
-            padding-left: 10px;
-            height: 40px;
-            &:hover {
-                color: #525252;
-            }
-            .icon-cancel-circle:before {
-                line-height: 40px;
-                float: left;
-                font-size: 18px;
-            }
-            .tooltip-error-ignore-text {
-                margin-left: 5px;
-                margin-right: 10px;
-                float: left;
-                line-height: 40px;
-            }
-        }
-        &:not(:first-child) {
-            border-top: 1px solid rgba(255, 255, 255, 0.36);
-        }
-
+    &:not(:first-child) {
+      border-top: 1px solid rgba(255, 255, 255, 0.36);
     }
+  }
 }
 /*
  ==============================
@@ -123,70 +124,75 @@
  ==============================
  */
 .lexiqahighlight {
-    display: inline-block;
-    position: relative;
-    /*
+  display: inline-block;
+  position: relative;
+  /*
      ******
      Display and visibility helpers
      ******
      */
-    .lxq-hide {
-        display: none !important;
-    }
+  .lxq-hide {
+    display: none !important;
+  }
 
-    .lxq-visible {
-        display: block !important;
-    }
+  .lxq-visible {
+    display: block !important;
+  }
 
-    .n0 {
-        background-color: #D08053;
-    }
+  .n0 {
+    background-color: #d08053;
+  }
 
-    .p0 {
-        background-color: #65C783
-    }
+  .p0 {
+    background-color: #65c783;
+  }
 
-    .c0 {
-        background-color: #65C783;
-    }
+  .c0 {
+    background-color: #65c783;
+  }
 
-    .u0 {
-        background-color: #b8a300;
-    }
+  .u0 {
+    background-color: #b8a300;
+  }
 
-    .s0 {
-        background-color: #38C0C5;
-    }
+  .s0 {
+    background-color: #38c0c5;
+  }
 
-    .l0 {
-        background-color: #B792E6;
-    }
+  .l0 {
+    background-color: #b792e6;
+  }
 
-    .b0 {
-        text-decoration: line-through;
-    }
+  .b0 {
+    text-decoration: line-through;
+  }
 
-    .g0 {
-        text-decoration: underline;
-    }
+  .g0 {
+    text-decoration: underline;
+  }
 
-    .d0 {
-        border-bottom: 2px red dotted;
-    }
+  .d0 {
+    border-bottom: 2px red dotted;
+  }
 
-    .o0 {
-        background-color: rgba(#209FAA, .75);
-    }
+  .o0 {
+    background-color: rgba(#209faa, 0.75);
+  }
 
-    .m {
-        background-color: #EA92B8;
-    }
+  .m {
+    background-color: #ea92b8;
+  }
 
-    .m, .l0, .p0, .c0, .u0, .s0 .g0 {
-        padding: 0.1rem 0.2rem;
-    }
+  .m,
+  .l0,
+  .p0,
+  .c0,
+  .u0,
+  .s0 .g0 {
+    padding: 0.1rem 0.2rem;
+  }
 
-    /*.m, .l1, .l2, .l3, .l4, .n1, .n2, .n3, .n4, .p1, .p2, .p2sub1, .p2sub2, .p3, .p3sub1, .p4, .p5, .p6, .p7, .p8,
+  /*.m, .l1, .l2, .l3, .l4, .n1, .n2, .n3, .n4, .p1, .p2, .p2sub1, .p2sub2, .p3, .p3sub1, .p4, .p5, .p6, .p7, .p8,
     .c1, .c2, .c3, .c2sub1, .c3sub1, .c4, .c5, .u1, .u2, .u3, .u4, .u5, .s1, .s2, .s3, .s3sub1, .s3sub1, .s4, .s5 {
         padding: 0.1rem 0.2rem;
     }*/

--- a/public/css/sass/main.scss
+++ b/public/css/sass/main.scss
@@ -1,9 +1,9 @@
-@import "vendor_mc/semantic/matecat_semantic";
-@import "vendor_mc/jquery.atwho";
-@import "commons/colors";
-@import "commons/matecat_fonts";
-@import "commons/icons";
-@import "commons/buttons";
+@import 'vendor_mc/semantic/matecat_semantic';
+@import 'vendor_mc/jquery.atwho';
+@import 'commons/colors';
+@import 'commons/matecat_fonts';
+@import 'commons/icons';
+@import 'commons/buttons';
 @import 'common-main';
 @import 'style';
 @import 'mbc-style';
@@ -14,18 +14,18 @@
 @import 'components/header/segmentsFilter';
 @import 'revise';
 //components
-@import "components/segment/segment";
-@import "components/segment/segmentFooter";
-@import "components/segment/issuesContainer";
-@import "components/segment/tagsMenu";
-@import "components/segment/Tag";
-@import "components/segment/TooltipInfo";
-@import "components/segment/Glossary";
-@import "components/segment/Editor";
-@import "components/bulk-approve-bar/bulk_approve_bar";
-@import "components/header/search";
-@import "components/header/qaComponent";
-@import "components/header/header";
+@import 'components/segment/segment';
+@import 'components/segment/segmentFooter';
+@import 'components/segment/issuesContainer';
+@import 'components/segment/tagsMenu';
+@import 'components/segment/Tag';
+@import 'components/segment/TooltipInfo';
+@import 'components/segment/Glossary';
+@import 'components/segment/Editor';
+@import 'components/bulk-approve-bar/bulk_approve_bar';
+@import 'components/header/search';
+@import 'components/header/qaComponent';
+@import 'components/header/header';
 
 @import 'cattool';
 

--- a/public/css/sass/manage_main.scss
+++ b/public/css/sass/manage_main.scss
@@ -1,27 +1,25 @@
-@import "vendor_mc/semantic/matecat_semantic";
+@import 'vendor_mc/semantic/matecat_semantic';
 
-@import "commons/colors";
-@import "commons/matecat_fonts";
-@import "commons/filter-teams";
-@import "commons/nav-bar";
-@import "commons/icons";
-@import "commons/project";
-@import "commons/shadows";
-@import "commons/divider";
-@import "commons/progress-mc-bar";
-@import "commons/buttons";
-@import "popup";
+@import 'commons/colors';
+@import 'commons/matecat_fonts';
+@import 'commons/filter-teams';
+@import 'commons/nav-bar';
+@import 'commons/icons';
+@import 'commons/project';
+@import 'commons/shadows';
+@import 'commons/divider';
+@import 'commons/progress-mc-bar';
+@import 'commons/buttons';
+@import 'popup';
 
 //libs: move it?
 @import '../libs/calendar.css';
 
 @import 'common-modals';
 @import 'modals/split_modal';
-@import "notifications";
-@import "commons/sub-header";
-@import "commons/team-member";
-@import "commons/manage";
-@import "commons/outsource";
-@import "commons/date-picker-translator";
-
-
+@import 'notifications';
+@import 'commons/sub-header';
+@import 'commons/team-member';
+@import 'commons/manage';
+@import 'commons/outsource';
+@import 'commons/date-picker-translator';

--- a/public/css/sass/mbc-style.scss
+++ b/public/css/sass/mbc-style.scss
@@ -26,9 +26,8 @@
  ******
  */
 .mbc-reply-input {
-    background: #ffffff;
+  background: #ffffff;
 }
-
 
 /*
  ******
@@ -72,8 +71,8 @@
  ******
  */
 .mbc-thread-wrap-resolved {
-  background: rgba(124,197,118,.15);
-  border-bottom: 2px solid rgba(124,197,118,.6); /* $approvedGreen */
+  background: rgba(124, 197, 118, 0.15);
+  border-bottom: 2px solid rgba(124, 197, 118, 0.6); /* $approvedGreen */
 }
 
 /*
@@ -126,7 +125,6 @@
   word-wrap: break-word;
 }
 
-
 /*
  ******
  New incoming message notification
@@ -134,7 +132,7 @@
  */
 
 .mbc-new-message-notification {
-  background-color: #FFF9CC;
+  background-color: #fff9cc;
   color: #6d6e71;
   font-size: 14px;
   left: 0;
@@ -162,7 +160,6 @@ a.mbc-new-message-link:hover {
   padding: 0 6px 0 0;
 }
 
-
 /*
  ******
  ******
@@ -187,34 +184,34 @@ a.mbc-new-message-link:hover {
   border: 1px solid #dedede;
   box-shadow: inset 0 1px 2px #ccc;
   -webkit-box-shadow: inset 0 1px 2px #ccc;
-    min-height: 40px;
-    overflow-y: auto;
-    max-height: 160px;
-    border-radius: 20px;
+  min-height: 40px;
+  overflow-y: auto;
+  max-height: 160px;
+  border-radius: 20px;
   padding-top: 10px;
   padding-bottom: 10px;
 }
 
-.mbc-comment-textarea:hover{
+.mbc-comment-textarea:hover {
   border-color: rgba(34, 36, 38, 0.35);
   box-shadow: none;
 }
 .mbc-comment-textarea:focus {
-  border: 1px solid #96C8DA;
-  box-shadow: inset 0px 0px 2px 2px #96C8DA;
+  border: 1px solid #96c8da;
+  box-shadow: inset 0px 0px 2px 2px #96c8da;
   padding-top: 10px;
   padding-bottom: 10px;
 }
 
 .mbc-comment-textarea:empty:not(:focus):before {
-    content: attr(data-placeholder);
-    color: #999;
-    position: absolute;
-    top: 10px;
+  content: attr(data-placeholder);
+  color: #999;
+  position: absolute;
+  top: 10px;
 }
 
 .tagging-item {
-    color: $translatedBlue;
+  color: $translatedBlue;
 }
 
 .mbc-comment-textinput {
@@ -354,9 +351,15 @@ a:active.mbc-comment-default-btn {
  */
 a.mbc-comment-send-btn:link,
 a.mbc-comment-send-btn:visited {
-  background: -webkit-gradient(linear, left top, left bottom, from($translatedBlue), to(#119ec4));
-  background: -moz-linear-gradient(top,  $translatedBlue,  #119ec4);
-  background: linear-gradient(top,  $translatedBlue,  #119ec4);
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from($translatedBlue),
+    to(#119ec4)
+  );
+  background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
+  background: linear-gradient(top, $translatedBlue, #119ec4);
   border: 1px solid #848689;
   color: #fff;
 }
@@ -388,7 +391,8 @@ a.mbc-comment-resolve-btn:visited {
 
 a.mbc-comment-resolve-btn:hover,
 a.mbc-comment-resolve-btn:active {
-  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.24) !important;
 }
 
 /*
@@ -439,13 +443,12 @@ a.mbc-view-link:visited {
  */
 .mbc-nth-comment-label {
   display: block;
-  border-bottom: 1px solid #CCCCCC;
+  border-bottom: 1px solid #cccccc;
   font-size: 16px;
-  color: #9A9A9A;
+  color: #9a9a9a;
   line-height: 1.8;
   margin-bottom: 6px;
 }
-
 
 /*
  ******
@@ -460,7 +463,7 @@ a.mbc-close-icon:link,
 a.mbc-close-icon:visited {
   background: #fff;
   border-radius: 20px;
-  color: #AEAEAE;
+  color: #aeaeae;
   display: block;
   font-size: 15px;
   height: 14px;
@@ -479,16 +482,14 @@ a.mbc-close-icon:hover {
   text-align: center;
 }
 
-
 .mbc-close-icon:before {
-  content: "\ea0d";
+  content: '\ea0d';
   display: block;
   margin-left: -1px;
   margin-top: 0px;
   text-align: center;
   vertical-align: middle;
 }
-
 
 /*
  ******
@@ -512,7 +513,6 @@ a.mbc-close-icon:hover {
   display: block !important;
   top: 0px;
 }
-
 
 /*
  ******
@@ -578,7 +578,7 @@ a.mbc-close-icon:hover {
  Highlight element in header unique properties
  */
 .mbc-comment-highlight-history {
-  color:#6d6e71;
+  color: #6d6e71;
   position: absolute;
   right: 7px;
   top: 10px;
@@ -596,7 +596,6 @@ a.mbc-close-icon:hover {
   float: right;
 }
 
-
 /*
  ******
  ******
@@ -605,14 +604,12 @@ a.mbc-close-icon:hover {
  ******
  */
 
-
-
 /*
  ******
  Commenting opened. Article width reduced and room made for comment ballon
  ******
  */
-article section{
+article section {
   //-webkit-backface-visibility: hidden;
   //-webkit-transition: width .2s ease;
   //transition: width .2s ease;
@@ -645,10 +642,9 @@ article .mbc-comment-balloon-outer {
 }
 /* Warnings style.css line 136 */
 .mbc-warnings {
-  color:#D65959;
-  font-size:14px;
+  color: #d65959;
+  font-size: 14px;
 }
-
 
 /*
  ******
@@ -668,18 +664,18 @@ article .mbc-comment-balloon-outer {
   text-align: center;
   width: 45px;
   &.open svg {
-      opacity: 1;
+    opacity: 1;
   }
   &.mbc-history-balloon-icon-has-no-comments {
-      opacity: 0.4;
-      cursor: default;
-      pointer-events: none;
+    opacity: 0.4;
+    cursor: default;
+    pointer-events: none;
   }
 }
 
 #mbc-history:hover {
   /* #filterSwitch:hover line 86 style.css */
-  color:#ccc;
+  color: #ccc;
 }
 
 /*
@@ -691,8 +687,8 @@ article .mbc-comment-balloon-outer {
  */
 
 .mbc-history-balloon-outer {
-  background-color: rgba(247,247,247,1); /* #f7f77f */
-  box-shadow: 0 8px 16px rgba(0,0,0,0.3);
+  background-color: rgba(247, 247, 247, 1); /* #f7f77f */
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
   margin-top: 20px;
   padding-top: 10px;
   position: absolute;
@@ -714,7 +710,7 @@ article .mbc-comment-balloon-outer {
 }
 
 .mbc-history-balloon {
-  background-color: rgba(247,247,247,1); /* #ffffff */
+  background-color: rgba(247, 247, 247, 1); /* #ffffff */
   padding: 0;
   position: relative;
 }
@@ -735,7 +731,6 @@ article .mbc-comment-balloon-outer {
   max-height: 500px;
   overflow-y: auto;
 }
-
 
 /*
  ******
@@ -774,11 +769,11 @@ article .mbc-comment-balloon-outer {
 
 .divider {
   background-color: #dadada;
-  display:block; /* for use on default inline elements like span */
+  display: block; /* for use on default inline elements like span */
   height: 1px;
   margin: 0;
   overflow: hidden;
-  width:100%;
+  width: 100%;
 }
 
 /*
@@ -795,14 +790,13 @@ article .mbc-comment-balloon-outer {
  Triangle top top in history balloon
  */
 .mbc-triangle-top {
-  border-right: 14px solid rgba(247,247,247,1); /* #f7f77f */
+  border-right: 14px solid rgba(247, 247, 247, 1); /* #f7f77f */
   border-top: 14px solid transparent;
-  -webkit-filter: drop-shadow(-3px -1px 2px rgba(0,0,0,0.1));
-  filter: drop-shadow(-3px -1px 2px rgba(0,0,0,0.1));
+  -webkit-filter: drop-shadow(-3px -1px 2px rgba(0, 0, 0, 0.1));
+  filter: drop-shadow(-3px -1px 2px rgba(0, 0, 0, 0.1));
   float: right;
   margin-right: 20px;
   margin-top: -24px;
-
 }
 
 /*
@@ -829,7 +823,6 @@ section.editor .mbc-triangle.mbc-triangle-topleft {
   filter: drop-shadow(-2px 0px 1px rgba(0, 0, 0, 0.2));
   margin-left: -14px;
   position: absolute;
-
 }
 
 .mbc-open-view.mbc-re-messages {
@@ -840,7 +833,6 @@ section.editor .mbc-triangle.mbc-triangle-topleft {
   border-left: 14px solid transparent;
   filter: drop-shadow(-1px 2px 1px rgba(0, 0, 0, 0.2));
 }
-
 
 /*
 **********
@@ -881,7 +873,6 @@ Close icon ballon - Right panel
   right: -15px;
 }
 
-
 /*
  ******
  Clearfix helpers
@@ -893,7 +884,7 @@ Close icon ballon - Right panel
 .mbc-clearfix:before,
 .mbc-clearfix:after {
   display: table;
-  content: "";
+  content: '';
   line-height: 0;
 }
 
@@ -907,11 +898,11 @@ Close icon ballon - Right panel
  ******
  */
 .mbc-hide {
-  display: none!important;
+  display: none !important;
 }
 
 .mbc-visible {
-  display: block!important;
+  display: block !important;
 }
 /*
  ******
@@ -919,20 +910,17 @@ Close icon ballon - Right panel
  ******
  */
 
-
 .mbc-comment-icon-button {
-    visibility: hidden;
-    display:block;
+  visibility: hidden;
+  display: block;
 }
 .mbc-comment-icon-button.has-object {
-    visibility: visible;
-    display:block;
+  visibility: visible;
+  display: block;
 }
 
 section:hover .mbc-comment-icon-button,
 .segment-side-buttons:hover .mbc-comment-icon-button,
-.mbc-comment-icon-button:hover
- {
-    visibility: visible;
+.mbc-comment-icon-button:hover {
+  visibility: visible;
 }
-

--- a/public/css/sass/modals/instructionsModal.scss
+++ b/public/css/sass/modals/instructionsModal.scss
@@ -17,7 +17,7 @@
     border-radius: 0px;
     margin-bottom: 20px;
     .title {
-      color:  #666;
+      color: #666;
       &:hover {
         color: #000;
       }
@@ -32,15 +32,13 @@
           display: block;
           float: right;
         }
-
       }
-
     }
     .transition {
       line-height: 25px;
       padding-left: 72px;
       p {
-        line-height: 26px ;
+        line-height: 26px;
         word-break: break-all;
       }
     }
@@ -60,6 +58,4 @@
   .description {
     margin: 10px 20px 0 20px;
   }
-
-
 }

--- a/public/css/sass/modals/language-selector.scss
+++ b/public/css/sass/modals/language-selector.scss
@@ -1,24 +1,22 @@
 /* Language Selector Modal */
 
 #matecat-modal-languages {
-
   $light-blue: $translatedBlue;
   $medium-blue: $linkBlue;
   $dark-blue: $darkBlue;
 
-  $placeholder-gray: #CDD4DE;
+  $placeholder-gray: #cdd4de;
   $btn-shadow-gray: $grey1;
   $btn-hover-blue: $translatedBlueHover;
 
-  $light-gray: $grey3 ;
+  $light-gray: $grey3;
   $medium-gray: $grey2;
   $dark-gray: $grey1;
 
-
   /* Modal */
   .matecat-modal {
-    button:focus{
-      border: 1px solid $translatedBlue
+    button:focus {
+      border: 1px solid $translatedBlue;
     }
   }
 
@@ -40,7 +38,6 @@
     .close-matecat-modal {
       padding-bottom: 9px;
     }
-
   }
 
   /* Modal Subheader */
@@ -69,7 +66,6 @@
       }
 
       .language-search {
-
         display: flex;
         align-items: center;
         width: 100%;
@@ -83,7 +79,7 @@
           cursor: text;
         }
 
-        input[type=text] {
+        input[type='text'] {
           border: none;
           margin: 0;
           padding: 6px 8px;
@@ -99,9 +95,9 @@
         /* Tag chips */
         .react-tagsinput {
           width: 100%;
-          &>span{
+          & > span {
             display: inline-block;
-            &>*{
+            & > * {
               margin-top: 2px;
               margin-bottom: 2px;
             }
@@ -126,7 +122,7 @@
             margin: 0 0 0 4px;
             cursor: pointer;
           }
-          &.highlightDelete{
+          &.highlightDelete {
             background: $light-blue;
             color: #ffffff;
             .react-tagsinput-remove {
@@ -152,7 +148,7 @@
   .matecat-modal-footer {
     overflow: auto;
     height: 72px;
-    background: #FFF;
+    background: #fff;
     border-top: 1px solid $medium-gray;
     padding: 8px 16px 8px 32px;
 
@@ -181,7 +177,6 @@
         font-size: 0.9rem;
         color: #fff;
         line-height: 1;
-
       }
 
       /* Label */
@@ -191,7 +186,6 @@
         text-transform: uppercase;
       }
     }
-
   }
 
   /* Columns */
@@ -220,7 +214,7 @@
 
         &.selected {
           background: $dark-blue;
-          color: #FFF;
+          color: #fff;
         }
         &:not(.selected) .check {
           display: none;
@@ -236,7 +230,7 @@
             position: absolute;
             left: 14px;
             top: 12px;
-            content: "";
+            content: '';
             border-style: solid;
             border-width: 5px 0 5px 5px;
             border-color: transparent transparent transparent $medium-blue;
@@ -254,7 +248,6 @@
     margin: 4px 8px;
     cursor: pointer;
 
-
     &:focus {
       outline: none;
     }
@@ -268,18 +261,17 @@
 
     &.secondary {
       min-width: 100px;
-
     }
 
     &.blue {
       background: $light-blue;
       border: 1px solid $light-blue;
       color: #fff;
-      &:hover{
+      &:hover {
         background-color: $btn-hover-blue;
         //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
       }
-      &:focus{
+      &:focus {
         box-shadow: none;
         border: 1px solid $dark-blue;
       }
@@ -289,14 +281,12 @@
       background: #fff;
       color: #000;
       border: 1px solid $medium-gray;
-      &:focus{
+      &:focus {
         border: 1px solid $light-blue;
       }
-      &:hover{
+      &:hover {
         background-color: $grey3;
       }
     }
   }
-
-
 }

--- a/public/css/sass/modals/split_modal.scss
+++ b/public/css/sass/modals/split_modal.scss
@@ -1,403 +1,401 @@
 /*Split modal*/
 .popup-split {
-    box-sizing: content-box;
-    .popup#split-modal-cont {
-        margin: 0 auto;
-        position: relative;
-        padding: 0 0 0 0;
-        left: 0;
-        top: 0;
-        background: $grey3;
-        border-radius: 0 0 4px 4px;
-        text-align: left;
-        border: 1px solid #666;
-        min-width: 670px;
+  box-sizing: content-box;
+  .popup#split-modal-cont {
+    margin: 0 auto;
+    position: relative;
+    padding: 0 0 0 0;
+    left: 0;
+    top: 0;
+    background: $grey3;
+    border-radius: 0 0 4px 4px;
+    text-align: left;
+    border: 1px solid #666;
+    min-width: 670px;
+  }
+  .popup .splitbtn-cont {
+    //margin-left: 10px;
+    margin-top: 20px;
+    //width: 100%;
+    .popup-split-job-id {
+      font-weight: 100;
+      font-size: 16px;
+      color: $grey1;
+      margin-right: 5px;
     }
-    .popup .splitbtn-cont {
-        //margin-left: 10px;
-        margin-top: 20px;
-        //width: 100%;
-        .popup-split-job-id {
-            font-weight: 100;
-            font-size: 16px;
-            color: $grey1;
-            margin-right: 5px;
-        }
-    }
+  }
 
-    .error-count {
-        padding: 0;
-        margin-top: 0px;
-        margin-right: 15px !important;
-        font-size: 18px;
-        text-align: right;
-        color: #d65757 !important;
-        display: block;
-        line-height: 13px !important;
-    }
-    .error-number .error-count {
-        display: block;
+  .error-count {
+    padding: 0;
+    margin-top: 0px;
+    margin-right: 15px !important;
+    font-size: 18px;
+    text-align: right;
+    color: #d65757 !important;
+    display: block;
+    line-height: 13px !important;
+  }
+  .error-number .error-count {
+    display: block;
+  }
+  .error-count.current {
+    color: black !important;
+  }
+  .splitbtn-cont {
+    overflow: hidden;
+    font-size: 18px;
+    color: $grey1;
+    font-weight: bold;
+  }
+  .jobcontainer.splitted .splitbtn-cont {
+    display: none;
+  }
+  .splitbtn-cont .label {
+    padding: 5px 10px;
+  }
 
+  .nosplit {
+    float: right;
+    font-size: 20px;
+    color: $grey1;
+    display: none;
+    margin: 45px 140px 0 0;
+  }
+  .jobcontainer.splitted .nosplit {
+    display: block;
+  }
+  .btnsplit {
+    float: right;
+    margin: 0 auto;
+    padding: 20px 0 20px 0;
+    overflow: hidden;
+    .primary {
+      font-family: Calibri, Arial, Helvetica, sans-serif;
+      //padding: 11px 22px;
+      vertical-align: top;
+      //font-size: 18px;
+      //border: 1px solid #797979;
+      border-radius: 2px;
+      float: right;
     }
-    .error-count.current {
-        color: black !important;
-    }
-    .splitbtn-cont {
-        overflow: hidden;
-        font-size: 18px;
-        color: $grey1;
-        font-weight: bold;
-    }
-    .jobcontainer.splitted .splitbtn-cont {
-        display: none;
-    }
-    .splitbtn-cont .label {
-        padding: 5px 10px;
-    }
-
-    .nosplit {
-        float: right;
-        font-size: 20px;
-        color: $grey1;
-        display: none;
-        margin: 45px 140px 0 0;
-    }
-    .jobcontainer.splitted .nosplit {
-        display: block;
-    }
-    .btnsplit {
-        float: right;
-        margin: 0 auto;
-        padding: 20px 0 20px 0;
-        overflow: hidden;
-        .primary {
-            font-family: Calibri, Arial, Helvetica, sans-serif;
-            //padding: 11px 22px;
-            vertical-align: top;
-            //font-size: 18px;
-            //border: 1px solid #797979;
-            border-radius: 2px;
-            float: right;
-        }
-        .cancel-button {
-            font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-            //font-size: 18px;
-            margin-top: 0;
-            border: 1px solid $grey1;
-            border-radius: 2px;
-            //padding: 11px 22px;
-            background-color: #fff;
-            margin-right: 15px;
-            color: $grey1;
-            &:hover {
-                background-color: $grey3;
-                //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-            }
-            &:focus {
-                box-shadow: none;
-            }
-        }
-    }
-    .none {
-        display: none;
-    }
-
-
-    input[type="text"][disabled] {
-        background: #f0f0f0;
-    }
-
-    h2 {
-        font-size: 24px !important;
-        font-weight: bold !important;
-        padding: 0;
-        margin: 15px 10px !important;
-        margin-bottom: 21px !important;
-    }
-
-    h3 {
-        font-size: 20px !important;
-        font-weight: bold !important;
-        color: #333 !important;
-        width: 48%;
-        display: inline-block;
-        padding-left: 25px;
-        vertical-align: text-top;
-    }
-
-    h4 {
-        font-size: 18px;
-    }
-
-    .container-split-select {
-        display: inline-block;
-        text-align: right;
-        width: 45%;
-        position: relative;
-        top: 2px;
-        .label {
-            display: inline-block;
-        }
-        .splitselect {
-            width: auto;
-            height: 37px;
-            padding: 4px;
-            color: $grey1;
-            font-size: 18px;
-            border: 1px solid $grey1;
-            box-sizing: border-box;
-            display: inline-block;
-            background: white;
-            border-radius: 6px;
-        }
-
-    }
-
-    .splitbtn:before {
-        content: "\f065";
-        margin-right: 3px;
-        font-family: 'icomoon';
-        speak: none;
-        font-style: normal;
-        font-weight: normal;
-        font-variant: normal;
-        text-transform: none;
-        line-height: 1;
-        -webkit-font-smoothing: antialiased;
-    }
-
-
-    .popup-split-project-title {
-        display: none;
-    }
-
-    .splitbtn-cont.disabled {
-        background: none;
-        border: none;
-        opacity: 1 !important;
-    }
-    .disabled, .disabled:hover, .disabled:active {
-        opacity: 0.5 !important;
-        cursor: default;
-        -moz-box-shadow: none;
-        -webkit-box-shadow: none;
-        border: 1px solid $grey1;
-        background: #ccc;
-    }
-
-
-    .uploadbtn {
-        float: right;
-    }
-
-    .split-box2 {
-        display: none;
-        width: 670px;
-        margin: 0 auto;
-        position: fixed;
-        padding: 0px 0 0px 0;
-        top: 50%;
-        left: 50%;
-        margin: -300px 0 0 -350px;
-        z-index: 999999;
-        background: #fff;
-        box-shadow: 0px 0px 25px #000;
-        border-radius: 2px;
-        text-align: left;
-        font-size: 18px;
-        border: 1px solid $grey1;
-    }
-    .split-box3 .input, .split-box2 .input {
-        font-size: 16px;
-        width: 20px;
-        margin-top: -1px;
-        text-align: center;
-    }
-    .split-box3 {
-        margin: 5px 15px;
-    }
-    .split-box3 .jobs {
-        list-style: none;
-        padding: 0;
-        overflow-y: auto;
-        max-height: 325px;
-        width: 645px;
-        margin-top: 20px;
-    }
-
-    .input-small {
-        height: 20px;
-        float: left;
-        text-align: right;
-        width: 70px;
-        margin-right: 0px;
-        padding: 6px 5px 5px 5px;
-        font-size: 18px;
-        background: #fdfdfd;
-        background-size: 13px 11px;
-        box-sizing: content-box;
-        border: 1px solid #ccc;
-        border-radius: 6px;
-        box-shadow: inset 0 1px 3px #ddd;
-    }
-
-    .btn-cancel {
-        padding: 2px 15px !important;
-    }
-
-    .split-box3 .jobs li {
-        float: left;
-        margin: 0px 0 10px 0;
-        padding: 0px;
-        width: 99%;
-        border-radius: 0px;
-        background: #ffffff;
+    .cancel-button {
+      font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+      //font-size: 18px;
+      margin-top: 0;
+      border: 1px solid $grey1;
+      border-radius: 2px;
+      //padding: 11px 22px;
+      background-color: #fff;
+      margin-right: 15px;
+      color: $grey1;
+      &:hover {
+        background-color: $grey3;
         //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+      }
+      &:focus {
+        box-shadow: none;
+      }
     }
+  }
+  .none {
+    display: none;
+  }
 
-    .split-box3 .jobs li.void {
-        border: 1px solid red !important;
-    }
-    .error-perc {
-        float: left;
-        width: 82%;
-        margin: 25px 0 -20px 20px;
-        text-align: right;
-        color: #FF0000;
-        font-size: 12px
-    }
+  input[type='text'][disabled] {
+    background: #f0f0f0;
+  }
 
-    .error-message {
-        background: #d65757;
-        color: #fff;
-        margin: 0 0 10px 0;
-        float: left;
-        font-weight: bold;
-        width: 100%;
-        -moz-border-radius: 2px;
-        border-radius: 2px;
-        border: 1px solid #c45f5f;
-        margin-top: 10px;
-    }
+  h2 {
+    font-size: 24px !important;
+    font-weight: bold !important;
+    padding: 0;
+    margin: 15px 10px !important;
+    margin-bottom: 21px !important;
+  }
 
-    .jobcontainer {
-        padding-bottom: 50px;
-        border-bottom: 1px dashed #ccc;
-    }
+  h3 {
+    font-size: 20px !important;
+    font-weight: bold !important;
+    color: #333 !important;
+    width: 48%;
+    display: inline-block;
+    padding-left: 25px;
+    vertical-align: text-top;
+  }
 
-    div.wrapper div:last-child {
-        border: none;
-    }
+  h4 {
+    font-size: 18px;
+  }
 
-    .error-message p {
-        padding: 0 10px 0 10px;
-        line-height: 40px !important;
-
+  .container-split-select {
+    display: inline-block;
+    text-align: right;
+    width: 45%;
+    position: relative;
+    top: 2px;
+    .label {
+      display: inline-block;
     }
-
-    .error-message p:before {
-        font-family: 'icomoon';
-        speak: none;
-        font-style: normal;
-        font-weight: normal;
-        font-variant: normal;
-        text-transform: none;
-        line-height: 1;
-        -webkit-font-smoothing: antialiased;
-        content: "\f071";
-        margin-right: 10px;
+    .splitselect {
+      width: auto;
+      height: 37px;
+      padding: 4px;
+      color: $grey1;
+      font-size: 18px;
+      border: 1px solid $grey1;
+      box-sizing: border-box;
+      display: inline-block;
+      background: white;
+      border-radius: 6px;
     }
+  }
 
-    .jobs h4 {
-        margin: 11px 0 0 10px;
-        float: left;
-        line-height: 30px;
-    }
-    .job-details {
-        float: right;
-    }
-    .job-perc {
-        color: #999;
-        margin: 0;
-        float: left;
-        padding: 10px;
-        font-size: 18px;
-        color: #000;
-        text-align: right;
-    }
-    .job-perc p {
-        float: left;
-        font-size: 14px;
-        margin: 1px 6px 0 3px !important;
-        padding: 0;
-        line-height: 30px !important;
-    }
+  .splitbtn:before {
+    content: '\f065';
+    margin-right: 3px;
+    font-family: 'icomoon';
+    speak: none;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+  }
 
-    .total .wordsum {
-        font-size: 20px;
-        color: $grey1;
-        text-align: right;
-        margin-right: 15px;
-        margin-top: 10px;
-        padding: 0;
-        line-height: 13px;
-        font-weight: bold;
-        span {
-            color: black;
-        }
+  .popup-split-project-title {
+    display: none;
+  }
+
+  .splitbtn-cont.disabled {
+    background: none;
+    border: none;
+    opacity: 1 !important;
+  }
+  .disabled,
+  .disabled:hover,
+  .disabled:active {
+    opacity: 0.5 !important;
+    cursor: default;
+    -moz-box-shadow: none;
+    -webkit-box-shadow: none;
+    border: 1px solid $grey1;
+    background: #ccc;
+  }
+
+  .uploadbtn {
+    float: right;
+  }
+
+  .split-box2 {
+    display: none;
+    width: 670px;
+    margin: 0 auto;
+    position: fixed;
+    padding: 0px 0 0px 0;
+    top: 50%;
+    left: 50%;
+    margin: -300px 0 0 -350px;
+    z-index: 999999;
+    background: #fff;
+    box-shadow: 0px 0px 25px #000;
+    border-radius: 2px;
+    text-align: left;
+    font-size: 18px;
+    border: 1px solid $grey1;
+  }
+  .split-box3 .input,
+  .split-box2 .input {
+    font-size: 16px;
+    width: 20px;
+    margin-top: -1px;
+    text-align: center;
+  }
+  .split-box3 {
+    margin: 5px 15px;
+  }
+  .split-box3 .jobs {
+    list-style: none;
+    padding: 0;
+    overflow-y: auto;
+    max-height: 325px;
+    width: 645px;
+    margin-top: 20px;
+  }
+
+  .input-small {
+    height: 20px;
+    float: left;
+    text-align: right;
+    width: 70px;
+    margin-right: 0px;
+    padding: 6px 5px 5px 5px;
+    font-size: 18px;
+    background: #fdfdfd;
+    background-size: 13px 11px;
+    box-sizing: content-box;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    box-shadow: inset 0 1px 3px #ddd;
+  }
+
+  .btn-cancel {
+    padding: 2px 15px !important;
+  }
+
+  .split-box3 .jobs li {
+    float: left;
+    margin: 0px 0 10px 0;
+    padding: 0px;
+    width: 99%;
+    border-radius: 0px;
+    background: #ffffff;
+    //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  }
+
+  .split-box3 .jobs li.void {
+    border: 1px solid red !important;
+  }
+  .error-perc {
+    float: left;
+    width: 82%;
+    margin: 25px 0 -20px 20px;
+    text-align: right;
+    color: #ff0000;
+    font-size: 12px;
+  }
+
+  .error-message {
+    background: #d65757;
+    color: #fff;
+    margin: 0 0 10px 0;
+    float: left;
+    font-weight: bold;
+    width: 100%;
+    -moz-border-radius: 2px;
+    border-radius: 2px;
+    border: 1px solid #c45f5f;
+    margin-top: 10px;
+  }
+
+  .jobcontainer {
+    padding-bottom: 50px;
+    border-bottom: 1px dashed #ccc;
+  }
+
+  div.wrapper div:last-child {
+    border: none;
+  }
+
+  .error-message p {
+    padding: 0 10px 0 10px;
+    line-height: 40px !important;
+  }
+
+  .error-message p:before {
+    font-family: 'icomoon';
+    speak: none;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+    content: '\f071';
+    margin-right: 10px;
+  }
+
+  .jobs h4 {
+    margin: 11px 0 0 10px;
+    float: left;
+    line-height: 30px;
+  }
+  .job-details {
+    float: right;
+  }
+  .job-perc {
+    color: #999;
+    margin: 0;
+    float: left;
+    padding: 10px;
+    font-size: 18px;
+    color: #000;
+    text-align: right;
+  }
+  .job-perc p {
+    float: left;
+    font-size: 14px;
+    margin: 1px 6px 0 3px !important;
+    padding: 0;
+    line-height: 30px !important;
+  }
+
+  .total .wordsum {
+    font-size: 20px;
+    color: $grey1;
+    text-align: right;
+    margin-right: 15px;
+    margin-top: 10px;
+    padding: 0;
+    line-height: 13px;
+    font-weight: bold;
+    span {
+      color: black;
     }
+  }
 
+  .disabled,
+  .disabled:hover,
+  .disabled:active {
+    opacity: 0.5 !important;
+    cursor: default;
+    -moz-box-shadow: none;
+    -webkit-box-shadow: none;
+    border: 1px solid $grey1;
+    background: #ccc !important;
+  }
 
-    .disabled, .disabled:hover, .disabled:active {
-        opacity: 0.5 !important;
-        cursor: default;
-        -moz-box-shadow: none;
-        -webkit-box-shadow: none;
-        border: 1px solid $grey1;
-        background: #ccc !important;
+  .uploadloader {
+    background: url(../../img/loader.gif) center center no-repeat;
+    width: 20px;
+    height: 20px;
+    float: right;
+    margin-top: 11px;
+    position: absolute;
+    right: 86px;
+    background-size: 20px 20px;
+  }
+
+  .btn-cancel {
+    padding: 2px 15px !important;
+    float: right;
+  }
+
+  .total .wordsum .total-w,
+  .total .curr-w,
+  .total .diff-w {
+    float: right;
+    clear: both;
+    width: 83px;
+    font-weight: bold;
+  }
+
+  .empty {
+    border: 0 !important;
+    background: #f0f0f0 !important;
+    width: 120px;
+  }
+
+  input.input-small {
+    outline: none !important;
+    &:hover {
+      border-color: rgba(34, 36, 38, 0.35);
+      box-shadow: none;
     }
-
-    .uploadloader {
-        background: url(../../img/loader.gif) center center no-repeat;
-        width: 20px;
-        height: 20px;
-        float: right;
-        margin-top: 11px;
-        position: absolute;
-        right: 86px;
-        background-size: 20px 20px;
+    &:focus {
+      border-color: #96c8da;
+      box-shadow: none;
     }
-
-    .btn-cancel {
-        padding: 2px 15px!important;
-        float: right;
-    }
-
-    .total .wordsum .total-w, .total .curr-w, .total .diff-w {
-        float: right;
-        clear: both;
-        width: 83px;
-        font-weight: bold;
-    }
-
-    .empty {
-        border: 0 !important;
-        background: #F0F0F0 !important;
-        width: 120px;
-    }
-
-    input.input-small {
-        outline: none !important;
-        &:hover {
-            border-color: rgba(34, 36, 38, 0.35);
-            box-shadow: none;
-        }
-        &:focus {
-            border-color: #96C8DA;
-            box-shadow: none;
-        }
-    }
-
-
+  }
 }
 /************/

--- a/public/css/sass/notifications.scss
+++ b/public/css/sass/notifications.scss
@@ -1,7 +1,6 @@
 @import 'variables';
 /******* Notifications ************/
 
-
 .notifications-position {
   font-family: inherit;
   position: fixed;
@@ -24,7 +23,7 @@
   bottom: 30px;
   margin: 0 auto;
   left: 50%;
-  margin-left: -($notifications-width / 2)
+  margin-left: -($notifications-width / 2);
 }
 .notifications-position-br {
   @extend .notifications-position;
@@ -32,7 +31,6 @@
   bottom: 30px;
   left: auto;
   right: 0px;
-
 }
 .notifications-position-tl {
   @extend .notifications-position;
@@ -40,7 +38,6 @@
   bottom: auto;
   left: 0px;
   right: auto;
-
 }
 .notifications-position-tc {
   @extend .notifications-position;
@@ -49,7 +46,6 @@
   margin: 0 auto;
   left: 50%;
   margin-left: -($notifications-width / 2);
-
 }
 .notifications-position-tr {
   @extend .notifications-position;
@@ -58,11 +54,10 @@
   left: auto;
 }
 
-
 .notification-type {
   position: relative;
   width: 100%;
-  text-align:left;
+  text-align: left;
   background-color: #fff;
   @include border-radius(2px);
   font-size: 16px;
@@ -116,7 +111,7 @@
     text-align: right;
     a {
       text-decoration: underline;
-      color: #4183C4;
+      color: #4183c4;
       font-weight: 700;
       &:hover {
         text-decoration: none;
@@ -169,13 +164,11 @@
 }
 
 .notifications-wrapper-inside {
-    .translator-notification-sent {
-        font-weight: bold;
-        line-height: 28px;
-        span {
-            color: #4183C4;
-        }
+  .translator-notification-sent {
+    font-weight: bold;
+    line-height: 28px;
+    span {
+      color: #4183c4;
     }
+  }
 }
-
-

--- a/public/css/sass/popup.scss
+++ b/public/css/sass/popup.scss
@@ -1,1926 +1,1913 @@
 /*popup*/
-.modal, #modal {
-    .popup-outer {
-        background: #000;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        z-index: 12;
-        opacity: 0.4;
-    }
-    .popup {
-        overflow: hidden;
-        line-height: 30px;
-        border-radius: 0 0 4px 4px;
-        //-webkit-box-shadow: 0 1px 20px #000;
-        //box-shadow: 0 1px 20px #000;
-        min-width: 600px;
-        background: $grey5;
-        margin: -200px 0 0 -250px;
-        padding: 0 0px 20px 0px;
-        position: fixed;
-        left: 46%;
-        max-width: 400px;
-        z-index: 999999999;
-    }
-
-     .popup p.text-container-top {
-        font-size: 18px;
-        margin-top: 20px;
-        padding: 0 30px;
-        text-align: left;
-    }
-
-    p.button-aligned-right {
-        text-align: right !important;
-    }
-
-    .popup h1 {
-        overflow: visible;
-        max-height: inherit;
-        font-size: 24px;
-        padding: 10px 10px 7px 58px;
-        border-bottom: 1px solid #000;
-        color: #fff;
-        margin: 0 !important;
-        text-align: left;
-    }
-
-    .popup h2 {
-        font-weight: normal;
-        font-size: 16px;
-        color: black;
-        display: block;
-        margin: 20px 0 20px 0;
-    }
-
-    .popup a.anonymous {
-        padding: 8px 18px;
-        font-size: 12px;
-    }
-
-    .popup a.anonymous:visited, .popup a.anonymous:active {
-        color: black;
-    }
-
-    .popup h1 {
-        overflow: visible;
-        max-height: inherit;
-        font-size: 24px;
-        //background: #002b5c url(../../img/logo-onlycat-white.svg) 12px 12px no-repeat;
-        padding: 10px 10px 7px 64px;
-        background-size: 40px;
-        /* border-bottom: 1px solid #000; */
-        color: #fff;
-        margin: 0 !important;
-        text-align: left;
-        font-family: "calibri", Arial, Helvetica, sans-serif;
-    }
-
-    .popup .x-popup {
-        color: #fff;
-        text-decoration: none;
-        display: block;
-        height: 30px;
-        font-size: 20px;
-        padding-top: 10px;
-        float: right;
-        margin: 0 10px 0 0;
-        background-size: 22px;
-        font-family: 'icomoon';
-        speak: none;
-        font-style: normal;
-        font-weight: normal;
-        font-variant: normal;
-        text-transform: none;
-        line-height: 1;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-    }
-
-    .x-popup:before {
-        content: "\f057";
-    }
-
-    .inner {
-        width: 45px;
-        border-right: 1px solid #003366;
-        border-radius: 0 0 0 6px;
-    }
-
-    .login-google .outer,
-    .login-google-drive .outer {
-        margin-top: 10px;
-    }
-
-    .login-google .popup-box,
-    .login-google-drive .popup-box {
-        width: 100%;
-        min-height: 100px;
-    }
-
-    /* SPLIT JOB POPUP */
-
-    /* .popup-confirm,*/
-    /* .popup-alert {*/
-    /*margin:-200px 0 0 -250px;*/
-    /*position:fixed;*/
-    /*}*/
-
-
-    .btn-ok, .btn-cancel {
-        color: #fff;
-        background: $translatedBlue;
-        font-weight: bold;
-        text-decoration: none;
-        padding: 8px 10px;
-        border-radius: 2px;
-        font-size: 18px;
-        margin-right: 3px;
-        cursor: pointer;
-    }
-    .btn-ok:hover {
-        background-color: $translatedBlueHover;
-    }
-    .btn-ok:active {
-        background-color: $translatedBlueActive;
-    }
-
-    .btn-cancel {
-        color: $grey1 !important;
-        background: white !important;
-        border: 1px solid $grey1 !important;
-
-
-    }
-
-
-    .btn-cancel:hover {
-        cursor: pointer;
-        background-color: $grey3 !important;
-    }
-
-
-    /* outsource popup */
-
-    &.outsource .popup {
-        width: 100%;
-        margin: 0 !important;
-        padding-bottom: 10px;
-        box-sizing: content-box;
-        top: 25%;
-        left: 50%;
-        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-        font-size: 14px;
-        position: static !important;
-    }
-
-    &.outsource .popup-box {
-        text-align: left;
-        padding: 0 20px;
-        margin: 0 auto;
-        width: auto !important;
-        overflow: hidden;
-        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    }
-
-    &.outsource .out-email,
-    &.outsource .out-date {
-        padding: .7em .6em;
-        display: inline-block;
-        border: 1px solid #ccc;
-        box-shadow: inset 0 1px 3px #ddd;
-        border-radius: 2px;
-        -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        box-sizing: border-box;
-        margin-bottom: 20px;
-        font-size: 15px;
-        color: #333;
-        width: 70%;
-        margin: 2%;
-    }
-
-    &.outsource .out-email:focus,
-    &.outsource .out-date:focus {
-        border-color: #85B7D9;
-        background: #FFFFFF;
-        color: rgba(0, 0, 0, 0.8);
-        border-radius: 2px;
-        outline: none;
-    }
-
-     select:focus {
-        border-color: #85B7D9 !important;
-        background: #FFFFFF;
-        color: rgba(0, 0, 0, 0.8);
-        outline: none;
-    }
-
-     select:active {
-        border-color: #85B7D9;
-        background: #FFFFFF;
-        color: rgba(0, 0, 0, 0.8);
-        outline: none;
-    }
-
-    &.outsource .out-link {
-        padding: .7em .6em;
-        display: inline-block;
-        border: 1px solid #ccc;
-        box-shadow: inset 0 1px 3px #ddd;
-        border-radius: 2px;
-        -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        box-sizing: border-box;
-        margin-bottom: 20px;
-        font-size: 15px;
-        color: #777;
-        width: 70%;
-        margin: 2%;
-        background-color: #f1f1f1;
-    }
-
-    &.outsource .out-link.from-manage {
-        padding: .7em .6em;
-        display: inline-block;
-        border: 1px solid #ccc;
-        box-shadow: none;
-        border-radius: 2px;
-        -webkit-box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        box-sizing: border-box;
-        margin-bottom: 20px;
-        font-size: 15px;
-        color: #333;
-        width: 95.4%;
-        margin: 2%;
-        background-color: #f1f1f1;
-        box-shadow: inset 0 1px 3px #ddd;
-    }
-
-    &.outsource .out-email,
-    &.outsource .out-date {
-        width: 33%;
-        float: left;
-    }
-
-    &.outsource p {
-        margin: 0;
-        font-size: 16px;
-    }
-
-    .translator_info p {
-        text-align: left;
-        font-size: 15px !important;
-    }
-
-    p.translator_name {
-        font-size: 16px !important;
-    }
-
-
-    .addrevision h4,
-    .addrevision span {
-        display: inline-block;
-        margin: 0;
-    }
-
-    .translator_bio {
-        width: 100%;
-        float: left;
-    }
-
-    &.outsource h2 {
-        font-size: 24px;
-        font-weight: bold;
-        padding: 0;
-        margin: 15px 0;
-        font-family: "calibri", Arial, Helvetica, sans-serif;
-    }
-
-    .onyourown h2,
-    .contact_box h2 {
-        width: 100%;
-        padding: 1% 0%;
-    }
-
-    .onyourown a.uploadbtn.in-popup {
-        margin: 2% 2.5% 2% 2% !important;
-        width: 160px;
-    }
-
-
-    &.outsource.loading .delivery {
-        background: url(../../img/loader.gif) #f6f6f6 center center no-repeat;
-        background-size: 20px;
-    }
-
-    &.outsource.loading .tprice {
-        background: url(../../img/loader.gif) #f6f6f6 center 30px no-repeat;
-        background-size: 20px;
-        padding-top: 47px;
-    }
-
-    &.outsource.loading .translator_info_box {
-        background: url(../../img/loader.gif) center 20px no-repeat;
-        background-size: 20px;
-        padding-top: 45px;
-        border-left: none;
-    }
-
-    .outsourced .delivery_details .time,
-    .outsourced .tprice .displayprice,
-    .outsourced .tprice .euro:not(.currency_per_word) {
-        color: green !important;
-    }
-
-    &.outsource .standardbtn.checkstatus {
-        float: left;
-        background: #fff !important;
-        color: #333;
-        width: 160px !important;
-        margin: 10px 20px 0 !important;
-    }
-
-    .outsourced .outsource_notify {
-        float: right;
-        color: green;
-        font-size: 20px;
-        font-weight: bold;
-        margin-right: 10px;
-    }
-
-    &.outsource.loading .tprice.compress {
-        padding: 133px 1% 6px 1%;
-    }
-
-    .pricebox .tprice.compress {
-        padding: 20px 1% 5px 1%;
-    }
-
-    &.outsource.loading .delivery_details,
-    &.outsource.loading .displayprice,
-    &.outsource.loading .euro,
-    &.outsource.loading .addrevision .revision_delivery,
-    &.outsource.loading .addrevision .revision_price_box,
-    &.outsource.loading .translator_info,
-    &.outsource.loading .displaypriceperword,
-    &.outsource.loading .more {
-        display: none;
-    }
-
-    &.outsource.loading .outsourceto:not(.translatorNotAvailable) .trustbox1 {
-        margin-bottom: 22px !important;
-    }
-
-    &.outsource.loading .outsourceto.translatorNotAvailable .trustbox1 {
-        display: none;
-    }
-
-    .outs h2 {
-        background-size: 180px;
-        height: 41px;
-        margin-top: 20px;
-        margin-bottom: -10px;
-        width: 180px;
-    }
-
-    .revealprices .uploadbtn {
-        background: #7eaf3e;
-        width: auto;
-        float: left;
-        margin: -10px 0 5px 40% !important;
-    }
-
-    .revealprices img {
-        width: 140px;
-    }
-
-
-    body.showingOutsourceTo {
-        overflow: hidden !important;
-    }
-
-
-    .split-box3 .total:hover {
-        border: none;
-        box-shadow: none;
-        -moz-box-shadow: none;
-        -webkit-box-shadow: none;
-    }
-
-    .paylater, .gmt {
-        font-size: 14px;
-        font-weight: normal;
-        float: left;
-        clear: both;
-        margin-top: -10px;
-    }
-
-
-    .delivery span {
-        font-size: 25px;
-        font-weight: bold;
-    }
-
-    .delivery {
-        font-size: 16px !important;
-        font-weight: normal;
-
-    }
-
-    .tprice span {
-        font-weight: bold;
-        font-size: 40px;
-        padding-top: 10px;
-    }
-
-    .tprice span.currency_per_word {
-        font-size: 15px !important;
-        font-weight: normal !important;
-    }
-
-    .tprice {
-        font-size: 22px !important;
-        font-weight: bold;
-    }
-
-
-    .pricebox .heading {
-        margin-top: 15px;
-        text-align: left;
-        padding: 5px 2%;
-        margin: 0 auto;
-        overflow: hidden;
-        background: #efefef;
-        border-bottom: 1px solid #ccc;
-    }
-
-
-    .guaranteed_by {
-        background-color: #fff;
-        padding: 3px 2% 2px 2%;
-        text-align: left;
-        width: 33%;
-        float: left;
-        -webkit-align-items: center;
-        -ms-flex-align: center;
-        align-items: center;
-        display: -webkit-flex;
-        display: flex;
-        height: 136px;
-    }
-
-    .guaranteed_by p {
-        font-size: 14px !important;
-        line-height: 22px;
-        padding: 0;
-    }
-
-    .pricebox .outsourceto .guaranteed_by img {
-        width: 115px;
-        margin: 0 5px;
-        vertical-align: middle;
-    }
-
-    .pricebox .outsourceto .guaranteed_by img {
-        width: 115px;
-        margin: 0 5px;
-        vertical-align: middle;
-    }
-
-    &.outsource .standardbtn {
-        background: #f4f4f4 !important;
-        color: #333;
-    }
-
-    &.outsource a:hover {
-        text-decoration: none !important;
-        /*color: red;*/
-    }
-
-    .contact_box h3 {
-        font-size: 18px;
-    }
-
-    .contact_box p {
-        float: left;
-        margin-top: 3px !important;
-    }
-
-    .contact_box .standardbtn {
-        margin: 10px 2% !important;
-        width: 160px !important;
-    }
-
-    .revision_price_box {
-        width: 26%;
-        font-size: 20px;
-        text-align: center;
-        font-weight: bold;
-    }
-
-    div.modal-outsource-datepicker .x-popup2 {
-        color: #666;
-        position: absolute;
-        right: 8px;
-        top: 0;
-        text-decoration: none;
-    }
-
-    div.modal-outsource-datepicker .x-popup2:hover {
-        color: red;
-    }
-
-
-    span.revision_delivery {
-        width: 38%;
-        text-align: center;
-    }
-
-    .addrevision h4 {
-        font-size: 20px;
-        margin: 0 10px;
-        width: 31%;
-    }
-
-
-    .pricebox .copytext p:first-child {
-        margin-top: 0 !important;
-    }
-
-    .pricebox .copytext {
-        float: left;
-        width: 58%;
-        padding-right: 2%;
-    }
-
-    .outsourceto {
-        float: left;
-        width: 100%;
-        border-top: 1px solid #ccc;
-        text-align: center;
-        margin-top: 15px !important;
-    }
-
-    .pricebox .tprice,
-    .pricebox .delivery {
-        text-align: center;
-    }
-
-    .pricebox .tprice {
-        padding: 20px 1% 12px 1%;
-    }
-
-    .pricebox .delivery {
-        padding: 2.5% 2% 2% 2%;
-    }
-
-    .delivery.compress {
-        padding: 0;
-    }
-
-
-    .offer {
-        margin: 0 auto;
-        overflow: hidden;
-        width: 100%;
-        background: #f8f8f8;
-    }
-
-    .border {
-        background: #fafafa;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        margin: 0 auto;
-        overflow: hidden;
-    }
-
-    .heading img {
-        float: right;
-        height: 25px;
-        padding: 2px;
-    }
-
-    .delivery_label {
-        font-size: 19px;
-    }
-
-    .contact_box {
-        border-top: 1px dashed #ccc;
-        margin: 15px auto 0;
-        overflow: hidden;
-        padding: 1% 2% 0;
-    }
-
-    .onyourown, .outsourceto {
-        border: 1px solid #ccc;
-        border-radius: 3px;
-        margin: 0 auto;
-        overflow: hidden;
-    }
-
-    .onyourown.opened-send-translator {
-        border-radius: 3px 3px 0px 0px;
-    }
-
-    .outsource .heading h3 {
-        float: left;
-        font-size: 20px;
-        margin-bottom: 0;
-        line-height: 30px;
-        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    }
-
-    .onyourown h2,
-    .contact_box h2 {
-        border-bottom: 1px solid #ccc;
-        width: 97%;
-        padding: 1% 2%;
-    }
-
-    .contact_box h3 {
-        float: left;
-        margin-right: 10px;
-        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    }
-
-
-    .pricebox .continuebtn {
-        clear: both;
-        float: none;
-        width: 160px;
-        margin: 10px auto 0 auto !important;
-        overflow: hidden;
-    }
-
-    .paymentinfo p {
-        font-size: 15px;
-    }
-
-    .translator_info a,
-    .delivery a,
-    .contact_box p a {
-        color: #0d8fb2 !important;
-        text-decoration: underline;
-        cursor: pointer;
-    }
-
-    .guaranteed_by a.more {
-        color: #333 !important;
-        text-decoration: none;
-        cursor: pointer;
-        font-weight: normal !important;
-        float: right;
-    }
-
-    .guaranteed_by a.more span {
-        font-weight: normal !important;
-        text-decoration: underline !important;
-    }
-
-
-    .pricebox.compress #forceDeliveryContainer {
-        top: 500px;
-    }
-
-    .guaranteed_by a {
-        color: #333;
-    }
-
-    a.needitfaster {
-        font-weight: bold;
-        display: block;
-    }
-
-    .translator_info a {
-        float: left;
-    }
-
-    a.hide_translator {
-        float: right;
-    }
-
-    .outsourceto:not(.outsourced) .blink {
-        -webkit-animation-name: blinker;
-        -webkit-animation-duration: 0.4s;
-        -webkit-animation-timing-function: linear;
-        -moz-animation-name: blinker;
-        -moz-animation-duration: 0.4;
-        -moz-animation-timing-function: linear;
-        animation-name: blinker;
-        animation-duration: 0.4;
-        animation-timing-function: linear;
-    }
-
-    @-moz-keyframes blinker {
-        0% {
-            background: transparent;
-        }
-        50% {
-            background: rgb(255, 255, 153);
-        }
-        100% {
-            background: transparent;
-        }
-    }
-
-    @-webkit-keyframes blinker {
-        0% {
-            background: transparent;
-        }
-        50% {
-            background: rgb(255, 255, 153);
-        }
-        100% {
-            background: transparent;
-        }
-    }
-
-    @keyframes blinker {
-        0% {
-            background: transparent;
-        }
-        50% {
-            background: rgb(255, 255, 153);
-        }
-        100% {
-            background: transparent;
-        }
-    }
-
-    .translator_info_box {
-        width: 46%;
-        padding: 0% 0% 0% 3%;
-        float: left;
-        margin-top: 0%;
-        border-left: 1px solid #ECECEC;
-        margin-left: 4%;
-    }
-
-    .pricebox .translator_info,
-    .pricebox .tprice,
-    .pricebox .delivery,
-    .pricebox .torder {
-        float: left;
-    }
-
-
-    .guaranteed_by.expanded {
-        width: 70%;
-    }
-
-    .guaranteed_by.expanded .trust_text {
-        float: left;
-        width: 46%;
-    }
-
-    .pricebox .tprice {
-        width: calc(24% - 1px);
-    }
-
-    .pricebox .torder {
-        width: 20%;
-        margin-top: 15px;
-        padding: 1%;
-    }
-
-    .pricebox .delivery {
-        width: 33%;
-        min-height: 100px;
-        border-right: 1px solid #ccc;
-    }
-
-    .guaranteed_by.expanded {
-        width: 70%;
-        border-right: 1px solid #ccc;
-        height: auto;
-        min-height: 194px;
-        padding-bottom: 21px !important;
-        padding-top: 7px !important;
-    }
-
-    .pricebox .delivery.compress {
-        width: 94%;
-        line-height: 24px;
-        background: transparent;
-        border-top: 1px solid #ccc;
-        margin: 6px;
-        padding: 6px 0px;
-        min-height: 10px;
-        line-height: 22px;
-    }
-
-    .delivery.compress .delivery_label {
-        font-size: 15px;
-    }
-
-    .revision_delivery, .revision_price_box {
-        opacity: 0.4;
-    }
-
-    .addrevision h4 {
-        opacity: 0.6;
-        font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    }
-
-    .addrevision.noopacity {
-        opacity: 1;
-        background-color: #f8f8f8;
-        -webkit-transition: background-color 1000ms linear;
-        -moz-transition: background-color 1000ms linear;
-        -o-transition: background-color 1000ms linear;
-        -ms-transition: background-color 1000ms linear;
-        transition: background-color 1000ms linear;
-    }
-
-    .addrevision.noopacity h4 {
-        opacity: 1 !important;
-    }
-
-    .noopacity .revision_delivery, .noopacity .revision_price_box {
-        opacity: 0;
-    }
-
-    .delivery.compress span {
-        font-size: 17px;
-    }
-
-    .delivery.compress {
-        border-right: none;
-    }
-
-
-    .pricebox .tprice .tpricetitle {
-        border-bottom: 1px solid #ccc;
-        font-size: 22px !important;
-        padding-bottom: 5px;
-        margin-bottom: 10px;
-    }
-
-    .tpricedesc {
-        margin-top: -10px;
-    }
-
-    .references,
-    .paymentinfo {
-        text-align: center;
-        padding: 5px 0;
-        display: inline-block;
-        width: 100%;
-        background-color: #fff;
-        text-align: left;
-        padding-left: 20px;
-    }
-
-    .references > img {
-        width: 23%;
-        padding-left: 1.5%;
-        padding-right: 1.5%;
-        -webkit-filter: grayscale(100%);
-        -moz-filter: grayscale(100%);
-        filter: grayscale(100%);
-    }
-
-    .translator_bio a {
-        font-size: 13px;
-    }
-
-    .translator_bio p {
-        border-bottom: 1px dashed #ccc;
-        padding: 5px 0px 5px 0;
-        margin-right: 20px !important;
-        width: 100%;
-        float: left;
-        line-height: 20px;
-    }
-
-    .translator_bio p:last-child {
-        border-bottom: none;
-    }
-
-    .translator_name {
-        border-bottom: 1px solid #ccc;
-        font-size: inherit !important;
-        display: inline-block;
-        float: left;
-        width: 100%;
-        text-align: left;
-    }
-
-    .references > img:hover {
-        width: 23%;
-        padding-left: 1.5%;
-        padding-right: 1.5%;
-        -webkit-filter: grayscale(0%);
-        -moz-filter: grayscale(0%);
-        filter: grayscale(0%);
-    }
-
-
-    span.label_info {
-        float: left;
-        width: 76%;
-        font-weight: bold;
-        /* color: #7A7A7A; */
-    }
-
-    span.subjects {
-        width: 74% !important;
-    }
-
-    span.subjects, span.experience, span.translated_words, span.score_number {
-        float: right;
-        width: 24%;
-        text-align: right;
-    }
-
-
-    .translator_bio > p:nth-child(3) > span.label_info {
-        width: 24%;
-    }
-
-
-    .tprice span.displaypriceperword {
-        font-weight: normal !important;
-        font-size: 15px !important;
-        margin: -13px 0 -5px;
-        display: block;
-    }
-
-    .tprice span.displaypriceperword .price_p_word {
-        font-size: 15px;
-        font-weight: normal;
-    }
-
-
-    .addrevision {
-        float: left;
-        width: 98%;
-        border-top: 1px solid #ccc;
-        text-align: left;
-        padding: 5px 0% 5px 2%;
-        background: #fff;
-    }
-
-
-    span.zone, span.zone2 {
-        font-size: 14px;
-        font-weight: normal;
-    }
-
-    span.zone2 {
-        font-size: 12px;
-    }
-
-    .pricebox .tprice .euro, .pricebox .tprice .displayprice {
-        display: inline;
-    }
-
-    .pricebox .tprice, .pricebox delivery {
-        line-height: 30px;
-    }
-
-    .tprice.compress .delivery_container {
-        display: block;
-    }
-
-    .tprice .delivery_container {
-        display: none;
-    }
-
-    .compress .offer > .delivery_container {
-        display: none;
-    }
-
-    .showpricesloading {
-        float: right;
-        width: 160px;
-        height: 23px;
-        margin: 2% 2.5% 2% 2% !important;
-        padding: 5px 10px !important;
-    }
-
-    .uploadbtn.showprices {
-        margin: 2% 2.5% 2% 2% !important;
-        width: 160px;
-    }
-
-    .paybox {
-        font-size: 13px !important;
-        margin-bottom: 0;
-        margin-top: 0;
-    }
-
-    a.changeTimezoneTrigger {
-        float: right;
-        font-weight: normal;
-        margin-left: 10px;
-    }
-
-    a.changeTimezoneTrigger,
-    a.changecurrency {
-        color: #666;
-        text-decoration: underline;
-        cursor: pointer;
-        margin-left: 10px;
-        background-color: #fff;
-        border: 1px solid #ccc;
-        padding: 0px 12px;
-        border-radius: 4px;
-    }
-
-    select#changeTimezone,
-    #changecurrency,
-    a.changecurrency {
-        float: right;
-    }
-
-
-    select#changeTimezone,
-    #changecurrency {
-        width: 14%;
-        margin-right: 1%;
-        border: 1px solid #ccc;
-        height: 30px;
-        font-size: 13px;
-        font-family: Arial;
-    }
-
-    select#changeTimezone {
-        width: 90px;
-        margin-right: 10px;
-    }
-
-    .hide {
-        display: none;
-    }
-
-    &.outsource .hide {
-        display: none !important;
-    }
-
-    .revision_currency {
-        margin-right: 5px !important;
-    }
-
-    .tprice [data-currency="RUB"],
-    .tprice [data-currency="BRL"],
-    .tprice [data-currency="JPY"],
-    .tprice [data-currency="KRW"] {
-        font-size: 30px !important;
-    }
-
-    /* end outsource */
-
-    table.chunks {
-        overflow: hidden;
-        border: 2px solid #ccc;
-        background: #fefefe;
-        width: 100%;
-        border-collapse: collapse;
-    }
-
-    table.chunks th, table.chunks td {
-        padding: 0.5em 1em;
-        border: 1px solid #ccc;
-    }
-
-    .thead {
-        background: #F6F6F6;
-    }
-
-
-    table.chunks th:last-child {
-        width: 15%;
-    }
-
-    table.chunks tr:last-child {
-        background: #fff;
-    }
-
-
-    table.chunks td.last {
-        border-right: none;
-    }
-
-    table.chunks td {
-        border-top: 1px solid #e0e0e0;
-        border-right: 1px solid #e0e0e0;
-    }
-
-    table .chunks tr:first-child {
-        background: #E7E7E7;
-    }
-
-
-    .footer-popup ul li {
-        display: inline;
-    }
-
-    .footer-popup a {
-        font-size: 13px;
-        padding-right: 20px;
-    }
-
-    .footer-popup {
-        border-top: 1px solid #ccc;
-        clear: both;
-        margin-top: 30px;
-        padding: 4px 0px 0px;
-    }
-
-    /* scroll pop-up
+.modal,
+#modal {
+  .popup-outer {
+    background: #000;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 12;
+    opacity: 0.4;
+  }
+  .popup {
+    overflow: hidden;
+    line-height: 30px;
+    border-radius: 0 0 4px 4px;
+    //-webkit-box-shadow: 0 1px 20px #000;
+    //box-shadow: 0 1px 20px #000;
+    min-width: 600px;
+    background: $grey5;
+    margin: -200px 0 0 -250px;
+    padding: 0 0px 20px 0px;
+    position: fixed;
+    left: 46%;
+    max-width: 400px;
+    z-index: 999999999;
+  }
+
+  .popup p.text-container-top {
+    font-size: 18px;
+    margin-top: 20px;
+    padding: 0 30px;
+    text-align: left;
+  }
+
+  p.button-aligned-right {
+    text-align: right !important;
+  }
+
+  .popup h1 {
+    overflow: visible;
+    max-height: inherit;
+    font-size: 24px;
+    padding: 10px 10px 7px 58px;
+    border-bottom: 1px solid #000;
+    color: #fff;
+    margin: 0 !important;
+    text-align: left;
+  }
+
+  .popup h2 {
+    font-weight: normal;
+    font-size: 16px;
+    color: black;
+    display: block;
+    margin: 20px 0 20px 0;
+  }
+
+  .popup a.anonymous {
+    padding: 8px 18px;
+    font-size: 12px;
+  }
+
+  .popup a.anonymous:visited,
+  .popup a.anonymous:active {
+    color: black;
+  }
+
+  .popup h1 {
+    overflow: visible;
+    max-height: inherit;
+    font-size: 24px;
+    //background: #002b5c url(../../img/logo-onlycat-white.svg) 12px 12px no-repeat;
+    padding: 10px 10px 7px 64px;
+    background-size: 40px;
+    /* border-bottom: 1px solid #000; */
+    color: #fff;
+    margin: 0 !important;
+    text-align: left;
+    font-family: 'calibri', Arial, Helvetica, sans-serif;
+  }
+
+  .popup .x-popup {
+    color: #fff;
+    text-decoration: none;
+    display: block;
+    height: 30px;
+    font-size: 20px;
+    padding-top: 10px;
+    float: right;
+    margin: 0 10px 0 0;
+    background-size: 22px;
+    font-family: 'icomoon';
+    speak: none;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  .x-popup:before {
+    content: '\f057';
+  }
+
+  .inner {
+    width: 45px;
+    border-right: 1px solid #003366;
+    border-radius: 0 0 0 6px;
+  }
+
+  .login-google .outer,
+  .login-google-drive .outer {
+    margin-top: 10px;
+  }
+
+  .login-google .popup-box,
+  .login-google-drive .popup-box {
+    width: 100%;
+    min-height: 100px;
+  }
+
+  /* SPLIT JOB POPUP */
+
+  /* .popup-confirm,*/
+  /* .popup-alert {*/
+  /*margin:-200px 0 0 -250px;*/
+  /*position:fixed;*/
+  /*}*/
+
+  .btn-ok,
+  .btn-cancel {
+    color: #fff;
+    background: $translatedBlue;
+    font-weight: bold;
+    text-decoration: none;
+    padding: 8px 10px;
+    border-radius: 2px;
+    font-size: 18px;
+    margin-right: 3px;
+    cursor: pointer;
+  }
+  .btn-ok:hover {
+    background-color: $translatedBlueHover;
+  }
+  .btn-ok:active {
+    background-color: $translatedBlueActive;
+  }
+
+  .btn-cancel {
+    color: $grey1 !important;
+    background: white !important;
+    border: 1px solid $grey1 !important;
+  }
+
+  .btn-cancel:hover {
+    cursor: pointer;
+    background-color: $grey3 !important;
+  }
+
+  /* outsource popup */
+
+  &.outsource .popup {
+    width: 100%;
+    margin: 0 !important;
+    padding-bottom: 10px;
+    box-sizing: content-box;
+    top: 25%;
+    left: 50%;
+    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    font-size: 14px;
+    position: static !important;
+  }
+
+  &.outsource .popup-box {
+    text-align: left;
+    padding: 0 20px;
+    margin: 0 auto;
+    width: auto !important;
+    overflow: hidden;
+    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  }
+
+  &.outsource .out-email,
+  &.outsource .out-date {
+    padding: 0.7em 0.6em;
+    display: inline-block;
+    border: 1px solid #ccc;
+    box-shadow: inset 0 1px 3px #ddd;
+    border-radius: 2px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    margin-bottom: 20px;
+    font-size: 15px;
+    color: #333;
+    width: 70%;
+    margin: 2%;
+  }
+
+  &.outsource .out-email:focus,
+  &.outsource .out-date:focus {
+    border-color: #85b7d9;
+    background: #ffffff;
+    color: rgba(0, 0, 0, 0.8);
+    border-radius: 2px;
+    outline: none;
+  }
+
+  select:focus {
+    border-color: #85b7d9 !important;
+    background: #ffffff;
+    color: rgba(0, 0, 0, 0.8);
+    outline: none;
+  }
+
+  select:active {
+    border-color: #85b7d9;
+    background: #ffffff;
+    color: rgba(0, 0, 0, 0.8);
+    outline: none;
+  }
+
+  &.outsource .out-link {
+    padding: 0.7em 0.6em;
+    display: inline-block;
+    border: 1px solid #ccc;
+    box-shadow: inset 0 1px 3px #ddd;
+    border-radius: 2px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    margin-bottom: 20px;
+    font-size: 15px;
+    color: #777;
+    width: 70%;
+    margin: 2%;
+    background-color: #f1f1f1;
+  }
+
+  &.outsource .out-link.from-manage {
+    padding: 0.7em 0.6em;
+    display: inline-block;
+    border: 1px solid #ccc;
+    box-shadow: none;
+    border-radius: 2px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    margin-bottom: 20px;
+    font-size: 15px;
+    color: #333;
+    width: 95.4%;
+    margin: 2%;
+    background-color: #f1f1f1;
+    box-shadow: inset 0 1px 3px #ddd;
+  }
+
+  &.outsource .out-email,
+  &.outsource .out-date {
+    width: 33%;
+    float: left;
+  }
+
+  &.outsource p {
+    margin: 0;
+    font-size: 16px;
+  }
+
+  .translator_info p {
+    text-align: left;
+    font-size: 15px !important;
+  }
+
+  p.translator_name {
+    font-size: 16px !important;
+  }
+
+  .addrevision h4,
+  .addrevision span {
+    display: inline-block;
+    margin: 0;
+  }
+
+  .translator_bio {
+    width: 100%;
+    float: left;
+  }
+
+  &.outsource h2 {
+    font-size: 24px;
+    font-weight: bold;
+    padding: 0;
+    margin: 15px 0;
+    font-family: 'calibri', Arial, Helvetica, sans-serif;
+  }
+
+  .onyourown h2,
+  .contact_box h2 {
+    width: 100%;
+    padding: 1% 0%;
+  }
+
+  .onyourown a.uploadbtn.in-popup {
+    margin: 2% 2.5% 2% 2% !important;
+    width: 160px;
+  }
+
+  &.outsource.loading .delivery {
+    background: url(../../img/loader.gif) #f6f6f6 center center no-repeat;
+    background-size: 20px;
+  }
+
+  &.outsource.loading .tprice {
+    background: url(../../img/loader.gif) #f6f6f6 center 30px no-repeat;
+    background-size: 20px;
+    padding-top: 47px;
+  }
+
+  &.outsource.loading .translator_info_box {
+    background: url(../../img/loader.gif) center 20px no-repeat;
+    background-size: 20px;
+    padding-top: 45px;
+    border-left: none;
+  }
+
+  .outsourced .delivery_details .time,
+  .outsourced .tprice .displayprice,
+  .outsourced .tprice .euro:not(.currency_per_word) {
+    color: green !important;
+  }
+
+  &.outsource .standardbtn.checkstatus {
+    float: left;
+    background: #fff !important;
+    color: #333;
+    width: 160px !important;
+    margin: 10px 20px 0 !important;
+  }
+
+  .outsourced .outsource_notify {
+    float: right;
+    color: green;
+    font-size: 20px;
+    font-weight: bold;
+    margin-right: 10px;
+  }
+
+  &.outsource.loading .tprice.compress {
+    padding: 133px 1% 6px 1%;
+  }
+
+  .pricebox .tprice.compress {
+    padding: 20px 1% 5px 1%;
+  }
+
+  &.outsource.loading .delivery_details,
+  &.outsource.loading .displayprice,
+  &.outsource.loading .euro,
+  &.outsource.loading .addrevision .revision_delivery,
+  &.outsource.loading .addrevision .revision_price_box,
+  &.outsource.loading .translator_info,
+  &.outsource.loading .displaypriceperword,
+  &.outsource.loading .more {
+    display: none;
+  }
+
+  &.outsource.loading .outsourceto:not(.translatorNotAvailable) .trustbox1 {
+    margin-bottom: 22px !important;
+  }
+
+  &.outsource.loading .outsourceto.translatorNotAvailable .trustbox1 {
+    display: none;
+  }
+
+  .outs h2 {
+    background-size: 180px;
+    height: 41px;
+    margin-top: 20px;
+    margin-bottom: -10px;
+    width: 180px;
+  }
+
+  .revealprices .uploadbtn {
+    background: #7eaf3e;
+    width: auto;
+    float: left;
+    margin: -10px 0 5px 40% !important;
+  }
+
+  .revealprices img {
+    width: 140px;
+  }
+
+  body.showingOutsourceTo {
+    overflow: hidden !important;
+  }
+
+  .split-box3 .total:hover {
+    border: none;
+    box-shadow: none;
+    -moz-box-shadow: none;
+    -webkit-box-shadow: none;
+  }
+
+  .paylater,
+  .gmt {
+    font-size: 14px;
+    font-weight: normal;
+    float: left;
+    clear: both;
+    margin-top: -10px;
+  }
+
+  .delivery span {
+    font-size: 25px;
+    font-weight: bold;
+  }
+
+  .delivery {
+    font-size: 16px !important;
+    font-weight: normal;
+  }
+
+  .tprice span {
+    font-weight: bold;
+    font-size: 40px;
+    padding-top: 10px;
+  }
+
+  .tprice span.currency_per_word {
+    font-size: 15px !important;
+    font-weight: normal !important;
+  }
+
+  .tprice {
+    font-size: 22px !important;
+    font-weight: bold;
+  }
+
+  .pricebox .heading {
+    margin-top: 15px;
+    text-align: left;
+    padding: 5px 2%;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #efefef;
+    border-bottom: 1px solid #ccc;
+  }
+
+  .guaranteed_by {
+    background-color: #fff;
+    padding: 3px 2% 2px 2%;
+    text-align: left;
+    width: 33%;
+    float: left;
+    -webkit-align-items: center;
+    -ms-flex-align: center;
+    align-items: center;
+    display: -webkit-flex;
+    display: flex;
+    height: 136px;
+  }
+
+  .guaranteed_by p {
+    font-size: 14px !important;
+    line-height: 22px;
+    padding: 0;
+  }
+
+  .pricebox .outsourceto .guaranteed_by img {
+    width: 115px;
+    margin: 0 5px;
+    vertical-align: middle;
+  }
+
+  .pricebox .outsourceto .guaranteed_by img {
+    width: 115px;
+    margin: 0 5px;
+    vertical-align: middle;
+  }
+
+  &.outsource .standardbtn {
+    background: #f4f4f4 !important;
+    color: #333;
+  }
+
+  &.outsource a:hover {
+    text-decoration: none !important;
+    /*color: red;*/
+  }
+
+  .contact_box h3 {
+    font-size: 18px;
+  }
+
+  .contact_box p {
+    float: left;
+    margin-top: 3px !important;
+  }
+
+  .contact_box .standardbtn {
+    margin: 10px 2% !important;
+    width: 160px !important;
+  }
+
+  .revision_price_box {
+    width: 26%;
+    font-size: 20px;
+    text-align: center;
+    font-weight: bold;
+  }
+
+  div.modal-outsource-datepicker .x-popup2 {
+    color: #666;
+    position: absolute;
+    right: 8px;
+    top: 0;
+    text-decoration: none;
+  }
+
+  div.modal-outsource-datepicker .x-popup2:hover {
+    color: red;
+  }
+
+  span.revision_delivery {
+    width: 38%;
+    text-align: center;
+  }
+
+  .addrevision h4 {
+    font-size: 20px;
+    margin: 0 10px;
+    width: 31%;
+  }
+
+  .pricebox .copytext p:first-child {
+    margin-top: 0 !important;
+  }
+
+  .pricebox .copytext {
+    float: left;
+    width: 58%;
+    padding-right: 2%;
+  }
+
+  .outsourceto {
+    float: left;
+    width: 100%;
+    border-top: 1px solid #ccc;
+    text-align: center;
+    margin-top: 15px !important;
+  }
+
+  .pricebox .tprice,
+  .pricebox .delivery {
+    text-align: center;
+  }
+
+  .pricebox .tprice {
+    padding: 20px 1% 12px 1%;
+  }
+
+  .pricebox .delivery {
+    padding: 2.5% 2% 2% 2%;
+  }
+
+  .delivery.compress {
+    padding: 0;
+  }
+
+  .offer {
+    margin: 0 auto;
+    overflow: hidden;
+    width: 100%;
+    background: #f8f8f8;
+  }
+
+  .border {
+    background: #fafafa;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin: 0 auto;
+    overflow: hidden;
+  }
+
+  .heading img {
+    float: right;
+    height: 25px;
+    padding: 2px;
+  }
+
+  .delivery_label {
+    font-size: 19px;
+  }
+
+  .contact_box {
+    border-top: 1px dashed #ccc;
+    margin: 15px auto 0;
+    overflow: hidden;
+    padding: 1% 2% 0;
+  }
+
+  .onyourown,
+  .outsourceto {
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    margin: 0 auto;
+    overflow: hidden;
+  }
+
+  .onyourown.opened-send-translator {
+    border-radius: 3px 3px 0px 0px;
+  }
+
+  .outsource .heading h3 {
+    float: left;
+    font-size: 20px;
+    margin-bottom: 0;
+    line-height: 30px;
+    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  }
+
+  .onyourown h2,
+  .contact_box h2 {
+    border-bottom: 1px solid #ccc;
+    width: 97%;
+    padding: 1% 2%;
+  }
+
+  .contact_box h3 {
+    float: left;
+    margin-right: 10px;
+    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  }
+
+  .pricebox .continuebtn {
+    clear: both;
+    float: none;
+    width: 160px;
+    margin: 10px auto 0 auto !important;
+    overflow: hidden;
+  }
+
+  .paymentinfo p {
+    font-size: 15px;
+  }
+
+  .translator_info a,
+  .delivery a,
+  .contact_box p a {
+    color: #0d8fb2 !important;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .guaranteed_by a.more {
+    color: #333 !important;
+    text-decoration: none;
+    cursor: pointer;
+    font-weight: normal !important;
+    float: right;
+  }
+
+  .guaranteed_by a.more span {
+    font-weight: normal !important;
+    text-decoration: underline !important;
+  }
+
+  .pricebox.compress #forceDeliveryContainer {
+    top: 500px;
+  }
+
+  .guaranteed_by a {
+    color: #333;
+  }
+
+  a.needitfaster {
+    font-weight: bold;
+    display: block;
+  }
+
+  .translator_info a {
+    float: left;
+  }
+
+  a.hide_translator {
+    float: right;
+  }
+
+  .outsourceto:not(.outsourced) .blink {
+    -webkit-animation-name: blinker;
+    -webkit-animation-duration: 0.4s;
+    -webkit-animation-timing-function: linear;
+    -moz-animation-name: blinker;
+    -moz-animation-duration: 0.4;
+    -moz-animation-timing-function: linear;
+    animation-name: blinker;
+    animation-duration: 0.4;
+    animation-timing-function: linear;
+  }
+
+  @-moz-keyframes blinker {
+    0% {
+      background: transparent;
+    }
+    50% {
+      background: rgb(255, 255, 153);
+    }
+    100% {
+      background: transparent;
+    }
+  }
+
+  @-webkit-keyframes blinker {
+    0% {
+      background: transparent;
+    }
+    50% {
+      background: rgb(255, 255, 153);
+    }
+    100% {
+      background: transparent;
+    }
+  }
+
+  @keyframes blinker {
+    0% {
+      background: transparent;
+    }
+    50% {
+      background: rgb(255, 255, 153);
+    }
+    100% {
+      background: transparent;
+    }
+  }
+
+  .translator_info_box {
+    width: 46%;
+    padding: 0% 0% 0% 3%;
+    float: left;
+    margin-top: 0%;
+    border-left: 1px solid #ececec;
+    margin-left: 4%;
+  }
+
+  .pricebox .translator_info,
+  .pricebox .tprice,
+  .pricebox .delivery,
+  .pricebox .torder {
+    float: left;
+  }
+
+  .guaranteed_by.expanded {
+    width: 70%;
+  }
+
+  .guaranteed_by.expanded .trust_text {
+    float: left;
+    width: 46%;
+  }
+
+  .pricebox .tprice {
+    width: calc(24% - 1px);
+  }
+
+  .pricebox .torder {
+    width: 20%;
+    margin-top: 15px;
+    padding: 1%;
+  }
+
+  .pricebox .delivery {
+    width: 33%;
+    min-height: 100px;
+    border-right: 1px solid #ccc;
+  }
+
+  .guaranteed_by.expanded {
+    width: 70%;
+    border-right: 1px solid #ccc;
+    height: auto;
+    min-height: 194px;
+    padding-bottom: 21px !important;
+    padding-top: 7px !important;
+  }
+
+  .pricebox .delivery.compress {
+    width: 94%;
+    line-height: 24px;
+    background: transparent;
+    border-top: 1px solid #ccc;
+    margin: 6px;
+    padding: 6px 0px;
+    min-height: 10px;
+    line-height: 22px;
+  }
+
+  .delivery.compress .delivery_label {
+    font-size: 15px;
+  }
+
+  .revision_delivery,
+  .revision_price_box {
+    opacity: 0.4;
+  }
+
+  .addrevision h4 {
+    opacity: 0.6;
+    font-family: 'Calibri', 'Helvetica Neue', Arial, Helvetica, sans-serif;
+  }
+
+  .addrevision.noopacity {
+    opacity: 1;
+    background-color: #f8f8f8;
+    -webkit-transition: background-color 1000ms linear;
+    -moz-transition: background-color 1000ms linear;
+    -o-transition: background-color 1000ms linear;
+    -ms-transition: background-color 1000ms linear;
+    transition: background-color 1000ms linear;
+  }
+
+  .addrevision.noopacity h4 {
+    opacity: 1 !important;
+  }
+
+  .noopacity .revision_delivery,
+  .noopacity .revision_price_box {
+    opacity: 0;
+  }
+
+  .delivery.compress span {
+    font-size: 17px;
+  }
+
+  .delivery.compress {
+    border-right: none;
+  }
+
+  .pricebox .tprice .tpricetitle {
+    border-bottom: 1px solid #ccc;
+    font-size: 22px !important;
+    padding-bottom: 5px;
+    margin-bottom: 10px;
+  }
+
+  .tpricedesc {
+    margin-top: -10px;
+  }
+
+  .references,
+  .paymentinfo {
+    text-align: center;
+    padding: 5px 0;
+    display: inline-block;
+    width: 100%;
+    background-color: #fff;
+    text-align: left;
+    padding-left: 20px;
+  }
+
+  .references > img {
+    width: 23%;
+    padding-left: 1.5%;
+    padding-right: 1.5%;
+    -webkit-filter: grayscale(100%);
+    -moz-filter: grayscale(100%);
+    filter: grayscale(100%);
+  }
+
+  .translator_bio a {
+    font-size: 13px;
+  }
+
+  .translator_bio p {
+    border-bottom: 1px dashed #ccc;
+    padding: 5px 0px 5px 0;
+    margin-right: 20px !important;
+    width: 100%;
+    float: left;
+    line-height: 20px;
+  }
+
+  .translator_bio p:last-child {
+    border-bottom: none;
+  }
+
+  .translator_name {
+    border-bottom: 1px solid #ccc;
+    font-size: inherit !important;
+    display: inline-block;
+    float: left;
+    width: 100%;
+    text-align: left;
+  }
+
+  .references > img:hover {
+    width: 23%;
+    padding-left: 1.5%;
+    padding-right: 1.5%;
+    -webkit-filter: grayscale(0%);
+    -moz-filter: grayscale(0%);
+    filter: grayscale(0%);
+  }
+
+  span.label_info {
+    float: left;
+    width: 76%;
+    font-weight: bold;
+    /* color: #7A7A7A; */
+  }
+
+  span.subjects {
+    width: 74% !important;
+  }
+
+  span.subjects,
+  span.experience,
+  span.translated_words,
+  span.score_number {
+    float: right;
+    width: 24%;
+    text-align: right;
+  }
+
+  .translator_bio > p:nth-child(3) > span.label_info {
+    width: 24%;
+  }
+
+  .tprice span.displaypriceperword {
+    font-weight: normal !important;
+    font-size: 15px !important;
+    margin: -13px 0 -5px;
+    display: block;
+  }
+
+  .tprice span.displaypriceperword .price_p_word {
+    font-size: 15px;
+    font-weight: normal;
+  }
+
+  .addrevision {
+    float: left;
+    width: 98%;
+    border-top: 1px solid #ccc;
+    text-align: left;
+    padding: 5px 0% 5px 2%;
+    background: #fff;
+  }
+
+  span.zone,
+  span.zone2 {
+    font-size: 14px;
+    font-weight: normal;
+  }
+
+  span.zone2 {
+    font-size: 12px;
+  }
+
+  .pricebox .tprice .euro,
+  .pricebox .tprice .displayprice {
+    display: inline;
+  }
+
+  .pricebox .tprice,
+  .pricebox delivery {
+    line-height: 30px;
+  }
+
+  .tprice.compress .delivery_container {
+    display: block;
+  }
+
+  .tprice .delivery_container {
+    display: none;
+  }
+
+  .compress .offer > .delivery_container {
+    display: none;
+  }
+
+  .showpricesloading {
+    float: right;
+    width: 160px;
+    height: 23px;
+    margin: 2% 2.5% 2% 2% !important;
+    padding: 5px 10px !important;
+  }
+
+  .uploadbtn.showprices {
+    margin: 2% 2.5% 2% 2% !important;
+    width: 160px;
+  }
+
+  .paybox {
+    font-size: 13px !important;
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+
+  a.changeTimezoneTrigger {
+    float: right;
+    font-weight: normal;
+    margin-left: 10px;
+  }
+
+  a.changeTimezoneTrigger,
+  a.changecurrency {
+    color: #666;
+    text-decoration: underline;
+    cursor: pointer;
+    margin-left: 10px;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    padding: 0px 12px;
+    border-radius: 4px;
+  }
+
+  select#changeTimezone,
+  #changecurrency,
+  a.changecurrency {
+    float: right;
+  }
+
+  select#changeTimezone,
+  #changecurrency {
+    width: 14%;
+    margin-right: 1%;
+    border: 1px solid #ccc;
+    height: 30px;
+    font-size: 13px;
+    font-family: Arial;
+  }
+
+  select#changeTimezone {
+    width: 90px;
+    margin-right: 10px;
+  }
+
+  .hide {
+    display: none;
+  }
+
+  &.outsource .hide {
+    display: none !important;
+  }
+
+  .revision_currency {
+    margin-right: 5px !important;
+  }
+
+  .tprice [data-currency='RUB'],
+  .tprice [data-currency='BRL'],
+  .tprice [data-currency='JPY'],
+  .tprice [data-currency='KRW'] {
+    font-size: 30px !important;
+  }
+
+  /* end outsource */
+
+  table.chunks {
+    overflow: hidden;
+    border: 2px solid #ccc;
+    background: #fefefe;
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  table.chunks th,
+  table.chunks td {
+    padding: 0.5em 1em;
+    border: 1px solid #ccc;
+  }
+
+  .thead {
+    background: #f6f6f6;
+  }
+
+  table.chunks th:last-child {
+    width: 15%;
+  }
+
+  table.chunks tr:last-child {
+    background: #fff;
+  }
+
+  table.chunks td.last {
+    border-right: none;
+  }
+
+  table.chunks td {
+    border-top: 1px solid #e0e0e0;
+    border-right: 1px solid #e0e0e0;
+  }
+
+  table .chunks tr:first-child {
+    background: #e7e7e7;
+  }
+
+  .footer-popup ul li {
+    display: inline;
+  }
+
+  .footer-popup a {
+    font-size: 13px;
+    padding-right: 20px;
+  }
+
+  .footer-popup {
+    border-top: 1px solid #ccc;
+    clear: both;
+    margin-top: 30px;
+    padding: 4px 0px 0px;
+  }
+
+  /* scroll pop-up
     .outsourcemodal .popup-box {
         overflow-y: auto;
     max-height: 525px;
     }
     */
 
-    .noselect {
-        -webkit-appearance: none;
-        border: none;
-        pointer-events: none;
-        background: transparent !important;
+  .noselect {
+    -webkit-appearance: none;
+    border: none;
+    pointer-events: none;
+    background: transparent !important;
+  }
+
+  .deliverychange,
+  .currencychange {
+    font-size: 12px;
+    text-decoration: underline;
+    color: blue;
+    display: block;
+    cursor: pointer;
+  }
+
+  @media screen and (min-height: 715px) {
+    .contact_box {
+      margin-bottom: 10px;
+    }
+  }
+
+  @media screen and (max-height: 715px) and (min-height: 600px) {
+    &.outsource .popup {
+      top: 25%;
+    }
+    &.outsource .popup-box {
+      overflow-y: visible;
+      max-height: 590px;
+    }
+  }
+
+  @media screen and (max-height: 650px) and (min-height: 600px) {
+    &.outsource .popup-box {
+      overflow-y: visible;
+      max-height: 540px;
     }
 
-    .deliverychange, .currencychange {
-        font-size: 12px;
-        text-decoration: underline;
-        color: blue;
-        display: block;
-        cursor: pointer;
+    &.outsource .popup {
+      top: 27%;
     }
+  }
 
-    @media screen and (min-height: 715px) {
-        .contact_box {
-            margin-bottom: 10px;
-        }
-    }
-
-    @media screen and (max-height: 715px) and (min-height: 600px) {
-        &.outsource .popup {
-            top: 25%;
-        }
-        &.outsource .popup-box {
-            overflow-y: visible;
-            max-height: 590px;
-        }
-    }
-
-    @media screen and (max-height: 650px) and (min-height: 600px) {
-        &.outsource .popup-box {
-            overflow-y: visible;
-            max-height: 540px;
-        }
-
-        &.outsource .popup {
-            top: 27%;
-        }
-    }
-
-
-    @media screen and (max-height: 600px) {
-        &.outsource .popup {
-            zoom: 0.8;
-            top: 2%;
-            /*margin: 0 0 0 -400px;   */
-        }
-
-        #forceDeliveryContainer {
-            top: 425px !important;
-        }
-
-        .guaranteed_by.expanded {
-            width: calc(70% - 1px);
-        }
-        .guaranteed_by {
-            width: calc(32% - 1px);
-        }
-        &.outsource .popup-box {
-            overflow-y: visible;
-            max-height: 560px;
-        }
-
-        &.outsource .popup p {
-            background-size: 200px;
-            background-position: 300px 35px;
-            padding: 0 !important;
-        }
-        .pricebox .total {
-            margin-top: -40px;
-        }
-    }
-
-    .tooltip span {
-        font-size: 15px;
-        line-height: 20px;
-        font-weight: normal;
-        /* background-color: #f8f8f8; */
-    }
-
-    .compress .tooltip.gray span {
-        left: -197px;
-    }
-
-    .compress .tooltip span:before, .compress .tooltip span:after {
-        left: 87%;
-    }
-
-    .tooltip:hover span {
-        opacity: 1;
-        top: -150px;
-    }
-
-    a.tooltip.gray {
-        background: #EEE;
-        text-decoration: none;
-        color: #333;
-    }
-
-    a.tooltip.gray span {
-        background: #EEE;
-        font-size: 15px;
-    }
-
-    a.tooltip.gray span:after {
-        border-top: 10px solid #eee;
-    }
-
-    /* force delivery */
-
-    .modal-outsource-datepicker {
-        height: 215px;
-        width: 520px;
-        background: #FFFFFF;
-        border: 5px solid #F4F4F4;
-        border-radius: 4px;
-        position: absolute;
-        z-index: 10001;
-        color: #fff;
-        padding: 20px;
-        top: 120px;
-        left: 435px;
-        zoom: 0.9;
-        z-index: 99999999999999999999;
-        text-align: left;
-        -moz-box-shadow: 0 0px 11px #888;
-        -webkit-box-shadow: 0 0px 11px #888;
+  @media screen and (max-height: 600px) {
+    &.outsource .popup {
+      zoom: 0.8;
+      top: 2%;
+      /*margin: 0 0 0 -400px;   */
     }
 
     #forceDeliveryContainer {
-        top: 385px;
-        left: 465px;
-    }
-
-    .modal-outsource-datepicker .title {
-        font-size: 220%;
-        margin: 0px 0 10px 0px;
-        color: #002f65;
-        border-bottom: 1px solid #ccc;
-        padding: 5px 0 8px 11px;
-        background: #b1c7d6;
-        float: none;
-        line-height: 1;
-    }
-
-    #SnapABug_WP {
-        z-index: 100000000000000000000000000000000 !important;
-    }
-
-    .modal-outsource-datepicker .delivery-auto {
-        width: 635px;
-        height: auto;
-        padding: 10px;
-        border: 1px solid #ccc;
-        margin: 10px 10px 0px 10px;
-        border-radius: 3px;
-        background-color: #CEDBE5;
-        color: #999;
-    }
-
-    .modal-outsource-datepicker tbody:nth-child(3) tr td:not(.empty) {
-        border-top: 0 !important;
-    }
-
-    .modal-outsource-datepicker .delivery-auto h2 {
-        font-size: 24px;
-        margin: 0 0 10px 0;
-        color: #002F65;
-    }
-
-    .modal-outsource-datepicker .delivery-auto h2 label {
-        cursor: pointer;
-    }
-
-
-    .modal-outsource-datepicker .delivery-auto p {
-        font-size: 16px;
-        margin: -5px 0 0 10px;
-    }
-
-    .modal-outsource-datepicker .delivery-manual {
-
-        vertical-align: baseline;
-        line-height: 1;
-        color: #999;
-
-    }
-
-    .modal-outsource-datepicker .delivery-manual br {
-        line-height: 1.15;
-    }
-
-    .modal-outsource-datepicker .delivery-manual h2 {
-        font-size: 24px;
-        margin: 0 0 10px 0;
-        color: #002F65;
-    }
-
-    .modal-outsource-datepicker .delivery-manual h2 label {
-        cursor: pointer;
-    }
-
-
-    .modal-outsource-datepicker .delivery-manual-date {
-        float: left;
-        width: 240px;
-        height: 200px;
-    }
-
-    .modal-outsource-datepicker .delivery-manual-date h3 {
-        text-align: left;
-        margin-left: 20px;
-        font-size: 19px;
-        font-weight: normal;
-        margin: 0px 0 10px 15px;
-        line-height: 100%;
-    }
-
-    .modal-outsource-datepicker .delivery-manual-time {
-        float: left;
-        width: 255px;
-        height: 200px;
-        margin: 0px 10px 0px 0;
-    }
-
-    .modal-outsource-datepicker .delivery-manual-time h3 {
-        text-align: left;
-        margin-left: 20px;
-        font-size: 17px;
-        font-weight: normal;
-        margin: 0px 0 6px 12px;
-        line-height: 100%;
-        color: #333;
-    }
-
-    .modal-outsource-datepicker .delivery-manual-time select {
-        width: 250px;
-        margin-left: 12px;
-        color: #333;
-    }
-
-
-    .modal-outsource-datepicker .delivery_manual_error,
-    .modal-outsource-datepicker .delivery_not_available,
-    .modal-outsource-datepicker .delivery_before_time {
-        opacity: 0.87;
-        color: red;
-        margin-left: 12px;
-        text-align: right;
-        font-weight: bold;
-        font-size: 14px;
-        margin-top: 5px;
-        position: absolute;
-        padding-bottom: 13px;
-        z-index: 100000;
-    }
-
-    .modal-outsource-datepicker .delivery_manual_error div,
-    .modal-outsource-datepicker .delivery_not_available div
-    .modal-outsource-datepicker .delivery_before_time div {
-        width: 225px;
-        text-align: left;
-        font-size: 13px;
-        font-weight: bold;
-        border-radius: 6px;
-    }
-
-    .modal-outsource-datepicker #delivery_before_time {
-        color: green;
-    }
-
-    .modal-outsource-datepicker select {
-        border: 1px solid #ccc;
-        height: 30px;
-        font-size: 12px;
-        font-family: Arial;
-    }
-
-    .modal-outsource-datepicker .clear {
-        clear: both;
-    }
-
-    .modal-outsource-datepicker input[type="button"],
-    .modal-outsource-datepicker .btn-cancel {
-        width: auto !important;
-        float: right !important;
-        margin-top: 25px !important;
-        margin-right: 35px;
-    }
-
-    a.btn-cancel.in-popup.cancelForceDelivery {
-        margin-right: 40px !important;
-        height: 15px;
-    }
-
-    a.btn-cancel.in-popup.cancelForceDelivery:hover {
-        margin-right: 40px !important;
-        color: #333333;
-    }
-
-    .modal-outsource-datepicker .delivery-selected {
-        color: #000 !important;
-    }
-
-
-    .modal-outsource-datepicker .tprice {
-        width: 250px;
-        box-shadow: none;
-    }
-
-    .updatedprice {
-        font-size: 20px !important;
-        margin-bottom: 5px;
-        padding: 0 10px 5px;
-        font-weight: normal;
-    }
-
-    .deliverybuttons {
-        margin: 0 auto;
-        overflow: hidden;
-        width: 250px;
-        height: auto;
-        color: #333;
-        padding-bottom: 15px;
-    }
-
-
-    .modal-outsource-datepicker .datepickerMonths,
-    .modal-outsource-datepicker .datepickerYears {
-        display: none;
-    }
-
-    .modal-outsource-datepicker td.datepickerSpecial a {
-        border: 1px solid;
-        color: $translatedBlue;
-        background-color: #F3F3F3 !important;
-    }
-
-    .modal-outsource-datepicker .datepickerDoW th {
-        padding: 5px 0;
-    }
-
-    .modal-outsource-datepicker .datepickerDoW th:first-child,
-    .modal-outsource-datepicker th.datepickerWeek {
-        display: none;
-    }
-
-    .modal-outsource-datepicker .datepickerNotInMonth {
-        visibility: hidden;
-    }
-
-
-    .modal-outsource-datepicker .datepicker table {
-        background-color: transparent;
-        border: none;
-        font-size: 16px;
-        text-align: right;
-        font-weight: normal !important;
-        border-collapse: collapse;
-    }
-
-    .modal-outsource-datepicker .datepicker table tr td a {
-        background-color: #E1E1E1;
-        text-decoration: none;
-    }
-
-    .modal-outsource-datepicker .datepicker table td.datepickerDisabled a,
-    .modal-outsource-datepicker .datepicker table a.datepickerDisabled,
-    .modal-outsource-datepicker .datepickerGoPrev a,
-    .modal-outsource-datepicker .datepickerGoNext a {
-        background-color: transparent;
-        color: #333;
-    }
-
-    .modal-outsource-datepicker .datepickerGoPrev a,
-    .modal-outsource-datepicker .datepickerGoNext a {
-        font-size: 13px;
-        background-color: transparent !important;
-    }
-
-    .modal-outsource-datepicker .datepickerDisabled a {
-        color: #666 !important;
-        font-weight: normal;
-        cursor: default;
-    }
-
-    .modal-outsource-datepicker .datepicker table .datepickerDoW {
-        font-size: 12px;
-    }
-
-    .modal-outsource-datepicker .datepicker a {
-        text-decoration: none;
-        padding: 4px;
-        outline: none;
-        display: block;
-        color: #333;
-    }
-
-    .modal-outsource-datepicker .datepickerDays a {
-        line-height: 20px;
-        height: 16px;
-        margin: 1px;
-        background: #D6E7F4;
-        padding: 4px;
-    }
-
-
-    .modal-outsource-datepicker .datepickerDays a:hover {
-        background-color: $translatedBlue;
-        color: #fff;
-    }
-
-    .modal-outsource-datepicker td.datepickerSpecial a:hover {
-        background-color: $translatedBlue !important;
-        color: #fff;
-    }
-
-    .modal-outsource-datepicker .datepickerWeek a {
-        font-weight: normal;
-    }
-
-    .modal-outsource-datepicker .datepickerMonth a,
-    .modal-outsource-datepicker .datepickerDoW span {
-        text-decoration: none;
-        font-weight: normal;
-        text-align: center;
-    }
-
-    .modal-outsource-datepicker .datepicker table td.datepickerDisabled a {
-        opacity: 0.5;
-    }
-
-    .modal-outsource-datepicker .datepickerSelected a {
-        background-color: #7eaf3e !important;
-        color: #fff;
-    }
-
-    .forceNotAvailable {
-        position: absolute;
-        text-align: center;
-        width: 332px;
-        margin-top: 10%;
-    }
-
-    .forceNotAvailable > p > span.title {
-        font-size: 22px;
-    }
-
-    .forceNotAvailable > p > span.description {
-        font-size: 15px;
-    }
-
-    .link-needfaster {
-        font-weight: bold;
-    }
-
-
-    #forceDeliveryContainer td.datepickerSaturday:not(.datepickerDisabled) a,
-    #forceDeliveryContainer td.datepickerSunday:not(.datepickerDisabled) a {
-        cursor: not-allowed !important;
-        background-color: #E7E7E7 !important;
-        color: #C2C2C2 !important;
-    }
-
-
-    #fasterDeliveryContainer {
-        overflow: hidden;
-        height: 180px;
-        width: 470px;
-        border: 1px solid rgb(177, 199, 214);
-        position: absolute;
-        z-index: 10001;
-        left: 564px;
-        top: 455px;
-        background-color: rgb(255, 255, 255);
-        background-repeat: no-repeat;
-        text-align: left;
-        border-radius: 6px;
-    }
-
-    #fasterDeliveryContainer h1 {
-        font-size: 30px;
-        width: 100%;
-        margin: 0px 0 10px 0px;
-        color: #002f65;
-        border-bottom: 1px solid #ccc;
-        padding: 5px 0 0px 11px;
-        background: #b1c7d6;
-    }
-
-    #fasterDeliveryContainer p {
-        font-size: 16px;
-        margin: 0px 10px;
-        line-height: 20px;
-        padding: 0;
-        border: 0;
-        outline: 0;
-    }
-
-    #fasterDeliveryContainer input[type="button"] {
-        margin-right: 10px;
-        float: right;
-        width: 167px !important;
-        border: 1px double #ccc;
-        border-radius: 4px;
-        background: linear-gradient(to bottom, #fefefe 23%, #fefefe 35%, #cfcfcf 100%);
-        height: 36px;
-        padding: 5px 10px;
-        font-weight: bold;
-        font-size: 15px;
-        cursor: pointer;
-    }
-
-    /* errors outsource */
-
-    .ErrorMsg {
-        width: 96%;
-        height: 60px;
-        padding: 2% 4%;
-        text-align: left;
-        font-weight: normal;
-    }
-
-    .tprice .ErrorMsgQuoteError, .tprice .ErrorMsg a {
-        color: #333 !important;
-    }
-
-    .delivery .ErrorMsg.ErrorMsgQuoteError {
-        margin-top: 16px;
-    }
-
-    .ErrorMsg, .ErrorMsg h3, .ErrorMsg a {
-        color: red !important;
-        font-weight: normal;
-    }
-
-    .quoteError {
-        margin-bottom: 20px;
-    }
-
-    .ErrorMsgquoteNotAvailable .delivery a {
-        margin-bottom: 0 !important;
-    }
-
-    .ErrorMsgquoteNotAvailable p {
-        font-size: 15px !important;
-        line-height: 20px;
-        color: red;
-    }
-
-    .ErrorMsgquoteNotAvailable {
-        margin-top: -8px;
-    }
-
-    .quoteNotAvailable .tprice {
-        min-height: 109px;
-    }
-
-    .quoteError .delivery {
-        padding: 0.5% 2% 4% 2%;
-    }
-
-    /******** Outsource Modal *******/
-    &.outsource .uploadbtn.in-popup,
-    &.outsource .continuebtn,
-    &.outsource .standardbtn,
-    &.outsource .send-to-translator-btn.in-popup {
-        background: $translatedBlue;
-        font-weight: bold;
-        -webkit-transition: all 100ms ease-in;
-        -moz-transition: all 100ms ease-in;
-        font-size: 20px !important;
-        cursor: pointer;
-        color: #fff;
-        -moz-box-shadow: 0 1px 2px #ccc;
-        -webkit-box-shadow: 0 1px 2px #ccc;
-        box-shadow: 0 1px 2px #ccc;
-        border: 1px solid #666;
-        -moz-border-radius: 2px;
-        border-radius: 2px;
-        text-decoration: none;
-        opacity: 0.9;
-        text-align: center;
-        padding: 5px 10px !important;
-        float: right;
-        margin: 2% 2.5% 2% 2%;
-        width: 160px;
-    }
-
-    &.outsource .send-to-translator-btn.in-popup {
-        margin-left: 30px
-    }
-
-    &.outsource .uploadbtn:hover,
-    &.outsource .continuebtn:hover,
-    &.outsource .standardbtn:hover,
-    &.outsource .send-to-translator-btn.in-popup:hover {
-        -moz-box-shadow: 0 1px 2px #666;
-        -webkit-box-shadow: 0 1px 2px #666;
-        box-shadow: 0 1px 2px #666;
-        background: #12b4df;
-    }
-
-    &.outsource .continuebtn {
-        clear: both;
-        float: none;
-        width: 160px;
-        margin: 10px auto 0 auto !important;
-        overflow: hidden;
-        background: #7eaf3e;
-        display: block;
-    }
-
-    &.outsource .continuebtn:hover {
-        background: #7eaf3e;
-    }
-
-    &.outsource .more:before {
-        content: "\f196";
-        margin-right: 7px;
-        font-family: 'icomoon';
-        speak: none;
-        font-style: normal;
-        font-weight: normal;
-        font-variant: normal;
-        text-transform: none;
-        line-height: 1;
-        -webkit-font-smoothing: antialiased;
-    }
-
-    &.outsource .trustbox2 a {
-        text-decoration: underline;
-    }
-
-    &.outsource .tooltip {
-        cursor: help;
-        position: absolute;
-        border: 1px solid #717171;
-        border-radius: 20px;
-        width: 13px !important;
-        font-size: 13px;
-        height: 11px;
-        font-weight: bold;
-        padding-left: 0px;
-        padding-top: 2px;
-        margin-top: -3px;
-        line-height: 11px;
-        margin-left: 5px;
-        color: #717171;
-        box-shadow: 1px 1px 1px #999;
-    }
-
-    &.outsource .tooltip span {
-        width: 200px;
-        height: auto;
-        line-height: 22px;
-        color: #333;
-        padding: 10px;
-        left: -98px;
-        font-weight: 400;
-        font-size: 15px;
-        text-align: center;
-        border: 1px solid #727272;
-        text-indent: 0px;
-        border-radius: 5px;
-        position: absolute;
-        pointer-events: none;
-        top: -110px;
-        opacity: 0;
-        box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
-        -webkit-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
-        -moz-box-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
-        -webkit-transition: all 0.3s ease-in-out;
-        -moz-transition: all 0.3s ease-in-out;
-        -o-transition: all 0.3s ease-in-out;
-        -ms-transition: all 0.3s ease-in-out;
-        transition: all 0.3s ease-in-out;
-        z-index: 1000000000000000;
-    }
-
-    &.outsource .tooltip:hover span {
-        opacity: 1;
-        top: -165px;
-    }
-
-    &.outsource .tooltip span:after {
-        bottom: -10px;
-        margin-left: -1px;
-        border-top: 10px solid #EEE;
-    }
-
-    &.outsource .tooltip span:before, .tooltip span:after {
-        content: '';
-        position: absolute;
-        bottom: -11px;
-        left: 43%;
-        width: 0;
-        height: 0;
-        border-left: 10px solid transparent;
-        border-right: 10px solid transparent;
-        border-top: 10px solid #727272;
-    }
-
-    &.outsource .disabled {
-        cursor: default;
-        opacity: 0.45 !important;
-        background-image: none !important;
-        box-shadow: none !important;
-        pointer-events: none !important;
-    }
-
-    &.outsource input.error {
-        border: 1px solid red !important;
-    }
-
-    div#open-translator {
-        float: right;
-        text-decoration: underline;
-        font-weight: bold;
-        cursor: pointer;
-        margin-right: 52px;
-        color: #0d8fb2;
-    }
-
-    div#open-translator:hover {
-        text-decoration: none;
-    }
-
-    &.outsource .send-to-translator {
-        border: 1px solid #ccc;
-        border-radius: 0px 0px 3px 3px;
-        margin: 0 auto;
-        overflow: hidden;
-        margin-top: -2px;
-        background: #f8f8f8;
-    }
-
-    &.outsource .outsource-divider {
-        width: 230px;
-        margin: 0 auto;
-        text-align: center;
-        position: relative;
-        height: 20px;
-        line-height: 20px;
-        margin-top: 15px;
-    }
-
-    &.outsource .divider-line {
-        height: 2px;
-        width: 100px;
-        background-color: #c5c5c5;
-        margin-top: 10px;
-        display: block;
-        float: left;
-    }
-
-    &.outsource .outsource-divider span {
-        float: left;
-        width: 30px;
-    }
-
-    span.title-source {
-        margin-left: 5px;
-    }
-
-
-    .popup.popup-confirm.confirm_checkbox,
-    .popup.popup-alert {
-        text-align: right;
-    }
-
-    .popup.popup-confirm.confirm_checkbox p.text-container-top,
-    .popup.popup-alert p.text-container-top {
-        text-align: left;
-        padding: 20px;
-    }
-
-    .popup.popup-confirm.confirm_checkbox .btn-ok,
-    .popup.popup-alert .btn-ok {
-        margin-right: 20px;
-    }
+      top: 425px !important;
+    }
+
+    .guaranteed_by.expanded {
+      width: calc(70% - 1px);
+    }
+    .guaranteed_by {
+      width: calc(32% - 1px);
+    }
+    &.outsource .popup-box {
+      overflow-y: visible;
+      max-height: 560px;
+    }
+
+    &.outsource .popup p {
+      background-size: 200px;
+      background-position: 300px 35px;
+      padding: 0 !important;
+    }
+    .pricebox .total {
+      margin-top: -40px;
+    }
+  }
+
+  .tooltip span {
+    font-size: 15px;
+    line-height: 20px;
+    font-weight: normal;
+    /* background-color: #f8f8f8; */
+  }
+
+  .compress .tooltip.gray span {
+    left: -197px;
+  }
+
+  .compress .tooltip span:before,
+  .compress .tooltip span:after {
+    left: 87%;
+  }
+
+  .tooltip:hover span {
+    opacity: 1;
+    top: -150px;
+  }
+
+  a.tooltip.gray {
+    background: #eee;
+    text-decoration: none;
+    color: #333;
+  }
+
+  a.tooltip.gray span {
+    background: #eee;
+    font-size: 15px;
+  }
+
+  a.tooltip.gray span:after {
+    border-top: 10px solid #eee;
+  }
+
+  /* force delivery */
+
+  .modal-outsource-datepicker {
+    height: 215px;
+    width: 520px;
+    background: #ffffff;
+    border: 5px solid #f4f4f4;
+    border-radius: 4px;
+    position: absolute;
+    z-index: 10001;
+    color: #fff;
+    padding: 20px;
+    top: 120px;
+    left: 435px;
+    zoom: 0.9;
+    z-index: 99999999999999999999;
+    text-align: left;
+    -moz-box-shadow: 0 0px 11px #888;
+    -webkit-box-shadow: 0 0px 11px #888;
+  }
+
+  #forceDeliveryContainer {
+    top: 385px;
+    left: 465px;
+  }
+
+  .modal-outsource-datepicker .title {
+    font-size: 220%;
+    margin: 0px 0 10px 0px;
+    color: #002f65;
+    border-bottom: 1px solid #ccc;
+    padding: 5px 0 8px 11px;
+    background: #b1c7d6;
+    float: none;
+    line-height: 1;
+  }
+
+  #SnapABug_WP {
+    z-index: 100000000000000000000000000000000 !important;
+  }
+
+  .modal-outsource-datepicker .delivery-auto {
+    width: 635px;
+    height: auto;
+    padding: 10px;
+    border: 1px solid #ccc;
+    margin: 10px 10px 0px 10px;
+    border-radius: 3px;
+    background-color: #cedbe5;
+    color: #999;
+  }
+
+  .modal-outsource-datepicker tbody:nth-child(3) tr td:not(.empty) {
+    border-top: 0 !important;
+  }
+
+  .modal-outsource-datepicker .delivery-auto h2 {
+    font-size: 24px;
+    margin: 0 0 10px 0;
+    color: #002f65;
+  }
+
+  .modal-outsource-datepicker .delivery-auto h2 label {
+    cursor: pointer;
+  }
+
+  .modal-outsource-datepicker .delivery-auto p {
+    font-size: 16px;
+    margin: -5px 0 0 10px;
+  }
+
+  .modal-outsource-datepicker .delivery-manual {
+    vertical-align: baseline;
+    line-height: 1;
+    color: #999;
+  }
+
+  .modal-outsource-datepicker .delivery-manual br {
+    line-height: 1.15;
+  }
+
+  .modal-outsource-datepicker .delivery-manual h2 {
+    font-size: 24px;
+    margin: 0 0 10px 0;
+    color: #002f65;
+  }
+
+  .modal-outsource-datepicker .delivery-manual h2 label {
+    cursor: pointer;
+  }
+
+  .modal-outsource-datepicker .delivery-manual-date {
+    float: left;
+    width: 240px;
+    height: 200px;
+  }
+
+  .modal-outsource-datepicker .delivery-manual-date h3 {
+    text-align: left;
+    margin-left: 20px;
+    font-size: 19px;
+    font-weight: normal;
+    margin: 0px 0 10px 15px;
+    line-height: 100%;
+  }
+
+  .modal-outsource-datepicker .delivery-manual-time {
+    float: left;
+    width: 255px;
+    height: 200px;
+    margin: 0px 10px 0px 0;
+  }
+
+  .modal-outsource-datepicker .delivery-manual-time h3 {
+    text-align: left;
+    margin-left: 20px;
+    font-size: 17px;
+    font-weight: normal;
+    margin: 0px 0 6px 12px;
+    line-height: 100%;
+    color: #333;
+  }
+
+  .modal-outsource-datepicker .delivery-manual-time select {
+    width: 250px;
+    margin-left: 12px;
+    color: #333;
+  }
+
+  .modal-outsource-datepicker .delivery_manual_error,
+  .modal-outsource-datepicker .delivery_not_available,
+  .modal-outsource-datepicker .delivery_before_time {
+    opacity: 0.87;
+    color: red;
+    margin-left: 12px;
+    text-align: right;
+    font-weight: bold;
+    font-size: 14px;
+    margin-top: 5px;
+    position: absolute;
+    padding-bottom: 13px;
+    z-index: 100000;
+  }
+
+  .modal-outsource-datepicker .delivery_manual_error div,
+  .modal-outsource-datepicker
+    .delivery_not_available
+    div
+    .modal-outsource-datepicker
+    .delivery_before_time
+    div {
+    width: 225px;
+    text-align: left;
+    font-size: 13px;
+    font-weight: bold;
+    border-radius: 6px;
+  }
+
+  .modal-outsource-datepicker #delivery_before_time {
+    color: green;
+  }
+
+  .modal-outsource-datepicker select {
+    border: 1px solid #ccc;
+    height: 30px;
+    font-size: 12px;
+    font-family: Arial;
+  }
+
+  .modal-outsource-datepicker .clear {
+    clear: both;
+  }
+
+  .modal-outsource-datepicker input[type='button'],
+  .modal-outsource-datepicker .btn-cancel {
+    width: auto !important;
+    float: right !important;
+    margin-top: 25px !important;
+    margin-right: 35px;
+  }
+
+  a.btn-cancel.in-popup.cancelForceDelivery {
+    margin-right: 40px !important;
+    height: 15px;
+  }
+
+  a.btn-cancel.in-popup.cancelForceDelivery:hover {
+    margin-right: 40px !important;
+    color: #333333;
+  }
+
+  .modal-outsource-datepicker .delivery-selected {
+    color: #000 !important;
+  }
+
+  .modal-outsource-datepicker .tprice {
+    width: 250px;
+    box-shadow: none;
+  }
+
+  .updatedprice {
+    font-size: 20px !important;
+    margin-bottom: 5px;
+    padding: 0 10px 5px;
+    font-weight: normal;
+  }
+
+  .deliverybuttons {
+    margin: 0 auto;
+    overflow: hidden;
+    width: 250px;
+    height: auto;
+    color: #333;
+    padding-bottom: 15px;
+  }
+
+  .modal-outsource-datepicker .datepickerMonths,
+  .modal-outsource-datepicker .datepickerYears {
+    display: none;
+  }
+
+  .modal-outsource-datepicker td.datepickerSpecial a {
+    border: 1px solid;
+    color: $translatedBlue;
+    background-color: #f3f3f3 !important;
+  }
+
+  .modal-outsource-datepicker .datepickerDoW th {
+    padding: 5px 0;
+  }
+
+  .modal-outsource-datepicker .datepickerDoW th:first-child,
+  .modal-outsource-datepicker th.datepickerWeek {
+    display: none;
+  }
+
+  .modal-outsource-datepicker .datepickerNotInMonth {
+    visibility: hidden;
+  }
+
+  .modal-outsource-datepicker .datepicker table {
+    background-color: transparent;
+    border: none;
+    font-size: 16px;
+    text-align: right;
+    font-weight: normal !important;
+    border-collapse: collapse;
+  }
+
+  .modal-outsource-datepicker .datepicker table tr td a {
+    background-color: #e1e1e1;
+    text-decoration: none;
+  }
+
+  .modal-outsource-datepicker .datepicker table td.datepickerDisabled a,
+  .modal-outsource-datepicker .datepicker table a.datepickerDisabled,
+  .modal-outsource-datepicker .datepickerGoPrev a,
+  .modal-outsource-datepicker .datepickerGoNext a {
+    background-color: transparent;
+    color: #333;
+  }
+
+  .modal-outsource-datepicker .datepickerGoPrev a,
+  .modal-outsource-datepicker .datepickerGoNext a {
+    font-size: 13px;
+    background-color: transparent !important;
+  }
+
+  .modal-outsource-datepicker .datepickerDisabled a {
+    color: #666 !important;
+    font-weight: normal;
+    cursor: default;
+  }
+
+  .modal-outsource-datepicker .datepicker table .datepickerDoW {
+    font-size: 12px;
+  }
+
+  .modal-outsource-datepicker .datepicker a {
+    text-decoration: none;
+    padding: 4px;
+    outline: none;
+    display: block;
+    color: #333;
+  }
+
+  .modal-outsource-datepicker .datepickerDays a {
+    line-height: 20px;
+    height: 16px;
+    margin: 1px;
+    background: #d6e7f4;
+    padding: 4px;
+  }
+
+  .modal-outsource-datepicker .datepickerDays a:hover {
+    background-color: $translatedBlue;
+    color: #fff;
+  }
+
+  .modal-outsource-datepicker td.datepickerSpecial a:hover {
+    background-color: $translatedBlue !important;
+    color: #fff;
+  }
+
+  .modal-outsource-datepicker .datepickerWeek a {
+    font-weight: normal;
+  }
+
+  .modal-outsource-datepicker .datepickerMonth a,
+  .modal-outsource-datepicker .datepickerDoW span {
+    text-decoration: none;
+    font-weight: normal;
+    text-align: center;
+  }
+
+  .modal-outsource-datepicker .datepicker table td.datepickerDisabled a {
+    opacity: 0.5;
+  }
+
+  .modal-outsource-datepicker .datepickerSelected a {
+    background-color: #7eaf3e !important;
+    color: #fff;
+  }
+
+  .forceNotAvailable {
+    position: absolute;
+    text-align: center;
+    width: 332px;
+    margin-top: 10%;
+  }
+
+  .forceNotAvailable > p > span.title {
+    font-size: 22px;
+  }
+
+  .forceNotAvailable > p > span.description {
+    font-size: 15px;
+  }
+
+  .link-needfaster {
+    font-weight: bold;
+  }
+
+  #forceDeliveryContainer td.datepickerSaturday:not(.datepickerDisabled) a,
+  #forceDeliveryContainer td.datepickerSunday:not(.datepickerDisabled) a {
+    cursor: not-allowed !important;
+    background-color: #e7e7e7 !important;
+    color: #c2c2c2 !important;
+  }
+
+  #fasterDeliveryContainer {
+    overflow: hidden;
+    height: 180px;
+    width: 470px;
+    border: 1px solid rgb(177, 199, 214);
+    position: absolute;
+    z-index: 10001;
+    left: 564px;
+    top: 455px;
+    background-color: rgb(255, 255, 255);
+    background-repeat: no-repeat;
+    text-align: left;
+    border-radius: 6px;
+  }
+
+  #fasterDeliveryContainer h1 {
+    font-size: 30px;
+    width: 100%;
+    margin: 0px 0 10px 0px;
+    color: #002f65;
+    border-bottom: 1px solid #ccc;
+    padding: 5px 0 0px 11px;
+    background: #b1c7d6;
+  }
+
+  #fasterDeliveryContainer p {
+    font-size: 16px;
+    margin: 0px 10px;
+    line-height: 20px;
+    padding: 0;
+    border: 0;
+    outline: 0;
+  }
+
+  #fasterDeliveryContainer input[type='button'] {
+    margin-right: 10px;
+    float: right;
+    width: 167px !important;
+    border: 1px double #ccc;
+    border-radius: 4px;
+    background: linear-gradient(
+      to bottom,
+      #fefefe 23%,
+      #fefefe 35%,
+      #cfcfcf 100%
+    );
+    height: 36px;
+    padding: 5px 10px;
+    font-weight: bold;
+    font-size: 15px;
+    cursor: pointer;
+  }
+
+  /* errors outsource */
+
+  .ErrorMsg {
+    width: 96%;
+    height: 60px;
+    padding: 2% 4%;
+    text-align: left;
+    font-weight: normal;
+  }
+
+  .tprice .ErrorMsgQuoteError,
+  .tprice .ErrorMsg a {
+    color: #333 !important;
+  }
+
+  .delivery .ErrorMsg.ErrorMsgQuoteError {
+    margin-top: 16px;
+  }
+
+  .ErrorMsg,
+  .ErrorMsg h3,
+  .ErrorMsg a {
+    color: red !important;
+    font-weight: normal;
+  }
+
+  .quoteError {
+    margin-bottom: 20px;
+  }
+
+  .ErrorMsgquoteNotAvailable .delivery a {
+    margin-bottom: 0 !important;
+  }
+
+  .ErrorMsgquoteNotAvailable p {
+    font-size: 15px !important;
+    line-height: 20px;
+    color: red;
+  }
+
+  .ErrorMsgquoteNotAvailable {
+    margin-top: -8px;
+  }
+
+  .quoteNotAvailable .tprice {
+    min-height: 109px;
+  }
+
+  .quoteError .delivery {
+    padding: 0.5% 2% 4% 2%;
+  }
+
+  /******** Outsource Modal *******/
+  &.outsource .uploadbtn.in-popup,
+  &.outsource .continuebtn,
+  &.outsource .standardbtn,
+  &.outsource .send-to-translator-btn.in-popup {
+    background: $translatedBlue;
+    font-weight: bold;
+    -webkit-transition: all 100ms ease-in;
+    -moz-transition: all 100ms ease-in;
+    font-size: 20px !important;
+    cursor: pointer;
+    color: #fff;
+    -moz-box-shadow: 0 1px 2px #ccc;
+    -webkit-box-shadow: 0 1px 2px #ccc;
+    box-shadow: 0 1px 2px #ccc;
+    border: 1px solid #666;
+    -moz-border-radius: 2px;
+    border-radius: 2px;
+    text-decoration: none;
+    opacity: 0.9;
+    text-align: center;
+    padding: 5px 10px !important;
+    float: right;
+    margin: 2% 2.5% 2% 2%;
+    width: 160px;
+  }
+
+  &.outsource .send-to-translator-btn.in-popup {
+    margin-left: 30px;
+  }
+
+  &.outsource .uploadbtn:hover,
+  &.outsource .continuebtn:hover,
+  &.outsource .standardbtn:hover,
+  &.outsource .send-to-translator-btn.in-popup:hover {
+    -moz-box-shadow: 0 1px 2px #666;
+    -webkit-box-shadow: 0 1px 2px #666;
+    box-shadow: 0 1px 2px #666;
+    background: #12b4df;
+  }
+
+  &.outsource .continuebtn {
+    clear: both;
+    float: none;
+    width: 160px;
+    margin: 10px auto 0 auto !important;
+    overflow: hidden;
+    background: #7eaf3e;
+    display: block;
+  }
+
+  &.outsource .continuebtn:hover {
+    background: #7eaf3e;
+  }
+
+  &.outsource .more:before {
+    content: '\f196';
+    margin-right: 7px;
+    font-family: 'icomoon';
+    speak: none;
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  &.outsource .trustbox2 a {
+    text-decoration: underline;
+  }
+
+  &.outsource .tooltip {
+    cursor: help;
+    position: absolute;
+    border: 1px solid #717171;
+    border-radius: 20px;
+    width: 13px !important;
+    font-size: 13px;
+    height: 11px;
+    font-weight: bold;
+    padding-left: 0px;
+    padding-top: 2px;
+    margin-top: -3px;
+    line-height: 11px;
+    margin-left: 5px;
+    color: #717171;
+    box-shadow: 1px 1px 1px #999;
+  }
+
+  &.outsource .tooltip span {
+    width: 200px;
+    height: auto;
+    line-height: 22px;
+    color: #333;
+    padding: 10px;
+    left: -98px;
+    font-weight: 400;
+    font-size: 15px;
+    text-align: center;
+    border: 1px solid #727272;
+    text-indent: 0px;
+    border-radius: 5px;
+    position: absolute;
+    pointer-events: none;
+    top: -110px;
+    opacity: 0;
+    box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
+    -webkit-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
+    -moz-box-box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.4);
+    -webkit-transition: all 0.3s ease-in-out;
+    -moz-transition: all 0.3s ease-in-out;
+    -o-transition: all 0.3s ease-in-out;
+    -ms-transition: all 0.3s ease-in-out;
+    transition: all 0.3s ease-in-out;
+    z-index: 1000000000000000;
+  }
+
+  &.outsource .tooltip:hover span {
+    opacity: 1;
+    top: -165px;
+  }
+
+  &.outsource .tooltip span:after {
+    bottom: -10px;
+    margin-left: -1px;
+    border-top: 10px solid #eee;
+  }
+
+  &.outsource .tooltip span:before,
+  .tooltip span:after {
+    content: '';
+    position: absolute;
+    bottom: -11px;
+    left: 43%;
+    width: 0;
+    height: 0;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-top: 10px solid #727272;
+  }
+
+  &.outsource .disabled {
+    cursor: default;
+    opacity: 0.45 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+    pointer-events: none !important;
+  }
+
+  &.outsource input.error {
+    border: 1px solid red !important;
+  }
+
+  div#open-translator {
+    float: right;
+    text-decoration: underline;
+    font-weight: bold;
+    cursor: pointer;
+    margin-right: 52px;
+    color: #0d8fb2;
+  }
+
+  div#open-translator:hover {
+    text-decoration: none;
+  }
+
+  &.outsource .send-to-translator {
+    border: 1px solid #ccc;
+    border-radius: 0px 0px 3px 3px;
+    margin: 0 auto;
+    overflow: hidden;
+    margin-top: -2px;
+    background: #f8f8f8;
+  }
+
+  &.outsource .outsource-divider {
+    width: 230px;
+    margin: 0 auto;
+    text-align: center;
+    position: relative;
+    height: 20px;
+    line-height: 20px;
+    margin-top: 15px;
+  }
+
+  &.outsource .divider-line {
+    height: 2px;
+    width: 100px;
+    background-color: #c5c5c5;
+    margin-top: 10px;
+    display: block;
+    float: left;
+  }
+
+  &.outsource .outsource-divider span {
+    float: left;
+    width: 30px;
+  }
+
+  span.title-source {
+    margin-left: 5px;
+  }
+
+  .popup.popup-confirm.confirm_checkbox,
+  .popup.popup-alert {
+    text-align: right;
+  }
+
+  .popup.popup-confirm.confirm_checkbox p.text-container-top,
+  .popup.popup-alert p.text-container-top {
+    text-align: left;
+    padding: 20px;
+  }
+
+  .popup.popup-confirm.confirm_checkbox .btn-ok,
+  .popup.popup-alert .btn-ok {
+    margin-right: 20px;
+  }
 }

--- a/public/css/sass/project-completion-feature.scss
+++ b/public/css/sass/project-completion-feature.scss
@@ -1,11 +1,9 @@
 #markAsCompleteButton.isMarkableAsComplete {
   background: $translatedBlue;
-  color: #fff!important;
-  width: auto!important;
+  color: #fff !important;
+  width: auto !important;
   border-radius: 2px 0 0 2px;
-  padding: 0 5px!important;
+  padding: 0 5px !important;
   text-transform: uppercase;
-  margin: 0!important
+  margin: 0 !important;
 }
-
-

--- a/public/css/sass/quality-report.scss
+++ b/public/css/sass/quality-report.scss
@@ -1,590 +1,596 @@
-@import "vendor_mc/semantic/matecat_semantic";
-@import "commons/icons";
-@import "commons/shadows";
-@import "commons/divider";
-@import "commons/progress-mc-bar";
-@import "commons/buttons";
-@import "commons/nav-bar";
-@import "components/segment/tagsMenu";
+@import 'vendor_mc/semantic/matecat_semantic';
+@import 'commons/icons';
+@import 'commons/shadows';
+@import 'commons/divider';
+@import 'commons/progress-mc-bar';
+@import 'commons/buttons';
+@import 'commons/nav-bar';
+@import 'components/segment/tagsMenu';
 
-$color-red: #FB2A0D;
-$color-orange: #FBAA0D;
-$color-green: #83FD97;
-$color-yellow: #FFE600;
+$color-red: #fb2a0d;
+$color-orange: #fbaa0d;
+$color-green: #83fd97;
+$color-yellow: #ffe600;
 
 body {
-    font-family: Calibri, Arial, Helvetica, sans-serif;
-    text-align: left;
-    background: $grey5;
-    font-size: 16px;
-    min-width: 1024px;
-    overflow: auto;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
+  text-align: left;
+  background: $grey5;
+  font-size: 16px;
+  min-width: 1024px;
+  overflow: auto;
 }
 
 header {
-    min-width: 1024px;
-    .nav-mc-bar {
-        width: 100%;
-        background: #002b5c !important;
-        .logo {
-            /*left: 13px;*/
-            margin:0;
-        }
-        .header-project-container-info {
-            width: 75%;
-            /*background: #00123a;*/
-            color: #FFF;
-            margin-top: 9px;
-            height: 47px;
-            .header-project-info {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                height: 47px;
-                .header-id-project-name {
-                    display: flex;
-                    .header-project-id {
-                        margin-right: 20px;
-                    }
-                    .header-project-name {
-
-                    }
-                }
-                .header-team-assignee-icon {
-                    display: flex;
-                    align-items: center;
-                    .header-team {
-                        border: 1px solid white;
-                        padding: 5px 15px;
-                        border-radius: 20px;
-                    }
-                    .header-assignee {
-                        margin-left: 20px;
-                        border: 1px solid #676767;
-                        padding: 1px 12px 1px 3px;
-                        border-radius: 20px;
-                        background: #676767;
-                        display: flex;
-                        align-items: center;
-                        flex-wrap: nowrap;
-                        .assignee-first-name {
-                            margin-right: 5px;
-                        }
-                        .header-icon-assignee {
-                            width: 30px;
-                            height: 30px;
-                            margin-right: 10px;
-                            .header-img-assignee {
-                                width: 30px;
-                                height: 30px;
-                                border-radius: 50%;
-                            }
-                        }
-                    }
-                    .header-icon-dropdown {
-                        margin-left: 10px;
-                        width: 34px;
-                        height: 34px;
-                        display: flex;
-                        justify-content: center;
-                        align-items: center;
-                        background: transparent;
-                        color: white;
-                        &:hover {
-                            background: #676767;
-                        }
-                        i {
-                            font-size: 20px;
-                            position: relative;
-                            top: -2px;
-                        }
-                    }
-                    .ui.top.right.pointing.dropdown > .menu {
-                        margin: 7px -4px 0 0px !important;
-                    }
-                }
-            }
-        }
-        .user-teams {
-            padding-right: 10px !important;
-        }
+  min-width: 1024px;
+  .nav-mc-bar {
+    width: 100%;
+    background: #002b5c !important;
+    .logo {
+      /*left: 13px;*/
+      margin: 0;
     }
+    .header-project-container-info {
+      width: 75%;
+      /*background: #00123a;*/
+      color: #fff;
+      margin-top: 9px;
+      height: 47px;
+      .header-project-info {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        height: 47px;
+        .header-id-project-name {
+          display: flex;
+          .header-project-id {
+            margin-right: 20px;
+          }
+          .header-project-name {
+          }
+        }
+        .header-team-assignee-icon {
+          display: flex;
+          align-items: center;
+          .header-team {
+            border: 1px solid white;
+            padding: 5px 15px;
+            border-radius: 20px;
+          }
+          .header-assignee {
+            margin-left: 20px;
+            border: 1px solid #676767;
+            padding: 1px 12px 1px 3px;
+            border-radius: 20px;
+            background: #676767;
+            display: flex;
+            align-items: center;
+            flex-wrap: nowrap;
+            .assignee-first-name {
+              margin-right: 5px;
+            }
+            .header-icon-assignee {
+              width: 30px;
+              height: 30px;
+              margin-right: 10px;
+              .header-img-assignee {
+                width: 30px;
+                height: 30px;
+                border-radius: 50%;
+              }
+            }
+          }
+          .header-icon-dropdown {
+            margin-left: 10px;
+            width: 34px;
+            height: 34px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            background: transparent;
+            color: white;
+            &:hover {
+              background: #676767;
+            }
+            i {
+              font-size: 20px;
+              position: relative;
+              top: -2px;
+            }
+          }
+          .ui.top.right.pointing.dropdown > .menu {
+            margin: 7px -4px 0 0px !important;
+          }
+        }
+      }
+    }
+    .user-teams {
+      padding-right: 10px !important;
+    }
+  }
 }
 
-
 .qr-wrapper {
-    width: 100%;
-    height: auto;
-    padding-bottom: 60px;
-    .qr-container {
-        display: block;
-        .qr-container-inside {
-            height: 100%;
-            display: flex;
-            .qr-job-summary-container {
-                width: 100%;
-                transition: 0.3s ease;
-                .qr-bg-head {
-                    height: 258px;
-                    background: $grey5;
-                    position: absolute;
-                    width: 100%;
-                    z-index: -1;
+  width: 100%;
+  height: auto;
+  padding-bottom: 60px;
+  .qr-container {
+    display: block;
+    .qr-container-inside {
+      height: 100%;
+      display: flex;
+      .qr-job-summary-container {
+        width: 100%;
+        transition: 0.3s ease;
+        .qr-bg-head {
+          height: 258px;
+          background: $grey5;
+          position: absolute;
+          width: 100%;
+          z-index: -1;
+        }
+        .ui.table thead th {
+          background: #fff;
+          border: none;
+          border-bottom: 1px solid #f2f4f7;
+          border-radius: 0;
+        }
+        .ui.celled.table tr th,
+        .ui.celled.table tr td {
+          border-left: 1px solid #f2f4f7;
+          border-radius: 0;
+        }
+        .qr-job-summary {
+          max-width: 1366px;
+          min-width: 1024px;
+          margin: 0 auto;
+          padding: 80px 15px 0;
+          h3 {
+          }
+          .qr-label {
+            font-weight: 100;
+            font-size: 14px;
+            line-height: 12px;
+            padding-right: 9px;
+          }
+          .qr-production-quality {
+            .qr-production {
+              display: flex;
+              background: $grey3;
+              justify-content: space-between;
+              width: 100%;
+              padding-left: 15px;
+              align-items: center;
+              position: relative;
+              .job-id {
+                font-size: 14px;
+              }
+              .source-to-target {
+                display: flex;
+                align-items: center;
+                .qr-to {
+                  display: flex;
+                  i {
+                    font-size: 0.8em;
+                    color: gray;
+                    margin: 0 3px;
+                  }
                 }
-                .ui.table thead th {
-                    background: #FFF;
+              }
+              .progress-percent {
+                display: flex;
+                align-items: center;
+                .progress-bar {
+                  margin: 0;
+                  min-width: 130px;
+                }
+                .percent {
+                  padding-left: 5px;
+                }
+              }
+              .qr-effort {
+                padding: 15px 0;
+                &:last-child {
+                  padding-right: 15px !important;
+                }
+                &.translator {
+                  max-width: 15%;
+                  min-width: 30px;
+                  b {
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                  }
+                }
+                &.qr-score {
+                  padding: 15px 25px;
+                  .qr-tolerated-score,
+                  .qr-pass-score {
+                    font-size: 20px;
+                  }
+                  .qr-info {
+                    flex-direction: column;
+                    align-items: unset;
+                  }
+                }
+
+                &.qr-pass {
+                  background: $greenDefaultTransparent;
+                }
+                &.qr-fail {
+                  background: $redDefaultTransparent;
+                }
+                &.qr-pass,
+                &.qr-fail,
+                &.qr-norevision {
+                  margin-right: -1px;
+                  .qr-info {
+                    display: flex;
+                    flex-direction: row;
+                    align-items: center;
+                    .qr-tolerated-score {
+                      font-size: 42px;
+                      margin-right: 10px;
+                    }
+                  }
+                  .qr-label {
+                    text-decoration: underline;
+                    cursor: pointer;
+                    width: fit-content;
+                    padding-right: 8px;
+                    &:hover {
+                      text-decoration: none;
+                    }
+                    &:first-child {
+                      text-decoration: none;
+                    }
+                  }
+                }
+                .qr-info {
+                  display: flex;
+                  align-items: center;
+                  justify-content: space-between;
+                }
+              }
+            }
+            .qr-quality {
+              margin-top: 20px;
+              margin-bottom: 20px;
+              border-bottom: 2px solid $grey4;
+              position: relative;
+              z-index: 1;
+              .qr-head {
+                display: flex;
+                align-items: center;
+                font-weight: 700;
+                background: $grey4;
+                .qr-title {
+                  text-align: center;
+                  text-transform: capitalize;
+                  &:first-child {
+                    text-align: left;
+                  }
+                }
+              }
+              .qr-body-list {
+                display: flex;
+                border-top: 2px solid $grey4;
+                border-left: 2px solid $grey4;
+                border-right: 2px solid $grey4;
+                &:first-child {
+                  //border: none;
+                }
+                .qr-element {
+                  border-left: 1px solid $grey4;
+                  background: white;
+                  position: relative;
+                  z-index: -1;
+                  &:first-child {
                     border: none;
-                    border-bottom: 1px solid #f2f4f7;
-                    border-radius: 0;
+                  }
                 }
-                .ui.celled.table tr th, .ui.celled.table tr td {
-                    border-left: 1px solid #f2f4f7;
-                    border-radius: 0;
+              }
+              .qr-title,
+              .qr-element {
+                padding: 10px 15px;
+              }
+              .qr-issue,
+              .qr-issue-name {
+                width: 56%;
+                font-weight: 500;
+                font-size: 15px;
+              }
+              .qr-severity,
+              .severity {
+                width: 16%;
+                text-align: center;
+              }
+              .qr-total-severity,
+              .total-severity {
+                width: 20%;
+                background: $grey1;
+              }
+              .qr-total-severity {
+                display: flex;
+                justify-content: space-between;
+                padding: 20px 15px;
+                &.job-not-passed {
+                  background-color: #fb590d;
                 }
-                .qr-job-summary {
-                    max-width: 1366px;
-                    min-width: 1024px;
-                    margin: 0 auto;
-                    padding: 80px 15px 0;
-                    h3 {}
-                    .qr-label {
-                        font-weight: 100;
-                        font-size: 14px;
-                        line-height: 12px;
-                        padding-right: 9px;
+                &.job-passed {
+                  background-color: #83fd97;
+                  &.qr-old {
+                    background-color: #83fd97;
+                    display: unset;
+                  }
+                }
+                &.qr-old {
+                  background: inherit;
+                  display: unset;
+                }
+              }
+              .qr-element.total-severity {
+              }
+              .total-severity {
+                &.job-not-passed {
+                  background-color: rgba(255, 123, 35, 0.31);
+                  text-align: center;
+                  border-left: 1px solid rgba(255, 123, 35, 0.31);
+                }
+                &.job-passed {
+                  background-color: rgba(0, 255, 0, 0.23);
+                  text-align: center;
+                  border-left: 1px solid rgba(0, 255, 0, 0.23);
+                }
+              }
+              .total-severity {
+                text-align: right;
+              }
+            }
+          }
+          .qr-header {
+            height: 70px;
+            h3 {
+              font-size: 22px;
+              font-weight: bold;
+            }
+            .filter-dropdown .dropdown {
+              font-size: 20px !important;
+              max-width: 190px;
+            }
+          }
+          .qr-feedback-container {
+            min-height: 73px;
+            position: relative;
+            margin-bottom: 20px;
+            .qr-feedback {
+              .qr-head {
+                padding: 10px 20px;
+                background: $grey4;
+                .label.revision-color {
+                  float: left;
+
+                  margin-right: 10px;
+                  margin-top: 5px;
+                  &.revision-1 {
+                    background: #2fb177;
+                  }
+                  &.revision-2 {
+                    background: #9352c1;
+                  }
+                }
+              }
+              p {
+                padding: 17px;
+                word-wrap: break-word;
+                white-space: pre-line;
+              }
+            }
+          }
+          .qr-filter-container,
+          .qr-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+          }
+          .qr-segment-details-container {
+            background: $grey4;
+            padding: 35px 15px 15px;
+            .qr-segments-summary {
+              h3 {
+                margin-bottom: 0;
+              }
+              .qr-segments {
+                margin-top: 50px;
+                &:nth-child(2) {
+                  margin-top: 0px;
+                }
+                .qr-segments-list {
+                  .qr-single-segment {
+                    padding-top: 30px;
+                    &:first-child {
+                      padding-top: 15px;
                     }
-                    .qr-production-quality {
-                        .qr-production {
-                            display: flex;
-                            background: $grey3;
-                            justify-content: space-between;
-                            width: 100%;
-                            padding-left: 15px;
-                            align-items: center;
-                            position: relative;
-                            .job-id {
-                                font-size: 14px;
-                            }
-                            .source-to-target {
-                                display: flex;
-                                align-items: center;
-                                .qr-to {
-                                    display: flex;
-                                    i {
-                                        font-size: .8em;
-                                        color: gray;
-                                        margin: 0 3px;
-                                    }
-                                }
-                            }
-                            .progress-percent {
-                                display: flex;
-                                align-items: center;
-                                .progress-bar {
-                                    margin: 0;
-                                    min-width: 130px;
-                                }
-                                .percent {
-                                    padding-left: 5px;
-                                }
-                            }
-                            .qr-effort {
-                                padding: 15px 0;
-                                &:last-child {
-                                    padding-right: 15px !important;
-                                }
-                                &.translator {
-                                    max-width: 15%;
-                                    min-width: 30px;
-                                    b {
-                                        white-space: nowrap;
-                                        overflow: hidden;
-                                        text-overflow: ellipsis;
-                                    }
-                                }
-                                &.qr-score {
-                                    padding: 15px 25px;
-                                    .qr-tolerated-score, .qr-pass-score {
-                                        font-size: 20px;
-                                    }
-                                    .qr-info {
-                                        flex-direction: column;
-                                        align-items: unset;
-                                    }
-                                }
-
-                                &.qr-pass {
-                                    background: $greenDefaultTransparent;
-                                }
-                                &.qr-fail {
-                                    background: $redDefaultTransparent;
-                                }
-                                &.qr-pass, &.qr-fail, &.qr-norevision {
-                                    margin-right: -1px;
-                                    .qr-info {
-                                        display: flex;
-                                        flex-direction: row;
-                                        align-items: center;
-                                        .qr-tolerated-score {
-                                            font-size: 42px;
-                                            margin-right: 10px;
-                                        }
-                                    }
-                                    .qr-label {
-                                        text-decoration: underline;
-                                        cursor: pointer;
-                                        width: fit-content;
-                                        padding-right: 8px;
-                                        &:hover {
-                                            text-decoration: none;
-                                        }
-                                        &:first-child {
-                                            text-decoration: none;
-                                        }
-                                    }
-                                }
-                                .qr-info {
-                                    display: flex;
-                                    align-items: center;
-                                    justify-content: space-between;
-                                }
-
-                            }
-                        }
-                        .qr-quality {
-                            margin-top: 20px;
-                            margin-bottom: 20px;
-                            border-bottom: 2px solid $grey4;
-                            position: relative;
-                            z-index: 1;
-                            .qr-head {
-                                display: flex;
-                                align-items: center;
-                                font-weight: 700;
-                                background: $grey4;
-                                .qr-title {
-                                    text-align: center;
-                                    text-transform: capitalize;
-                                    &:first-child {
-                                        text-align: left;
-                                    }
-                                }
-                            }
-                            .qr-body-list {
-                                display: flex;
-                                border-top: 2px solid $grey4;
-                                border-left: 2px solid $grey4;
-                                border-right: 2px solid $grey4;
-                                &:first-child {
-                                    //border: none;
-                                }
-                                .qr-element {
-                                    border-left: 1px solid $grey4;
-                                    background: white;
-                                    position: relative;
-                                    z-index: -1;
-                                    &:first-child {
-                                        border: none;
-                                    }
-                                }
-
-                            }
-                            .qr-title, .qr-element {
-                                padding: 10px 15px;
-                            }
-                            .qr-issue, .qr-issue-name {
-                                width: 56%;
-                                font-weight: 500;
-                                font-size: 15px;
-                            }
-                            .qr-severity, .severity {
-                                width: 16%;
-                                text-align: center;
-                            }
-                            .qr-total-severity, .total-severity {
-                                width: 20%;
-                                background: $grey1;
-                            }
-                            .qr-total-severity {
-                                display: flex;
-                                justify-content: space-between;
-                                padding: 20px 15px;
-                                &.job-not-passed {
-                                    background-color: #FB590D;
-                                }
-                                &.job-passed {
-                                    background-color: #83FD97;
-                                    &.qr-old {
-                                        background-color: #83FD97;
-                                        display: unset;
-
-                                    }
-                                }
-                                &.qr-old {
-                                    background: inherit;
-                                    display: unset;
-                                }
-                            }
-                            .qr-element.total-severity {
-
-                            }
-                            .total-severity {
-                                &.job-not-passed {
-                                    background-color: rgba(255, 123, 35, 0.31);
-                                    text-align: center;
-                                    border-left: 1px solid rgba(255, 123, 35, 0.31);
-                                }
-                                &.job-passed {
-                                    background-color: rgba(0, 255, 0, 0.23);
-                                    text-align: center;
-                                    border-left: 1px solid rgba(0, 255, 0, 0.23);
-                                }
-                            }
-                            .total-severity {
-                                text-align: right;
-                            }
-                        }
-                    }
-                    .qr-header {
-                        height: 70px;
-                        h3 {
-                            font-size: 22px;
-                            font-weight: bold;
-                        }
-                        .filter-dropdown .dropdown{
-                            font-size: 20px !important;
-                            max-width: 190px;
-                        }
-                    }
-                    .qr-feedback-container {
-                        min-height: 73px;
-                        position: relative;
-                        margin-bottom: 20px;
-                        .qr-feedback {
-                            .qr-head {
-                                padding: 10px 20px;
-                                background: $grey4;
-                                .label.revision-color {
-                                    float: left;
-
-                                    margin-right: 10px;
-                                    margin-top: 5px;
-                                    &.revision-1 {
-                                        background: #2FB177;
-                                    }
-                                    &.revision-2 {
-                                        background: #9352C1;
-                                    }
-                                }
-                            }
-                            p {
-                                padding: 17px;
-                                word-wrap: break-word;
-                                white-space: pre-line;
-                            }
-                        }
-                    }
-                    .qr-filter-container, .qr-header {
+                    .qr-segment-head {
+                      display: flex;
+                      position: relative;
+                      background: #fff;
+                      align-items: center;
+                      .segment-id {
+                        width: 18%;
+                        padding: 15px 0.78571429em;
+                      }
+                      .segment-production-container {
+                        width: 68%;
+                        padding: 15px 0.78571429em;
                         display: flex;
                         justify-content: space-between;
                         align-items: center;
+                        margin-left: 20px;
+                        .segment-production {
+                          display: flex;
+                          .production {
+                            padding: 0 10px;
+                          }
+                        }
+                      }
+                      .segment-status-container {
+                        width: 14%;
+                        padding: 15px 0.78571429em;
+                        .status-new {
+                          font-size: 20px;
+                          color: #8b8e92;
+                        }
+                        .status-translated {
+                          font-size: 20px;
+                          color: $translatedBlue;
+                        }
+                        .status-approved {
+                          &.approved-r2 {
+                            color: $approved2Green;
+                          }
+                          font-size: 20px;
+                          color: $approvedGreen;
+                        }
+                        .status-draft {
+                          font-size: 20px;
+                          color: $grey1;
+                        }
+                        .status-rejected {
+                          font-size: 20px;
+                          color: $rebuttedRed;
+                        }
+                      }
                     }
-                    .qr-segment-details-container {
-                        background: $grey4;
-                        padding: 35px 15px 15px;
-                        .qr-segments-summary {
-                            h3{
-                                margin-bottom: 0;
+                    .qr-segment-body {
+                      border-bottom: 1px solid $grey2;
+                      border-left: 1px solid $grey2;
+                      border-right: 1px solid $grey2;
+                      .segment-container {
+                        display: flex;
+                        background: $grey3;
+                        &.qr-issues {
+                          .qr-text {
+                            width: 80%;
+                          }
+                          .button.no-hover {
+                            cursor: default !important;
+                          }
+                        }
+                        .segment-content {
+                          display: flex;
+                          align-items: center;
+                          padding: 10px 0.78571429em;
+                          margin-top: 1px;
+                          .tte {
+                            max-width: 110px;
+                            font-weight: bold;
+                          }
+                        }
+
+                        .qr-segment-title {
+                          width: 20%;
+                          background: $grey5;
+                          justify-content: space-between;
+
+                          button {
+                            width: 22px;
+                            height: 22px;
+                            border-radius: 50%;
+                            margin: 0;
+                            padding: 0;
+                            border: none;
+                            outline: none;
+                            background: none;
+                            cursor: pointer;
+                            i {
+                              font-size: 0.9em;
+                              color: gray;
+                              margin: 0;
                             }
-                            .qr-segments {
-                                margin-top: 50px;
-                                &:nth-child(2) {
-                                    margin-top: 0px;
+                            &:hover {
+                              background: #e8e9ef;
+                              i {
+                                color: #000000;
+                              }
+                            }
+                            &.active,
+                            &:active,
+                            &:hover {
+                              background: #e8e9ef;
+                              i {
+                                color: #000000;
+                              }
+                            }
+                          }
+                        }
+                        a.qr-segment-title {
+                          b {
+                            text-decoration: underline;
+                            cursor: pointer;
+                            &:hover {
+                              text-decoration: none;
+                            }
+                          }
+                        }
+                        &.qr-translated {
+                          b {
+                            color: $translatedBlue;
+                          }
+                        }
+                        &.qr-revised {
+                          b {
+                            color: $approvedGreen;
+                          }
+                        }
+                        &.qr-revised-2ndpass {
+                          b {
+                            color: $approved2Green;
+                          }
+                        }
+                        &.rtl-lang {
+                          .qr-text {
+                            direction: rtl !important;
+                            text-align: right !important;
+                          }
+                        }
+                        .qr-text {
+                          width: 66%;
+                          background: $white;
+                          margin-right: 1px;
+                          display: inline-block;
+                          color: #5f5f5f;
+                          .added {
+                            background: rgba(158, 255, 0, 0.5);
+                          }
+                          .deleted {
+                            background: rgba(255, 46, 0, 0.3);
+                            text-decoration: line-through;
+                          }
+                          .qr-issues-list {
+                            display: flex;
+                            flex-wrap: wrap;
+                            margin-top: -5px;
+                            .qr-issue {
+                              display: flex;
+                              align-items: center;
+                              width: fit-content;
+                              padding: 3px 10px;
+                              margin-right: 5px;
+                              margin-top: 5px;
+                              background: $grey4;
+
+                              &.automated {
+                                padding: 0;
+                                padding-right: 5px;
+                                .box-icon {
+                                  display: flex;
+                                  padding: 5px 3px 5px 5px;
+                                  background: $grey5;
+                                  margin-right: 6px;
                                 }
-                                .qr-segments-list {
-                                    .qr-single-segment {
-                                        padding-top: 30px;
-                                        &:first-child {
-                                            padding-top: 15px;
-                                        }
-                                        .qr-segment-head {
-                                            display: flex;
-                                            position: relative;
-                                            background: #FFF;
-                                            align-items: center;
-                                             .segment-id {
-                                                 width: 18%;
-                                                 padding: 15px 0.78571429em;
-                                             }
-                                             .segment-production-container{
-                                                 width: 68%;
-                                                 padding: 15px 0.78571429em;
-                                                 display: flex;
-                                                 justify-content: space-between;
-                                                 align-items: center;
-                                                 margin-left: 20px;
-                                                 .segment-production {
-                                                     display: flex;
-                                                     .production {
-                                                         padding: 0 10px;
-                                                     }
-                                                 }
-                                             }
-                                            .segment-status-container {
-                                                width: 14%;
-                                                padding: 15px 0.78571429em;
-                                                .status-new {
-                                                    font-size: 20px;
-                                                    color: #8b8e92;
-                                                }
-                                                .status-translated {
-                                                    font-size: 20px;
-                                                    color: $translatedBlue;
-                                                }
-                                                .status-approved {
-                                                    &.approved-r2 {
-                                                        color: $approved2Green;
-                                                    }
-                                                    font-size: 20px;
-                                                    color: $approvedGreen;
-                                                }
-                                                .status-draft {
-                                                    font-size: 20px;
-                                                    color: $grey1;
-                                                }
-                                                .status-rejected {
-                                                    font-size: 20px;
-                                                    color: $rebuttedRed;
-                                                }
-                                            }
-                                        }
-                                        .qr-segment-body {
-                                            border-bottom: 1px solid $grey2;
-                                            border-left: 1px solid $grey2;
-                                            border-right: 1px solid $grey2;
-                                                .segment-container {
-                                                    display: flex;
-                                                    background: $grey3;
-                                                    &.qr-issues {
-                                                        .qr-text {
-                                                            width: 80%;
-                                                        }
-                                                        .button.no-hover {
-                                                            cursor: default !important;
-                                                        }
-                                                    }
-                                                    .segment-content {
-                                                        display: flex;
-                                                        align-items: center;
-                                                        padding: 10px 0.78571429em;
-                                                        margin-top: 1px;
-                                                        .tte {
-                                                            max-width: 110px;
-                                                            font-weight: bold;
-                                                        }
-                                                    }
-
-                                                    .qr-segment-title {
-                                                        width: 20%;
-                                                        background: $grey5;
-                                                        justify-content: space-between;
-
-                                                        button {
-                                                            width: 22px;
-                                                            height: 22px;
-                                                            border-radius: 50%;
-                                                            margin: 0;
-                                                            padding: 0;
-                                                            border: none;
-                                                            outline: none;
-                                                            background: none;
-                                                            cursor: pointer;
-                                                            i {
-                                                                font-size: .9em;
-                                                                color: gray;
-                                                                margin: 0;
-                                                            }
-                                                            &:hover {
-                                                                background: #e8e9ef;
-                                                                i {
-                                                                    color: #000000;
-                                                                }
-                                                            }
-                                                            &.active, &:active, &:hover {
-                                                                background: #e8e9ef;
-                                                                i {
-                                                                    color: #000000
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                    a.qr-segment-title {
-                                                        b {
-                                                            text-decoration: underline;
-                                                            cursor: pointer;
-                                                            &:hover {
-                                                                text-decoration: none;
-                                                            }
-                                                        }
-                                                    }
-                                                    &.qr-translated {
-                                                        b {
-                                                            color: $translatedBlue;
-                                                        }
-                                                    }
-                                                    &.qr-revised {
-                                                        b {
-                                                            color: $approvedGreen;
-                                                        }
-                                                    }
-                                                    &.qr-revised-2ndpass {
-                                                        b {
-                                                            color: $approved2Green;
-                                                        }
-                                                    }
-                                                    &.rtl-lang {
-                                                        .qr-text {
-                                                            direction: rtl !important;
-                                                            text-align: right !important;
-                                                        }
-                                                    }
-                                                    .qr-text {
-                                                        width: 66%;
-                                                        background: $white;
-                                                        margin-right: 1px;
-                                                        display: inline-block;
-                                                        color: #5f5f5f;
-                                                        .added {
-                                                            background: rgba(158, 255, 0, 0.5);
-                                                        }
-                                                        .deleted {
-                                                            background: rgba(255, 46, 0, 0.3) ;
-                                                            text-decoration: line-through ;
-                                                        }
-                                                        .qr-issues-list {
-                                                            display: flex;
-                                                            flex-wrap: wrap;
-                                                            margin-top: -5px;
-                                                            .qr-issue {
-                                                                display: flex;
-                                                                align-items: center;
-                                                                width: fit-content;
-                                                                padding: 3px 10px;
-                                                                margin-right: 5px;
-                                                                margin-top: 5px;
-                                                                background: $grey4;
-
-                                                                &.automated {
-                                                                    padding: 0;
-                                                                    padding-right: 5px;
-                                                                    .box-icon {
-                                                                        display: flex;
-                                                                        padding: 5px 3px 5px 5px;
-                                                                        background: $grey5;
-                                                                        margin-right: 6px;
-                                                                    }
-                                                                }
-                                                                /*&.human {
+                              }
+                              /*&.human {
                                                                     &.critical {
                                                                         border-bottom: 2px solid #FB2A0D;
                                                                     }
@@ -595,414 +601,418 @@ header {
                                                                         border-bottom: 2px solid #FFE600;
                                                                     }
                                                                 }*/
-                                                                .qr-error {
-
-                                                                }
-                                                                .qr-severity {
-                                                                    margin-left: 5px;
-                                                                }
-                                                                .qr-comment-list {
-                                                                    padding: 5px 10px;
-                                                                    font-size: 14px;
-                                                                    background: #ffffff;
-                                                                    color: #787878;
-                                                                    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                                                                    max-height: 300px;
-                                                                    min-width: 200px;
-                                                                    overflow: auto !important;
-                                                                    .re-comment {
-                                                                        font-size: 16px;
-                                                                        margin-bottom: 0;
-                                                                        .re-revisor {
-                                                                            color: $approvedGreen;
-                                                                        }
-                                                                        .re-revisor2 {
-                                                                            color: $approved2Green;
-                                                                        }
-                                                                        .re-translator {
-                                                                            color: $translatedBlue;
-                                                                        }
-                                                                        .re-comment-date{
-                                                                            font-size: 13px;
-                                                                            color: $grey1;
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                    .qr-spec {
-                                                        width: 14%;
-                                                        justify-content: space-between;
-                                                        background: #FFFFFF;
-                                                        .spec-words {
-
-                                                        }
-                                                        .tm-percent {
-                                                            background: #0abeed;
-                                                            color: #FFFFFF;
-                                                            padding: 0 3px;
-                                                            font-size: 14px;
-                                                        }
-                                                        .per-yellow {
-                                                            padding: 0 3px;
-                                                            background: #FFCC00 !important;
-                                                            color: #333 !important;
-                                                        }
-                                                    }
-                                                }
-                                            &.qr-diff-off {
-                                            }
-
-                                            &.qr-diff-on {
-                                                .segment-container {
-                                                    box-shadow: none !important;
-                                                    .segment-content {
-                                                        background: $grey5;
-                                                        .qr-issues-list {
-                                                            .qr-issue {
-                                                                background: #FFFFFF;
-                                                            }
-                                                        }
-                                                        &.qr-text {
-                                                            border-left: 1px solid #e8e9ec;
-                                                        }
-                                                    }
-                                                    &.shadow-1 {
-                                                        position: relative;
-                                                        .segment-content {
-                                                            background: $white;
-                                                        }
-                                                        .qr-segment-title {
-                                                            background: $grey4;
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
+                              .qr-error {
+                              }
+                              .qr-severity {
+                                margin-left: 5px;
+                              }
+                              .qr-comment-list {
+                                padding: 5px 10px;
+                                font-size: 14px;
+                                background: #ffffff;
+                                color: #787878;
+                                box-shadow: 0 0 0 #e0e0e0,
+                                  0 0 2px rgba(0, 0, 0, 0.12),
+                                  0 2px 4px rgba(0, 0, 0, 0.24) !important;
+                                max-height: 300px;
+                                min-width: 200px;
+                                overflow: auto !important;
+                                .re-comment {
+                                  font-size: 16px;
+                                  margin-bottom: 0;
+                                  .re-revisor {
+                                    color: $approvedGreen;
+                                  }
+                                  .re-revisor2 {
+                                    color: $approved2Green;
+                                  }
+                                  .re-translator {
+                                    color: $translatedBlue;
+                                  }
+                                  .re-comment-date {
+                                    font-size: 13px;
+                                    color: $grey1;
+                                  }
                                 }
+                              }
                             }
+                          }
                         }
+                        .qr-spec {
+                          width: 14%;
+                          justify-content: space-between;
+                          background: #ffffff;
+                          .spec-words {
+                          }
+                          .tm-percent {
+                            background: #0abeed;
+                            color: #ffffff;
+                            padding: 0 3px;
+                            font-size: 14px;
+                          }
+                          .per-yellow {
+                            padding: 0 3px;
+                            background: #ffcc00 !important;
+                            color: #333 !important;
+                          }
+                        }
+                      }
+                      &.qr-diff-off {
+                      }
+
+                      &.qr-diff-on {
+                        .segment-container {
+                          box-shadow: none !important;
+                          .segment-content {
+                            background: $grey5;
+                            .qr-issues-list {
+                              .qr-issue {
+                                background: #ffffff;
+                              }
+                            }
+                            &.qr-text {
+                              border-left: 1px solid #e8e9ec;
+                            }
+                          }
+                          &.shadow-1 {
+                            position: relative;
+                            .segment-content {
+                              background: $white;
+                            }
+                            .qr-segment-title {
+                              background: $grey4;
+                            }
+                          }
+                        }
+                      }
                     }
+                  }
                 }
+              }
             }
+          }
         }
+      }
     }
+  }
 }
 
 /*Placeholder*/
 
 .softReturn {
-    display: inline;
-    margin-left: 6px;
-    padding: 1px 2px 3px 40px;
-    background-image: url(../../img/soft-return1.png);
-    background-size: 16px;
-    background-repeat: no-repeat;
-    background-position: center left;
-    width: 20px;
-    position: relative;
+  display: inline;
+  margin-left: 6px;
+  padding: 1px 2px 3px 40px;
+  background-image: url(../../img/soft-return1.png);
+  background-size: 16px;
+  background-repeat: no-repeat;
+  background-position: center left;
+  width: 20px;
+  position: relative;
 }
 .hardReturn {
-    display: inline;
-    margin-left: 6px;
-    padding: 1px 2px 3px 40px;
-    background-image: url(../../img/hard-return.png);
-    background-size: 16px;
-    background-repeat: no-repeat;
-    background-position: center left;
-    width: 20px;
-    position: relative;
+  display: inline;
+  margin-left: 6px;
+  padding: 1px 2px 3px 40px;
+  background-image: url(../../img/hard-return.png);
+  background-size: 16px;
+  background-repeat: no-repeat;
+  background-position: center left;
+  width: 20px;
+  position: relative;
 }
 
 .tab-marker {
-    color: #999;
-    margin-left: 4px;
-    margin-right: 4px;
-    position: relative;
-    top: 2px;
+  color: #999;
+  margin-left: 4px;
+  margin-right: 4px;
+  position: relative;
+  top: 2px;
 }
 
 .space-marker,
 .nbsp-marker {
-    color: #CCC;
-    position: relative;
-    left: 4px;
-    padding-right: 12px;
-    opacity: 0.2;
-    top: 3px;
-    font-size: 15px;
-    background: url(../img/dot.png) 0 0 no-repeat;
-    background-size: 6px;
+  color: #ccc;
+  position: relative;
+  left: 4px;
+  padding-right: 12px;
+  opacity: 0.2;
+  top: 3px;
+  font-size: 15px;
+  background: url(../img/dot.png) 0 0 no-repeat;
+  background-size: 6px;
 }
 
 /*End Placehoder*/
 
 .qr-filter-list {
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  .filter-dropdown {
     display: flex;
     align-items: center;
-    box-sizing: border-box;
-    .filter-dropdown {
-        display: flex;
+    .dropdown {
+      background: $white !important;
+    }
+    &:nth-child(2) {
+      margin-left: 15px;
+    }
+    .ui.basic.button {
+      font-family: 'calibri', Arial, Helvetica, sans-serif;
+      font-size: 16px !important;
+      padding: 10px 20px;
+      border-radius: 40px;
+      transition: 0.3s ease;
+      box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
+      max-width: 155px;
+      min-width: 30px;
+      display: flex;
+      .text {
+        transition: 0.3s ease;
         align-items: center;
-        .dropdown {
-            background: $white !important;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+    .ui.cancel.label {
+      position: absolute;
+      padding: 4px;
+      background-color: #d6d6d6;
+      border-radius: 15px;
+      top: 8px;
+      line-height: 0px;
+      right: 0px;
+      visibility: hidden;
+      &:hover {
+        background-color: #cccccc !important;
+      }
+    }
+    .filter-category {
+      margin-left: 5px;
+    }
+    .not-filtered {
+      .ui.basic.button {
+        &:hover {
+          box-shadow: 0px 0px 0px 1px $translatedBlue inset;
+          color: $translatedBlue !important;
         }
-        &:nth-child(2){
-            margin-left: 15px;
+        &.disabled {
+          box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.25) inset !important;
+          pointer-events: none;
         }
-        .ui.basic.button{
-            font-family: "calibri", Arial, Helvetica, sans-serif;
-            font-size: 16px !important;
-            padding: 10px 20px;
-            border-radius: 40px;
-            transition: 0.3s ease;
-            box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
-            max-width: 155px;
-            min-width: 30px;
-            display: flex;
-            .text {
-                transition: 0.3s ease;
-                align-items: center;
-                white-space: nowrap;
-                overflow: hidden;
-                text-overflow: ellipsis;
-            }
-
-        }
-        .ui.cancel.label {
-          position: absolute;
-          padding: 4px;
-          background-color: #d6d6d6;
-          border-radius: 15px;
-          top: 8px;
-          line-height: 0px;
-          right: 0px;
-          visibility: hidden;
-          &:hover {
-            background-color: #cccccc !important;
+      }
+    }
+    .filtered {
+      .ui.basic.button {
+        background-color: #ffffff !important;
+        box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+          0 2px 4px rgba(0, 0, 0, 0.24) !important;
+        color: #000000 !important;
+        padding: 9px 20px 9px 15px;
+        &:hover {
+          width: fit-content;
+          .text {
+            margin-right: 15px;
+          }
+          .ui.cancel.label {
+            visibility: unset;
+            right: 5px;
           }
         }
-        .filter-category {
-            margin-left: 5px;
-        }
-        .not-filtered {
-            .ui.basic.button {
-                &:hover {
-                    box-shadow: 0px 0px 0px 1px $translatedBlue inset;
-                    color: $translatedBlue !important;
-                }
-                &.disabled {
-                    box-shadow: 0 0 0 1px rgba(34, 36, 38, 0.25) inset !important;
-                    pointer-events: none;
-                }
-            }
-        }
-        .filtered {
-            .ui.basic.button {
-                background-color: #ffffff !important;
-                box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                color: #000000 !important;
-                padding: 9px 20px 9px 15px;
-                &:hover {
-                    width: fit-content;
-                    .text {
-                        margin-right: 15px;
-                    }
-                    .ui.cancel.label {
-                        visibility: unset;
-                        right: 5px;
-                    }
-                }
-            }
-        }
-        .active {
-            .ui.basic.button {
-                background: transparent none !important;
-                box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-                color: #000000 !important;
-                padding: 9px 20px 9px 15px;
-                &:hover {
-                    background-color: #ffffff !important;
-                    .ui.cancel.label {
-                        visibility: unset;
-                        right: 5px;
-                    }
-                }
-            }
-        }
-        .disabled {
-            background: unset;
-            opacity: 0.5 !important;
-            box-shadow: unset;
-            border: none;
-            pointer-events: none;
-        }
-
-        .circular.label {
-            &.new-color {
-                box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
-                background: #FFFFFF
-            }
-            &.draft-color {
-                background: $grey1;
-            }
-            &.translated-color {
-                background: $translatedBlue;
-            }
-            &.approved-color {
-                background: $approvedGreen;
-            }
-            &.rejected-color {
-                background: $rebuttedRed;
-            }
-            &.revision-color {
-                background: $approvedGreen;
-            }
-            &.second-revision-color, &.approved-2ndpass-color {
-                background: $approved2Green;
-            }
-        }
-
-        .filter-toggle {
-            .checkbox {
-                left: 5px;
-                top: 4px;
-                margin: 0 !important;
-                float: none;
-                label {
-                    &:before {
-                        background: #dcdfe4 !important;
-                    }
-                    &:after {
-                        box-shadow: inset 0 0 0 1px rgba(34, 36, 38, 0.25);
-                        background: #FFFFFF;
-                    }
-                }
-            }
-        }
-        .filter-data-sample {
-            display: flex;
-            align-items: center;
-            .percent-item {
-                margin-left: 5px;
-            }
-            .menu {
-                width: 220px;
-                .head-dropdown {
-                    label {
-                        display: inline-block;
-                        width: 60%;
-                        position: relative;
-                        font-size: 12px;
-                        top: 16px;
-                    }
-                    input {
-                        width: 40%;
-                        display: inline-block;
-                        right: 0;
-                        padding: 5px 10px;
-                        margin-top: 10px;
-                    }
-                }
-            }
-            .item, .text {
-                .type-item, .order-item {
-                    display: inline-block;
-                }
-                .order-item {
-                    float: right;
-                }
-            }
-            .text {
-                .order-item {
-                    margin-left: 2px;
-                }
-            }
-        }
+      }
     }
-    .clear-filter-element {
-        margin-left: 13px;
-        border-left: 1px solid #d6d6d7;
-        padding-left: 13px;
-        color: black;
-        display: flex;
-        justify-content: space-between;
-        width: 135px;
-        .clear-filter, .select-all-filter {
-            display: inline;
-            button {
-                background: none;
-                color: grey;
-                text-decoration: underline;
-                cursor: pointer;
-                border: none;
-                padding: 0;
-                outline: none;
-                &:hover {
-                    text-decoration: none;
-                }
-            }
+    .active {
+      .ui.basic.button {
+        background: transparent none !important;
+        box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+          0 2px 4px rgba(0, 0, 0, 0.24) !important;
+        color: #000000 !important;
+        padding: 9px 20px 9px 15px;
+        &:hover {
+          background-color: #ffffff !important;
+          .ui.cancel.label {
+            visibility: unset;
+            right: 5px;
+          }
         }
+      }
     }
+    .disabled {
+      background: unset;
+      opacity: 0.5 !important;
+      box-shadow: unset;
+      border: none;
+      pointer-events: none;
+    }
+
+    .circular.label {
+      &.new-color {
+        box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.25) inset;
+        background: #ffffff;
+      }
+      &.draft-color {
+        background: $grey1;
+      }
+      &.translated-color {
+        background: $translatedBlue;
+      }
+      &.approved-color {
+        background: $approvedGreen;
+      }
+      &.rejected-color {
+        background: $rebuttedRed;
+      }
+      &.revision-color {
+        background: $approvedGreen;
+      }
+      &.second-revision-color,
+      &.approved-2ndpass-color {
+        background: $approved2Green;
+      }
+    }
+
+    .filter-toggle {
+      .checkbox {
+        left: 5px;
+        top: 4px;
+        margin: 0 !important;
+        float: none;
+        label {
+          &:before {
+            background: #dcdfe4 !important;
+          }
+          &:after {
+            box-shadow: inset 0 0 0 1px rgba(34, 36, 38, 0.25);
+            background: #ffffff;
+          }
+        }
+      }
+    }
+    .filter-data-sample {
+      display: flex;
+      align-items: center;
+      .percent-item {
+        margin-left: 5px;
+      }
+      .menu {
+        width: 220px;
+        .head-dropdown {
+          label {
+            display: inline-block;
+            width: 60%;
+            position: relative;
+            font-size: 12px;
+            top: 16px;
+          }
+          input {
+            width: 40%;
+            display: inline-block;
+            right: 0;
+            padding: 5px 10px;
+            margin-top: 10px;
+          }
+        }
+      }
+      .item,
+      .text {
+        .type-item,
+        .order-item {
+          display: inline-block;
+        }
+        .order-item {
+          float: right;
+        }
+      }
+      .text {
+        .order-item {
+          margin-left: 2px;
+        }
+      }
+    }
+  }
+  .clear-filter-element {
+    margin-left: 13px;
+    border-left: 1px solid #d6d6d7;
+    padding-left: 13px;
+    color: black;
+    display: flex;
+    justify-content: space-between;
+    width: 135px;
+    .clear-filter,
+    .select-all-filter {
+      display: inline;
+      button {
+        background: none;
+        color: grey;
+        text-decoration: underline;
+        cursor: pointer;
+        border: none;
+        padding: 0;
+        outline: none;
+        &:hover {
+          text-decoration: none;
+        }
+      }
+    }
+  }
 }
 
 footer {
-    #statistics {
-        display: none;
-    }
+  #statistics {
+    display: none;
+  }
 }
 
 .no-segments-found {
-    text-align: center;
-    margin: 15px 0;
-    border: 1px dashed #c3c8d0;
-    padding: 15px;
+  text-align: center;
+  margin: 15px 0;
+  border: 1px dashed #c3c8d0;
+  padding: 15px;
 }
 
 .one.column.spinner {
-    margin: 30px 15px 15px;
-    z-index: 1;
-    .ui.active.inverted.dimmer {
-        background: $grey4;
-    }
+  margin: 30px 15px 15px;
+  z-index: 1;
+  .ui.active.inverted.dimmer {
+    background: $grey4;
+  }
 }
 
 .per-orange {
-    background: $orangeDefault !important;
-    color: #fff !important
+  background: $orangeDefault !important;
+  color: #fff !important;
 }
 
 .per-blue {
-    background: $translatedBlue !important;
-    color: #fff !important
+  background: $translatedBlue !important;
+  color: #fff !important;
 }
 
 .per-green {
-    background: $approvedGreen !important;
-    color: #fff !important
+  background: $approvedGreen !important;
+  color: #fff !important;
 }
 
 .per-yellow {
-    background: #FFCC00 !important;
-    color: #333 !important
+  background: #ffcc00 !important;
+  color: #333 !important;
 }
 
 .per-red {
-    background: $redDefault !important;
-    color: #fff !important
+  background: $redDefault !important;
+  color: #fff !important;
 }
 
 .per-gray {
-    background: #aaa !important;
-    color: $grey1 !important
+  background: #aaa !important;
+  color: $grey1 !important;
 }
 
 .ui.popup.bottom.right.qr-score-popup {
-    max-width: 350px !important;
-    code {
-        font-size: 12px;
-    }
-
+  max-width: 350px !important;
+  code {
+    font-size: 12px;
+  }
 }

--- a/public/css/sass/review_extended.scss
+++ b/public/css/sass/review_extended.scss
@@ -1,225 +1,232 @@
-@import "commons/divider";
-@import "commons/shadows";
+@import 'commons/divider';
+@import 'commons/shadows';
 
-h1, h2, h3, h4, h5, a, input {
-    font-family: Calibri, Arial, Helvetica, sans-serif !important;
+h1,
+h2,
+h3,
+h4,
+h5,
+a,
+input {
+  font-family: Calibri, Arial, Helvetica, sans-serif !important;
 }
 
 .review-balloon-container {
-    padding-right: 15px;
-    position: absolute;
-    top: 80px;
-    width: 100%;
-    .re-wrapper {
-        height: 100%;
-        position: relative;
-        .re-warning-not-added-issue {
-            p {
-                background: $notification-error;
-                color: #fff;
-                padding: 5px 10px;
-                a {
-                    color: #fff;
-                    font-weight: bolder;
-                    cursor: pointer;
-                    &:hover {
-                        color: #fff;
-                        text-decoration: underline;
-                    }
-                }
-            }
+  padding-right: 15px;
+  position: absolute;
+  top: 80px;
+  width: 100%;
+  .re-wrapper {
+    height: 100%;
+    position: relative;
+    .re-warning-not-added-issue {
+      p {
+        background: $notification-error;
+        color: #fff;
+        padding: 5px 10px;
+        a {
+          color: #fff;
+          font-weight: bolder;
+          cursor: pointer;
+          &:hover {
+            color: #fff;
+            text-decoration: underline;
+          }
         }
-        .re-warning-selected-text-issue {
-            p {
-                background: #FFEB3B;;
-                color: #000;
-                padding: 5px 10px;
-            }
-        }
-        .re-issues-box {
-            .re-issues-box-title {}
-            .re-list {
-                overflow-y: auto;
-                max-height: 250px;
-
-                &.no-scroll {
-                    overflow-y: hidden;
-                }
-                .re-item-head {
-                    border-bottom: 1px solid #f2f4f7;
-                    padding-top: 10px;
-                    margin-right: 1px;
-                    font-size: 16px;
-                    font-weight: bold;
-                    padding-bottom: 3px;
-                }
-                &.issues {
-                    .re-item-head {
-                        margin-top: 3px;
-                        padding-bottom: 5px;
-                    }
-                }
-                .re-item {
-                    &:hover, &.active {
-                        background: #f2f4f7 !important;
-                    }
-                    .re-item-box {
-                        display: flex;
-                        justify-content: space-between;
-                        align-items: center;
-                        position: relative;
-                        padding: 5px 5px 5px 7px;
-
-                    }
-                    .re-issue {
-                        .issue-head {
-                            max-width: 85%;
-                            min-width: 30px;
-                            white-space: nowrap;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            display: flex;
-                            .re-category-issue-head {
-                                overflow: hidden;
-                                text-overflow: ellipsis;
-                                margin-right: 3px;
-                            }
-                        }
-                        .issue-activity-icon {
-                            .icon-buttons {
-                                display: flex;
-                            }
-                        }
-
-                    }
-                    .re-error {
-                        padding: 0 10px;
-                        height: 100%;
-                        min-height: 45px;
-                        min-width: 30px;
-                        display: flex;
-                        align-items: center;
-                        justify-content: space-between;
-                        .error-name {
-
-                        }
-                    }
-                    .comments-view {
-                        .re-add-comment {
-                            padding: 7px 5px;
-                            .re-comment-input {
-                                border-radius: 20px !important;
-                            }
-                        }
-                        .re-comment-list {
-                            .re-comment {
-                                background: #FFF;
-                                padding: 5px 10px;
-                                margin-bottom: 0;
-                                .re-revisor {
-                                    color: $approvedGreen;
-                                }
-                                .re-revisor2 {
-                                    color: $approved2Green;
-                                }
-                                .re-translator {
-                                    color: $translatedBlue;
-                                }
-                                .re-comment-date {
-                                    color: lightslategray;
-                                }
-                                .re-selected-text {
-                                    color: #000;
-                                }
-                            }
-                            .re-highlighted {
-                                padding: 10px;
-                                border-bottom: 1px solid #797979;
-                            }
-
-                            span.re-selected-text {
-                                margin-right: 5px;
-                            }
-                        }
-                    }
-                    .re-severities-buttons {
-                        display: none;
-                    }
-                    &.severity-buttons:hover, &.active {
-                        .re-severities-buttons {
-                            display: flex;
-                            button {
-                                padding: 7px 10px;
-                                background-color: #f2f4f7;
-                                &:hover, &.active {
-                                    background-color: #CACBCD;
-                                }
-                            }
-                        }
-                        .error-name {
-                            padding-right: 10px;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                            white-space: nowrap;
-                        }
-                        @media only screen and (max-width: 1260px) {
-                            .error-name {
-                                max-width: 55% !important;
-                            }
-                        }
-                        @media only screen and (max-width: 1024px) {
-                            .error-name {
-                                max-width: 53% !important;
-                            }
-                        }
-                    }
-
-                }
-            }
-            &.re-issues-box-empty {
-                display: none;
-            }
-        }
-        .re-item.issue-comments-open {
-            margin: 20px 0 20px;
-            transition: 0.3s ease;
-            background: #f2f4f7;
-            &:nth-child(2) {
-                margin-top: 5px !important;
-            }
-        }
-        .re-created {
-            background: $grey3;
-            padding: 10px 10px 10px;
-            margin-bottom: 0;
-            .issues {
-                .re-item-box {
-                    background: #ffffff;
-                }
-            }
-        }
-        .re-to-create {
-            background: #ffffff;
-            .errors {
-                max-height: 290px;
-                .re-category-item {}
-            }
-        }
+      }
     }
+    .re-warning-selected-text-issue {
+      p {
+        background: #ffeb3b;
+        color: #000;
+        padding: 5px 10px;
+      }
+    }
+    .re-issues-box {
+      .re-issues-box-title {
+      }
+      .re-list {
+        overflow-y: auto;
+        max-height: 250px;
+
+        &.no-scroll {
+          overflow-y: hidden;
+        }
+        .re-item-head {
+          border-bottom: 1px solid #f2f4f7;
+          padding-top: 10px;
+          margin-right: 1px;
+          font-size: 16px;
+          font-weight: bold;
+          padding-bottom: 3px;
+        }
+        &.issues {
+          .re-item-head {
+            margin-top: 3px;
+            padding-bottom: 5px;
+          }
+        }
+        .re-item {
+          &:hover,
+          &.active {
+            background: #f2f4f7 !important;
+          }
+          .re-item-box {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            position: relative;
+            padding: 5px 5px 5px 7px;
+          }
+          .re-issue {
+            .issue-head {
+              max-width: 85%;
+              min-width: 30px;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              display: flex;
+              .re-category-issue-head {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                margin-right: 3px;
+              }
+            }
+            .issue-activity-icon {
+              .icon-buttons {
+                display: flex;
+              }
+            }
+          }
+          .re-error {
+            padding: 0 10px;
+            height: 100%;
+            min-height: 45px;
+            min-width: 30px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            .error-name {
+            }
+          }
+          .comments-view {
+            .re-add-comment {
+              padding: 7px 5px;
+              .re-comment-input {
+                border-radius: 20px !important;
+              }
+            }
+            .re-comment-list {
+              .re-comment {
+                background: #fff;
+                padding: 5px 10px;
+                margin-bottom: 0;
+                .re-revisor {
+                  color: $approvedGreen;
+                }
+                .re-revisor2 {
+                  color: $approved2Green;
+                }
+                .re-translator {
+                  color: $translatedBlue;
+                }
+                .re-comment-date {
+                  color: lightslategray;
+                }
+                .re-selected-text {
+                  color: #000;
+                }
+              }
+              .re-highlighted {
+                padding: 10px;
+                border-bottom: 1px solid #797979;
+              }
+
+              span.re-selected-text {
+                margin-right: 5px;
+              }
+            }
+          }
+          .re-severities-buttons {
+            display: none;
+          }
+          &.severity-buttons:hover,
+          &.active {
+            .re-severities-buttons {
+              display: flex;
+              button {
+                padding: 7px 10px;
+                background-color: #f2f4f7;
+                &:hover,
+                &.active {
+                  background-color: #cacbcd;
+                }
+              }
+            }
+            .error-name {
+              padding-right: 10px;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            @media only screen and (max-width: 1260px) {
+              .error-name {
+                max-width: 55% !important;
+              }
+            }
+            @media only screen and (max-width: 1024px) {
+              .error-name {
+                max-width: 53% !important;
+              }
+            }
+          }
+        }
+      }
+      &.re-issues-box-empty {
+        display: none;
+      }
+    }
+    .re-item.issue-comments-open {
+      margin: 20px 0 20px;
+      transition: 0.3s ease;
+      background: #f2f4f7;
+      &:nth-child(2) {
+        margin-top: 5px !important;
+      }
+    }
+    .re-created {
+      background: $grey3;
+      padding: 10px 10px 10px;
+      margin-bottom: 0;
+      .issues {
+        .re-item-box {
+          background: #ffffff;
+        }
+      }
+    }
+    .re-to-create {
+      background: #ffffff;
+      .errors {
+        max-height: 290px;
+        .re-category-item {
+        }
+      }
+    }
+  }
 }
 article {
-    &.comment-opened-0 {
-        margin-top: 270px;
-    }
-    &.comment-opened-1 {
-        margin-top: 180px;
-    }
-    &.comment-opened-2 {
-        margin-top: 120px;
-    }
-    &.comment-opened-empty-0 {
-        margin-top: 110px;
-    }
+  &.comment-opened-0 {
+    margin-top: 270px;
+  }
+  &.comment-opened-1 {
+    margin-top: 180px;
+  }
+  &.comment-opened-2 {
+    margin-top: 120px;
+  }
+  &.comment-opened-empty-0 {
+    margin-top: 110px;
+  }
 }
 //article:first-child {
 //    section {
@@ -252,225 +259,221 @@ article {
 //}
 
 .re-abb-issue {
-    background: #e5e9f1;
-    padding: 0 4px;
-    margin-right: 5px;
-    color: black;
-    width: fit-content;
-    height: fit-content;
-    min-width: 25px;
-    text-align: center;
+  background: #e5e9f1;
+  padding: 0 4px;
+  margin-right: 5px;
+  color: black;
+  width: fit-content;
+  height: fit-content;
+  min-width: 25px;
+  text-align: center;
 }
 
 .re-open-view.re-issues {
-    top: 0px;
-    border-top: 12px solid #fff;
-    border-left: 14px solid transparent;
-    filter: drop-shadow(-1px 0px 1px rgba(0, 0, 0, 0.2));
-    margin-left: -14px;
-    position: absolute;
-    &.error {
-        border-top: 12px solid $notification-error;
-    }
-    &.warning {
-        border-top: 12px solid #FFEB3B;
-    }
+  top: 0px;
+  border-top: 12px solid #fff;
+  border-left: 14px solid transparent;
+  filter: drop-shadow(-1px 0px 1px rgba(0, 0, 0, 0.2));
+  margin-left: -14px;
+  position: absolute;
+  &.error {
+    border-top: 12px solid $notification-error;
+  }
+  &.warning {
+    border-top: 12px solid #ffeb3b;
+  }
 }
 
 .re-wrapper.thereAreIssues .re-open-view.re-issues {
-    top: -1px;
-    border-top: 12px solid $grey3;
+  top: -1px;
+  border-top: 12px solid $grey3;
 }
 
 section {
-
-
-    &.editAreaLocked.opened {
-        .outersource .copy {
-            display: none;
-        }
-        .segment-text-area-container {
-            position: relative !important;
-            width: 100% !important;
-            float: right !important;
-            .textarea-container {
-                padding: 0 5px;
-                font-size: 18px;
-                margin: 3px 0 2px;
-            }
-        }
-        .buttons {
-
-            .left {
-                float: left;
-            }
-
-            .right {
-                float: right;
-            }
-        }
+  &.editAreaLocked.opened {
+    .outersource .copy {
+      display: none;
     }
-    &.editAreaLocked .errorTaggingArea {
-        line-height: 27px;
-        padding: 4px 0 0 0 ;
+    .segment-text-area-container {
+      position: relative !important;
+      width: 100% !important;
+      float: right !important;
+      .textarea-container {
+        padding: 0 5px;
+        font-size: 18px;
+        margin: 3px 0 2px;
+      }
     }
-    .errorTaggingArea, .editableTarget, .trackChanges {
-        font-family: "calibri", Arial, Helvetica, sans-serif;
-        padding: 3px;
-        line-height: 27px;
-        padding: 4px 0 0 0 ;
+    .buttons {
+      .left {
+        float: left;
+      }
+
+      .right {
+        float: right;
+      }
     }
+  }
+  &.editAreaLocked .errorTaggingArea {
+    line-height: 27px;
+    padding: 4px 0 0 0;
+  }
+  .errorTaggingArea,
+  .editableTarget,
+  .trackChanges {
+    font-family: 'calibri', Arial, Helvetica, sans-serif;
+    padding: 3px;
+    line-height: 27px;
+    padding: 4px 0 0 0;
+  }
 
-    .errorTaggingArea {
-        .highlight {
-            background-color: #7EB30C;
-        }
+  .errorTaggingArea {
+    .highlight {
+      background-color: #7eb30c;
     }
+  }
 
-    .errorTaggingArea::selection {
-        background-color: #FFEB3B;
+  .errorTaggingArea::selection {
+    background-color: #ffeb3b;
+  }
+
+  .toolbar {
+    .revise-lock-editArea {
+      float: left;
+      font-size: 60%;
+      min-width: 20px;
+      cursor: pointer;
+      border-radius: 3px;
+      //padding: 2px;
+      border: 1px solid #c6c6c6;
+      margin-right: 10px;
+      color: $grey1 !important;
+
+      background: #fff url(../../img/highlighter_icon.png) center center
+        no-repeat;
+      background-color: white;
+      width: 20px;
+      height: 20px;
+      background-size: cover;
+      opacity: 0.7;
     }
-
-    .toolbar {
-        .revise-lock-editArea {
-            float: left;
-            font-size: 60%;
-            min-width: 20px;
-            cursor: pointer;
-            border-radius: 3px;
-            //padding: 2px;
-            border: 1px solid #C6C6C6;
-            margin-right: 10px;
-            color: $grey1 !important;
-
-            background: #fff url(../../img/highlighter_icon.png) center center no-repeat;
-            background-color: white;
-            width: 20px;
-            height: 20px;
-            background-size: cover;
-            opacity: 0.7;
-        }
-        .revise-lock-editArea.active {
-            box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-            background-color: #eee;
-            //background-image: -webkit-linear-gradient(top, #eee, #e0e0e0);
-            margin-top: 18px;
-        }
-        .revise-qr-link {
-            float: left;
-            min-width: 20px;
-            cursor: pointer;
-            border-radius: 3px;
-            //padding: 2px;
-            border: 1px solid #C6C6C6;
-            margin-right: 10px;
-            color: #333 !important;
-            font-size: 16px;
-            line-height: 20px;
-            font-weight: bold;
-            background: #ffffff;
-            width: 20px;
-            height: 20px;
-            opacity: 0.7;
-            white-space: nowrap;
-        }
-        .revise-qr-link.hover {
-            box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-            color: #222;
-            //background-image: -webkit-linear-gradient(top, #eee, #e0e0e0);
-            margin-top: 18px;
-        }
-        //.revise-lock-editArea:before {
-        //    font-size: 19px;
-        //    display: block;
-        //}
+    .revise-lock-editArea.active {
+      box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+      background-color: #eee;
+      //background-image: -webkit-linear-gradient(top, #eee, #e0e0e0);
+      margin-top: 18px;
     }
-
-    .segment-side-buttons .revise-button {
-        text-decoration: none !important;
-        font-size: 28px;
-        color: $grey1;
-        font-weight: bold;
+    .revise-qr-link {
+      float: left;
+      min-width: 20px;
+      cursor: pointer;
+      border-radius: 3px;
+      //padding: 2px;
+      border: 1px solid #c6c6c6;
+      margin-right: 10px;
+      color: #333 !important;
+      font-size: 16px;
+      line-height: 20px;
+      font-weight: bold;
+      background: #ffffff;
+      width: 20px;
+      height: 20px;
+      opacity: 0.7;
+      white-space: nowrap;
     }
-
-
-    .translation-issues-button {
-        cursor: pointer;
-        padding: 5px 7px 5px;
-        width: 50px;
-        position: absolute;
-        top: 50px;
+    .revise-qr-link.hover {
+      box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+      color: #222;
+      //background-image: -webkit-linear-gradient(top, #eee, #e0e0e0);
+      margin-top: 18px;
     }
+    //.revise-lock-editArea:before {
+    //    font-size: 19px;
+    //    display: block;
+    //}
+  }
 
-    .translation-issues-button .revise-button {
-        visibility: hidden;
-        display:block;
-        &.has-object {
-            visibility: visible;
-        }
-    }
+  .segment-side-buttons .revise-button {
+    text-decoration: none !important;
+    font-size: 28px;
+    color: $grey1;
+    font-weight: bold;
+  }
 
+  .translation-issues-button {
+    cursor: pointer;
+    padding: 5px 7px 5px;
+    width: 50px;
+    position: absolute;
+    top: 50px;
+  }
 
-    &:hover .translation-issues-button .revise-button,
-    .translation-issues-button:hover .revise-button,
-    .segment-side-buttons:hover .translation-issues-button .revise-button {
-        visibility: visible;
+  .translation-issues-button .revise-button {
+    visibility: hidden;
+    display: block;
+    &.has-object {
+      visibility: visible;
     }
+  }
 
-    .revise-button-counter {
-        left: 35px;
-        position: absolute;
-        top: 2px;
-        background: $redDefault;
-        color: #fff;
-        border: 1px solid #fff;
-        border-radius: 14px;
-        display: block;
-        font-size: 11px;
-        font-weight: bold;
-        padding: 0 7px;
-        text-align: center;
-        width: 8px;
-        height: 15px;
-        line-height: 1.5;
-    }
+  &:hover .translation-issues-button .revise-button,
+  .translation-issues-button:hover .revise-button,
+  .segment-side-buttons:hover .translation-issues-button .revise-button {
+    visibility: visible;
+  }
 
-    .revise-button-2 {
-        background: $approved2Green;
-    }
-    &.approved-step-2 .status {
-        background-color: $approved2Green !important;
-    }
+  .revise-button-counter {
+    left: 35px;
+    position: absolute;
+    top: 2px;
+    background: $redDefault;
+    color: #fff;
+    border: 1px solid #fff;
+    border-radius: 14px;
+    display: block;
+    font-size: 11px;
+    font-weight: bold;
+    padding: 0 7px;
+    text-align: center;
+    width: 8px;
+    height: 15px;
+    line-height: 1.5;
+  }
+
+  .revise-button-2 {
+    background: $approved2Green;
+  }
+  &.approved-step-2 .status {
+    background-color: $approved2Green !important;
+  }
 }
 
-
-
 .undo-issue-deleted {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 body {
-    &.review-side-panel-opened article {
-        //-webkit-transform: translate3d(0, 0, 0);
-        -webkit-backface-visibility: hidden;
-        //-webkit-perspective: 1000;
-        -webkit-transition: width .2s ease;
-        transition: width .2s ease;
-        width: 69%;
-    }
-    /* code to hide scroll of the body */
-    &.review-side-panel-opened {
-        overflow-y: hidden!important;
-    }
+  &.review-side-panel-opened article {
+    //-webkit-transform: translate3d(0, 0, 0);
+    -webkit-backface-visibility: hidden;
+    //-webkit-perspective: 1000;
+    -webkit-transition: width 0.2s ease;
+    transition: width 0.2s ease;
+    width: 69%;
+  }
+  /* code to hide scroll of the body */
+  &.review-side-panel-opened {
+    overflow-y: hidden !important;
+  }
 
-    &.review-side-panel-opened a.cancel-project:before {
-        margin-right: 5px;
-    }
+  &.review-side-panel-opened a.cancel-project:before {
+    margin-right: 5px;
+  }
 }
 //*******************************************************/
 
 //Download Button
 .downloadtr-button.approved-2ndpass {
-    background: $approved2Green;
-    color: #fff !important;
+  background: $approved2Green;
+  color: #fff !important;
 }

--- a/public/css/sass/revise.scss
+++ b/public/css/sass/revise.scss
@@ -1,2 +1,1 @@
 @import 'review_extended';
-

--- a/public/css/sass/segment-notes.scss
+++ b/public/css/sass/segment-notes.scss
@@ -1,119 +1,122 @@
 div.segment-notes ul.graysmall li {
-    width: 90%;
+  width: 90%;
 }
 
 div.segment-notes ul.graysmall li span.note-label {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .segments-notes-container {
-    float: left;
+  float: left;
 }
 .segments-preview-footer {
-    display: inline-block;
-    padding: 15px 20px 0px;
-    width: 50%;
-    box-sizing: border-box;
-    position: relative;
-    border: 5px solid white;
-    border-right: 1px solid #ccc;
-    float: left;
+  display: inline-block;
+  padding: 15px 20px 0px;
+  width: 50%;
+  box-sizing: border-box;
+  position: relative;
+  border: 5px solid white;
+  border-right: 1px solid #ccc;
+  float: left;
 }
 
 .segment-notes-container {
-    display: inline-block;
-    max-width: 95%;
-    box-sizing: border-box;
-    vertical-align: top;
-    text-align: left;
-    float:left;
+  display: inline-block;
+  max-width: 95%;
+  box-sizing: border-box;
+  vertical-align: top;
+  text-align: left;
+  float: left;
 }
 
 .segments-preview-container {
-    max-width: 380px;
-    max-height: 260px;
-    min-height: 170px;
-    background-image: url(../../img/loading.gif);
-    background-size: 30px 30px;
-    background-repeat: no-repeat;
-    background-position: 50%;
-    overflow-y: auto;
-    cursor: pointer;
-    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24);
-    margin: 0 auto;
+  max-width: 380px;
+  max-height: 260px;
+  min-height: 170px;
+  background-image: url(../../img/loading.gif);
+  background-size: 30px 30px;
+  background-repeat: no-repeat;
+  background-position: 50%;
+  overflow-y: auto;
+  cursor: pointer;
+  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.24);
+  margin: 0 auto;
 }
 
 .segments-preview-container:hover {
-    box-shadow: 0 0 0 #e0e0e0, 0 0 8px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.24);
-    transition: 0.2s ease;
+  box-shadow: 0 0 0 #e0e0e0, 0 0 8px rgba(0, 0, 0, 0.12),
+    0 2px 8px rgba(0, 0, 0, 0.24);
+  transition: 0.2s ease;
 }
 
 .segments-preview-container img {
-    width: 100%;
-    text-align: center;
+  width: 100%;
+  text-align: center;
 }
 
 .segments-notes-container div.note,
 .segments-notes-container div.context-group {
-    text-align: left;
-    padding: 12px 20px;
-    color: #666;
-    list-style: none;
-    font-size: 16px;
-    float: left;
-    width: 100%;
-    word-break: break-word;
+  text-align: left;
+  padding: 12px 20px;
+  color: #666;
+  list-style: none;
+  font-size: 16px;
+  float: left;
+  width: 100%;
+  word-break: break-word;
 }
 
-.segments-notes-container div.note p{
-    margin: 0;
-    line-height: 25px;
+.segments-notes-container div.note p {
+  margin: 0;
+  line-height: 25px;
 }
 
 .segments-notes-container div.note p a {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .segments-notes-container div.note p a:hover {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .segments-notes-container .note-label,
-.segments-notes-container .context-group-name
-{
-    font-weight: bold;
+.segments-notes-container .context-group-name {
+  font-weight: bold;
 }
 
 .tab-preview-screenshot {
-    text-align: center;
-    padding-top: 10px;
+  text-align: center;
+  padding-top: 10px;
 }
 
 .tab-preview-screenshot button {
-    font-size: 14px;
-    text-align: center;
-    margin: 0 3px;
-    border-radius: 2px;
-    border: 1px solid #C6C6C6;
-    cursor: pointer;
-    color: #666666;
-    outline: none;
-    position: relative;
-    background-color: transparent;
+  font-size: 14px;
+  text-align: center;
+  margin: 0 3px;
+  border-radius: 2px;
+  border: 1px solid #c6c6c6;
+  cursor: pointer;
+  color: #666666;
+  outline: none;
+  position: relative;
+  background-color: transparent;
 }
 
 .tab-preview-screenshot button:hover {
-    color: #000000;
+  color: #000000;
 }
 
 .tab-preview-screenshot button i {
-    position: relative;
-    top: 2px;
-    margin: 0;
+  position: relative;
+  top: 2px;
+  margin: 0;
 }
 
-.preview-button, .n-segments-available, .text-n-segments-available {
-    display: inline-block;
-    font-size: 14px;
-    font-weight: 100;
+.preview-button,
+.n-segments-available,
+.text-n-segments-available {
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 100;
 }

--- a/public/css/sass/speech2text.scss
+++ b/public/css/sass/speech2text.scss
@@ -1,168 +1,159 @@
 @import '_mixins';
 
 .activeSegmentButton {
-    @include box-shadow(inset 0 1px 2px rgba(0,0,0,.1));
-    @include linear-gradient(#eee, top, #eee, #e0e0e0);
-    border-color:#ccc;
+  @include box-shadow(inset 0 1px 2px rgba(0, 0, 0, 0.1));
+  @include linear-gradient(#eee, top, #eee, #e0e0e0);
+  border-color: #ccc;
 }
 
-
 .editarea.micActive {
-    width: 94%;
-    padding-right: 7%;
+  width: 94%;
+  padding-right: 7%;
 }
 
 .micSpeech {
-    /* @extend .segmentButton; */
+  /* @extend .segmentButton; */
 
-    display: none;
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    cursor:pointer;
-    padding:3px 4px 5px 4px;
-    z-index: 9999999;
+  display: none;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  cursor: pointer;
+  padding: 3px 4px 5px 4px;
+  z-index: 9999999;
 
-    &:hover {
-        svg g {
-            fill: #000000;
-        }
+  &:hover {
+    svg g {
+      fill: #000000;
     }
+  }
 
-
-    
-
-   
-    &.micSpeechActive {
-        svg g {
-            fill: red;
-        }
+  &.micSpeechActive {
+    svg g {
+      fill: red;
     }
+  }
 
-    &.micSpeechReceiving {
-      /*  @extend .activeSegmentButton; */
-
-        svg g {
-            fill: #fff;
-        }
-    }
-
-/*    &.micSpeechActive .micBg, */
-    &.micSpeechReceiving .micBg {
-        background: red;
-          -webkit-border-radius: 60px;
-          -moz-border-radius: 60px;
-          border-radius: 60px;
-          height: 50px;
-          width: 50px;
-          position: absolute;
-        right: -11px;
-        top: -10px;
-        @include animation-duration(1s);
-        @include animation-name(speaking);
-        @include animation-iteration-count(infinite);
-        @include animation-timing-function(ease-in-out);
-        @include animation-direction(alternate);
-
-        svg g {
-            fill: #FFFFFF;
-        }
-    }
+  &.micSpeechReceiving {
+    /*  @extend .activeSegmentButton; */
 
     svg g {
-        fill: #737373;
+      fill: #fff;
     }
+  }
+
+  /*    &.micSpeechActive .micBg, */
+  &.micSpeechReceiving .micBg {
+    background: red;
+    -webkit-border-radius: 60px;
+    -moz-border-radius: 60px;
+    border-radius: 60px;
+    height: 50px;
+    width: 50px;
+    position: absolute;
+    right: -11px;
+    top: -10px;
+    @include animation-duration(1s);
+    @include animation-name(speaking);
+    @include animation-iteration-count(infinite);
+    @include animation-timing-function(ease-in-out);
+    @include animation-direction(alternate);
+
+    svg g {
+      fill: #ffffff;
+    }
+  }
+
+  svg g {
+    fill: #737373;
+  }
 }
 
 section.opened .micSpeech,
 section.opened .micSpeechActive,
 section.opened svg.micBgSpeechActive,
 section.opened svg.micBgSpeechReceiving {
-    display: block;
+  display: block;
 }
 
 section.opened {
-    ul.buttons {
-        margin-top: -13px;
-    }
+  ul.buttons {
+    margin-top: -13px;
+  }
 
-    .toolbar {
-        /* Tied to speech2text removal */
-        /* margin-left: 20px; */
-        float: left;
-        margin-top: 3px;
-        width: 65%;
-    }
+  .toolbar {
+    /* Tied to speech2text removal */
+    /* margin-left: 20px; */
+    float: left;
+    margin-top: 3px;
+    width: 65%;
+  }
 }
 
 $tlbr-btn-bg: -webkit-linear-gradient(top, #f8f8f8, #f1f1f1);
 $tlbr-btn-bg-act: -webkit-linear-gradient(top, #eee, #e0e0e0);
 
 .tlbr-btn-act {
-    opacity: 1.0;
+  opacity: 1;
 }
 
 .editToolbar {
-    li {
-        @extend .segmentButton;
+  li {
+    @extend .segmentButton;
 
-        &.uppercase {
+    &.uppercase {
+      &:hover {
+        @extend .tlbr-btn-act;
+      }
 
-            &:hover {
-                @extend .tlbr-btn-act;
-            }
-
-            &:active {
-            }
-        }
-
-        &.lowercase {
-
-            &:hover {
-                @extend .tlbr-btn-act;
-            }
-
-            &:active {
-            }
-        }
-
-        &.capitalize {
-
-            &:hover {
-                @extend .tlbr-btn-act;
-            }
-
-            &:active {
-            }
-        }
+      &:active {
+      }
     }
+
+    &.lowercase {
+      &:hover {
+        @extend .tlbr-btn-act;
+      }
+
+      &:active {
+      }
+    }
+
+    &.capitalize {
+      &:hover {
+        @extend .tlbr-btn-act;
+      }
+
+      &:active {
+      }
+    }
+  }
 }
 
 .micBg2 {
-    position: absolute;
-    background: transparent;
-    width: 20px;
-    right: 4px;
-    height: 20px;
-    border-radius: 20px;
+  position: absolute;
+  background: transparent;
+  width: 20px;
+  right: 4px;
+  height: 20px;
+  border-radius: 20px;
 }
 
 .micSpeech {
-    zoom: 0.8;
+  zoom: 0.8;
 }
-
 
 @include keyframes(speaking) {
-    0% {
+  0% {
     -webkit-transform: scale(0.6);
     opacity: 0.6;
-}
- 50% {
+  }
+  50% {
     -webkit-transform: scale(0.8);
     opacity: 0.8;
-    }
- 100% {
+  }
+  100% {
     -webkit-transform: scale(0.6);
     opacity: 0.6;
- }
+  }
 }

--- a/public/css/sass/style.scss
+++ b/public/css/sass/style.scss
@@ -1,128 +1,130 @@
 body {
-    transition: padding-top 200ms ease-out;
-    -webkit-transition: padding-top 200ms ease-out;
+  transition: padding-top 200ms ease-out;
+  -webkit-transition: padding-top 200ms ease-out;
 }
 
 body.incomingMsg {
-    padding-top: 140px;
+  padding-top: 140px;
 }
 
-input, textarea {
-    font-family: calibri, Arial, Helvetica, sans-serif;
-    font-size: 16px;
+input,
+textarea {
+  font-family: calibri, Arial, Helvetica, sans-serif;
+  font-size: 16px;
 }
 
 body.login header {
-    margin-top: 0 !important;
-    height: 47px;
+  margin-top: 0 !important;
+  height: 47px;
 }
 
 body.incomingMsg header {
-    margin-top: 0px;
+  margin-top: 0px;
 }
 
 header .wrapper {
-    width: 100%;
-    background: #002b5c;
-    height: 60px;
-    display: grid;
-    grid-template-columns: 170px auto auto 64px;
-    padding: 0 33px;
-    align-content: center;
-    box-sizing: border-box;
-    top:0;
+  width: 100%;
+  background: #002b5c;
+  height: 60px;
+  display: grid;
+  grid-template-columns: 170px auto auto 64px;
+  padding: 0 33px;
+  align-content: center;
+  box-sizing: border-box;
+  top: 0;
 }
 
-.header-menu {;
-    float: right;
-    margin-right: 16px;
-    margin-left: 15px;
+.header-menu {
+  float: right;
+  margin-right: 16px;
+  margin-left: 15px;
 }
 
 .header-menu li {
-    /*border-left:1px solid #000;*/
-    float: left;
-    height: 37px;
-    padding: 5px 0px;
+  /*border-left:1px solid #000;*/
+  float: left;
+  height: 37px;
+  padding: 5px 0px;
 }
 
 .text .source.item,
 .text .target.item,
 .white li {
-    width: 45%;
-    table-layout: fixed;
-    float: left;
-    padding: 3px 1%;
-    text-align: left;
-    list-style: none;
-    height: 95%;
-    outline: none;
-    line-height: 23px;
-    word-break: break-word;
+  width: 45%;
+  table-layout: fixed;
+  float: left;
+  padding: 3px 1%;
+  text-align: left;
+  list-style: none;
+  height: 95%;
+  outline: none;
+  line-height: 23px;
+  word-break: break-word;
 }
 
 .text .source.item {
-    padding-bottom: 10px;
-    padding-top: 11px !important;
+  padding-bottom: 10px;
+  padding-top: 11px !important;
 }
 
 .text a {
-    text-color: #000
+  text-color: #000;
 }
 
 #notifbox {
-    opacity: 0.9;
-    text-align: center;
-    width: 45px;
-    color: #777;
-    height: 27px;
-    padding-top: 12px;
-    cursor: pointer;
+  opacity: 0.9;
+  text-align: center;
+  width: 45px;
+  color: #777;
+  height: 27px;
+  padding-top: 12px;
+  cursor: pointer;
 }
 
 #notifbox.warningbox {
-    padding-top: 12px !important;
+  padding-top: 12px !important;
 }
 
 #notifbox a {
-    display: block;
-    width: 36px;
-    height: 36px;
-    padding: 0;
-    margin: 0 auto;
-    text-decoration: none;
+  display: block;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  margin: 0 auto;
+  text-decoration: none;
 }
 
-#filterSwitch, #advancedOptions {
-    text-align: center;
-    width: 45px;
-    height: 27px;
-    padding-top: 11px;
-    color: #eee;
-    font-size: 23px;
-    cursor: pointer;
+#filterSwitch,
+#advancedOptions {
+  text-align: center;
+  width: 45px;
+  height: 27px;
+  padding-top: 11px;
+  color: #eee;
+  font-size: 23px;
+  cursor: pointer;
 }
 
 #point2seg {
-    color: #fff;
+  color: #fff;
 }
 
 #filterSwitch:hover,
 #point2seg:hover {
-    color: #ccc;
+  color: #ccc;
 }
 
 body.search-open header .action-menu #action-search {
-    /*background-image: url("../../img/icons/icon-search-active.svg");*/
-    opacity: 1;
-    svg {
-        circle {
-            fill:#002b5c;
-        }
-        .st1{
-            fill:#fff;
-        }
+  /*background-image: url("../../img/icons/icon-search-active.svg");*/
+  opacity: 1;
+  svg {
+    circle {
+      fill: #002b5c;
     }
+    .st1 {
+      fill: #fff;
+    }
+  }
 }
 
 .numbererror,
@@ -131,159 +133,158 @@ body.search-open header .action-menu #action-search {
 .qa-glossary-counter,
 .qa-conflicts-issues-counter,
 .qa-lexiqa-counter {
-    position: absolute;
-    color: #fff;
-    background: #e20001;
-    margin-left: 20px;
-    margin-top: -8px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    /*border: 1px solid #fff;*/
-    display: block;
-    font-size: 11px;
-    padding: 0 4px;
-    text-align: center;
-    /*min-width: 8px;*/
-    height: 15px;
-    line-height: 1.5;
-    box-sizing: content-box;
+  position: absolute;
+  color: #fff;
+  background: #e20001;
+  margin-left: 20px;
+  margin-top: -8px;
+  -moz-border-radius: 10px;
+  border-radius: 10px;
+  /*border: 1px solid #fff;*/
+  display: block;
+  font-size: 11px;
+  padding: 0 4px;
+  text-align: center;
+  /*min-width: 8px;*/
+  height: 15px;
+  line-height: 1.5;
+  box-sizing: content-box;
 }
 
 .numbererror {
-    border-radius: 25px;
-    right: -4px;
-    font-size: 10px;
-    line-height: 16px;
-    top: 0;
-    margin:0;
-    padding: 1px 6px;
+  border-radius: 25px;
+  right: -4px;
+  font-size: 10px;
+  line-height: 16px;
+  top: 0;
+  margin: 0;
+  padding: 1px 6px;
 }
 
-.numberwarning{
-    background: #E2BE26!important;
+.numberwarning {
+  background: #e2be26 !important;
 }
-.numberinfo{
-    background: #0bbeec!important;
+.numberinfo {
+  background: #0bbeec !important;
 }
 
 .numbererror:empty {
-    display: none
+  display: none;
 }
 
 .action-submenu.notific:before {
-        font-size: 18px ;
-        color: #3aa94f;
-        content: "";
-        display: none; /* Don't display icon if all ok */
+  font-size: 18px;
+  color: #3aa94f;
+  content: '';
+  display: none; /* Don't display icon if all ok */
 }
 
 #point2seg:after {
-    font-size: 18px ;
-    content: "";
-    display: none; /* Don't display icon */
+  font-size: 18px;
+  content: '';
+  display: none; /* Don't display icon */
 }
 
-
 .notific a {
-    color: #fff;
-    text-decoration: none;
-    height: 16px;
-    padding: 2px 4px 0 2px !important;
-    display: block;
-    margin: -2px 0px 0 2px;
-    font-size: 12px;
-    position: absolute;
-    border-radius: 2px;
-    -webkit-box-shadow: 0 1px 2px #666;
-    box-shadow: 0 1px 2px #666;
-    display: none;
+  color: #fff;
+  text-decoration: none;
+  height: 16px;
+  padding: 2px 4px 0 2px !important;
+  display: block;
+  margin: -2px 0px 0 2px;
+  font-size: 12px;
+  position: absolute;
+  border-radius: 2px;
+  -webkit-box-shadow: 0 1px 2px #666;
+  box-shadow: 0 1px 2px #666;
+  display: none;
 }
 
 .notific.error {
-    color: #fff !important;
+  color: #fff !important;
 }
 
 .error a {
-    display: block !important;
+  display: block !important;
 }
 
 .error {
-    font-size: 16px;
+  font-size: 16px;
 }
 
 .error-type a.tooltip {
-    left: -5px;
-    top: 10px;
+  left: -5px;
+  top: 10px;
 }
 
 .tag-mismatch {
-    float: left !important
+  float: left !important;
 }
 
 .auto-propagation-review {
-    cursor: pointer;
-    text-decoration: underline;
-    color: blue;
-    color: -webkit-link;
+  cursor: pointer;
+  text-decoration: underline;
+  color: blue;
+  color: -webkit-link;
 }
 
 .warnings,
 .text .alternatives {
-    clear: left;
-    color: #D65959;
-    float: left;
-    margin-left: -10px;
-    font-size: 14px;
-    max-width: 50%;
-    margin-top: 12px;
-    display: none;
-    margin-bottom: 0;
+  clear: left;
+  color: #d65959;
+  float: left;
+  margin-left: -10px;
+  font-size: 14px;
+  max-width: 50%;
+  margin-top: 12px;
+  display: none;
+  margin-bottom: 0;
 }
 
 .warnings,
-section.opened .warnings:empty{
-     display: none;
+section.opened .warnings:empty {
+  display: none;
 }
 
 section.opened .warnings {
-    display: block;
+  display: block;
 }
 
 .warnings,
-section.opened .warnings:empty{
-    display: none;
+section.opened .warnings:empty {
+  display: none;
 }
 
 section.opened .warnings {
-    display: block;
+  display: block;
 }
 
 .warnings:last-child {
-    margin-bottom: 25px;
+  margin-bottom: 25px;
 }
 
 .text .alternatives {
-    max-width: 300px;
+  max-width: 300px;
 }
 
 .alternatives a {
-    color: $black !important;
+  color: $black !important;
 }
 
 .mismatch .warnings {
-    display: block
+  display: block;
 }
 
 .warnings .tip {
-    display: block;
-    margin-left: 24px;
+  display: block;
+  margin-left: 24px;
 }
 
 /*ul{margin:0;padding:0;list-style:none}
 .wrapper{width:98%;min-width:960px;margin:0px auto 0 auto;padding:5px 0 0 0;width:92%;font-size:14px;position:relative;text-align:left;}*/
 .breadcrumbs {
-    color: #fff;
-    padding: 19px 0 4px 0px;
+  color: #fff;
+  padding: 19px 0 4px 0px;
 }
 
 /*.cattool #quality-report {
@@ -299,585 +300,581 @@ section.opened .warnings {
     display: none;
 }*/
 
-.cattool #quality-report[data-vote=acceptable],
-.cattool #quality-report[data-vote=poor],
-.cattool #quality-report[data-vote=fail],
+.cattool #quality-report[data-vote='acceptable'],
+.cattool #quality-report[data-vote='poor'],
+.cattool #quality-report[data-vote='fail'],
 .cattool.review #quality-report {
-    display: block;
+  display: block;
 }
 
-.cattool #quality-report[data-vote=excellent],
-.cattool #quality-report[data-vote=verygood],
-.cattool #quality-report[data-vote=good] {
-    border-right: 10px solid #3C9423;
+.cattool #quality-report[data-vote='excellent'],
+.cattool #quality-report[data-vote='verygood'],
+.cattool #quality-report[data-vote='good'] {
+  border-right: 10px solid #3c9423;
 }
 
-.cattool #quality-report[data-vote=poor] {
-    border-right: 10px solid #FFA935;
+.cattool #quality-report[data-vote='poor'] {
+  border-right: 10px solid #ffa935;
 }
 
-.cattool #quality-report[data-vote=acceptable] {
-    border-right: 10px solid #EABA22;
+.cattool #quality-report[data-vote='acceptable'] {
+  border-right: 10px solid #eaba22;
 }
 
-.cattool #quality-report[data-vote=fail] {
-    border-right: 10px solid #E7504D;
+.cattool #quality-report[data-vote='fail'] {
+  border-right: 10px solid #e7504d;
 }
 
 .breadcrumbs a {
-    color: #fff
+  color: #fff;
 }
 
 .breadcrumbs a:hover {
-    text-decoration: none
+  text-decoration: none;
 }
-#pname-container{
-    margin: 0 10px 0 0;
+#pname-container {
+  margin: 0 10px 0 0;
 }
 .breadcrumbs #pname {
-    word-break: break-all;
-    text-decoration: underline;
+  word-break: break-all;
+  text-decoration: underline;
 }
 .breadcrumbs #pname:hover {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .breadcrumbs #pname .details {
-    float: left;
+  float: left;
 }
 
 .logo {
-    position: relative;
-    float: left;
-    border: 0;
-    margin-top: 10px;
-    /*background: url(../../img/logo.png) 0px 2px no-repeat;*/
-    width: 180px;
-    height: 38px;
-    background-size: cover;
-    margin-left: 13px;
-    margin-right: 13px;
+  position: relative;
+  float: left;
+  border: 0;
+  margin-top: 10px;
+  /*background: url(../../img/logo.png) 0px 2px no-repeat;*/
+  width: 180px;
+  height: 38px;
+  background-size: cover;
+  margin-left: 13px;
+  margin-right: 13px;
 }
 
 .grayed {
-    background: #000;
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    top: 0;
-    left: 0;
-    opacity: 0.2;
-    display: none;
-    z-index: 1;
+  background: #000;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  opacity: 0.2;
+  display: none;
+  z-index: 1;
 }
 
 .toggle {
-    display: none;
+  display: none;
 }
 
 .editor .toggle {
-    display: block;
+  display: block;
 }
 
 .projectbar {
-    color: #788190;
+  color: #788190;
+  display: flex;
+  justify-content: flex-start;
+  padding: 40px 115px 10px 4.5%;
+  align-items: center;
+  &.first-segment {
+    padding-top: 25px;
+  }
+  span.fileFormat {
+    padding: 10px 15px 9px 47px;
+    background-size: 25px !important;
+    line-height: 16px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-weight: bold;
+    font-size: 16px;
+  }
+  .projectbar-filename {
     display: flex;
-    justify-content: flex-start;
-    padding: 40px 115px 10px 4.5%;
+    flex-direction: row;
     align-items: center;
-    &.first-segment {
-        padding-top: 25px;
+    max-width: 80%;
+  }
+  .button-notes {
+    color: #fff !important;
+    font-weight: bold;
+    text-decoration: none;
+    padding: 6px 12px;
+    border-radius: 2px;
+    font-size: 16px;
+    background: $translatedBlue;
+    background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
+    background: linear-gradient(top, $translatedBlue, #119ec4);
+    user-select: none;
+    cursor: pointer;
+    min-width: 95px;
+    margin-left: 15px;
+    &:hover {
+      background-color: $translatedBlueHover;
     }
-    span.fileFormat {
-        padding: 10px 15px 9px 47px;
-        background-size: 25px !important;
-        line-height: 16px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        font-weight: bold;
-        font-size: 16px;
+    svg {
+      display: block;
+      margin-top: 1px;
+      float: left;
     }
-    .projectbar-filename {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        max-width: 80%;
-    }
-    .button-notes {
-        color: #fff !important;
-        font-weight: bold;
-        text-decoration: none;
-        padding: 6px 12px;
-        border-radius: 2px;
-        font-size: 16px;
-        background: $translatedBlue;
-        background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
-        background: linear-gradient(top, $translatedBlue, #119ec4);
-        user-select: none;
-        cursor: pointer;
-        min-width: 95px;
-        margin-left: 15px;
-        &:hover {
-            background-color: $translatedBlueHover;
-        }
-        svg {
-            display: block;
-            margin-top: 1px;
-            float: left;
-        }
-    }
-    .projectbar-wordcounter {
-        min-width: 140px;
-        display: list-item;
-        list-style-type: disc;
-        list-style-position: inside;
-        font-size: 16px;
-    }
-
+  }
+  .projectbar-wordcounter {
+    min-width: 140px;
+    display: list-item;
+    list-style-type: disc;
+    list-style-position: inside;
+    font-size: 16px;
+  }
 }
 
 #rejected.hidden {
-    display: none
+  display: none;
 }
 
 .meter {
-	height: 15px;  /* Can be anything */
-	width:15%;
-	float:left;
-	margin:0 15px 5px 0 !important;
-	background:#fff;
-	overflow: hidden;
-	-webkit-border-radius:10px;
-	-moz-border-radius:10px;
-	border-radius:10px;
+  height: 15px; /* Can be anything */
+  width: 15%;
+  float: left;
+  margin: 0 15px 5px 0 !important;
+  background: #fff;
+  overflow: hidden;
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  border-radius: 10px;
 }
 
 .approved-bar {
-    background-color: $approvedGreen;
+  background-color: $approvedGreen;
 }
 .approved-bar-2nd-pass {
-    background-color: $approved2Green;
+  background-color: $approved2Green;
 }
 
 .draft-bar {
-    background-color: $grey4;
+  background-color: $grey4;
 }
 
 .rejected-bar {
-    background-color: #ed1c24;
+  background-color: #ed1c24;
 }
 
 .translated-bar {
-    background-color: $translatedBlue;
+  background-color: $translatedBlue;
 }
 
 .rejected-background {
-    background-color: #ed1c24;
+  background-color: #ed1c24;
 }
 
 .approved-backgruond {
-    background-color: $approvedGreen;
+  background-color: $approvedGreen;
 }
 
 .rejected-foreground {
-    color: #ed1c24;
+  color: #ed1c24;
 }
 
 .approved-foreground {
-    color: $approvedGreen;
+  color: $approvedGreen;
 }
 
 .meter > a {
-    display: block;
-    height: 100%;
-    max-width: 100%;
-    float: left;
-    position: relative;
-    overflow: hidden;
-    -webkit-transition: all 200ms ease-in;
-    transition: all 200ms ease-in;
+  display: block;
+  height: 100%;
+  max-width: 100%;
+  float: left;
+  position: relative;
+  overflow: hidden;
+  -webkit-transition: all 200ms ease-in;
+  transition: all 200ms ease-in;
 }
 
 .meter > a:after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    background-image: -webkit-gradient(linear, 0 0, 100% 100%,
-    color-stop(.25, rgba(255, 255, 255, .2)),
-    color-stop(.25, transparent), color-stop(.5, transparent),
-    color-stop(.5, rgba(255, 255, 255, .2)),
-    color-stop(.75, rgba(255, 255, 255, .2)),
-    color-stop(.75, transparent), to(transparent)
-    );
-    background-image: -webkit-linear-gradient(
-            -45deg,
-            rgba(255, 255, 255, .2) 25%,
-            transparent 25%,
-            transparent 50%,
-            rgba(255, 255, 255, .2) 50%,
-            rgba(255, 255, 255, .2) 75%,
-            transparent 75%,
-            transparent
-    );
-    background-image: -moz-linear-gradient(
-            -45deg,
-            rgba(255, 255, 255, .2) 25%,
-            transparent 25%,
-            transparent 50%,
-            rgba(255, 255, 255, .2) 50%,
-            rgba(255, 255, 255, .2) 75%,
-            transparent 75%,
-            transparent
-    );
-    background-image: -ms-linear-gradient(
-            -45deg,
-            rgba(255, 255, 255, .2) 25%,
-            transparent 25%,
-            transparent 50%,
-            rgba(255, 255, 255, .2) 50%,
-            rgba(255, 255, 255, .2) 75%,
-            transparent 75%,
-            transparent
-    );
-    background-image: -o-linear-gradient(
-            -45deg,
-            rgba(255, 255, 255, .2) 25%,
-            transparent 25%,
-            transparent 50%,
-            rgba(255, 255, 255, .2) 50%,
-            rgba(255, 255, 255, .2) 75%,
-            transparent 75%,
-            transparent
-    );
-    z-index: 1;
-    -webkit-background-size: 50px 50px;
-    -moz-background-size: 50px 50px;
-    background-size: 50px 50px;
-    -webkit-animation: move 2s linear infinite;
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background-image: -webkit-gradient(
+    linear,
+    0 0,
+    100% 100%,
+    color-stop(0.25, rgba(255, 255, 255, 0.2)),
+    color-stop(0.25, transparent),
+    color-stop(0.5, transparent),
+    color-stop(0.5, rgba(255, 255, 255, 0.2)),
+    color-stop(0.75, rgba(255, 255, 255, 0.2)),
+    color-stop(0.75, transparent),
+    to(transparent)
+  );
+  background-image: -webkit-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-image: -moz-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-image: -ms-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
+  background-image: -o-linear-gradient(
+    -45deg,
+    rgba(255, 255, 255, 0.2) 25%,
+    transparent 25%,
+    transparent 50%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.2) 75%,
+    transparent 75%,
+    transparent
+  );
+  z-index: 1;
+  -webkit-background-size: 50px 50px;
+  -moz-background-size: 50px 50px;
+  background-size: 50px 50px;
+  -webkit-animation: move 2s linear infinite;
 
-    overflow: hidden;
+  overflow: hidden;
 }
 
 .pagination {
-    float: right;
-    border-right: 1px solid #000;
-    margin-left: 10px;
-    margin-right: 18px;
+  float: right;
+  border-right: 1px solid #000;
+  margin-left: 10px;
+  margin-right: 18px;
 }
 
 .pagination li {
-    padding: 5px 0 !important;
+  padding: 5px 0 !important;
 }
 
 .pagination a {
-    text-decoration: none;
-    padding: 5px 15px;
-    font-weight: bold;
-    -webkit-transition: all 100ms ease-in;
-    transition: all 100ms ease-in;
+  text-decoration: none;
+  padding: 5px 15px;
+  font-weight: bold;
+  -webkit-transition: all 100ms ease-in;
+  transition: all 100ms ease-in;
 }
 
 .pagination a:hover {
-    background: $translatedBlue;
+  background: $translatedBlue;
 }
 
 .pagination a:active {
-    box-shadow: inset 0 1px 1px #000;
-    -webkit-box-shadow: inset 0 1px 1px #000;
+  box-shadow: inset 0 1px 1px #000;
+  -webkit-box-shadow: inset 0 1px 1px #000;
 }
 
 .sid {
-    position: absolute;
-    left: -5.5%;
-    text-align: center;
-    display: block;
-    font-size: 11px;
-    color: #b6b8bb;
-    text-decoration: none;
-    cursor: default;
-    height: 100%;
-    padding-bottom: 1px;
-    width: 4.5%;
-
+  position: absolute;
+  left: -5.5%;
+  text-align: center;
+  display: block;
+  font-size: 11px;
+  color: #b6b8bb;
+  text-decoration: none;
+  cursor: default;
+  height: 100%;
+  padding-bottom: 1px;
+  width: 4.5%;
 }
 
 .slide-right .sid {
-    left: -6%;
+  left: -6%;
 }
 
 .sid .txt {
-    padding: 0px 3px;
-    margin: 2px 0px 0 0px;
-    background: $grey5;
-    display: contents;
+  padding: 0px 3px;
+  margin: 2px 0px 0 0px;
+  background: $grey5;
+  display: contents;
 }
 
 section.readonly .txt input {
-    display: none !important;
+  display: none !important;
 }
 
 section.segment-selected-inBulk .sid .txt input {
-    display: unset;
+  display: unset;
 }
 /*section.editor .sid .txt input {
     display: unset;
 }*/
 
 section.editor.segment-selected-inBulk .sid .txt.segment-add-inBulk {
-    display: unset;
+  display: unset;
 }
 
 section.editor .txt.segment-add-inBulk {
-    display: block;
+  display: block;
 }
 
 section.segment-selected-inBulk .body .text {
-    background: #edf4fd;
+  background: #edf4fd;
 }
 section.segment-selected-inBulk .body .text:hover {
-    background: #edf4fd !important;
+  background: #edf4fd !important;
 }
 
-
-
 p.split-shortcut {
-    padding: 1px 0px;
-    width: 55px;
-    margin: 0 auto;
-    margin-top: 5px;
+  padding: 1px 0px;
+  width: 55px;
+  margin: 0 auto;
+  margin-top: 5px;
 }
 
 .splitStart .sid {
-    background: url(../../img/split-bg.png) no-repeat;
-    background-position: 48.5% 23px;
+  background: url(../../img/split-bg.png) no-repeat;
+  background-position: 48.5% 23px;
 }
 
 .splitInner .sid {
-    background: url(../../img/split-bg.png) no-repeat;
-    background-position: 48.5% 16px;
+  background: url(../../img/split-bg.png) no-repeat;
+  background-position: 48.5% 16px;
 }
 
 .splitEnd .sid {
-    background: url(../../img/split-bg.png) no-repeat;
-    background-position: 49% bottom;
+  background: url(../../img/split-bg.png) no-repeat;
+  background-position: 49% bottom;
 }
 
 .editor.splitStart .sid {
-    background-position: 49% 43px;
+  background-position: 49% 43px;
 }
 
 .editor.splitInner .sid {
-    background-position: 52% -40px;
+  background-position: 52% -40px;
 }
 
 .editor.splitEnd .sid {
-    background-position: 50.5% bottom;
+  background-position: 50.5% bottom;
 }
 
 .start-job-marker,
 .end-job-marker {
-    width: 20px !important;
-    position: absolute;
-    top: 0px;
-    left: -2.8%;
-    display: block;
-    height: 10px;
-    opacity: 0.3;
+  width: 20px !important;
+  position: absolute;
+  top: 0px;
+  left: -2.8%;
+  display: block;
+  height: 10px;
+  opacity: 0.3;
 }
 
 .end-job-marker {
-    top: auto;
-    bottom: 0px;
+  top: auto;
+  bottom: 0px;
 }
 
 section:hover .sid {
-    color: $grey1
+  color: $grey1;
 }
 
 section.currSearchSegment .sid .txt {
-    background: $translatedBlue;
-    color: white;
-    margin-bottom: 5px;
+  background: $translatedBlue;
+  color: white;
+  margin-bottom: 5px;
 }
 
 .editor .sid {
-    height: 100%;
+  height: 100%;
 }
 
 div.sid .implicit {
-    /*    display: none; */
+  /*    display: none; */
 }
 
 .sid .actions.disabled {
-    background: none;
-    border: none;
+  background: none;
+  border: none;
 }
 
 .outersource .actions {
-    display: none;
-    position: absolute;
-    bottom: 25px;
+  display: none;
+  position: absolute;
+  bottom: 25px;
 }
 
 .editor .outersource .actions {
-    display: block;
+  display: block;
 }
 
 .split-action .outersource .actions,
 .split-action .actions {
-    display: block !important;
+  display: block !important;
 }
 
-
 .comments {
-    position: absolute;
-    right: 10px;
-    top: 20px;
-    width: 30px !important;
-    margin-right: -50px !important;
-    height: 100% !important;
-    font-size: 10px;
-    text-align: center !important;
-    z-index: 99;
+  position: absolute;
+  right: 10px;
+  top: 20px;
+  width: 30px !important;
+  margin-right: -50px !important;
+  height: 100% !important;
+  font-size: 10px;
+  text-align: center !important;
+  z-index: 99;
 }
 
 .comments a {
-    display: block;
-    padding: 16px 0 10px 0px !important;
+  display: block;
+  padding: 16px 0 10px 0px !important;
 }
 
 section {
-    position: relative;
-    float: left;
-    width: 88%;
-    margin-left: 5%;
-    min-width: 700px;
-    //height: 100%;
-    /*-webkit-transition: all 100ms ease-in;*/
-    /*transition: all 100ms ease-in;*/
-    //box-shadow: 0 0 0 #e0e0e0, 0 0 0px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
-    //border: 1px solid $grey4;
+  position: relative;
+  float: left;
+  width: 88%;
+  margin-left: 5%;
+  min-width: 700px;
+  //height: 100%;
+  /*-webkit-transition: all 100ms ease-in;*/
+  /*transition: all 100ms ease-in;*/
+  //box-shadow: 0 0 0 #e0e0e0, 0 0 0px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  //border: 1px solid $grey4;
 }
 
 /*projectbar*/
 .languages {
-    text-align: center !important;
-    padding: 15px 0 0 50px;
+  text-align: center !important;
+  padding: 15px 0 0 50px;
 }
 
 .wordscounter {
-    float: right;
-    text-align: right
+  float: right;
+  text-align: right;
 }
 
 .wordcounter {
-    display: block !important;
-    text-align: right;
-    margin-right: -70px !important;
+  display: block !important;
+  text-align: right;
+  margin-right: -70px !important;
 }
 
 .wordcounter strong {
-    margin-right: 0px
+  margin-right: 0px;
 }
 
 strong:first-child {
-    margin-right: 0px !important
+  margin-right: 0px !important;
 }
 
 .download {
-    position: absolute;
+  position: absolute;
 }
 
 .filenameshow {
-    max-height: 35px;
-    height: 15px;
-    width: 300px;
-    overflow: hidden
+  max-height: 35px;
+  height: 15px;
+  width: 300px;
+  overflow: hidden;
 }
-
-
-
-
 
 .desc {
-    font-size: 14px !important
+  font-size: 14px !important;
 }
-
 
 /*tools*/
 .tools {
-    height: 32px;
-    background: #f5f5f5;
-    border-top: 1px solid #fbfbfb;
-    border-bottom: 1px solid #adadad;
-    width: 100%;
-    border: 1px solid #adadad;
+  height: 32px;
+  background: #f5f5f5;
+  border-top: 1px solid #fbfbfb;
+  border-bottom: 1px solid #adadad;
+  width: 100%;
+  border: 1px solid #adadad;
 }
 
 .tools .wrapper {
-    background: url(../../img/tools.gif) 5px 3px no-repeat;
-    height: 27px;
+  background: url(../../img/tools.gif) 5px 3px no-repeat;
+  height: 27px;
 }
 
 .tools a {
-    display: block;
-    width: 22px;
-    height: 25px;
-    margin-right: 5px;
-    float: left
+  display: block;
+  width: 22px;
+  height: 25px;
+  margin-right: 5px;
+  float: left;
 }
 
-.editor .text:hover .editor-click, editor .gray2:hover .editor-click {
-    border: 1px solid #fff;
-    background: none;
-    -webkit-box-shadow: none;
-    -moz-box-shadow: none;
-    cursor: default
+.editor .text:hover .editor-click,
+editor .gray2:hover .editor-click {
+  border: 1px solid #fff;
+  background: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  cursor: default;
 }
 
 .editor-click {
-    display: block;
-    border: 1px solid transparent;
-    padding: 4px 10px;
-    min-height: 50px;
-    cursor: pointer;
+  display: block;
+  border: 1px solid transparent;
+  padding: 4px 10px;
+  min-height: 50px;
+  cursor: pointer;
 }
 
 /*done & draft*/
 .translated,
 .approved,
 .guesstags {
-    color: #fff !important;
-    font-weight: bold;
-    text-decoration: none;
-    padding: 8px 18px;
-    border-radius: 2px;
-    font-size: 18px;
-    background: $translatedBlue;
-    background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
-    background: linear-gradient(top, $translatedBlue, #119ec4);
-    text-transform: uppercase;
-    user-select: none;
+  color: #fff !important;
+  font-weight: bold;
+  text-decoration: none;
+  padding: 8px 18px;
+  border-radius: 2px;
+  font-size: 18px;
+  background: $translatedBlue;
+  background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
+  background: linear-gradient(top, $translatedBlue, #119ec4);
+  text-transform: uppercase;
+  user-select: none;
 }
 
 .buttons .approved.disabled,
-.buttons .next-unapproved.disabled ,
-.buttons .next-untranslated.disabled ,
+.buttons .next-unapproved.disabled,
+.buttons .next-untranslated.disabled,
 .buttons .translated.disabled,
 .buttons .guesstags.disabled,
 .buttons .disabled {
-    pointer-events: none;
-    color: #666 !important;
-    border-color: #666;
-    background: #efefef;
+  pointer-events: none;
+  color: #666 !important;
+  border-color: #666;
+  background: #efefef;
 }
 
 .approved {
-    background: $approvedGreen;
+  background: $approvedGreen;
 }
 
 /*.guesstags {
@@ -914,68 +911,67 @@ strong:first-child {
 }*/
 
 .button-reject,
-.button-rebutted{
-    border: 1px solid;
-    background: $rebuttedRed;
-    color: #fff;
-    font-weight: bold;
-    text-decoration: none;
-    padding: 8px 18px;
-    border-radius: 2px;
-    border-radius: 2px;
-    font-size: 18px;
-    text-transform: uppercase;
+.button-rebutted {
+  border: 1px solid;
+  background: $rebuttedRed;
+  color: #fff;
+  font-weight: bold;
+  text-decoration: none;
+  padding: 8px 18px;
+  border-radius: 2px;
+  border-radius: 2px;
+  font-size: 18px;
+  text-transform: uppercase;
 }
 
 .button-reject:hover,
-.button-rebutted:hover
-{
-    color: #fff;
+.button-rebutted:hover {
+  color: #fff;
 }
 
 article .translated,
 .guesstags,
 article .draft,
 article .approved {
-    margin: 0 0px 5px 5px
+  margin: 0 0px 5px 5px;
 }
 
 .buttons {
-    float: right;
-    padding: 0;
-    -webkit-transition: all 100ms ease-in;
-    -moz-transition: all 100ms ease-in; /*margin: -15px 2% 0 0;*/
-    margin: 0;
-    position: absolute;
-    right: 0;
+  float: right;
+  padding: 0;
+  -webkit-transition: all 100ms ease-in;
+  -moz-transition: all 100ms ease-in; /*margin: -15px 2% 0 0;*/
+  margin: 0;
+  position: absolute;
+  right: 0;
 }
 
 .buttons p {
-    margin: 2px 0 0 5px;
-    font-size: 11px;
-    font-weight: normal;
-    color: #666;
-    display: none;
-    text-align: center;
+  margin: 2px 0 0 5px;
+  font-size: 11px;
+  font-weight: normal;
+  color: #666;
+  display: none;
+  text-align: center;
 }
 
 .buttons a + p {
-    padding-top: 5px;
-    margin-left: 0px;
+  padding-top: 5px;
+  margin-left: 0px;
 }
 
 .buttons li:hover p {
-    display: block;
+  display: block;
 }
 
 .translated {
-    color: #fff !important
+  color: #fff !important;
 }
 
 article .translated,
 article .approved,
 .guesstags {
-    text-transform: uppercase;
+  text-transform: uppercase;
 }
 
 article .translated:hover,
@@ -986,10 +982,10 @@ article .btn:hover,
 article .approved:hover,
 article .next-unapproved:hover,
 .search .btn:hover {
-    cursor: pointer;
-    //-webkit-box-shadow: 0 1px 2px #ccc;
-    //box-shadow: 0 1px 2px #ccc;
-    //border: 1px solid #000;
+  cursor: pointer;
+  //-webkit-box-shadow: 0 1px 2px #ccc;
+  //box-shadow: 0 1px 2px #ccc;
+  //border: 1px solid #000;
 }
 
 article .translated:active,
@@ -997,20 +993,20 @@ article .translated:active,
 article .draft:active,
 article .btn:active,
 article .approved:active {
-    -moz-box-shadow: none;
-    -webkit-box-shadow: none;
-    box-shadow: none;
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
 }
 
 .translated:hover,
 .next-untranslated:hover,
 .guesstags:hover {
-    background-color: $translatedBlueHover;
-    //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  background-color: $translatedBlueHover;
+  //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
 }
 
 .draft:hover {
-    background: #eee;
+  background: #eee;
 }
 
 .translated:active,
@@ -1018,280 +1014,288 @@ article .approved:active {
 .guesstags:active,
 .btn:active,
 .copysource:active {
-    -moz-box-shadow: none;
-    -webkit-box-shadow: none;
-    box-shadow: none;
- /*   border: 1px solid #000*/
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  /*   border: 1px solid #000*/
 }
 
 .next-untranslated,
 .next-unapproved {
-    width: 50px !important;
-    height: 27px !important;
-    background: $translatedBlue;
-    font-weight: bold;
-    text-decoration: none;
-    padding: 5px 2px 3px 2px;
-    border-radius: 2px;
-    font-size: 18px;
-    margin: -6px 25px -7px 25px;
-    color: #fff !important;
-    user-select: none;
+  width: 50px !important;
+  height: 27px !important;
+  background: $translatedBlue;
+  font-weight: bold;
+  text-decoration: none;
+  padding: 5px 2px 3px 2px;
+  border-radius: 2px;
+  font-size: 18px;
+  margin: -6px 25px -7px 25px;
+  color: #fff !important;
+  user-select: none;
 }
 
 .approved,
 .next-unapproved {
-    background: $approvedGreen;
-    color: #fff !important;
+  background: $approvedGreen;
+  color: #fff !important;
 }
 
-.draft, .header-menu .wrapper-dropdown-5 {
-    background: -webkit-gradient(linear, left top, left bottom, from(#f5f5f5), to(#d3d4d5));
-    background: -moz-linear-gradient(top, #f5f5f5, #d3d4d5);
-    background: linear-gradient(top, #f5f5f5, #d3d4d5);
-
+.draft,
+.header-menu .wrapper-dropdown-5 {
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#f5f5f5),
+    to(#d3d4d5)
+  );
+  background: -moz-linear-gradient(top, #f5f5f5, #d3d4d5);
+  background: linear-gradient(top, #f5f5f5, #d3d4d5);
 }
 
 /*buttons editor*/
 
-
-
 .topmenu-drop {
-    height: 31px !important;
-    margin: 3px 0;
-    box-shadow: none;
+  height: 31px !important;
+  margin: 3px 0;
+  box-shadow: none;
 }
 
 .topmenu-drop input,
 .wrapper-dropdown-5 input {
-    border: none !important;
-    box-shadow: none;
-    cursor: pointer;
+  border: none !important;
+  box-shadow: none;
+  cursor: pointer;
 }
 
 .topmenu-drop input {
-    font-weight: normal;
-    border: 0;
-    padding: 5px 10px !important;
-    font-size: 17px !important;
-    text-align: center;
-    min-width: 130px;
-    height: 31px !important;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    border-radius: 0;
-    color: #403e3e;
+  font-weight: normal;
+  border: 0;
+  padding: 5px 10px !important;
+  font-size: 17px !important;
+  text-align: center;
+  min-width: 130px;
+  height: 31px !important;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  border-radius: 0;
+  color: #403e3e;
 }
 
 .topmenu-drop input.translated {
-    background: $translatedBlue;
-    color: #fff !important;
+  background: $translatedBlue;
+  color: #fff !important;
 }
 
-.topmenu-drop input.translated, .topmenu-drop input.approved {
-    width: auto !important;
-    border-radius: 2px 0 0 2px;
-    padding: 0 18px !important;
-    text-transform: uppercase;
-    margin: 0 !important
+.topmenu-drop input.translated,
+.topmenu-drop input.approved {
+  width: auto !important;
+  border-radius: 2px 0 0 2px;
+  padding: 0 18px !important;
+  text-transform: uppercase;
+  margin: 0 !important;
 }
 
 .topmenu-drop input.approved:hover {
-    background: #76bb70;
+  background: #76bb70;
 }
 
 .topmenu-drop input.translated:hover {
-    background: #12b4df;
+  background: #12b4df;
 }
 
 .topmenu-drop .text {
-    margin: 0;
+  margin: 0;
 }
 
 .wrapper-dropdown-5 input {
-    width: auto !important;
-    float: left;
+  width: auto !important;
+  float: left;
 }
 
 .header-menu .wrapper-dropdown-5 {
-    margin: 3px 0 !important;
-    box-shadow: none;
-    width: 13px;
-    padding: 6px 10px !important;
+  margin: 3px 0 !important;
+  box-shadow: none;
+  width: 13px;
+  padding: 6px 10px !important;
 }
 
 .header-menu li:first-child {
-    margin-right: 15px;
+  margin-right: 15px;
 }
 
 .header-dropdown-menu {
-    margin-right: 15px;
+  margin-right: 15px;
 }
 
-.header-menu .wrapper-dropdown-5 .dropdown[data-download='false'] li.downloadTranslation,
-.header-menu .wrapper-dropdown-5 .dropdown[data-download='true'] li.previewLink {
-    display: none;
+.header-menu
+  .wrapper-dropdown-5
+  .dropdown[data-download='false']
+  li.downloadTranslation,
+.header-menu
+  .wrapper-dropdown-5
+  .dropdown[data-download='true']
+  li.previewLink {
+  display: none;
 }
 
 .topmenu-drop form {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 .btn {
-    cursor: pointer;
-    min-height: 26px;
-    display: block;
-    text-decoration: none;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
+  cursor: pointer;
+  min-height: 26px;
+  display: block;
+  text-decoration: none;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
 }
 
 .buttons .btn {
-    height: 33px;
+  height: 33px;
 }
 
 .outersource .copy {
-    display: none;
-    position: absolute;
-    float: left;
-    margin-left: 47%;
-    margin-top: 5px;
-    background: url(../../img/outercopy.png) center 1px no-repeat;
-    width: 50px !important;
-    z-index: 1000;
-    background-size: 42px;
-    /*	opacity: 0.4;*/
+  display: none;
+  position: absolute;
+  float: left;
+  margin-left: 47%;
+  margin-top: 5px;
+  background: url(../../img/outercopy.png) center 1px no-repeat;
+  width: 50px !important;
+  z-index: 1000;
+  background-size: 42px;
+  /*	opacity: 0.4;*/
 }
 
 .outersource .copy:hover {
-    background: url(../../img/outercopy.png) 4px -69px no-repeat;
-    background-size: 42px;
-
+  background: url(../../img/outercopy.png) 4px -69px no-repeat;
+  background-size: 42px;
 }
 
 .editor .outersource .copy {
-    display: block;
-    background-size: 42px;
+  display: block;
+  background-size: 42px;
 }
 
 .outersource .copy:hover {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .outersource .copy p {
-    visibility: hidden;
-    font-size: 11px;
-    color: #666;
-    margin-top: 46px;
-    margin-left: -4px;
+  visibility: hidden;
+  font-size: 11px;
+  color: #666;
+  margin-top: 46px;
+  margin-left: -4px;
 }
 
 .outersource .copy:hover p {
-    visibility: visible;
+  visibility: visible;
 }
 
 article {
-    //margin: 0px auto 100px auto;
-    -moz-border-radius: 2px;
-    -moz-box-shadow: 0 1px 3px #ccc;
-    position: relative;
-    width: 91.5%;
-    float: left;
-    box-sizing: content-box;
-    #hiddenHtml {
-        position: absolute;
-        top: 0;
-    }
+  //margin: 0px auto 100px auto;
+  -moz-border-radius: 2px;
+  -moz-box-shadow: 0 1px 3px #ccc;
+  position: relative;
+  width: 91.5%;
+  float: left;
+  box-sizing: content-box;
+  #hiddenHtml {
+    position: absolute;
+    top: 0;
+  }
 }
 body #outer {
-    overflow: hidden;
-    position: relative;
-    display: inline-block;
-    height: 100%;
-    width: 100%;
+  overflow: hidden;
+  position: relative;
+  display: inline-block;
+  height: 100%;
+  width: 100%;
 }
 
 body .main-container {
-    width: 100%;
-    height: 100%;
+  width: 100%;
+  height: 100%;
 }
 #outer {
-    #file {
-        z-index: 2;
-    }
+  #file {
+    z-index: 2;
+  }
+  #loader-getMoreSegments {
+    display: none;
+    position: fixed;
+    background: url(../../img/loading.gif) 48% top no-repeat !important;
+    background-size: 30px 30px !important;
+    width: 30px;
+    height: 30px;
+    z-index: 1;
+  }
+  &.loadingBefore {
+    margin-top: 20px;
     #loader-getMoreSegments {
-        display: none;
-        position: fixed;
-        background: url(../../img/loading.gif) 48% top no-repeat !important;
-        background-size: 30px 30px !important;
-        width: 30px;
-        height: 30px;
-        z-index: 1;
+      display: block;
+      top: 70px;
+      left: 50%;
     }
-    &.loadingBefore{
-        margin-top: 20px;
-        #loader-getMoreSegments {
-            display: block;
-            top: 70px;
-            left: 50%;
-        }
-    }
-    &.loading #loader-getMoreSegments {
-        display: block;
-        bottom: 100px;
-        left: 50%;
-    }
+  }
+  &.loading #loader-getMoreSegments {
+    display: block;
+    bottom: 100px;
+    left: 50%;
+  }
 }
 
 #outer.loading {
-    display: block;
-    background: url(../../img/loading.gif) 48% center no-repeat;
-    background-size: 30px 30px !important;
-    float: left;
-    position: relative;
+  display: block;
+  background: url(../../img/loading.gif) 48% center no-repeat;
+  background-size: 30px 30px !important;
+  float: left;
+  position: relative;
 }
 
-
-
 .main-searched {
-    margin-top: 100px !important
+  margin-top: 100px !important;
 }
 
 .maincomment .editor textarea {
-    width: 110% !important;
+  width: 110% !important;
 }
 
 .maincomment .ed textarea {
-    width: 104%;
+  width: 104%;
 }
 
 .footer {
-    float: left;
-    width: 100%;
-    margin-top: 0;
-    height: 0;
-    transition: width 2s;
-    -moz-transition: width 2s; /* Firefox 4 */
-    -webkit-transition: width 2s; /* Safari and Chrome */
-    -o-transition: width 2s; /* Opera */
-    transition: all 1.1s linear;
-    -webkit-transition: all 1.2s linear;
-    -moz-transition: all 1.2s linear;
-    -o-transition: all 1.2s linear;
-    -ms-transition: all 1.2s linear;
+  float: left;
+  width: 100%;
+  margin-top: 0;
+  height: 0;
+  transition: width 2s;
+  -moz-transition: width 2s; /* Firefox 4 */
+  -webkit-transition: width 2s; /* Safari and Chrome */
+  -o-transition: width 2s; /* Opera */
+  transition: all 1.1s linear;
+  -webkit-transition: all 1.2s linear;
+  -moz-transition: all 1.2s linear;
+  -o-transition: all 1.2s linear;
+  -ms-transition: all 1.2s linear;
 }
 
 .editor .footer {
-    height: 100%;
+  height: 100%;
 }
 
 section .body > .text {
-    width: 100%;
-    position: relative;
-    float: left;
-    min-height: 88px;
-    height: 100%;
+  width: 100%;
+  position: relative;
+  float: left;
+  min-height: 88px;
+  height: 100%;
 }
 
 /*.text {
@@ -1299,23 +1303,26 @@ section .body > .text {
     float: left;
 }*/
 
-.popup-tm .text, .popup-tm .text:hover, .header-menu .text, .header-menu .text:hover {
-    background: transparent;
-    box-shadow: none;
+.popup-tm .text,
+.popup-tm .text:hover,
+.header-menu .text,
+.header-menu .text:hover {
+  background: transparent;
+  box-shadow: none;
 }
 
 body #file section:not(.editor) {
-    background: $grey3;
-    cursor: pointer;
-    border: 1px solid $grey2 !important;
-    .body {
-        height: 100%;
-    }
+  background: $grey3;
+  cursor: pointer;
+  border: 1px solid $grey2 !important;
+  .body {
+    height: 100%;
+  }
 }
 
 #file section:not(.editor) .text:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
 /*body.cattool .editor .text:hover {
@@ -1328,15 +1335,15 @@ body #file section:not(.editor) {
 }*/
 
 #file section.editor .body > .text {
-    overflow: visible;
-    -webkit-box-shadow: none;
-    box-shadow: none;
-    padding: 5px 0 19px 0;
-    color: #000
+  overflow: visible;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+  padding: 5px 0 19px 0;
+  color: #000;
 }
 
 .cl {
-    clear: both
+  clear: both;
 }
 
 /*.disabled, .disabled:hover, .disabled:active {
@@ -1349,22 +1356,22 @@ body #file section:not(.editor) {
 }*/
 
 .sub-editor .set-glossary.disabled {
-    background: none !important;
+  background: none !important;
 }
 
 .graysmall {
-    width: 100%;
-    //background: #fff;
-    float: left;
-    position: relative;
-    color: #666;
-    -webkit-transition: all 100ms ease-in;
-    transition: all 100ms ease-in;
-    //border-bottom: 1px solid $grey2;
+  width: 100%;
+  //background: #fff;
+  float: left;
+  position: relative;
+  color: #666;
+  -webkit-transition: all 100ms ease-in;
+  transition: all 100ms ease-in;
+  //border-bottom: 1px solid $grey2;
 }
 
 ul.suggestion-item.graysmall:last-child {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 /*
@@ -1374,336 +1381,337 @@ ul.suggestion-item.graysmall:last-child {
 */
 
 .tab.concordances {
-    text-align: center;
+  text-align: center;
 }
 
 .tab.concordances .graysmall:not(.prime) {
-    display: none;
+  display: none;
 }
 
 .tab.concordances .graysmall.prime {
-    display: block;
+  display: block;
 }
 
 .tab.concordances.extended .graysmall {
-    display: block !important;
+  display: block !important;
 }
 
 .tab.concordances.extended .overflow {
-    overflow: auto;
+  overflow: auto;
 }
 
 .graygreen {
-    color: #fff !important;
-    border-top: 1px solid #ccc;
-    border-left: 1px solid #ccc;
-    width: 25px !important;
-    text-align: center !important
+  color: #fff !important;
+  border-top: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  width: 25px !important;
+  text-align: center !important;
 }
 
 /*submenu*/
 .submenu {
-    background: #fff;
-    text-align: left;
-    width: 100%;
+  background: #fff;
+  text-align: left;
+  width: 100%;
 }
 
 /*.submenu {*/
-    /*display: none;*/
+/*display: none;*/
 /*}*/
 
 .popup .submenu {
-    display: block;
-    padding-top: 20px;
+  display: block;
+  padding-top: 20px;
 }
 
 .submenu:after {
-    content: ".";
-    display: block;
-    height: 0;
-    clear: both;
-    visibility: hidden;
+  content: '.';
+  display: block;
+  height: 0;
+  clear: both;
+  visibility: hidden;
 }
 
 section.loaded .submenu {
-    display: block;
+  display: block;
 }
 
 .loaded {
-    overflow: visible !important
+  overflow: visible !important;
 }
 
 .submenu li {
-    float: left;
-    position: relative;
-    width: auto !important;
-    background: $grey4;
-    z-index: 1;
-    border-bottom: 1px solid $grey3;
-    cursor: pointer;
-    user-select: none;
+  float: left;
+  position: relative;
+  width: auto !important;
+  background: $grey4;
+  z-index: 1;
+  border-bottom: 1px solid $grey3;
+  cursor: pointer;
+  user-select: none;
 }
 
 .submenu li.active {
-    border-bottom: 1px solid white;
-    background-color: $white;
+  border-bottom: 1px solid white;
+  background-color: $white;
 }
 
 body.noGlossary .tab-switcher-gl {
-    display: none;
+  display: none;
 }
 
 .submenu a {
-    -webkit-transition: all 100ms ease-in;
-    -moz-transition: all 100ms ease-in;
-    padding: 5px 20px;
-    display: block;
-    color: $grey1;
-    font-size: 16px;
-    float: left;
-    text-decoration: none;
-    border-right: 2px solid $grey3;
-    border-top: 2px solid $grey3;
+  -webkit-transition: all 100ms ease-in;
+  -moz-transition: all 100ms ease-in;
+  padding: 5px 20px;
+  display: block;
+  color: $grey1;
+  font-size: 16px;
+  float: left;
+  text-decoration: none;
+  border-right: 2px solid $grey3;
+  border-top: 2px solid $grey3;
 }
 
 .submenu .notification:hover {
-    border: 0;
+  border: 0;
 }
 
 .submenu a:hover {
-    background: #f5f5f5;
-    color: $grey1;
-    -moz-box-shadow: none;
-    position: relative;
-    -webkit-box-shadow: none;
+  background: #f5f5f5;
+  color: $grey1;
+  -moz-box-shadow: none;
+  position: relative;
+  -webkit-box-shadow: none;
 }
 
 .submenu .on {
-    background: #fff;
-    color: #000;
-    font-size: 14px;
-    text-shadow: none;
+  background: #fff;
+  color: #000;
+  font-size: 14px;
+  text-shadow: none;
 }
 
 .tab-switcher.loading-tab a {
-    color: #929292;
-    padding-right: 36px;
+  color: #929292;
+  padding-right: 36px;
 }
 
 .loading-tab .loader.loader_on {
-    left: unset;
-    right: 12px;
-    top: 6px;
+  left: unset;
+  right: 12px;
+  top: 6px;
 }
 
 .submenu li a {
-    outline: none;
+  outline: none;
 }
 
 .submenu li.active a {
-    //background: #fff !important;
-    outline: none;
-    color: #000;
+  //background: #fff !important;
+  outline: none;
+  color: #000;
 }
 
 .submenu li.modified a {
-    color: red;
+  color: red;
 }
 
 .sub-editor {
-    display: none;
-    float: left;
-    width: 100%;
-    background: #ffffff;
+  display: none;
+  float: left;
+  width: 100%;
+  background: #ffffff;
 }
 
 .sub-editor.open {
-    display: block;
+  display: block;
 }
 
 body .footer.showMatches .sub-editor.open {
-    display: block !important;
+  display: block !important;
 }
 
 .sub-editor.matches .overflow {
-    min-height: 50px;
+  min-height: 50px;
 }
 .sub-editor.matches .overflow span.loader {
-    bottom: 20px;
+  bottom: 20px;
 }
 
-
 .addtmx-tr .open-popup-addtm-tr {
-    height: 13px;
-    width: 140px;
-    position: absolute;
-    bottom: -24px;
-    right: 0px;
-    border-radius: 0 0 0 2px;
-    color: #fff;
-    padding: 3px 10px 7px 4px;
-    font-size: 12px;
-    background: $translatedBlue;
-    box-shadow: 0px 2px 4px 0px #868686;
-    z-index: 2;
+  height: 13px;
+  width: 140px;
+  position: absolute;
+  bottom: -24px;
+  right: 0px;
+  border-radius: 0 0 0 2px;
+  color: #fff;
+  padding: 3px 10px 7px 4px;
+  font-size: 12px;
+  background: $translatedBlue;
+  box-shadow: 0px 2px 4px 0px #868686;
+  z-index: 2;
 }
 
 .sub-editor.concordances .results {
-    float: left;
-    width: 100%;
+  float: left;
+  width: 100%;
 }
 
 .sub-editor.concordances .more {
-    display: inline-block;
-    text-decoration: none;
-    color: #FFF;
-    padding: 0 10px;
-    background: #999;
-    font-size: 14px;
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
-    min-width: 40px;
-    line-height: 20px;
-    position: relative;
-    top: 2px;
-    cursor: pointer;
+  display: inline-block;
+  text-decoration: none;
+  color: #fff;
+  padding: 0 10px;
+  background: #999;
+  font-size: 14px;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  min-width: 40px;
+  line-height: 20px;
+  position: relative;
+  top: 2px;
+  cursor: pointer;
 }
 
-.sub-editor .cc-search, .sub-editor .gl-search {
-    background: none;
-    clear: both;
+.sub-editor .cc-search,
+.sub-editor .gl-search {
+  background: none;
+  clear: both;
 }
 
-.sub-editor .cc-search.loading, .sub-editor .gl-search.loading {
-    background: url(../../img/loading.gif) 50% 22px no-repeat;
-    float: left;
-    width: 100%;
-    background-size: 20px 20px;
+.sub-editor .cc-search.loading,
+.sub-editor .gl-search.loading {
+  background: url(../../img/loading.gif) 50% 22px no-repeat;
+  float: left;
+  width: 100%;
+  background-size: 20px 20px;
 }
 
 .sub-editor .cc-search.loading {
-    background-position-x: 49.8%;
+  background-position-x: 49.8%;
 }
 
 .sub-editor.glossary .private-tm-key {
-    float: left;
-    padding-top: 12px;
-    margin-left: 20px;
+  float: left;
+  padding-top: 12px;
+  margin-left: 20px;
 }
 
 .footer-message {
-    margin-left: 20px;
-    background: #FFDE33 !important;
-    padding: 2px 10px;
+  margin-left: 20px;
+  background: #ffde33 !important;
+  padding: 2px 10px;
 }
 
 .sub-editor.glossary .gl-search.setting .set-glossary {
-    background: url(../../img/loading.gif);
-    background-size: 20px;
-    cursor: pointer;
+  background: url(../../img/loading.gif);
+  background-size: 20px;
+  cursor: pointer;
 }
 
 .sub-editor .gl-search .search-source,
 .sub-editor .gl-search .search-target,
 .sub-editor .gl-search .gl-comment {
-    float: left;
-    width: 45.8%;
-    margin: 20px 2% 20px 1.5%;
-    border: 1px solid #aaa;
-    padding: 2px 0.4%;
-    border-radius: 2px;
-    box-shadow: inset 0 1px 2px #ddd;
-    -webkit-box-shadow: inset 0 1px 2px #ddd;
-    text-align: left;
-    min-height: 20px;
-    background-color: #fff;
-    outline-color: $grey1;
+  float: left;
+  width: 45.8%;
+  margin: 20px 2% 20px 1.5%;
+  border: 1px solid #aaa;
+  padding: 2px 0.4%;
+  border-radius: 2px;
+  box-shadow: inset 0 1px 2px #ddd;
+  -webkit-box-shadow: inset 0 1px 2px #ddd;
+  text-align: left;
+  min-height: 20px;
+  background-color: #fff;
+  outline-color: $grey1;
 }
 
 .sub-editor .gl-search .search-source,
 .sub-editor .gl-search .search-target {
-    margin-bottom: 4px;
+  margin-bottom: 4px;
 }
 
 .sub-editor .gl-search .search-target {
-    width: 41%;
+  width: 41%;
 }
 
 .sub-editor .cc-search .search-target {
-    width: 44.2%;
+  width: 44.2%;
 }
 
 .sub-editor .gl-search .gl-comment {
-    margin-bottom: 4px;
+  margin-bottom: 4px;
 }
 
 .sub-editor .gl-search .gl-comment {
-    float: left;
-    display: none;
-    width: 47.8%;
-    margin: 5px 1.5%;
-    clear: both;
+  float: left;
+  display: none;
+  width: 47.8%;
+  margin: 5px 1.5%;
+  clear: both;
 }
 
 .sub-editor.glossary .gl-search .gl-comment {
-    display: block;
+  display: block;
 }
 
 .sub-editor .gl-search .set-glossary {
-    float: left;
-    height: 20px;
-    font-size: 24px;
-    width: 26px;
-    margin: 21px 0 0 0;
-    color: $grey1;
-    cursor: pointer;
+  float: left;
+  height: 20px;
+  font-size: 24px;
+  width: 26px;
+  margin: 21px 0 0 0;
+  color: $grey1;
+  cursor: pointer;
 }
 
 .sub-editor .gl-search .set-glossary.disabled,
 .sub-editor .gl-search .set-glossary.disabled:hover {
-    border: none !important;
-    opacity: 0.5 !important;
+  border: none !important;
+  opacity: 0.5 !important;
 }
 
 .sub-editor .gl-search .comment {
-    float: left;
-    text-align: left;
-    width: 96%;
-    margin-bottom: 8px;
+  float: left;
+  text-align: left;
+  width: 96%;
+  margin-bottom: 8px;
 }
 
 .sub-editor .gl-search .comment a,
 .sub-editor .glossary-add-comment a {
-    float: left;
-    margin: 0 1.5% 0 1.5%;
-    text-decoration: none;
-    color: $grey1;
-    width: 50%;
-    font-size: 80%;
-    font-style: italic;
+  float: left;
+  margin: 0 1.5% 0 1.5%;
+  text-decoration: none;
+  color: $grey1;
+  width: 50%;
+  font-size: 80%;
+  font-style: italic;
 }
 
 .sub-editor .gl-search .comment a:hover,
 .sub-editor .glossary-add-comment a:hover {
-    color: #000;
+  color: #000;
 }
 
 .glossary-add-comment {
-    float: left;
-    text-align: left;
-    width: 50%;
-    margin-bottom: 8px;
+  float: left;
+  text-align: left;
+  width: 50%;
+  margin-bottom: 8px;
 }
 
 .sub-editor .glossary-add-comment a {
-    font-size: 90%;
-    margin-bottom: 11px;
-    margin-left: 29px;
+  font-size: 90%;
+  margin-bottom: 11px;
+  margin-left: 29px;
 }
 
 .glossary-add-comment .input.gl-comment {
-    width: 93%;
-    margin-left: 30px;
+  width: 93%;
+  margin-left: 30px;
 }
 
 //.content {
@@ -1718,210 +1726,207 @@ body .footer.showMatches .sub-editor.open {
 //}
 
 .preview {
-    font-family: Cambria, Arial, Helvetica, sans-serif !important;
-    height: 300px
+  font-family: Cambria, Arial, Helvetica, sans-serif !important;
+  height: 300px;
 }
 
 .filter {
-    width: 24px;
-    height: 24px;
-    box-shadow: 0px 0px 1px #AEAEAE;
-    display: block;
-    float: right;
-    margin: -5px 10px -2px 0;
-    border-left: 1px solid #333;
-    border-right: 1px solid #333;
-    -webkit-transition: all 100ms ease-in;
-    -moz-transition: all 100ms ease-in;
-    position: relative;
-    display: none !important;
+  width: 24px;
+  height: 24px;
+  box-shadow: 0px 0px 1px #aeaeae;
+  display: block;
+  float: right;
+  margin: -5px 10px -2px 0;
+  border-left: 1px solid #333;
+  border-right: 1px solid #333;
+  -webkit-transition: all 100ms ease-in;
+  -moz-transition: all 100ms ease-in;
+  position: relative;
+  display: none !important;
 }
-
 
 .search-display .found .warning {
-    color: #e60000;
+  color: #e60000;
 }
-
-
 
 .search .loader {
-    display: block !important;
-    position: absolute !important;
-    left: auto !important;
-    right: 100px;
-    top: 12px;
-    background: url(../../img/loading-black.gif) 0 0 no-repeat !important
+  display: block !important;
+  position: absolute !important;
+  left: auto !important;
+  right: 100px;
+  top: 12px;
+  background: url(../../img/loading-black.gif) 0 0 no-repeat !important;
 }
 
-
-.filtering .filter, .filtering .filter:hover {
-    background-color: #434345;
+.filtering .filter,
+.filtering .filter:hover {
+  background-color: #434345;
 }
 
 .filter:hover {
-    background-color: #636567;
+  background-color: #636567;
 }
 
 .checkbox {
-    margin: 16px -5px 0 10px !important;
-    float: left;
+  margin: 16px -5px 0 10px !important;
+  float: left;
 }
 
 .search-icon {
-    margin-left: 200px;
-    display: block;
-    width: 25px;
-    height: 35px;
+  margin-left: 200px;
+  display: block;
+  width: 25px;
+  height: 35px;
 }
 
 .search .btn {
-    float: right;
-    font-weight: bold;
-    margin: 4px 10px 3px 0;
-    padding: 2px 20px;
-    height: 28px;
-    background: #dcdedf;
-    cursor: pointer;
-    font-size: 14px;
-    width: 120px
+  float: right;
+  font-weight: bold;
+  margin: 4px 10px 3px 0;
+  padding: 2px 20px;
+  height: 28px;
+  background: #dcdedf;
+  cursor: pointer;
+  font-size: 14px;
+  width: 120px;
 }
 
 .checkbox-box .btn {
-    margin: 6px 10px 3px 0;
+  margin: 6px 10px 3px 0;
 }
 
 .checkbox-filter {
-    float: right;
-    width: 120px
+  float: right;
+  width: 120px;
 }
 
 .checkbox-filter .custom-checkbox {
-    margin: 9px 10px 0 0
+  margin: 9px 10px 0 0;
 }
 
 /*concordance*/
 .border-search {
-    border-bottom: 1px solid #dedede;
-    margin: -10px 200px 0 5px;
-    float: left;
-    height: 20px;
-    width: 70%
+  border-bottom: 1px solid #dedede;
+  margin: -10px 200px 0 5px;
+  float: left;
+  height: 20px;
+  width: 70%;
 }
 
 .col1-search {
-    float: left;
-    width: 100%;
+  float: left;
+  width: 100%;
 }
 
 .col1-search ul {
-    margin: -5px 0 0px 0;
-    padding: 0;
-    float: left;
-    width: 100%;
+  margin: -5px 0 0px 0;
+  padding: 0;
+  float: left;
+  width: 100%;
 }
 
 .col1-search li {
-    margin: 0;
-    padding: 0 0px 0 0;
-    float: left;
+  margin: 0;
+  padding: 0 0px 0 0;
+  float: left;
 }
 
 .search-editarea {
-    background: #fff;
-    width: 300px !important;
-    text-align: left;
-    border: 1px solid #abadb3 !important;
-    margin-top: 8px !important;
-    min-height: 18px !important;
-    max-height: 60px;
-    padding: 0 5px !important;
-    line-height: 22px !important;
-    color: #999 !important;
-    -webkit-transition: all 100ms ease-in;
-    -moz-transition: all 100ms ease-in;
+  background: #fff;
+  width: 300px !important;
+  text-align: left;
+  border: 1px solid #abadb3 !important;
+  margin-top: 8px !important;
+  min-height: 18px !important;
+  max-height: 60px;
+  padding: 0 5px !important;
+  line-height: 22px !important;
+  color: #999 !important;
+  -webkit-transition: all 100ms ease-in;
+  -moz-transition: all 100ms ease-in;
 }
 
 .search-editarea:focus {
-    color: #000 !important
+  color: #000 !important;
 }
 
 .checkbox-box {
-    background: #dcdedf;
-    float: left;
-    padding: 2px 0 4px 0;
-    width: 100%;
-    border-top: 1px solid #9fa1a1
+  background: #dcdedf;
+  float: left;
+  padding: 2px 0 4px 0;
+  width: 100%;
+  border-top: 1px solid #9fa1a1;
 }
 
 .checkbox-box p {
-    margin: 5px 10px 0 10px;
+  margin: 5px 10px 0 10px;
 }
 
 .checkbox-box .custom-checkbox {
-    margin-top: 3px;
+  margin-top: 3px;
 }
 
 .custom-checkbox {
-    position: relative;
-    float: left;
-    display: inline-block;
-    margin: 12px -5px 0 10px
+  position: relative;
+  float: left;
+  display: inline-block;
+  margin: 12px -5px 0 10px;
 }
 
 .custom-checkbox > .box {
-    position: relative;
-    display: block;
-    width: 14px;
-    height: 14px;
-    border: 1px solid $grey1;
-    background-color: #eee;
-    border-radius: 2px;
+  position: relative;
+  display: block;
+  width: 14px;
+  height: 14px;
+  border: 1px solid $grey1;
+  background-color: #eee;
+  border-radius: 2px;
 }
 
 .custom-checkbox > .tr-check {
-    background-color: $translatedBlue !important
+  background-color: $translatedBlue !important;
 }
 
 .custom-checkbox > .dr-check {
-    background-color: #d0d1d1 !important
+  background-color: #d0d1d1 !important;
 }
 
 .custom-checkbox > .rj-check {
-    background-color: #ed1c24 !important
+  background-color: #ed1c24 !important;
 }
 
 .custom-checkbox > .ap-check {
-    background-color: $approvedGreen !important
+  background-color: $approvedGreen !important;
 }
 
 .custom-checkbox > .normal-check {
-    background-color: #fff !important
+  background-color: #fff !important;
 }
 
 .custom-checkbox:hover {
-    -moz-box-shadow: 0 1px 2px $grey2;
-    -webkit-box-shadow: 0 1px 2px $grey2;
-    box-shadow: 0 1px 2px $grey2;
+  -moz-box-shadow: 0 1px 2px $grey2;
+  -webkit-box-shadow: 0 1px 2px $grey2;
+  box-shadow: 0 1px 2px $grey2;
 }
 
 .custom-checkbox > .box > .tick {
-    position: absolute;
-    left: 2px;
-    top: 2px;
-    width: 8px;
-    height: 4px;
-    border-bottom: 2px solid #333;
-    border-left: 2px solid #333;
-    -webkit-transform: rotate(-45deg);
-    -moz-transform: rotate(-45deg);
-    -o-transform: rotate(-45deg);
-    -ms-transform: rotate(-45deg);
-    transform: rotate(-45deg);
-    display: none;
+  position: absolute;
+  left: 2px;
+  top: 2px;
+  width: 8px;
+  height: 4px;
+  border-bottom: 2px solid #333;
+  border-left: 2px solid #333;
+  -webkit-transform: rotate(-45deg);
+  -moz-transform: rotate(-45deg);
+  -o-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+  display: none;
 }
 
 .custom-checkbox > input:checked + .box > .tick {
-    display: block;
+  display: block;
 }
 
 //.replace-box .replace .tick {
@@ -1929,387 +1934,385 @@ body .footer.showMatches .sub-editor.open {
 //}
 
 .custom-checkbox > input {
-    position: absolute;
-    outline: none;
-    left: 0;
-    top: 0;
-    padding: 0;
-    width: 16px;
-    height: 16px;
-    border: none;
-    margin: 0;
-    opacity: 0;
-    z-index: 1;
+  position: absolute;
+  outline: none;
+  left: 0;
+  top: 0;
+  padding: 0;
+  width: 16px;
+  height: 16px;
+  border: none;
+  margin: 0;
+  opacity: 0;
+  z-index: 1;
 }
 
 /*editor*/
-.editor{
-    width: 100%;
-    position: relative;
-    z-index: 999;
-    -moz-border-radius: 2px;
+.editor {
+  width: 100%;
+  position: relative;
+  z-index: 999;
+  -moz-border-radius: 2px;
 }
 
-.editor, .editor .text{
-    background:#fff;
+.editor,
+.editor .text {
+  background: #fff;
 }
 
 .loader:not(.ui) {
-    width: 20px;
-    height: 20px;
-    background: url(../../img/loading.gif) 0 0 no-repeat !important;
-    position: absolute;
-    bottom: 11px;
-    display: none;
-    left: 50%;
-    background-size: 20px 20px !important;
+  width: 20px;
+  height: 20px;
+  background: url(../../img/loading.gif) 0 0 no-repeat !important;
+  position: absolute;
+  bottom: 11px;
+  display: none;
+  left: 50%;
+  background-size: 20px 20px !important;
 }
 
 @-moz-document url-prefix() {
+  .loader {
+    bottom: -40px;
+  }
+  .wrap {
+    padding-bottom: 15px !important;
+  }
 
-    .loader {
-        bottom: -40px;
-    }
-    .wrap {
-        padding-bottom: 15px !important;
-    }
+  .editor .wrap {
+    padding-bottom: 31px !important;
+  }
 
-    .editor .wrap {
-        padding-bottom: 31px !important;
-    }
-
-    .editor .status {
-        padding-bottom: 8px !important;
-    }
-
+  .editor .status {
+    padding-bottom: 8px !important;
+  }
 }
 
 section.editor .loader_on {
-    display: block !important
+  display: block !important;
 }
 
 .btnmargin {
-    margin-right: -23px !important
+  margin-right: -23px !important;
 }
 
 .source-title {
-    margin: 3px 0 0 20px !important;
+  margin: 3px 0 0 20px !important;
 }
 
 .target-title {
-    float: right;
-    margin: 3px 30px 0 0
+  float: right;
+  margin: 3px 30px 0 0;
 }
 
 .header {
-    height: 20px;
-    width: 100%;
-    color: $grey1;
-    font-size: 12px;
-    background: $grey4 !important;
-    margin-bottom: 0px;
+  height: 20px;
+  width: 100%;
+  color: $grey1;
+  font-size: 12px;
+  background: $grey4 !important;
+  margin-bottom: 0px;
 }
 
 .header .repetition {
-    margin: 0 auto;
-    text-transform: uppercase;
-    color: #FFF;
-    font-size: 12px;
-    background: $grey2;
-    padding: 4px 8px;
-    position: relative;
-    z-index: 12;
-    max-width: 102px;
+  margin: 0 auto;
+  text-transform: uppercase;
+  color: #fff;
+  font-size: 12px;
+  background: $grey2;
+  padding: 4px 8px;
+  position: relative;
+  z-index: 12;
+  max-width: 102px;
 }
 
 .header.header-closed {
-    background: transparent !important;
-    position: absolute;
-    span {
-        z-index: 1;
-        padding: 2px 6px;
-        font-size: 11px;
-        top: -2px;
-    }
+  background: transparent !important;
+  position: absolute;
+  span {
+    z-index: 1;
+    padding: 2px 6px;
+    font-size: 11px;
+    top: -2px;
+  }
 }
 
 .close {
-    width: 14px;
-    height: 14px;
-    padding-top: 0px;
-    padding-left: 0px;
-    vertical-align: middle;
-    margin-right: 7px;
-    display: block;
-    position: absolute;
-    right: 0;
-    padding-top: 0px;
-    top: 0;
-    text-decoration: none;
-    font-size: 15px;
-    margin-top: 3px;
-    border-radius: 20px;
-    background: #fff;
-    color: #AEAEAE;
+  width: 14px;
+  height: 14px;
+  padding-top: 0px;
+  padding-left: 0px;
+  vertical-align: middle;
+  margin-right: 7px;
+  display: block;
+  position: absolute;
+  right: 0;
+  padding-top: 0px;
+  top: 0;
+  text-decoration: none;
+  font-size: 15px;
+  margin-top: 3px;
+  border-radius: 20px;
+  background: #fff;
+  color: #aeaeae;
 }
 
 .close:hover {
-    background: red;
-    color: #fff;
-    text-align: center;
+  background: red;
+  color: #fff;
+  text-align: center;
 }
 
 .h-text {
-    width: auto;
-    height: 20px;
-    display: block;
-    position: absolute;
-    left: 10px;
-    top: 2px;
-    color: #fff;
-    font-size: 12px;
-    text-decoration: none;
-    text-transform: none;
+  width: auto;
+  height: 20px;
+  display: block;
+  position: absolute;
+  left: 10px;
+  top: 2px;
+  color: #fff;
+  font-size: 12px;
+  text-decoration: none;
+  text-transform: none;
 }
 
 .percentuage {
-    position: relative;
-    display: none;
-    width: 45px;
-    line-height: 182%;
-    color: #fff;
-    font-size: 12px;
-    text-decoration: none;
-    font-weight: 100;
-    margin: 0 auto;
-    text-align: center;
+  position: relative;
+  display: none;
+  width: 45px;
+  line-height: 182%;
+  color: #fff;
+  font-size: 12px;
+  text-decoration: none;
+  font-weight: 100;
+  margin: 0 auto;
+  text-align: center;
 }
 
 /*
 .editor .percentuage{display:block !important;}
 */
 section .header .context {
-    display: none;
-    float: left;
-    color: $grey1;
-    text-decoration: none;
-    margin: 3px 0 0 10px;
+  display: none;
+  float: left;
+  color: $grey1;
+  text-decoration: none;
+  margin: 3px 0 0 10px;
 }
 
 section.has-reference .header .context {
-    display: block;
+  display: block;
 }
 
 section .header .context:hover {
-    color: #000;
+  color: #000;
 }
 
 .percentuage.visible {
-    display: block !important
+  display: block !important;
 }
 
 .smart-suggestion-target {
-    border: 2px solid #00a651;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
-    padding: 0 5px;
-    -moz-box-shadow: 0 1px 3px $grey2;
-    -webkit-box-shadow: 0 1px 3px $grey2;
-    -webkit-transition: all 100ms ease-in;
-    -moz-transition: all 100ms ease-in;
+  border: 2px solid #00a651;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  padding: 0 5px;
+  -moz-box-shadow: 0 1px 3px $grey2;
+  -webkit-box-shadow: 0 1px 3px $grey2;
+  -webkit-transition: all 100ms ease-in;
+  -moz-transition: all 100ms ease-in;
 }
 
 .qa {
-    background: #FFCC00;
-    -moz-box-shadow: 0 1px 3px $grey2;
-    -webkit-box-shadow: 0 1px 3px $grey2;
-    padding: 0 2px;
+  background: #ffcc00;
+  -moz-box-shadow: 0 1px 3px $grey2;
+  -webkit-box-shadow: 0 1px 3px $grey2;
+  padding: 0 2px;
 }
 
 section .text .warning {
-    background: #FFCC00;
-    padding: 2px 7px;
-    text-align: center;
-    border: 1px solid #333;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
-    -moz-box-shadow: 0 1px 3px $grey2;
-    -webkit-box-shadow: 0 1px 3px $grey2;
-    display: block;
-    position: absolute;
-    bottom: -30px;
-    font-size: 12px;
-    font-weight: bold
+  background: #ffcc00;
+  padding: 2px 7px;
+  text-align: center;
+  border: 1px solid #333;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  -moz-box-shadow: 0 1px 3px $grey2;
+  -webkit-box-shadow: 0 1px 3px $grey2;
+  display: block;
+  position: absolute;
+  bottom: -30px;
+  font-size: 12px;
+  font-weight: bold;
 }
 
 .body .charleft {
-    display: none;
+  display: none;
 }
 
 section.status-new.opened .editarea {
-    text-indent: 0;
+  text-indent: 0;
 }
 
 section.editor {
-    z-index: 2;
-    position: relative;
-    //height: 100%;
-    width: 89%;
-    margin-left: 4.5%;
-    //height: 100%;
+  z-index: 2;
+  position: relative;
+  //height: 100%;
+  width: 89%;
+  margin-left: 4.5%;
+  //height: 100%;
 }
 
 section.editor .sid {
-    color: black;
-    left: -5%;
+  color: black;
+  left: -5%;
 }
 section.editor.slide-right .sid {
-    left: -6%;
+  left: -6%;
 }
 
 .source {
-    line-height: 27px;
-    padding-top: 7px !important;
+  line-height: 27px;
+  padding-top: 7px !important;
 }
 
 .editor .source {
-    padding-top: 4px !important;
-    font-size: 18px;
+  padding-top: 4px !important;
+  font-size: 18px;
 
-    /*word-wrap: break-word;*/
-    /*word-break: normal;*/
+  /*word-wrap: break-word;*/
+  /*word-break: normal;*/
 }
 
 .grayed-text {
-    color: #4c4c4c;
+  color: #4c4c4c;
 }
 
 .textarea-container {
-    height: inherit;
-    table-layout: fixed;
+  height: inherit;
+  table-layout: fixed;
 }
 
 .editor .textarea-container {
-    position: relative;
-    width: 100%;
-    float: right !important; /*padding-bottom:5px;*/
+  position: relative;
+  width: 100%;
+  float: right !important; /*padding-bottom:5px;*/
 }
 
-.editarea, .search-editarea, .textarea-container .area {
-    /*display: inline-block;*/
-    /*float:right;*/
-    width: 100%;
-    //height: 96%;
-    min-height: 54px;
-    resize: none;
-    //overflow: hidden;
-    margin: 2px 0 0px -11px;
-    padding: 5px;
-    color: #4d4d4f;
-    border: 1px solid transparent;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
-    word-wrap: break-word;
-    word-break: normal;
-    hyphens: auto;
-    -moz-hyphens: auto;
-    transition: all 50ms ease-in;
-    -webkit-transition: all 50ms ease-in;
+.editarea,
+.search-editarea,
+.textarea-container .area {
+  /*display: inline-block;*/
+  /*float:right;*/
+  width: 100%;
+  //height: 96%;
+  min-height: 54px;
+  resize: none;
+  //overflow: hidden;
+  margin: 2px 0 0px -11px;
+  padding: 5px;
+  color: #4d4d4f;
+  border: 1px solid transparent;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  word-wrap: break-word;
+  word-break: normal;
+  hyphens: auto;
+  -moz-hyphens: auto;
+  transition: all 50ms ease-in;
+  -webkit-transition: all 50ms ease-in;
 }
 
 section.readonly {
-    background: transparent;
+  background: transparent;
 }
 
 section.ice-locked:not(.segment-selected) .text {
-    cursor: no-drop !important;
-    background-color: #f2f4f7 !important;
+  cursor: no-drop !important;
+  background-color: #f2f4f7 !important;
 }
 
 body section:not(.editor).ice-locked {
-    background: #dde0e4 !important;
+  background: #dde0e4 !important;
 }
 
-
 /*body.cattool.editing section.ice-locked:not(.editor) .text:hover {*/
-    /*background-color: rgba(99, 157, 94, 0.1) !important;*/
+/*background-color: rgba(99, 157, 94, 0.1) !important;*/
 /*}*/
 
 .ice-locked-icon > button {
-    padding: 4px;
-    font-size: 15px;
-    background-color: transparent;
-    border: 1px solid transparent;
-    border-radius: 2px;
-    cursor: pointer;
-    color: #aaa;
-    position: relative;
-    margin-bottom: 5px;
-    top: 2px;
-    outline: none;
+  padding: 4px;
+  font-size: 15px;
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  cursor: pointer;
+  color: #aaa;
+  position: relative;
+  margin-bottom: 5px;
+  top: 2px;
+  outline: none;
 }
 button.icon-lock.unlock-button.locked:before {
-    position: relative;
-    left: 3px;
+  position: relative;
+  left: 3px;
 }
 
 button.unlock-button.unlocked.icon-unlocked3:before {
-    left: 2px;
-    position: relative;
+  left: 2px;
+  position: relative;
 }
 
-section:hover  .ice-locked-icon > button{
-    color: #6d6e71;
+section:hover .ice-locked-icon > button {
+  color: #6d6e71;
 }
 
 .ice-locked-icon > button:hover {
-    background-color: #9E9E9E;
-    border: 1px solid #5F5F5F;
-    color: white !important;
+  background-color: #9e9e9e;
+  border: 1px solid #5f5f5f;
+  color: white !important;
 }
 
 body.archived section {
-    z-index: 9998;
-    background: transparent;
+  z-index: 9998;
+  background: transparent;
 }
 
 section.readonly,
 body.archived section {
-    background: #f2f4f7;
-    color: #a4a6a9;
-    cursor: not-allowed !important;
+  background: #f2f4f7;
+  color: #a4a6a9;
+  cursor: not-allowed !important;
 }
 section.readonly .status-container a.status:hover,
 body.archived section .status-container a.status:hover {
-    cursor: default !important;
+  cursor: default !important;
 }
 
 .editor .editarea {
-    width: 100%;
-    font-size: 18px;
-    margin: 2px 0 10px -11px;
-    word-break: normal;
-    line-height: 25px;
-    outline: none;
-    color: #000;
-    border: 1px solid #dedede;
-    box-shadow: inset 0 1px 2px $grey2;
-    -webkit-box-shadow: inset 0 1px 2px $grey2;
-    /*font-variant-ligatures: none;*/
-    cursor: text;
+  width: 100%;
+  font-size: 18px;
+  margin: 2px 0 10px -11px;
+  word-break: normal;
+  line-height: 25px;
+  outline: none;
+  color: #000;
+  border: 1px solid #dedede;
+  box-shadow: inset 0 1px 2px $grey2;
+  -webkit-box-shadow: inset 0 1px 2px $grey2;
+  /*font-variant-ligatures: none;*/
+  cursor: text;
 }
-.editor.editarea
-.highlighted1{
-	background-color: #ffff94;
+.editor.editarea .highlighted1 {
+  background-color: #ffff94;
 }
 
-.editor .editarea.highlighted2
-{
-	-moz-transition:background-color 1.5s;
-	-webkit-transition:background-color 1.5s !important;
-	-o-transition:background-color 1.5s;
-	transition:background-color 1.5s !important;
-	background-color: transparent;
+.editor .editarea.highlighted2 {
+  -moz-transition: background-color 1.5s;
+  -webkit-transition: background-color 1.5s !important;
+  -o-transition: background-color 1.5s;
+  transition: background-color 1.5s !important;
+  background-color: transparent;
 }
 
 /*
@@ -2328,16 +2331,15 @@ section.highlighted2 .editarea
 */
 
 section:not(.editor) .editarea.highlighted1 {
-    border-color: #00C1E6;
-    background: rgba(0, 193, 230, 0.15);
+  border-color: #00c1e6;
+  background: rgba(0, 193, 230, 0.15);
 }
-section:not(.editor).editarea
-.highlighted2{
--moz-transition: border-color 3s;
--webkit-transition: border-color 3s !important;
--o-transition: border-color 3s;
-transition: border-color 3s !important;
-border-color: transparent;
+section:not(.editor).editarea .highlighted2 {
+  -moz-transition: border-color 3s;
+  -webkit-transition: border-color 3s !important;
+  -o-transition: border-color 3s;
+  transition: border-color 3s !important;
+  border-color: transparent;
 }
 
 /*.editor.modified .editarea
@@ -2349,194 +2351,202 @@ border-color: transparent;
 	background-color: #fff !important;
 }*/
 .editarea:hover {
-    border-color: rgba(34, 36, 38, 0.35);
-    box-shadow: none;
+  border-color: rgba(34, 36, 38, 0.35);
+  box-shadow: none;
 }
 
 .editarea:focus {
-    border: 1px solid #96C8DA;
-    box-shadow: inset 0px 0px 2px 2px #96C8DA;
-    outline-color: #96C8DA;
+  border: 1px solid #96c8da;
+  box-shadow: inset 0px 0px 2px 2px #96c8da;
+  outline-color: #96c8da;
 }
 
 body.rtl-target .editor .editarea span {
-    display: inline-block;
+  display: inline-block;
 }
 
 .search-editarea {
-    overflow: auto;
-    min-height: 22px !important;
-    cursor: text
+  overflow: auto;
+  min-height: 22px !important;
+  cursor: text;
 }
 
 .source {
-    position: relative;
-    z-index: 0;
-    /*word-break: break-all;*/
+  position: relative;
+  z-index: 0;
+  /*word-break: break-all;*/
 }
 
 .suggestion_source,
 .translation {
-    word-wrap: break-word;
-    /*word-break: break-all;*/
+  word-wrap: break-word;
+  /*word-break: break-all;*/
 }
 
 .graysmall .translation {
-    display: block;
-    padding-bottom: 4px;
-    /*padding: 4px;
+  display: block;
+  padding-bottom: 4px;
+  /*padding: 4px;
     margin-left: -4px;*/
 }
 
 .graysmall .translation.editing,
 .graysmall .comment.editing,
 .graysmall .glossary-add-comment .gl-comment {
-    padding: 2px 0.4%;
-    background: #fff;
-    border: 1px solid #aaa;
-    border-radius: 2px;
-    box-shadow: inset 0 1px 2px #ddd;
-    outline: none;
-    min-height: 20px;
-    line-height: 20px;
+  padding: 2px 0.4%;
+  background: #fff;
+  border: 1px solid #aaa;
+  border-radius: 2px;
+  box-shadow: inset 0 1px 2px #ddd;
+  outline: none;
+  min-height: 20px;
+  line-height: 20px;
 }
 
 .graysmall .switch-editing {
-    display: none;
-    float: left;
-    position: absolute;
-    width: 16px;
-    height: 16px;
-    cursor: pointer;
-    right: 40px;
-    top: 15px;
+  display: none;
+  float: left;
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  right: 40px;
+  top: 15px;
 }
 
 .graysmall:hover .switch-editing {
-    display: block;
+  display: block;
 }
 
 .graysmall:hover .switch-editing:hover {
-    margin-top: -2px;
-    color: #000;
+  margin-top: -2px;
+  color: #000;
 }
 
 .graysmall .edit-buttons {
-    float: right;
+  float: right;
 }
 
 .graysmall .edit-buttons button {
-    color: #fff;
-    background: $translatedBlue;
-    font-weight: bold;
-    text-decoration: none;
-    padding: 4px 9px;
-    margin: 4px 3px;
-    border-radius: 2px;
-    font-size: 10px;
-    background: -webkit-gradient(linear, left top, left bottom, from($translatedBlue), to(#119ec4));
-    background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
-    background: linear-gradient(top, $translatedBlue, #119ec4);
-    cursor: pointer;
+  color: #fff;
+  background: $translatedBlue;
+  font-weight: bold;
+  text-decoration: none;
+  padding: 4px 9px;
+  margin: 4px 3px;
+  border-radius: 2px;
+  font-size: 10px;
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from($translatedBlue),
+    to(#119ec4)
+  );
+  background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
+  background: linear-gradient(top, $translatedBlue, #119ec4);
+  cursor: pointer;
 }
 
 .graysmall .edit-buttons button.cancel {
-    color: #333;
-    background: #f6f6f6;
-    background: -webkit-gradient(linear, left top, left bottom, from(#f6f6f6), to(#e2e3e5));
-    background: -moz-linear-gradient(top, #f6f6f6, #e2e3e5);
-    background: linear-gradient(top, #f6f6f6, #e2e3e5);
+  color: #333;
+  background: #f6f6f6;
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#f6f6f6),
+    to(#e2e3e5)
+  );
+  background: -moz-linear-gradient(top, #f6f6f6, #e2e3e5);
+  background: linear-gradient(top, #f6f6f6, #e2e3e5);
 }
 
 .wrap {
-    float: left;
-    width: 99%;
-    height: 100%;
-    padding-bottom: 5px;
-    padding-top: 5px;
-    font-size: 16px;
-
+  float: left;
+  width: 99%;
+  height: 100%;
+  padding-bottom: 5px;
+  padding-top: 5px;
+  font-size: 16px;
 }
 
 .editor .wrap {
-    height: 87% !important;
+  height: 87% !important;
 }
 
 .editor .wrap {
-    margin-bottom: 0px;
-
+  margin-bottom: 0px;
 }
 
 .wrap:after {
-    clear: both
+  clear: both;
 }
 
 .source {
-    display: table-cell;
-    vertical-align: top;
-    padding-right: 26px !important;
+  display: table-cell;
+  vertical-align: top;
+  padding-right: 26px !important;
 }
 
 .target {
-    display: table-cell;
-    height: inherit;
-    float: right !important;
-    vertical-align: top;
-    padding-left: 26px !important;
+  display: table-cell;
+  height: inherit;
+  float: right !important;
+  vertical-align: top;
+  padding-left: 26px !important;
 }
 
 .editor .charleft {
-    display: none
+  display: none;
 }
 
 .buttons {
-    position: relative;
-    top: 0px;
+  position: relative;
+  top: 0px;
 }
-
-
 
 /*tab rows */
 /*.overflow{overflow-y:auto;min-height:8px;margin-bottom:-1px;position:relative;z-index:9999999999999999999999999999999;}*/
 .graysmall li {
-    width: 48%;
-    float: left;
-    margin: 2px 1px 0px 0;
-    padding: 12px 20px 12px 34px;
-    text-align: left;
-    color: #666;
-    list-style: none;
-    font-size: 14px;
-    line-height: 16px;
-    cursor: text;
-    -webkit-transition: all 100ms ease-in;
-    transition: all 100ms ease-in;
+  width: 48%;
+  float: left;
+  margin: 2px 1px 0px 0;
+  padding: 12px 20px 12px 34px;
+  text-align: left;
+  color: #666;
+  list-style: none;
+  font-size: 14px;
+  line-height: 16px;
+  cursor: text;
+  -webkit-transition: all 100ms ease-in;
+  transition: all 100ms ease-in;
 }
 .concordances .graysmall li.sugg-source {
-    padding-left: 34px;
+  padding-left: 34px;
 }
 
 .suggestion-item.graysmall > li {
-    width: 48%;
-    float: left;
-    margin: 2px 1px 0px 0;
-    padding: 12px 5px 30px 5px;
-    text-align: left;
-    list-style: none;
-    cursor: text;
-    -webkit-transition: all 100ms ease-in;
-    transition: all 100ms ease-in;
-    box-sizing: border-box;
-    line-height: 26px;
+  width: 48%;
+  float: left;
+  margin: 2px 1px 0px 0;
+  padding: 12px 5px 30px 5px;
+  text-align: left;
+  list-style: none;
+  cursor: text;
+  -webkit-transition: all 100ms ease-in;
+  transition: all 100ms ease-in;
+  box-sizing: border-box;
+  line-height: 26px;
 }
 
 .alternatives.tab ul li {
-    padding: 12px 5px 30px 5px;
+  padding: 12px 5px 30px 5px;
 }
 
 .alternatives.tab ul li.sugg-source {
-    padding-left: 20px;
-    width: 50%;
+  padding-left: 20px;
+  width: 50%;
 }
 
 /*.alternatives.tab ul li.sugg-target {
@@ -2544,117 +2554,117 @@ body.rtl-target .editor .editarea span {
 }*/
 
 .suggestion-item li.sugg-source {
-    padding-left: 25px;
+  padding-left: 25px;
 }
 
 .graysmall li.goto {
-    width: 33px !important;
-    padding: 15px !important;
-    //font-weight: bold;
-    text-decoration: underline;
-    cursor: pointer;
-    &:hover {
-        text-decoration: none;
-    }
+  width: 33px !important;
+  padding: 15px !important;
+  //font-weight: bold;
+  text-decoration: underline;
+  cursor: pointer;
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 .graysmall li.details {
-    width: 100%;
-    padding: 0;
-    margin: 0;
+  width: 100%;
+  padding: 0;
+  margin: 0;
 }
 
 .graysmall div.comment {
-    float: left;
-    margin-left: 30px;
-    width: 60%;
-    padding: 3px 0;
-    border-top: 1px dotted $grey2;
-    font-style: italic;
-    overflow: hidden;
+  float: left;
+  margin-left: 30px;
+  width: 60%;
+  padding: 3px 0;
+  border-top: 1px dotted $grey2;
+  font-style: italic;
+  overflow: hidden;
 }
 
 .graysmall div.comment.editing {
-    width: 46%;
+  width: 46%;
 }
 
 .graysmall .b {
-    padding-left: 12px !important;
-    position: relative;
-    padding-right: 0;
+  padding-left: 12px !important;
+  position: relative;
+  padding-right: 0;
 }
 
 .suggestion-item.graysmall .b {
-    float: right;
-    padding-right: 30px;
+  float: right;
+  padding-right: 30px;
 }
 
 .message li {
-    background: url(../../img/bad.png) 22px center no-repeat;
-    padding-left: 40px !important;
-    background-size: 12px 12px
+  background: url(../../img/bad.png) 22px center no-repeat;
+  padding-left: 40px !important;
+  background-size: 12px 12px;
 }
 
 .graysmall:hover .trash {
-    height: 20px;
+  height: 20px;
 }
 
 .trash:hover {
-    margin-top: -2px;
-    color: #000;
+  margin-top: -2px;
+  color: #000;
 }
 
 .trash {
-    transition: all 0.1s linear;
-    color: $grey1;
-    text-decoration: none;
-    -o-transition: all 0.1s linear;
-    -webkit-transition: all 0.1s linear;
-    display: block;
-    height: 0;
-    width: 20px;
-    position: absolute;
-    right: 5px;
-    top: 14px;
-	cursor: pointer;
+  transition: all 0.1s linear;
+  color: $grey1;
+  text-decoration: none;
+  -o-transition: all 0.1s linear;
+  -webkit-transition: all 0.1s linear;
+  display: block;
+  height: 0;
+  width: 20px;
+  position: absolute;
+  right: 5px;
+  top: 14px;
+  cursor: pointer;
 }
 
 .graysmall-message {
-    bottom: 0px;
-    left: 25px;
-    position: absolute;
-    font-size: 10px;
-    display: none;
-    color: #999999
+  bottom: 0px;
+  left: 25px;
+  position: absolute;
+  font-size: 10px;
+  display: none;
+  color: #999999;
 }
 
 .graysmall:hover .graysmall-message {
-    display: block;
+  display: block;
 }
 
 .graysmall-details {
-    display: none;
-    position: absolute;
-    bottom: 0px;
-    color: $grey1;
-    width: 100%;
-    float: left;
-    margin: 0;
-    padding: 0;
+  display: none;
+  position: absolute;
+  bottom: 0px;
+  color: $grey1;
+  width: 100%;
+  float: left;
+  margin: 0;
+  padding: 0;
 }
 
 .glossary .graysmall .graysmall-details {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 .graysmall .graysmall-details {
-    display: block;
-    width: 100%; /*To be tested*/
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    margin-top: 10px;
-    margin-right: 15px;
+  display: block;
+  width: 100%; /*To be tested*/
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin-top: 10px;
+  margin-right: 15px;
 }
 
 /*.graysmall {
@@ -2663,28 +2673,28 @@ body.rtl-target .editor .editarea span {
 }*/
 
 .graysmall.notEditable {
-   /* background: $grey2;*/
+  /* background: $grey2;*/
 }
 
 .graysmall-details li {
-    float: right;
-    width: auto !important;
-    font-size: 11px;
-    margin: 0 0px;
-    padding: 2px 5px 0px 5px;
-    border-bottom: none;
+  float: right;
+  width: auto !important;
+  font-size: 11px;
+  margin: 0 0px;
+  padding: 2px 5px 0px 5px;
+  border-bottom: none;
 }
 
 .graysmall:hover {
-    background: $grey5;
-    cursor: default;
-    .tag {
-        opacity: 1;
-    }
+  background: $grey5;
+  cursor: default;
+  .tag {
+    opacity: 1;
+  }
 }
 
 .graysmall.notEditable:hover {
-    /*background: #999;*/
+  /*background: #999;*/
 }
 
 /*.graysmall:hover li span {
@@ -2692,14 +2702,14 @@ body.rtl-target .editor .editarea span {
 }*/
 
 .sub-editor.glossary .glossary-item {
-    float: right;
-    width: 100%;
-    margin-top: 2px;
-    padding: 3px 0px 3px 0;
-    text-align: left;
-    background: $grey2;
-    border-top: 1px solid #999;
-    border-bottom: 1px solid #999;
+  float: right;
+  width: 100%;
+  margin-top: 2px;
+  padding: 3px 0px 3px 0;
+  text-align: left;
+  background: $grey2;
+  border-top: 1px solid #999;
+  border-bottom: 1px solid #999;
 }
 
 .glossary .sugg-target {
@@ -2707,497 +2717,514 @@ body.rtl-target .editor .editarea span {
 }
 
 .sub-editor.glossary .glossary-item span {
-    margin-left: 20px;
-    font-style: italic;
+  margin-left: 20px;
+  font-style: italic;
 }
 
 .message:hover {
-    background: #fbfbfb !important;
-    cursor: auto;
+  background: #fbfbfb !important;
+  cursor: auto;
 }
 
 .doubleclick {
-    display: none;
-    font-size: 10px;
+  display: none;
+  font-size: 10px;
 }
 
 .editor:hover .doubleclick {
-    display: block !important;
+  display: block !important;
 }
 
 /*suggestion*/
 .addsuggestion {
-    -webkit-transition: all 100ms ease-in;
-    -moz-transition: all 100ms ease-in;
-    border-bottom: 1px solid $grey2;
-    background: #fff;
-    -moz-box-shadow: 0 1px 3px $grey2;
-    -webkit-box-shadow: 0 1px 3px $grey2;
-    position: relative;
-    z-index: 9999999999999;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
+  -webkit-transition: all 100ms ease-in;
+  -moz-transition: all 100ms ease-in;
+  border-bottom: 1px solid $grey2;
+  background: #fff;
+  -moz-box-shadow: 0 1px 3px $grey2;
+  -webkit-box-shadow: 0 1px 3px $grey2;
+  position: relative;
+  z-index: 9999999999999;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
 }
 
 .addsuggestion p {
-    float: left;
+  float: left;
 }
 
 .sugg-input {
-    float: left;
-    width: 95%;
-    margin: -5px 10px 0px 0px;
-    border: 1px solid #727272;
-    -moz-box-shadow: inset 0 1px 2px #888;
-    -webkit-box-shadow: inset 0 1px 2px #888;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
-    box-shadow: inset 0 1px 2px #888;
-    padding: 5px 5px 6px 5px;
-    color: $grey1;
-    font-size: 14px !important
+  float: left;
+  width: 95%;
+  margin: -5px 10px 0px 0px;
+  border: 1px solid #727272;
+  -moz-box-shadow: inset 0 1px 2px #888;
+  -webkit-box-shadow: inset 0 1px 2px #888;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  box-shadow: inset 0 1px 2px #888;
+  padding: 5px 5px 6px 5px;
+  color: $grey1;
+  font-size: 14px !important;
 }
 
 .sugg-input:focus {
-    color: #000
+  color: #000;
 }
 
 .sugg-submit {
-    float: left;
-    margin: -4px 0px 10px 0;
-    font-size: 14px !important;
+  float: left;
+  margin: -4px 0px 10px 0;
+  font-size: 14px !important;
 }
 
 .second {
-    width: 66%;
+  width: 66%;
 }
 
 .addsuggestion {
-    border: 1px solid $grey2;
-    padding: 0px 6px;
-    text-decoration: none;
-    color: #939598;
+  border: 1px solid $grey2;
+  padding: 0px 6px;
+  text-decoration: none;
+  color: #939598;
 }
 
 .add-ul li {
-    padding: 6px 0px 0px 20px !important;
-    color: #939598;
-    font-size: 12px;
+  padding: 6px 0px 0px 20px !important;
+  color: #939598;
+  font-size: 12px;
 }
 
 .add-ul li:hover {
-    color: #000
+  color: #000;
 }
 
 .addsuggestion:hover {
-    border: 1px solid $grey1;
-    color: #333;
+  border: 1px solid $grey1;
+  color: #333;
 }
 
 .addline-suggestion {
-    display: none;
-    float: left;
-    height: 50px;
-    background: #fff
+  display: none;
+  float: left;
+  height: 50px;
+  background: #fff;
 }
 
 .add-ul {
-    background: #efefef !important
+  background: #efefef !important;
 }
 
 /*engine errror messages*/
 .engine-errrors summary {
-    text-align: left;
-    padding-left: 20px;
-    cursor: pointer;
+  text-align: left;
+  padding-left: 20px;
+  cursor: pointer;
 }
 
 .engine-errrors summary:focus {
-    outline: 0;
+  outline: 0;
 }
 
 .engine-errrors .error {
-    color: red;
+  color: red;
 }
 
 .engine-error {
-    padding-left: 40px !important;
+  padding-left: 40px !important;
 }
 
 .error-img {
-    background: #c5351c url(../../img/warning.png) no-repeat center;
-    background-size: 17px;
-    width: 22px;
-    height: 22px;
-    margin: 0;
-    border-radius: 5px;
-    margin-left: -28px;
-    top: -4px;
-    position: relative;
-    float: left;
+  background: #c5351c url(../../img/warning.png) no-repeat center;
+  background-size: 17px;
+  width: 22px;
+  height: 22px;
+  margin: 0;
+  border-radius: 5px;
+  margin-left: -28px;
+  top: -4px;
+  position: relative;
+  float: left;
 }
 
 .warning-img {
-    background: #FF9900 url(../../img/warning.png) no-repeat center;
-    background-size: 17px;
-    width: 22px;
-    height: 22px;
-    margin: 0;
-    border-radius: 5px;
-    margin-left: -28px;
-    top: -4px;
-    position: relative;
-    float: left;
+  background: #ff9900 url(../../img/warning.png) no-repeat center;
+  background-size: 17px;
+  width: 22px;
+  height: 22px;
+  margin: 0;
+  border-radius: 5px;
+  margin-left: -28px;
+  top: -4px;
+  position: relative;
+  float: left;
 }
 
 .engine-errors {
-    position: absolute;
-    top: 13px;
-    width: 100%;
+  position: absolute;
+  top: 13px;
+  width: 100%;
 }
 
 .engine-error-item.graysmall:hover {
-    background-color: #fff;
-    border-top: unset;
+  background-color: #fff;
+  border-top: unset;
 }
 
 .engine-error-item.graysmall:hover span {
-    color: unset !important;
+  color: unset !important;
 }
 
 .engine-error-item.graysmall {
-    border-top: unset;
-    cursor: default;
+  border-top: unset;
+  cursor: default;
 }
-
 
 .ice-locked-label {
-    font-size: 11px;
-    margin: 0 0px;
-    padding: 2px 5px 0px 5px;
-    background-color: #0798bc;
-    width: 35px;
-    height: 16px;
-    position: absolute;
-    color: white;
-    top: 1px;
-    line-height: 14px;
-    transition: all 100ms ease-in;
-    left: 47.4%;
-    visibility: hidden;
+  font-size: 11px;
+  margin: 0 0px;
+  padding: 2px 5px 0px 5px;
+  background-color: #0798bc;
+  width: 35px;
+  height: 16px;
+  position: absolute;
+  color: white;
+  top: 1px;
+  line-height: 14px;
+  transition: all 100ms ease-in;
+  left: 47.4%;
+  visibility: hidden;
 }
 
-
 section.readonly:hover .ice-locked-label {
-    visibility: visible;
+  visibility: visible;
 }
 
 /*status*/
 .status-container .status {
-    width: 8px;
-    display: block;
-    position: absolute;
-    right: 0;
-    height: 100%;
-    background: $grey2;
-    top: 0;
-    border-bottom: 0;
-    z-index: 0;
-    &.no-hover {
-        cursor: default;
-    }
+  width: 8px;
+  display: block;
+  position: absolute;
+  right: 0;
+  height: 100%;
+  background: $grey2;
+  top: 0;
+  border-bottom: 0;
+  z-index: 0;
+  &.no-hover {
+    cursor: default;
+  }
 }
-
 
 section.readonly .status-container a.status:hover,
 body.archived section .status-container a.status:hover {
-    cursor: default !important;
+  cursor: default !important;
 }
 
-
 .status img {
-    display: none
+  display: none;
 }
 
 .editor .status img {
-    display: block;
-    margin: -6px 0px 0 0 !important;
-    position: absolute;
-    top: 0;
-    right: 0px
+  display: block;
+  margin: -6px 0px 0 0 !important;
+  position: absolute;
+  top: 0;
+  right: 0px;
 }
 
 section.status-translated .status {
-    background-color: $translatedBlue !important;
+  background-color: $translatedBlue !important;
 }
 
 section.status-approved .status {
-    background-color: $approvedGreen !important;
+  background-color: $approvedGreen !important;
 }
 
 /* section.status-draft .status{background-color:#dddedf !important;} */
 section.status-rejected .status {
-    background-color: $rebuttedRed !important;
+  background-color: $rebuttedRed !important;
 }
 
 .message-offline-icons {
-    float: left;
-    margin-right: 10px;
-    margin-top: 1px;
+  float: left;
+  margin-right: 10px;
+  margin-top: 1px;
 }
 
-body[data-offline-mode="light-off"] section.setTranslationPending .status, section.setTranslationError .status {
-    background-image: url(../../img/offline-bg.png) !important;
-    background-color: #0798bc !important;
-    background-repeat: no-repeat !important;
-    background-position: center center;
-    background-size: 20px 40px;
+body[data-offline-mode='light-off'] section.setTranslationPending .status,
+section.setTranslationError .status {
+  background-image: url(../../img/offline-bg.png) !important;
+  background-color: #0798bc !important;
+  background-repeat: no-repeat !important;
+  background-position: center center;
+  background-size: 20px 40px;
 }
 
-body[data-offline-mode="light-off"] .editor.setTranslationPending .status, .editor.setTranslationError .status {
-    background-size: 20px 50px;
+body[data-offline-mode='light-off'] .editor.setTranslationPending .status,
+.editor.setTranslationError .status {
+  background-size: 20px 50px;
 }
 
-body[data-offline-mode="light-off"] .msg span,
+body[data-offline-mode='light-off'] .msg span,
 .lightoff .msg span {
-    vertical-align: middle;
-    margin-top: -3px;
-    font-size: 18px;
-    display: inline-block;
+  vertical-align: middle;
+  margin-top: -3px;
+  font-size: 18px;
+  display: inline-block;
 }
 
 section.editor.status-rejected .status {
-    background-color: $rebuttedRed !important;
+  background-color: $rebuttedRed !important;
 }
 
 section.modified .status {
-    background-image: url(../../img/stripes.png) !important;
-    background-repeat: repeat !important;
-    background-size: 140% !important;
+  background-image: url(../../img/stripes.png) !important;
+  background-repeat: repeat !important;
+  background-size: 140% !important;
 }
 
 section.modified.editor .status {
-    background-size: 200% !important;
+  background-size: 200% !important;
 }
 section.opened.editor .status {
-    height: 100%;
-    position: absolute;
+  height: 100%;
+  position: absolute;
 }
 
-
 .statusmenu {
-    position: absolute;
-    text-align: left;
-    top: 0;
-    margin: 50px -3px 0 -200px;
-    background: #ffffff;
-    width: 143px;
-    z-index: 99999999999999;
-    border-bottom: none;
-    right: -10px;
-    box-shadow: 0 0 4px rgba(102, 102, 102, 0.45);
-    font-weight: bold;
-    -webkit-transition: all 100ms ease-in;
-    transition: all 100ms ease-in;
+  position: absolute;
+  text-align: left;
+  top: 0;
+  margin: 50px -3px 0 -200px;
+  background: #ffffff;
+  width: 143px;
+  z-index: 99999999999999;
+  border-bottom: none;
+  right: -10px;
+  box-shadow: 0 0 4px rgba(102, 102, 102, 0.45);
+  font-weight: bold;
+  -webkit-transition: all 100ms ease-in;
+  transition: all 100ms ease-in;
 }
 
 .editor .statusmenu {
-    top: 0;
-    margin: 100px -3px 0 -200px;
+  top: 0;
+  margin: 100px -3px 0 -200px;
 }
 
 .statusmenu li {
-    background: #ffffff;
-    margin: 0;
-    padding: 0;
-    float: none;
-    width: 100%;
+  background: #ffffff;
+  margin: 0;
+  padding: 0;
+  float: none;
+  width: 100%;
 }
 
 .statusmenu li:hover {
-    background: #f2f4f7;
+  background: #f2f4f7;
 }
 
 .statusmenu li a {
-    padding: 7px 20px 7px 10px;
-    display: block;
-    color: #000;
-    text-decoration: none;
+  padding: 7px 20px 7px 10px;
+  display: block;
+  color: #000;
+  text-decoration: none;
 }
 
 .arrow-mcolor {
-    display: block;
-    width: 20px;
-    height: 20px;
-    background: url(../../img/arrow-menucolor.png) 0 0 no-repeat;
-    position: absolute;
-    margin: -8px 0 0 123px;
-    background-size: 10px 8px
+  display: block;
+  width: 20px;
+  height: 20px;
+  background: url(../../img/arrow-menucolor.png) 0 0 no-repeat;
+  position: absolute;
+  margin: -8px 0 0 123px;
+  background-size: 10px 8px;
 }
 
 .arrow {
-    border: 0 !important;
+  border: 0 !important;
 }
-.arrow-mcolor{display:block;width:20px;height:20px;background:url(../../img/arrow-menucolor.png) 0 0 no-repeat;position:absolute;margin:-8px 0 0 123px;background-size:10px 8px}
-.arrow{border:0 !important; }
-.approvedStatusMenu{border-right:9px solid $approvedGreen}
-.translatedStatusMenu{border-right:9px solid $translatedBlue}
-.rejectedStatusMenu{border-right:9px solid $rebuttedRed}
-.draftStatusMenu{order-right: 9px solid $grey1;}
+.arrow-mcolor {
+  display: block;
+  width: 20px;
+  height: 20px;
+  background: url(../../img/arrow-menucolor.png) 0 0 no-repeat;
+  position: absolute;
+  margin: -8px 0 0 123px;
+  background-size: 10px 8px;
+}
+.arrow {
+  border: 0 !important;
+}
+.approvedStatusMenu {
+  border-right: 9px solid $approvedGreen;
+}
+.translatedStatusMenu {
+  border-right: 9px solid $translatedBlue;
+}
+.rejectedStatusMenu {
+  border-right: 9px solid $rebuttedRed;
+}
+.draftStatusMenu {
+  order-right: 9px solid $grey1;
+}
 
 /* overlay box */
 .boxoverlay {
-    display: none;
-    background: #fff;
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    z-index: 99999999;
-    top: 0;
-    left: 0;
-    opacity: 0.6;
-    filter: alpha(opacity=70); /*per Internet Explorer 6-7*/
-    filter: alpha(opacity=50); /*per Internet Explorer 8*/
-
+  display: none;
+  background: #fff;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  z-index: 99999999;
+  top: 0;
+  left: 0;
+  opacity: 0.6;
+  filter: alpha(opacity=70); /*per Internet Explorer 6-7*/
+  filter: alpha(opacity=50); /*per Internet Explorer 8*/
 }
 
 #box {
-    width: 90%;
-    text-align: center;
-    height: 400px;
-    background: #fff;
-    margin: 0 auto;
+  width: 90%;
+  text-align: center;
+  height: 400px;
+  background: #fff;
+  margin: 0 auto;
 }
 
 .secondline li {
-    background: #f5f5f5 !important
+  background: #f5f5f5 !important;
 }
 
 #box .h-editor {
-    color: #fff;
-    padding: 4px 0 0 0px;
-    border-bottom: 1px solid $grey2;
-    margin-bottom: 30px;
-    background: #efefef
+  color: #fff;
+  padding: 4px 0 0 0px;
+  border-bottom: 1px solid $grey2;
+  margin-bottom: 30px;
+  background: #efefef;
 }
 
 #box .x {
-    margin-top: -2px;
+  margin-top: -2px;
 }
 
 #box .title li {
-    background: #fff;
-    border: 0;
+  background: #fff;
+  border: 0;
 }
 
 #box ul {
-    clear: both;
-    font-size: 16px;
-    margin: 0 0 0 70px;
-    float: left;
-    width: 90%;
-    list-style: none
+  clear: both;
+  font-size: 16px;
+  margin: 0 0 0 70px;
+  float: left;
+  width: 90%;
+  list-style: none;
 }
 
 #box li {
-    padding: 10px;
-    width: 10%;
-    border-right: 1px solid $grey2;
-    border-bottom: 1px solid $grey2;
-    float: left;
-    text-align: right;
-    background: #efefef
+  padding: 10px;
+  width: 10%;
+  border-right: 1px solid $grey2;
+  border-bottom: 1px solid $grey2;
+  float: left;
+  text-align: right;
+  background: #efefef;
 }
 
 #box .first {
-    width: 40% !important;
-    text-align: left !important;
-    border-left: 1px solid $grey2
+  width: 40% !important;
+  text-align: left !important;
+  border-left: 1px solid $grey2;
 }
 
 .hide {
-    display: none
+  display: none;
 }
 
 .hidden {
-    visibility: hidden !important
+  visibility: hidden !important;
 }
 
 .source .original {
-    display: none
+  display: none;
 }
 
 .bold {
-    font-weight: 700}
+  font-weight: 700;
+}
 
 .per-orange {
-    background: $rebuttedRed !important;
-    color: #fff !important
+  background: $rebuttedRed !important;
+  color: #fff !important;
 }
 
 .per-blue {
-    background: $translatedBlue !important;
-    color: #fff !important
+  background: $translatedBlue !important;
+  color: #fff !important;
 }
 
 .per-green {
-    background: $approvedGreen !important;
-    color: #fff !important
+  background: $approvedGreen !important;
+  color: #fff !important;
 }
 
 .per-yellow {
-    background: $orangeDefault !important;
-    color: #333 !important
+  background: $orangeDefault !important;
+  color: #333 !important;
 }
 
 .per-red {
-    background: $redDefault !important;
-    color: #fff !important
+  background: $redDefault !important;
+  color: #fff !important;
 }
 
 .per-gray {
-    background: $grey3 !important;
-    color: #333 !important
+  background: $grey3 !important;
+  color: #333 !important;
 }
 
-.graysmall-details .per-yellow, .graysmall-details .per-blue, .graysmall-details .per-orange, .graysmall-details .per-green {
-    width: 35px !important;
-    text-align: center;
-    display: block !important;
+.graysmall-details .per-yellow,
+.graysmall-details .per-blue,
+.graysmall-details .per-orange,
+.graysmall-details .per-green {
+  width: 35px !important;
+  text-align: center;
+  display: block !important;
 }
 
 .timetoedit {
-    font-size: 12px;
-    text-align: left;
-    margin: 15px -55px 0 0;
-    color: #666666;
-    position: absolute;
-    right: 0;
+  font-size: 12px;
+  text-align: left;
+  margin: 15px -55px 0 0;
+  color: #666666;
+  position: absolute;
+  right: 0;
 }
 
 .editarea #placeHolder {
-    display: none;
+  display: none;
 }
 
 .editarea span.placeholder {
-    display: none;
+  display: none;
 }
 
 /* We should check if we have the rights di distribute Calibri in an open-source project... */
 
 @font-face {
-    font-family: Calibri;
-    src: local(Calibri),
-    url('../fonts/calibri-webfont.woff') format('woff'),
+  font-family: Calibri;
+  src: local(Calibri), url('../fonts/calibri-webfont.woff') format('woff'),
     url('../fonts/calibri-webfont.ttf') format('truetype'),
     url('../fonts/calibri-webfont.eot'),
     url('../fonts/calibri-webfont.eot?#iefix') format('embedded-opentype');
 }
 
 @font-face {
-    font-family: Calibri;
-    font-weight: bold;
-    src: local('Calibri Bold'),
+  font-family: Calibri;
+  font-weight: bold;
+  src: local('Calibri Bold'),
     url('../fonts/calibri_bold-webfont.woff') format('woff'),
     url('../fonts/calibri_bold-webfont.ttf') format('truetype'),
     url('../fonts/calibri_bold-webfont.eot'),
@@ -3205,518 +3232,525 @@ section.opened.editor .status {
 }
 
 .sendbox {
-    position: absolute;
-    bottom: 25px
+  position: absolute;
+  bottom: 25px;
 }
 
 .end-message-col2 p {
-    color: #8a8a8a;
-    margin: 0 0 5px 0;
-    font-size: 16px
+  color: #8a8a8a;
+  margin: 0 0 5px 0;
+  font-size: 16px;
 }
 
 .or-message {
-    text-align: center;
-    width: 320px
+  text-align: center;
+  width: 320px;
 }
 
 .end-message-col1 {
-    float: left;
-    margin: 0;
-    width: 150px;
+  float: left;
+  margin: 0;
+  width: 150px;
 }
 
 .end-message-col1 img {
-    float: left;
-    margin: 0px 0 0 0;
+  float: left;
+  margin: 0px 0 0 0;
 }
 
 .end-message-col1 p {
-    position: absolute;
-    bottom: 20px;
-    width: 300px;
-    left: 20px;
-    text-align: left;
-    color: #fff
+  position: absolute;
+  bottom: 20px;
+  width: 300px;
+  left: 20px;
+  text-align: left;
+  color: #fff;
 }
 
-.end-message-col1 p span, .end-message-col1 h3 span {
-    color: $translatedBlue
+.end-message-col1 p span,
+.end-message-col1 h3 span {
+  color: $translatedBlue;
 }
 
 .end-message-col2 input {
-    padding: 5px;
-    margin-top: 2px;
-    width: 300px
+  padding: 5px;
+  margin-top: 2px;
+  width: 300px;
 }
 
-
 @-webkit-keyframes Floatingx {
-    from {
-        -webkit-transform: translate(0, 0px);
-    }
-    65% {
-        -webkit-transform: translate(0, 15px);
-    }
-    to {
-        -webkit-transform: translate(0, -0px);
-    }
+  from {
+    -webkit-transform: translate(0, 0px);
+  }
+  65% {
+    -webkit-transform: translate(0, 15px);
+  }
+  to {
+    -webkit-transform: translate(0, -0px);
+  }
 }
 
 .d-open {
-    bottom: 20px !important;
+  bottom: 20px !important;
 }
 
 @media screen and (min-width: 1600px) {
+  .header-menu {
+    margin-right: 22px;
+  }
 
-    .header-menu {
-        margin-right: 22px
-    }
+  .text .source.item,
+  .text .target.item,
+  .white li {
+    width: 46% !important;
+  }
 
-    .text .source.item,
-    .text .target.item,
-    .white li {
-        width: 46% !important;
-    }
-
-    .track-changes {
-        width: 46.2% !important;
-        margin-right: 2.6% !important;
-    }
-
+  .track-changes {
+    width: 46.2% !important;
+    margin-right: 2.6% !important;
+  }
 }
 
 @media screen and (max-width: 1380px) {
-    /*.buttons{margin:-15px 43px 0 0 !important;}*/
-    .graysmall li {
-        width: 45.5%;
-    }
-    .header-menu {
-        margin-right: 18px
-    }
-    #stat-completion, #stat-wph {
-        display: block;
-    }
+  /*.buttons{margin:-15px 43px 0 0 !important;}*/
+  .graysmall li {
+    width: 45.5%;
+  }
+  .header-menu {
+    margin-right: 18px;
+  }
+  #stat-completion,
+  #stat-wph {
+    display: block;
+  }
 
-    p.split-shortcut, .sid .txt {
-        font-size: 10px;
-    }
-    .sid {
-        width: 5.3%;
-        left: -5.7%;
-    }
-    section.editor .sid {
-        left: -5.1%;
-        width: 4.5%;
-    }
-    //section.editor.slide-right {
-    //    width: 71% !important;
-    //}
-    section.slide-right .sid{
-        left: -6.5%;
-    }
-    section.editor.slide-right .sid{
-        left: -6%;
-    }
+  p.split-shortcut,
+  .sid .txt {
+    font-size: 10px;
+  }
+  .sid {
+    width: 5.3%;
+    left: -5.7%;
+  }
+  section.editor .sid {
+    left: -5.1%;
+    width: 4.5%;
+  }
+  //section.editor.slide-right {
+  //    width: 71% !important;
+  //}
+  section.slide-right .sid {
+    left: -6.5%;
+  }
+  section.editor.slide-right .sid {
+    left: -6%;
+  }
 }
 
 @media screen and (max-width: 1280px) {
-    /*.buttons{margin:-15px 42px 0 0 !important;}*/
-    .header-menu {
-        margin-right: 16px
-    }
+  /*.buttons{margin:-15px 42px 0 0 !important;}*/
+  .header-menu {
+    margin-right: 16px;
+  }
 
-    .text .source.item,
-    .text .target.item,
-    .white li {
-        width: 45% !important
-    }
+  .text .source.item,
+  .text .target.item,
+  .white li {
+    width: 45% !important;
+  }
 
-    .target.item {
-        margin-left: 10px !important
-    }
+  .target.item {
+    margin-left: 10px !important;
+  }
 
-    .alternatives .graysmall .sugg-target {
-        width: 37% !important;
-    }
+  .alternatives .graysmall .sugg-target {
+    width: 37% !important;
+  }
 }
 
 @media screen and (max-width: 1260px) {
-
-    .text .item, .white li, .track-changes {
-        width: 44.5% !important
-    }
-
+  .text .item,
+  .white li,
+  .track-changes {
+    width: 44.5% !important;
+  }
 }
 
 @media screen and (min-width: 1181px) {
-    .languages {
-        text-indent: -85px;
-    }
+  .languages {
+    text-indent: -85px;
+  }
 
-    .glossary .graysmall .b,
-    .concordances .graysmall .b,
-    .alternatives .graysmall .b{
-        /*padding-left:85px !important;*/
-        width: 41% !important
-    }
+  .glossary .graysmall .b,
+  .concordances .graysmall .b,
+  .alternatives .graysmall .b {
+    /*padding-left:85px !important;*/
+    width: 41% !important;
+  }
 
-    .graysmall-message {
-        left: 15px !important
-    }
-
+  .graysmall-message {
+    left: 15px !important;
+  }
 }
 
 @media screen and (max-width: 1180px) {
-    .con-input {
-        width: 70%;
-    }
+  .con-input {
+    width: 70%;
+  }
 
-    .second {
-        width: 30%;
-    }
+  .second {
+    width: 30%;
+  }
 
-    .number {
-        left: -40px;
-    }
+  .number {
+    left: -40px;
+  }
 
-    .main {
-        width: 90.3%;
-        margin-left: 3%;
-    }
+  .main {
+    width: 90.3%;
+    margin-left: 3%;
+  }
 
-    .number {
-        left: -52px;
-    }
+  .number {
+    left: -52px;
+  }
 
-    .editarea, .source { /* word-break: break-all */
-    }
+  .editarea,
+  .source {
+    /* word-break: break-all */
+  }
 
-    .translated,
-    .draft,
-    .approved,
-    .guesstags {
-        padding: 8px 6px;
-    }
+  .translated,
+  .draft,
+  .approved,
+  .guesstags {
+    padding: 8px 6px;
+  }
 
-    .meter {
-        width: 10%;
-    }
+  .meter {
+    width: 10%;
+  }
 
-    .con-input {
-        width: 63%;
-    }
+  .con-input {
+    width: 63%;
+  }
 
-    .con-input {
-        width: 62% !important;
-    }
+  .con-input {
+    width: 62% !important;
+  }
 
-    .languages {
-        text-indent: -62px
-    }
+  .languages {
+    text-indent: -62px;
+  }
 
-    .review .wrapper {
-        width: 100%;
-    }
+  .review .wrapper {
+    width: 100%;
+  }
 
-    .text .target {
-        padding-left: 45px;
-    }
+  .text .target {
+    padding-left: 45px;
+  }
 
-    .graysmall li {
-        width: 43%;
-    }
+  .graysmall li {
+    width: 43%;
+  }
 
-    #notifbox, #filterSwitch {
-        width: 45px;
-    }
+  #notifbox,
+  #filterSwitch {
+    width: 45px;
+  }
 
-    .search-editarea {
-        width: 200px !important
-    }
+  .search-editarea {
+    width: 200px !important;
+  }
 
-    .text .source.item,
-    .text .target.item,
-    .white li, .track-changes {
-        width: 44% !important
-    }
+  .text .source.item,
+  .text .target.item,
+  .white li,
+  .track-changes {
+    width: 44% !important;
+  }
 
-    section.editor {
-        width: 87%;
-        margin-left: 6%;
-    }
+  section.editor {
+    width: 87%;
+    margin-left: 6%;
+  }
 
-    .sid {
-        width: 6%;
-        left: -6.5%;
-    }
-    section.editor .sid {
-        left: -6.5%;
-        width: 6%;
-    }
-    section {
-        width: 86%;
-        margin-left: 6%;
-    }
-    section.editor.slide-right .sid {
-        left: -7%;
-        width: 6%;
-    }
-    section.editor.slide-right {
-        width: 70% !important;
-    }
-    section.slide-right {
-        width: 68% !important;
-    }
-    section.slide-right .sid {
-        left: -8%;
-    }
+  .sid {
+    width: 6%;
+    left: -6.5%;
+  }
+  section.editor .sid {
+    left: -6.5%;
+    width: 6%;
+  }
+  section {
+    width: 86%;
+    margin-left: 6%;
+  }
+  section.editor.slide-right .sid {
+    left: -7%;
+    width: 6%;
+  }
+  section.editor.slide-right {
+    width: 70% !important;
+  }
+  section.slide-right {
+    width: 68% !important;
+  }
+  section.slide-right .sid {
+    left: -8%;
+  }
 }
 
 @media screen and (max-width: 1100px) {
-    #notifbox, #filterSwitch {
-        width: 45px;
-    }
+  #notifbox,
+  #filterSwitch {
+    width: 45px;
+  }
 
-    .cattool #quality-report {
-        padding: 0 !important;
-    }
+  .cattool #quality-report {
+    padding: 0 !important;
+  }
 
-    .header-menu li a, .header-menu li input {
-        font-size: 14px;
-    }
-    .header-menu li:first-child {
-        margin-right: 5px;
-    }
+  .header-menu li a,
+  .header-menu li input {
+    font-size: 14px;
+  }
+  .header-menu li:first-child {
+    margin-right: 5px;
+  }
 
-    .header-dropdown-menu {
-        margin-right: 5px;
-    }
+  .header-dropdown-menu {
+    margin-right: 5px;
+  }
 }
 
 li.tag-mismatch {
-    display: none;
-    position: relative;
-    text-indent: -9999px;
-    width: 20px !important;
-    height: 20px !important;
-    overflow: hidden;
-    background: red;
+  display: none;
+  position: relative;
+  text-indent: -9999px;
+  width: 20px !important;
+  height: 20px !important;
+  overflow: hidden;
+  background: red;
 }
 
 section.mismatch li.tag-mismatch {
-    display: block;
+  display: block;
 }
 
 /*RTL language*/
-.editarea.rtl, .search-editarea.rtl, .source.rtl, .graysmall li.rtl {
-    direction: rtl !important;
-    text-align: right !important;
+.editarea.rtl,
+.search-editarea.rtl,
+.source.rtl,
+.graysmall li.rtl {
+  direction: rtl !important;
+  text-align: right !important;
 }
 
 body.rtl-source section .source,
 body.rtl-target section .targetarea,
 body.rtl-source .footer .sugg-source,
 body.rtl-target .footer .sugg-target {
-    direction: rtl !important;
-    text-align: right !important;
+  direction: rtl !important;
+  text-align: right !important;
 }
 body.rtl-target section.ice-locked .target {
-    text-align: right;
+  text-align: right;
 }
-
 
 body.archived ul.buttons,
 body.archived ul.header-menu,
 body.archived .footer {
-    display: none !important;
+  display: none !important;
 }
 
 #authentication {
-    float: right;
-    margin-left: 50px;
+  float: right;
+  margin-left: 50px;
 }
 
 p.percent {
-    margin-left: -10px;
-    margin-right: 10px;
+  margin-left: -10px;
+  margin-right: 10px;
 }
 
 .dialog form {
-    font-size: 70%;
+  font-size: 70%;
 }
 
 .misspelled {
-    border-bottom: 1px dashed red;
+  border-bottom: 1px dashed red;
 }
 
 #spellCheck {
-    border-bottom: 1px dotted $grey2;
+  border-bottom: 1px dotted $grey2;
 }
 
 #spellCheck .label {
-    color: #888;
-    font-style: italic;
+  color: #888;
+  font-style: italic;
 }
 
 #spellCheck .words {
-    display: block;
-    color: #000;
-    font-weight: bold;
-    margin-left: 10px;
-    text-decoration: none;
-    margin-top: 5px;
+  display: block;
+  color: #000;
+  font-weight: bold;
+  margin-left: 10px;
+  text-decoration: none;
+  margin-top: 5px;
 }
 
 #spellCheck .words:hover {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 #spellCheck .add {
-    display: block;
-    color: #000;
-    text-decoration: none;
-    margin-top: 5px;
-    border-top: 1px dotted $grey2;
+  display: block;
+  color: #000;
+  text-decoration: none;
+  margin-top: 5px;
+  border-top: 1px dotted $grey2;
 }
 
 .save-warning {
-    display: none;
-    width: 6px;
-    height: 6px;
-    margin-top: 0;
-    margin-left: 101%;
-    background: red;
+  display: none;
+  width: 6px;
+  height: 6px;
+  margin-top: 0;
+  margin-left: 101%;
+  background: red;
 }
 
 section.modified .save-warning {
-    display: none;
+  display: none;
 }
 
 #advancedOptions .more-options {
-    font-size: 25px;
+  font-size: 25px;
 }
 
 #advancedOptions .more-options:hover {
-    color: $grey2;
+  color: $grey2;
 }
 
 #advancedOptions .more-options:before {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 #filterSwitch .numbererror {
-    display: none;
-    margin: -28px 0 0 30px !important;
+  display: none;
+  margin: -28px 0 0 30px !important;
 }
 
 body.searchActive #filterSwitch .numbererror {
-    display: block;
+  display: block;
 }
 
 body.searchActive #filterSwitch .numbererror:empty {
-    display: none;
+  display: none;
 }
 
 .tag-autocomplete {
-    display: block;
-    position: absolute;
-    z-index: 99999;
-    background: #eee;
-    border: 1px solid #999;
-    min-width: 100px;
-    padding: 1px;
-    max-height: 400px;
-    overflow-y: auto;
+  display: block;
+  position: absolute;
+  z-index: 99999;
+  background: #eee;
+  border: 1px solid #999;
+  min-width: 100px;
+  padding: 1px;
+  max-height: 400px;
+  overflow-y: auto;
 }
 
 .tag-autocomplete.empty {
-    display: none;
+  display: none;
 }
 
 .tag-autocomplete li {
-    display: block;
-    text-align: left;
-    list-style-type: none;
-    z-index: 99999999999999;
-    font-size: 80%;
+  display: block;
+  text-align: left;
+  list-style-type: none;
+  z-index: 99999999999999;
+  font-size: 80%;
 }
 
 .tag-autocomplete li.current {
-    background: #00C1E6;
-    color: #fff;
+  background: #00c1e6;
+  color: #fff;
 }
 
 .tag-autocomplete li.hidden {
-    display: none;
+  display: none;
 }
 
 .popup-settings .popup {
-    width: 60% !important;
-    margin: 0 !important;
-    left: 20% !important;
-    top: 5%;
+  width: 60% !important;
+  margin: 0 !important;
+  left: 20% !important;
+  top: 5%;
 }
 
 .popup-settings .tab:first-of-type {
-    display: block;
+  display: block;
 }
 
 .popup-settings #settings-shortcuts .list {
-    margin: 10px;
-    text-align: left;
+  margin: 10px;
+  text-align: left;
 }
 
 .popup-settings #settings-shortcuts .list tr {
-    vertical-align: top;
+  vertical-align: top;
 }
 
 .popup-settings #settings-shortcuts .list .label {
-    width: 48%;
-    text-align: right;
-    line-height: 130%;
-    padding-top: 6px;
+  width: 48%;
+  text-align: right;
+  line-height: 130%;
+  padding-top: 6px;
 }
 
 .popup-settings #settings-shortcuts .list .combination {
-    padding-left: 20px;
+  padding-left: 20px;
 }
 
 .popup-settings #settings-shortcuts .list .combination .keystroke {
-    border: 1px solid #aaa;
-    padding: 1px 5px;
+  border: 1px solid #aaa;
+  padding: 1px 5px;
 }
 
 .popup-settings #settings-shortcuts .list .combination .keystroke.modified {
-    border-color: red;
+  border-color: red;
 }
 
 .popup-settings #settings-shortcuts .list .combination .keystroke.changing {
-    background: #0798BC;
-    color: #fff;
+  background: #0798bc;
+  color: #fff;
 }
 
 .popup-settings #settings-shortcuts .list .combination .msg {
-    margin-left: 20px;
-    color: #999;
+  margin-left: 20px;
+  color: #999;
 }
 
 .popup-settings #settings-restore {
-    display: none;
+  display: none;
 }
 
 .popup-settings.modified #settings-restore {
-    display: block;
+  display: block;
 }
 
 .editor .source mark.inGlossary {
-    border-bottom: 1px dotted #c0c;
-    cursor: pointer;
+  border-bottom: 1px dotted #c0c;
+  cursor: pointer;
 }
 
 .monad mark.inGlossary {
-    border-bottom: none !important;
-    color: #767676 !important;
+  border-bottom: none !important;
+  color: #767676 !important;
 }
 
 /*.popup-settings #settings-shortcuts .list dt
@@ -3734,37 +3768,37 @@ body.searchActive #filterSwitch .numbererror:empty {
 }*/
 
 ins.diff {
-    background: #C3FFC3;
+  background: #c3ffc3;
 }
 
 del.diff {
-    background: #FFCFCF;
+  background: #ffcfcf;
 }
 
 .tab-marker {
-    color: #999;
-    margin-left: 4px;
-    margin-right: 4px;
-    position: relative;
-    top: 2px;
+  color: #999;
+  margin-left: 4px;
+  margin-right: 4px;
+  position: relative;
+  top: 2px;
 }
 
 .space-marker,
 .nbsp-marker {
-    color: $grey2;
-    position: relative;
-    left: 4px;
-    padding-right: 12px;
-    /*	padding-left: 6px;
+  color: $grey2;
+  position: relative;
+  left: 4px;
+  padding-right: 12px;
+  /*	padding-left: 6px;
 	margin-right: 4px;
 	margin-left: 4px;*/
-    opacity: 0.2;
-    /*width: 20px !important;*/
-    top: 3px;
-    font-size: 15px;
-    background: url(../../img/dot.png) 0px 0px no-repeat;
-    background-size: 6px;
-    /*
+  opacity: 0.2;
+  /*width: 20px !important;*/
+  top: 3px;
+  font-size: 15px;
+  background: url(../../img/dot.png) 0px 0px no-repeat;
+  background-size: 6px;
+  /*
 	color: $grey2;
 	position: relative;
 	padding-left: 4px;
@@ -3775,217 +3809,215 @@ del.diff {
 
 section .toolbar .tagModeToggle,
 section .toolbar .autofillTag {
-    float: left;
-    font-size: 60%;
-    text-decoration: none;
-    display: none;
+  float: left;
+  font-size: 60%;
+  text-decoration: none;
+  display: none;
 }
 
 section .toolbar span {
-    font-size: 120%;
-    padding-top: 5px;
-    margin-left: 1px;
+  font-size: 120%;
+  padding-top: 5px;
+  margin-left: 1px;
 }
 
 .tagModeToggle span:before {
-    float: left;
+  float: left;
 }
 
 .tagModeToggle.active {
-    padding: 2px 1px 2px 0;
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-    background-color: #eee;
-    background-image: -webkit-linear-gradient(top, #eee, #e0e0e0);
-
+  padding: 2px 1px 2px 0;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  background-color: #eee;
+  background-image: -webkit-linear-gradient(top, #eee, #e0e0e0);
 }
 
 .tagModeToggle.active span {
-    font-size: 100% !important;
+  font-size: 100% !important;
 }
 
 .autofillTag {
-    display: block;
-    float: left;
-    cursor: pointer;
-    color: #444 !important;
+  display: block;
+  float: left;
+  cursor: pointer;
+  color: #444 !important;
 }
 
 .autofillTag:before {
-    content: "\e23a";
-    font-size: 19px;
-    display: block;
+  content: '\e23a';
+  font-size: 19px;
+  display: block;
 }
 
 .tagLockCustomize {
-    display: block;
-    float: left;
-    cursor: pointer;
-    color: #444 !important;
-    text-decoration: none;
+  display: block;
+  float: left;
+  cursor: pointer;
+  color: #444 !important;
+  text-decoration: none;
 }
 
 .tagLockCustomize:before {
-    font-size: 19px;
-    display: block;
-    margin-left: 5px;
+  font-size: 19px;
+  display: block;
+  margin-left: 5px;
 }
 
 section .toolbar .autofillTag {
-    float: left;
-    font-size: 60%;
-    text-decoration: none;
-    display: block;
+  float: left;
+  font-size: 60%;
+  text-decoration: none;
+  display: block;
 }
 
 .editToolbar {
-    /*float: left;*/
-    position: relative;
-    display: block;
-    visibility: hidden;
-    margin-top: -6px;
-    padding-top: 4px;
-    color: $grey1;
+  /*float: left;*/
+  position: relative;
+  display: block;
+  visibility: hidden;
+  margin-top: -6px;
+  padding-top: 4px;
+  color: $grey1;
 }
 
 .editToolbar.visible {
-    visibility: visible;
+  visibility: visible;
 }
 
 .editToolbar li {
-    float: left;
-    width: 16px;
-    height: 16px;
-    margin-right: 10px;
-    cursor: pointer;
+  float: left;
+  width: 16px;
+  height: 16px;
+  margin-right: 10px;
+  cursor: pointer;
 }
 
 .editarea span.softReturn,
 .source span.softReturn,
 .sugg-target span.softReturn,
 .sugg-source span.softReturn, /*to be tested*/
-.track-changes span.softReturn
-{
-    display: inline !important;
-    margin-left: 6px;
-    padding: 1px 2px 3px 40px;
-    background-image: url(../../img/soft-return1.png);
-    background-size: 16px;
-    background-repeat: no-repeat;
-    background-position: center left;
-    width: 20px;
-    position: relative;
-    direction: ltr;
-    text-align: unset;
+.track-changes span.softReturn {
+  display: inline !important;
+  margin-left: 6px;
+  padding: 1px 2px 3px 40px;
+  background-image: url(../../img/soft-return1.png);
+  background-size: 16px;
+  background-repeat: no-repeat;
+  background-position: center left;
+  width: 20px;
+  position: relative;
+  direction: ltr;
+  text-align: unset;
 }
 
 .editarea span.hardReturn,
 .source span.hardReturn,
 .sugg-target span.hardReturn,
 .sugg-source span.hardReturn, /*to be tested*/
-.track-changes span.hardReturn
-{
-    display: inline !important;
-    margin-left: 6px;
-    padding: 1px 2px 3px 40px;
-    background-image: url(../../img/hard-return.png);
-    background-size: 16px;
-    background-repeat: no-repeat;
-    background-position: center left;
-    width: 20px;
-    position: relative;
-    direction: ltr;
-    text-align: unset;
+.track-changes span.hardReturn {
+  display: inline !important;
+  margin-left: 6px;
+  padding: 1px 2px 3px 40px;
+  background-image: url(../../img/hard-return.png);
+  background-size: 16px;
+  background-repeat: no-repeat;
+  background-position: center left;
+  width: 20px;
+  position: relative;
+  direction: ltr;
+  text-align: unset;
 }
 
 .editarea br.soft {
-    display: block;
-    margin: -10px 0px 3px 40px;
-    padding: 1px 2px 3px 40px;
-    border: 1px dotted green;
-    font-size: 8px;
-    line-height: 8px;
-    height: 8px;
-    background: yellow;
-    background-image: url("https://sites.google.com/a/fundoogeek.com/home/images/WhiteStarinRedCircle.gif");
-    background-repeat: no-repeat;
-    background-position: top left;
-    background-origin: content-box;
-    color: blue;
-    content: "A";
-    width: 20px;
-    position: relative;
-    top: -7px;
+  display: block;
+  margin: -10px 0px 3px 40px;
+  padding: 1px 2px 3px 40px;
+  border: 1px dotted green;
+  font-size: 8px;
+  line-height: 8px;
+  height: 8px;
+  background: yellow;
+  background-image: url('https://sites.google.com/a/fundoogeek.com/home/images/WhiteStarinRedCircle.gif');
+  background-repeat: no-repeat;
+  background-position: top left;
+  background-origin: content-box;
+  color: blue;
+  content: 'A';
+  width: 20px;
+  position: relative;
+  top: -7px;
 }
 
 .editarea span.startRow {
-    width: 0px;
-    float: left;
+  width: 0px;
+  float: left;
 }
 
 .split {
-    border: 1px solid #5F5F5F;
-    cursor: pointer !important;
-    font-size: 17px;
-    background-color: #9E9E9E;
-    border-radius: 2px;
-    color: #ffffff;
-    margin-bottom: 0px;
-    top: 2px;
-    padding: 0;
-    width: 25px;
-    height: 25px;
-    outline: none;
-    margin-top: 10px;
+  border: 1px solid #5f5f5f;
+  cursor: pointer !important;
+  font-size: 17px;
+  background-color: #9e9e9e;
+  border-radius: 2px;
+  color: #ffffff;
+  margin-bottom: 0px;
+  top: 2px;
+  padding: 0;
+  width: 25px;
+  height: 25px;
+  outline: none;
+  margin-top: 10px;
 }
 
 .split i {
-    padding: 0;
-    margin: 0;
-    width: 25px;
-    height: 25px;
+  padding: 0;
+  margin: 0;
+  width: 25px;
+  height: 25px;
 }
 
 .split .icon-split:before {
-    position: relative;
-    top: 3px;
+  position: relative;
+  top: 3px;
 }
 
 .sid .actions.disabled .split {
-    cursor: no-drop !important;
+  cursor: no-drop !important;
 }
 
 .editor.split-action .actions .split {
-    background: $translatedBlue;
+  background: $translatedBlue;
 }
 
 .splitBar .buttons a {
-
 }
 
 body:not(.tagModes) .tagModeToggle {
-    display: none;
+  display: none;
 }
-body.rtl-source.tagModes.tagmode-default-extended .suggestion_source .monad.marker,
+body.rtl-source.tagModes.tagmode-default-extended
+  .suggestion_source
+  .monad.marker,
 body.rtl-source.tagModes.tagmode-default-extended .source .monad.marker,
 body.rtl-target.tagModes.tagmode-default-extended .editarea .monad.marker,
 body.rtl-target.tagModes.tagmode-default-extended .spliArea .monad.marker,
 body.rtl-target.tagModes.tagmode-default-extended .translation .monad.marker {
-    direction: ltr;
+  direction: ltr;
 }
 
 .monad .marker-inside {
-    display: none;
+  display: none;
 }
 
 .tagModeToggle,
 .autofillTag {
-    padding: 4px 2px 0px 2px;
-    border: 1px solid #fff;
-    color: $grey1 !important;
+  padding: 4px 2px 0px 2px;
+  border: 1px solid #fff;
+  color: $grey1 !important;
 }
 
 .autofillTag {
-    padding-top: 0;
+  padding-top: 0;
 }
 
 .tagLockCustomize:hover,
@@ -3994,335 +4026,342 @@ body.rtl-target.tagModes.tagmode-default-extended .translation .monad.marker {
 .tagModeToggle.active,
 .autofillTag:hover,
 .autofillTag.active {
-    color: #333 !important;
+  color: #333 !important;
 }
 
 .icon-tag-expand {
-    display: none;
+  display: none;
 }
 
 section .toolbar {
-    display: none;
-    margin-left: -10px;
+  display: none;
+  margin-left: -10px;
 }
 
 section.editor .toolbar {
-    display: block;
+  display: block;
 }
 
 .tagModeToggle span,
 .autofillTag span {
-    float: left;
+  float: left;
 }
 
 .tagModeToggle.active span.icon-chevron-right {
-    margin-left: 0px;
+  margin-left: 0px;
 }
 
 .tagModeToggle.active .icon-tag-expand {
-    display: inline-block;
-    font-weight: bold;
-    padding-top: 6px;
+  display: inline-block;
+  font-weight: bold;
+  padding-top: 6px;
 }
 
 .textarea-container .tagMode {
-    position: absolute;
-    display: none;
-    width: 100%;
-    text-align: right;
-    margin-top: -23px;
+  position: absolute;
+  display: none;
+  width: 100%;
+  text-align: right;
+  margin-top: -23px;
 }
 
 .tagModeToggle,
 .autofillTag,
 .tagLockCustomize {
-    margin-right: 10px;
+  margin-right: 10px;
 }
 
 body.tagModes .editor.hasTags .textarea-container .tagMode {
-    display: block;
+  display: block;
 }
 
 body.tagModes .editor.hasTagsToggle .toolbar .tagModeToggle,
 body.tagModes .editor.hasTagsToggle .toolbar .tagLockCustomize,
 body .editor.hasTagsAutofill .toolbar .autofillTag {
-    display: block;
+  display: block;
 }
 
 body.tagmarkDisabled .toolbar .tagModeToggle,
 body.tagmarkDisabled .toolbar .autofillTag {
-    display: none !important;
+  display: none !important;
 }
 
 .tagLockCustomize.unlock:before {
-    content: "\e990";
+  content: '\e990';
 }
 
-.tagModeToggle span.icon-expand, .tagModeToggle span.icon-compress {
-    -ms-transform: rotate(45deg);
-    -webkit-transform: rotate(45deg);
-    transform: rotate(45deg);
-    display: inline-block;
+.tagModeToggle span.icon-expand,
+.tagModeToggle span.icon-compress {
+  -ms-transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+  display: inline-block;
 }
 
 .textarea-container .tagMode li {
-    display: inline-block;
-    width: 40px;
-    height: 20px;
-    text-align: center;
-    font-weight: bold;
-    opacity: 0.3;
-    cursor: pointer
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+  text-align: center;
+  font-weight: bold;
+  opacity: 0.3;
+  cursor: pointer;
 }
 
-body.tagmode-default-compressed .editor[data-tagmode='crunched'] .textarea-container .tagMode li.crunched,
+body.tagmode-default-compressed
+  .editor[data-tagmode='crunched']
+  .textarea-container
+  .tagMode
+  li.crunched,
 body.tagmode-default-extended .textarea-container .tagMode li.extended,
 .editor[data-tagmode='extended'] .textarea-container .tagMode li.extended,
 .textarea-container .tagMode li:hover {
-    opacity: 1;
+  opacity: 1;
 }
 
-body.editlog .breadcrumbs #pname, body.reviselog .breadcrumbs #pname {
-    background: none;
+body.editlog .breadcrumbs #pname,
+body.reviselog .breadcrumbs #pname {
+  background: none;
 }
 
 @keyframes fadein {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 0.6
-    }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.6;
+  }
 }
 
 /* Firefox */
 @-moz-keyframes fadein {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 0.6;
-    }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.6;
+  }
 }
 
 /* Safari and Chrome */
 @-webkit-keyframes fadein {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 0.6;
-    }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.6;
+  }
 }
 
 /* Internet Explorer */
 @-ms-keyframes fadein {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 0.6;
-    }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.6;
+  }
 }
 
 /* Opera */
 @-o-keyframes fadein {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 0.6;
-    }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.6;
+  }
 }
 
 .noConnection {
-    -webkit-animation: fadein 0.5s; /* Safari and Chrome */
-    -moz-animation: fadein 0.5s; /* Firefox */
-    -ms-animation: fadein 0.5s; /* Internet Explorer */
-    -o-animation: fadein 0.5s; /* Opera */
-    animation: fadein 0.5s;
-    background: rgba(51, 51, 51, 0.47058823529411764);
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 99999999999999;
+  -webkit-animation: fadein 0.5s; /* Safari and Chrome */
+  -moz-animation: fadein 0.5s; /* Firefox */
+  -ms-animation: fadein 0.5s; /* Internet Explorer */
+  -o-animation: fadein 0.5s; /* Opera */
+  animation: fadein 0.5s;
+  background: rgba(51, 51, 51, 0.47058823529411764);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 99999999999999;
 }
 
-
 .reConnection {
-    -webkit-animation: fadeout 0.5s; /* Safari and Chrome */
-    -moz-animation: fadeout 0.5s; /* Firefox */
-    -ms-animation: fadeout 0.5s; /* Internet Explorer */
-    -o-animation: fadeout 0.5s; /* Opera */
-    animation: fadeout 0.5s;
-    background: rgba(51, 51, 51, 0.47058823529411764);
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 99999999999999;
+  -webkit-animation: fadeout 0.5s; /* Safari and Chrome */
+  -moz-animation: fadeout 0.5s; /* Firefox */
+  -ms-animation: fadeout 0.5s; /* Internet Explorer */
+  -o-animation: fadeout 0.5s; /* Opera */
+  animation: fadeout 0.5s;
+  background: rgba(51, 51, 51, 0.47058823529411764);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 99999999999999;
 }
 
 @keyframes fadeout {
-    from {
-        opacity: 0.6
-    }
-    to {
-        opacity: 0
-    }
+  from {
+    opacity: 0.6;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 /* Firefox */
 @-moz-keyframes fadeout {
-    from {
-        opacity: 0.6
-    }
-    to {
-        opacity: 0
-    }
+  from {
+    opacity: 0.6;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 /* Safari and Chrome */
 @-webkit-keyframes fadeout {
-    from {
-        opacity: 0.6
-    }
-    to {
-        opacity: 0
-    }
+  from {
+    opacity: 0.6;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 /* Internet Explorer */
 @-ms-keyframes fadeout {
-    from {
-        opacity: 0.6
-    }
-    to {
-        opacity: 0
-    }
+  from {
+    opacity: 0.6;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 /* Opera */
 @-o-keyframes fadeout {
-    from {
-        opacity: 0.6
-    }
-    to {
-        opacity: 0
-    }
+  from {
+    opacity: 0.6;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 .noConnectionMsg {
-    position: absolute;
-    left: 43%;
-    bottom: 50%;
-    z-index: 10001;
-    background: #434C56;
-    border: 1px solid #1A232E;
-    color: #DDE4EA;
-    border-left: 0px;
-    border-bottom: 0px;
-    padding: 14px;
-    padding-bottom: 30px;
-    border-radius: 0px 3px 0px 0px;
-    -webkit-border-radius: 0px 3px 0px 0px;
-    z-index: 999999999999999;
+  position: absolute;
+  left: 43%;
+  bottom: 50%;
+  z-index: 10001;
+  background: #434c56;
+  border: 1px solid #1a232e;
+  color: #dde4ea;
+  border-left: 0px;
+  border-bottom: 0px;
+  padding: 14px;
+  padding-bottom: 30px;
+  border-radius: 0px 3px 0px 0px;
+  -webkit-border-radius: 0px 3px 0px 0px;
+  z-index: 999999999999999;
 }
 
 /* retina display query */
-@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2/1), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
+@media only screen and (-webkit-min-device-pixel-ratio: 2),
+  only screen and (min--moz-device-pixel-ratio: 2),
+  only screen and (-o-min-device-pixel-ratio: 2/1),
+  only screen and (min-device-pixel-ratio: 2),
+  only screen and (min-resolution: 192dpi),
+  only screen and (min-resolution: 2dppx) {
+  .outersource .copy {
+    top: 7px;
+    background: url(../../img/outercopy@2x.png) center 1px no-repeat;
+    background-size: 12px 11px;
+  }
 
-    .outersource .copy {
-        top: 7px;
-        background: url(../../img/outercopy@2x.png) center 1px no-repeat;
-        background-size: 12px 11px;
-    }
+  .outersource .copy:hover {
+    background: url(../../img/outercopy@2x.png) 4px -69px no-repeat;
+    background-size: 42px;
+  }
 
-    .outersource .copy:hover {
-        background: url(../../img/outercopy@2x.png) 4px -69px no-repeat;
-        background-size: 42px;
+  a.showExtendedTags {
+    position: relative;
+    display: block;
+    float: left;
+    clear: left;
+    left: 52%;
+    top: -20px;
+  }
 
-    }
-
-    a.showExtendedTags {
-        position: relative;
-        display: block;
-        float: left;
-        clear: left;
-        left: 52%;
-        top: -20px;
-    }
-
-    body.tagmode-default-extended a.showExtendedTags {
-        display: none;
-    }
-
+  body.tagmode-default-extended a.showExtendedTags {
+    display: none;
+  }
 }
 
 .addtmx-tr.white-tx .open-popup-addtm-tr {
-    width: 130px;
-    color: #333;
-    background: #fff;
+  width: 130px;
+  color: #333;
+  background: #fff;
 }
 
 .addtmx-tr.white-tx .open-popup-addtm-tr:hover {
-    background: #ededed;
+  background: #ededed;
 }
 
 .popup-addtm-tr .popup {
-    width: 54% !important;
-    margin: 0 !important;
-    left: 23% !important;
-    top: 2%;
-    text-align: left;
+  width: 54% !important;
+  margin: 0 !important;
+  left: 23% !important;
+  top: 2%;
+  text-align: left;
 }
 
 #addtm-upload-form .block {
-    float: left;
-    width: 100%;
+  float: left;
+  width: 100%;
 }
 
 .popup-addtm-tr h2 {
-    font-size: 20px;
-    font-weight: bold;
-    margin: 10px 0;
+  font-size: 20px;
+  font-weight: bold;
+  margin: 10px 0;
 }
 
 .popup-addtm-tr .popup-box {
-    max-height: 550px;
-    overflow: auto;
+  max-height: 550px;
+  overflow: auto;
 }
 
 .addtm-break-2-lines {
-    border: 1px solid white;
-    height: 25px;
+  border: 1px solid white;
+  height: 25px;
 }
 
 .block-last .mgmt-input {
-    width: 62%;
+  width: 62%;
 }
 
 .open-popup-addtm-tr {
-    cursor: pointer;
-    margin-left: 5px;
+  cursor: pointer;
+  margin-left: 5px;
 }
 
-.popup-addtm-tr input[type="file"] {
-    font-size: 15px;
-    margin-bottom: 15px;
+.popup-addtm-tr input[type='file'] {
+  font-size: 15px;
+  margin-bottom: 15px;
 }
 
 .popup-addtm-tr input#key {
-    width: 96%;
-    color: $grey2;
+  width: 96%;
+  color: $grey2;
 }
 
 .popup-addtm-tr .btn-ok {
-    padding: 4px 18px;
-    margin: 2px 5px 1px 5px;
+  padding: 4px 18px;
+  margin: 2px 5px 1px 5px;
 }
 
 /*.addtmx-tr:hover {
@@ -4330,200 +4369,201 @@ body.editlog .breadcrumbs #pname, body.reviselog .breadcrumbs #pname {
 }*/
 
 .fileupload {
-    margin-right: 10px;
-    font-weight: bold;
+  margin-right: 10px;
+  font-weight: bold;
 }
 
 .addtmx-tr:active {
-    -moz-box-shadow: inset 0 0 1px 1px #888;
-    -webkit-box-shadow: inset 0 0 1px 1px #888;
-    box-shadow: inset 0 0 1px 1px #888;
+  -moz-box-shadow: inset 0 0 1px 1px #888;
+  -webkit-box-shadow: inset 0 0 1px 1px #888;
+  box-shadow: inset 0 0 1px 1px #888;
 }
 
 .sub-editor.review .error-type {
-    width: 45.6%;
-    padding: 0 1%;
-    margin: 0 0 2% 0;
-    float: left;
-    border: 3px solid #fff;
+  width: 45.6%;
+  padding: 0 1%;
+  margin: 0 0 2% 0;
+  float: left;
+  border: 3px solid #fff;
 }
 
 .sub-editor.review .error-type.error tbody {
-    border: 2px solid red !important;
+  border: 2px solid red !important;
 }
 
 .sub-editor.review .error-type.error h3 {
-    color: red !important;
+  color: red !important;
 }
 
 .track-changes {
-    float: right;
-    width: 45%;
-    margin-right: 2.9%;
-    margin-top: 2px;
+  float: right;
+  width: 45%;
+  margin-right: 2.9%;
+  margin-top: 2px;
 }
 
-.error-type h3, .track-changes h3 {
-    margin: 20px 0 0 1px;
-    text-align: left;
+.error-type h3,
+.track-changes h3 {
+  margin: 20px 0 0 1px;
+  text-align: left;
 }
 
-.track-changes p{
-    width: 100%;
-    line-height: 27px;
-    margin: 36px auto 17px auto;
-    min-height: 70px;
-    text-align: left;
-    height: 96% !important;
-    padding: 5px;
-    font-size: 18px;
-    cursor: default !important;
-    background: #efefef;
-    border-radius: 2px;
-    border: 1px solid #727272;
-    box-shadow: 0 1px 2px #DFDFDF;
-    -webkit-box-shadow: 0 1px 2px #DFDFDF;
-    -webkit-touch-callout: none;
-    /*-webkit-user-select: none;*/
-    /*-khtml-user-select: none;*/
-    /*-moz-user-select: none;*/
-    /*-ms-user-select: none;*/
-    /*user-select: none;*/
-    word-wrap: break-word;
-    word-break: normal;
+.track-changes p {
+  width: 100%;
+  line-height: 27px;
+  margin: 36px auto 17px auto;
+  min-height: 70px;
+  text-align: left;
+  height: 96% !important;
+  padding: 5px;
+  font-size: 18px;
+  cursor: default !important;
+  background: #efefef;
+  border-radius: 2px;
+  border: 1px solid #727272;
+  box-shadow: 0 1px 2px #dfdfdf;
+  -webkit-box-shadow: 0 1px 2px #dfdfdf;
+  -webkit-touch-callout: none;
+  /*-webkit-user-select: none;*/
+  /*-khtml-user-select: none;*/
+  /*-moz-user-select: none;*/
+  /*-ms-user-select: none;*/
+  /*user-select: none;*/
+  word-wrap: break-word;
+  word-break: normal;
 }
 
 .sub-editor.review .track-changes .deleted,
 .suggestion_source .deleted,
 .suggestion_source del {
-    background: #ffc7ca;
-    text-decoration: line-through;
+  background: #ffc7ca;
+  text-decoration: line-through;
 }
 
 .sub-editor.review .track-changes .added,
 .suggestion_source .added,
 .suggestion_source ins {
-    background: #b0ffb3;
-    text-decoration: none;
+  background: #b0ffb3;
+  text-decoration: none;
 }
 
 body.cattool table.mgmt-mt th.action {
-    display: none;
+  display: none;
 }
 
 body.cattool table.mgmt-mt tbody .action {
-    display: none;
+  display: none;
 }
 
 body.isAnonymous .add-mt-engine {
-    display: none;
+  display: none;
 }
 
 body.cattool .mgmt-table-mt .add-mt-engine {
-    display: none;
+  display: none;
 }
 
 body.cattool .mgmt-table-mt tbody tr {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 
 body.cattool .mgmt-table-mt .activemt {
-    opacity: 1 !important;
+  opacity: 1 !important;
 }
 
 .splitContainer {
-    position: relative;
+  position: relative;
+  float: left;
+  width: 45.2%;
+  .splitArea {
+    width: 100%;
+    padding: 3px 0px 5px 3px;
+    margin: 7px 1.7%;
+    background: #efefef;
+    font-size: 18px;
+    min-height: 70px;
+    outline: 0;
+    text-align: left;
+    border-radius: 2px;
+    line-height: 27px;
+    color: #000;
+    border: 1px solid #727272;
+    word-break: normal !important;
+    cursor: col-resize;
     float: left;
-    width: 45.2%;
-    .splitArea {
-        width: 100%;
-        padding: 3px 0px 5px 3px;
-        margin: 7px 1.7%;
-        background: #efefef;
-        font-size: 18px;
-        min-height: 70px;
-        outline: 0;
-        text-align: left;
-        border-radius: 2px;
-        line-height: 27px;
-        color: #000;
-        border: 1px solid #727272;
-        word-break: normal !important;
-        cursor: col-resize;
-        float: left;
-    }
-    .splitBar {
-        position: relative;
-        clear: both;
-        margin-top: 100px;
-        width: 100%;
-        margin-left: 19px;
-    }
-    .cancel {
-        margin-right: 4px;
-        width: 108px;
-        float: left;
-        color: #333;
-    }
+  }
+  .splitBar {
+    position: relative;
+    clear: both;
+    margin-top: 100px;
+    width: 100%;
+    margin-left: 19px;
+  }
+  .cancel {
+    margin-right: 4px;
+    width: 108px;
+    float: left;
+    color: #333;
+  }
 }
 
 .splitContainer .source.item {
-    width: 100% !important;
+  width: 100% !important;
 }
 
 .splitBar p,
 .splitBar .splitNum {
-    float: left;
-    margin: 0;
+  float: left;
+  margin: 0;
 }
 
 .splitBar .splitNum {
-    /*display: none;*/
-    margin-top: 7px;
+  /*display: none;*/
+  margin-top: 7px;
 }
 
 .splitBar .buttons {
-    float: right;
-    margin: 0;
+  float: right;
+  margin: 0;
 }
 
 .splitBar .buttons a {
-    margin-left: 20px;
-    margin-top: 2px;
+  margin-left: 20px;
+  margin-top: 2px;
 }
 
 .splitBar .btn-ok:hover {
-    background: #12b4df;
+  background: #12b4df;
 }
 
 .splitpoint {
-    display: inline-block;
-    width: 8px;
-    height: 26px;
-    color: #767676;
-    cursor: pointer;
-    width: 19px;
-    margin: 0px 5px;
+  display: inline-block;
+  width: 8px;
+  height: 26px;
+  color: #767676;
+  cursor: pointer;
+  width: 19px;
+  margin: 0px 5px;
 }
 
 .splitArea .currentSplittedSegment {
-    background: yellow;
-    border: 1px solid yellow;
-    border-radius: 3px;
+  background: yellow;
+  border: 1px solid yellow;
+  border-radius: 3px;
 }
 
 #export_edit_log_csv_link {
-    top: 30px;
-    position: relative;
-    font-style: italic;
+  top: 30px;
+  position: relative;
+  font-style: italic;
 }
 
 .color_green {
-    color: #6AA84F;
+  color: #6aa84f;
 }
 
 .bg_orange {
-    background: #ee6633;
+  background: #ee6633;
 }
 
 /**
@@ -4531,880 +4571,872 @@ body.cattool .mgmt-table-mt .activemt {
  * the segment completed loading.
  */
 section .footer .tab.open {
-    display: none;
+  display: none;
 }
 
 section .footer .tab.open {
-    display: block;
-    z-index: 0;
-    position: relative;
-    border-top: 2px solid $grey3;
-    top: -2px;
-    min-height: 40px;
-    background-color:$white;
+  display: block;
+  z-index: 0;
+  position: relative;
+  border-top: 2px solid $grey3;
+  top: -2px;
+  min-height: 40px;
+  background-color: $white;
 }
 
 section .segment-side-buttons {
-    color: $grey1
+  color: $grey1;
 }
 
-
 .blue-button {
-    background: $translatedBlue;
+  background: $translatedBlue;
 }
 
 .red-button {
-    background: #b02429;
+  background: #b02429;
 }
 
 .grey-button {
-    color: #333;
-    background: #f6f6f6;
-    background: -webkit-gradient(linear, left top, left bottom, from(#f6f6f6), to(#e2e3e5));
-    background: -moz-linear-gradient(top, #f6f6f6, #e2e3e5);
-    background: linear-gradient(top, #f6f6f6, #e2e3e5);
+  color: #333;
+  background: #f6f6f6;
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    from(#f6f6f6),
+    to(#e2e3e5)
+  );
+  background: -moz-linear-gradient(top, #f6f6f6, #e2e3e5);
+  background: linear-gradient(top, #f6f6f6, #e2e3e5);
 }
 
 .edit-distance {
-    display: none;
-    position: absolute;
-    top: 4px;
-    right: 6px;
-    font-size: 0.8rem;
-    color: #999;
+  display: none;
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 0.8rem;
+  color: #999;
 }
 
-
 .edit-log {
-    /*top: 5px;*/
-    font-weight: bold;
-    right: -1px;
+  /*top: 5px;*/
+  font-weight: bold;
+  right: -1px;
 }
 
 .ui.user.label {
-    margin-right: 13px;
-    /*top: 5px;*/
+  margin-right: 13px;
+  /*top: 5px;*/
 }
 
 .user-nolog.sing-in-header {
-    margin-right: 11px;
+  margin-right: 11px;
 }
 
 .tmx-import-slider {
-    width: 110px !important;
+  width: 110px !important;
 }
 
 /*Editor Toggle*/
 .editor .toggle {
-    //display: inline-block;
-    margin-right: 0;
-    z-index: 0;
-    position: relative;
-    margin-top: -2px;
+  //display: inline-block;
+  margin-right: 0;
+  z-index: 0;
+  position: relative;
+  margin-top: -2px;
 }
 
 .buttons li {
-    text-align: center;
-    height: 35px;
-    vertical-align: -webkit-baseline-middle;
-    display: inline-block;
+  text-align: center;
+  height: 35px;
+  vertical-align: -webkit-baseline-middle;
+  display: inline-block;
 }
 
 input#markAsCompleteButton[disabled] {
-    background: #d7d7d8;
+  background: #d7d7d8;
 }
 
 /* Header/Footer Restyling */
 
-$icon-scale : 30px;
+$icon-scale: 30px;
 $matecat-blue: #002b5c;
 $light-gray: #f2f5f7;
-$medium-gray : #acb3bd;
+$medium-gray: #acb3bd;
 $gray-2: #bbbbbb;
 
 $light-blue: #0055b8;
-$white: #FFF;
-
+$white: #fff;
 
 /* Edit Log */
 
 .editlog {
+  padding-top: 88px;
 
-    padding-top: 88px;
+  .wrapper {
+    margin: 0 auto 64px auto;
+  }
 
-    .wrapper {
-        margin: 0 auto 64px auto;
+  header {
+    #user-menu-dropdown {
+      .organization-name {
+        display: none;
+      }
     }
 
-    header {
+    .sing-in-header {
+      padding: 0;
+      width: 40px !important;
+      height: 40px !important;
+      display: grid;
+      background-color: transparent;
 
-        #user-menu-dropdown {
-            .organization-name {
-                display: none;
-            }
-        }
-
-        .sing-in-header {
-            padding: 0;
-            width: 40px !important;
-            height: 40px !important;
-            display: grid;
-            background-color: transparent;
-
-            svg {
-                width: 36px;
-            }
-        }
-        .logo {
-            margin-top:0 !important;
-        }
+      svg {
+        width: 36px;
+      }
     }
+    .logo {
+      margin-top: 0 !important;
+    }
+  }
 }
 
 /* XLIFF to Target page */
 
 .xliff-to-target-page {
-    header {
-        .wrapper {
-            grid-template-columns: 208px 1fr max-content !important;
-        }
+  header {
+    .wrapper {
+      grid-template-columns: 208px 1fr max-content !important;
     }
+  }
 }
 
 /* Quality Report improved */
 
 .improved-reviselog {
-    padding-top: 44px;
-    header {
-        .wrapper {
-            display: grid;
-            grid-template-columns: 208px auto 120px;
+  padding-top: 44px;
+  header {
+    .wrapper {
+      display: grid;
+      grid-template-columns: 208px auto 120px;
 
-            .btn-main {
-                background: #fff;
-                color: #002b5c;
-                font-size: 16px;
-                width: 152px;
-                text-align: center;
-                max-height: 40px;
-                border-radius: 2px;
-                line-height: 1.25;
-                border: none;
-                padding: 8px;
+      .btn-main {
+        background: #fff;
+        color: #002b5c;
+        font-size: 16px;
+        width: 152px;
+        text-align: center;
+        max-height: 40px;
+        border-radius: 2px;
+        line-height: 1.25;
+        border: none;
+        padding: 8px;
 
-                &:hover {
-                    color: $light-blue;
-                }
-            }
-
-            .action-menu {
-                grid-template-columns: auto auto;
-                margin-right: 8px;
-            }
-
-            #user-menu-dropdown {
-                .organization-name {
-                    display: none;
-                }
-            }
+        &:hover {
+          color: $light-blue;
         }
+      }
+
+      .action-menu {
+        grid-template-columns: auto auto;
+        margin-right: 8px;
+      }
+
+      #user-menu-dropdown {
+        .organization-name {
+          display: none;
+        }
+      }
     }
+  }
 }
 
 /* Default */
 
 header {
+  .wrapper {
+    grid-template-columns: 208px minmax(0, 48px) minmax(200px, max-content) auto max-content; /*208px minmax(0,48px) minmax(200px, max-content) auto 120px;*/
+    align-items: center;
+  }
 
-    .wrapper {
-        grid-template-columns: 208px minmax(0, 48px) minmax(200px, max-content) auto max-content; /*208px minmax(0,48px) minmax(200px, max-content) auto 120px;*/
-        align-items: center;
+  .logo-menu {
+    display: grid;
+    align-items: center;
+
+    .logo {
+      margin: 0;
+      background: url(../../img/logo_matecat.png) 0 0 no-repeat;
+      width: 180px;
+      height: 38px;
+      background-size: cover;
+      top: 0;
+      left: 0;
+    }
+  }
+
+  .breadcrumbs {
+    display: grid;
+    grid-template-columns: 25px auto;
+    padding: 14px 0 4px 0;
+
+    .icon-container {
+      position: relative;
+      span#project-badge {
+        position: absolute;
+        left: -10px;
+        top: -8px;
+        font-family: Calibri, Arial, Helvetica, sans-serif !important;
+      }
     }
 
-    .logo-menu {
-        display: grid;
-        align-items:center;
+    #pname {
+      &::before {
+        content: '' !important ;
+      }
+    }
+  }
 
+  .action-menu {
+    display: grid;
+    /*grid-template-columns: repeat(9, auto);*/
+    grid-auto-flow: column;
+    grid-template-rows: $icon-scale;
+    align-items: center;
+    justify-content: right;
+    column-gap: 15px;
 
-        .logo {
-            margin:0;
-            background: url(../../img/logo_matecat.png) 0 0 no-repeat;
-            width: 180px;
-            height: 38px;
-            background-size: cover;
-            top:0;
-            left:0;
-        }
+    &.qr-element {
+      grid-template-columns: auto;
     }
 
-    .breadcrumbs {
-        display: grid;
-        grid-template-columns: 25px auto;
-        padding:14px 0 4px 0;
-
-        .icon-container {
-            position: relative;
-            span#project-badge {
-                position: absolute;
-                left: -10px;
-                top: -8px;
-                font-family: Calibri, Arial, Helvetica, sans-serif !important;
-            }
-        }
-
-        #pname {
-
-            &::before {
-                content: "" !important ;
-            }
-        }
-
+    #previewDropdown[data-download='false'] li.downloadTranslation,
+    #previewDropdown[data-download='true'] li.previewLink {
+      display: none;
     }
 
-    .action-menu {
-        display: grid;
-        /*grid-template-columns: repeat(9, auto);*/
-        grid-auto-flow: column;
-        grid-template-rows: $icon-scale;
-        align-items:center;
-        justify-content: right;
-        column-gap: 15px;
+    .draft:hover {
+      background: transparent;
+    }
 
-        &.qr-element {
-            grid-template-columns: auto;
+    .action-submenu,
+    #quality-report {
+      position: relative;
+      display: grid;
+      align-items: center;
+      grid-template-columns: $icon-scale;
+      grid-template-rows: $icon-scale;
+      opacity: 0.8;
+
+      background-repeat: no-repeat;
+      background-position: center;
+      margin: 0;
+      border-radius: 2px;
+      cursor: pointer;
+      &.disabled {
+        opacity: 0.4 !important;
+        cursor: default !important;
+        &:hover {
+          opacity: 0.4 !important;
         }
-
-        #previewDropdown[data-download='false'] li.downloadTranslation,
-        #previewDropdown[data-download='true'] li.previewLink {
-            display: none;
+        a {
+          display: none !important;
         }
+      }
+      &:hover,
+      &.active {
+        opacity: 1;
+      }
 
-        .draft:hover {
-            background: transparent;
-        }
+      /* Bug fix for Semantic UI Dropdown hover */
+      .dropdown-menu-overlay {
+        width: 30px;
+        height: 80px;
+      }
 
-        .action-submenu, #quality-report {
+      .feedback-alert {
+        position: absolute;
+        margin: 0;
+        top: -8px;
+        padding: 0px 8px;
+        right: -12px;
+        background: $orangeDefault;
+        color: #fff;
+        font-size: 10px;
+        text-align: center;
+        border-radius: 25px;
+        vertical-align: middle;
+        line-height: 16px;
+        height: 17px;
+      }
 
-            position: relative;
-            display: grid;
-            align-items:center;
-            grid-template-columns: $icon-scale;
-            grid-template-rows: $icon-scale;
-            opacity: 0.8;
+      .menu {
+        position: absolute;
+        z-index: 1;
+        width: 200px !important;
+        left: -80px !important;
+        margin: 0 0 0 -1px;
+        background: white;
+        padding: 12px 8px;
+        top: 50px;
+        font-size: 16px;
+        border-radius: 2px;
+        border: solid 1px #cdd4de;
 
-            background-repeat: no-repeat;
-            background-position: center;
-            margin:0;
+        .item {
+          a {
+            display: block;
             border-radius: 2px;
-            cursor: pointer;
-            &.disabled {
-                opacity: 0.4 !important;
-                cursor: default !important;
-                &:hover {
-                    opacity: 0.4 !important;
-                }
-                a {
-                    display: none !important;
-                }
-            }
-            &:hover,
-            &.active {
-                opacity: 1;
-            }
-
-            /* Bug fix for Semantic UI Dropdown hover */
-            .dropdown-menu-overlay {
-                width: 30px;
-                height: 80px;
-            }
-
-            .feedback-alert {
-                position: absolute;
-                margin: 0;
-                top: -8px;
-                padding: 0px 8px;
-                right: -12px;
-                background: $orangeDefault;
-                color: #fff;
-                font-size: 10px;
-                text-align: center;
-                border-radius: 25px;
-                vertical-align: middle;
-                line-height: 16px;
-                height: 17px;
-            }
-
-            .menu {
-                position: absolute;
-                z-index: 1;
-                width: 200px !important;
-                left: -80px !important;
-                margin: 0 0 0 -1px;
-                background: white;
-                padding: 12px 8px;
-                top: 50px;
-                font-size: 16px;
-                border-radius: 2px;
-                border: solid 1px #cdd4de;
-
-                .item {
-
-                    a {
-                        display: block;
-                        border-radius: 2px;
-                        padding: 8px !important;
-                        font-size: 16px;
-                        color: #000000;
-                        &:hover {
-                            background-color: $light-gray;
-                            color: $light-blue;
-                        }
-                        &.selected {
-                            background-color: transparent !important;
-                            font-weight: normal !important;
-                        }
-                    }
-
-                    padding: 0 !important;
-                    border-radius: 3px;
-                }
-
-                .active.item {
-                    background-color: transparent !important;
-                    font-weight: normal !important;
-                }
-            }
-
-            .badge {
-                position: absolute;
-                margin: 0;
-                top: 0;
-                padding: 1px 6px;
-                right: -4px;
-                /*background: #e02020;*/
-                background: #0bbeec;
-                color: #fff;
-                font-size: 10px;
-                text-align: center;
-                border-radius: 25px;
-                vertical-align: middle;
-                line-height: 16px;
-                height: 17px;
-            }
-
-        }
-
-        #markAsCompleteButton {
-            width: $icon-scale !important;
-            height: $icon-scale;
-            text-align: right;
-            background: transparent;
-            border:none;
-
-            &.isMarkedComplete {
-                background-image: url("../../img/icons/icon-mark-active.svg");
-                background-size: cover;
-            }
-            &.isMarkableAsComplete {
-                opacity: 1;
-                padding:0 !important;
-                border-radius: 0;
-                background: transparent url("../../img/icons/icon-mark.svg");
-                background-size: cover;
-            }
-            &.notMarkedComplete {
-                background: transparent url("../../img/icons/icon-mark.svg");
-                opacity: 0.7;
-                background-size: cover;
-                cursor:not-allowed;
-            }
-        }
-        #action-download {
-            background-image: url("../../img/icons/icon-download.svg");
-            background-size: 30px;
-            &.job-completed {
-                background-image: url("../../img/icons/icon-download-complete.svg");
-            }
-        }
-        #action-QR,
-        #quality-report-button {
-            /*background-image: url("../../img/icons/icon-QR-line.svg");*/
-            #quality-report {
-                display: grid;
-                background: transparent;
-                border:none !important;
-                opacity: unset;
-            }
-            #quality-report svg {
-                position: absolute;
-            }
-        }
-
-        #quality-report-button{
-
-            #quality-report {
-                svg {
-                    .st0{
-                        fill:none;
-                        stroke:#FAFAFA;}
-
-                    .st2{
-                        fill:#FFFFFF;
-                    }
-                }
-            }
-
-            &[data-revised=true] {
-                #quality-report {
-
-                    &[data-vote=excellent],
-                    &[data-vote=good],
-                    &[data-vote=verygood]{
-                        svg {
-                            .st0{
-                                fill:#5EB304;
-                                stroke:#5EB304;}
-                        }
-                    }
-                    &[data-vote=poor]{
-                        svg {
-                            .st0{
-                                fill:#FFA935;
-                                stroke:#FFA935;}
-                        }
-                    }
-                    &[data-vote=acceptable]{
-                        svg {
-                            .st0{
-                                fill:#EABA22;
-                                stroke:#EABA22;}
-                        }
-                    }
-
-                    &[data-vote=fail]{
-                        svg {
-                            .st0{
-                                fill:#E02020;
-                                stroke:#E02020;}
-                        }
-                    }
-
-                }
-            }
-        }
-
-
-        #notifbox {
-            width: $icon-scale;
-            height: $icon-scale;
-            padding: 0 !important;
-            text-align: right;
-            opacity: 0.8;
+            padding: 8px !important;
+            font-size: 16px;
+            color: #000000;
             &:hover {
-                opacity: 1;
+              background-color: $light-gray;
+              color: $light-blue;
             }
-            a{
-             position: absolute;
+            &.selected {
+              background-color: transparent !important;
+              font-weight: normal !important;
             }
+          }
+
+          padding: 0 !important;
+          border-radius: 3px;
         }
 
-        #action-comments, #mbc-history {
-            width: $icon-scale !important;
-            height: $icon-scale;
-            padding:0 !important;
-            background-position: center;
-
-            svg {
-                opacity: 0.8;
-                &:hover {
-                    opacity:1;
-                }
-            }
-            &.open svg {
-                opacity: 1;
-            }
-
-            .badge {
-                position: absolute;
-                margin: 0;
-                top: 0;
-                padding: 1px 6px;
-                right: -4px;
-                /*background: #e02020;*/
-                background: #0bbeec;
-                color: #fff;
-                font-size: 10px;
-                text-align: center;
-                border-radius: 25px;
-                vertical-align: middle;
-                line-height: 16px;
-                height: 17px;
-            }
-
-            .mbc-history-balloon-outer {
-                background: #fff;
-                margin-top: 5px;
-                border-radius: 3px;
-                right: -136px;
-                z-index: 2;
-                .mbc-triangle-top {
-                    border-left: 6px solid transparent;
-                    border-right: 6px solid transparent;
-                    border-bottom: 6px solid #ffffff;
-                    bottom: 100%;
-                    left: 50%;
-                    right: auto;
-                    transform: translate(-90%, 0) !important;
-                    position: absolute;
-                    pointer-events: none;
-                }
-
-                .mbc-thread-wrap-active {
-                    border:none;
-                }
-            }
-            .mbc-history-balloon {
-                background: #fff;
-                border-radius: 3px;
-            }
-            .mbc-thread-wrap {
-                border-top: none;
-            }
-
+        .active.item {
+          background-color: transparent !important;
+          font-weight: normal !important;
         }
-        #action-search {
-            svg {
-                circle {
-                    fill: #fff;
-                }
+      }
 
-                .st1 {
-                    fill: #002b5c;
-                }
-            }
-        }
-        #action-filter {
-            &.active, &.open {
-                opacity: 1;
-                #filter {
-                    fill:#fff;
-                }
-            }
-        }
-        #action-three-dots {
-        }
-        #action-settings {
-        }
+      .badge {
+        position: absolute;
+        margin: 0;
+        top: 0;
+        padding: 1px 6px;
+        right: -4px;
+        /*background: #e02020;*/
+        background: #0bbeec;
+        color: #fff;
+        font-size: 10px;
+        text-align: center;
+        border-radius: 25px;
+        vertical-align: middle;
+        line-height: 16px;
+        height: 17px;
+      }
     }
 
+    #markAsCompleteButton {
+      width: $icon-scale !important;
+      height: $icon-scale;
+      text-align: right;
+      background: transparent;
+      border: none;
 
-    .profile-menu {
+      &.isMarkedComplete {
+        background-image: url('../../img/icons/icon-mark-active.svg');
+        background-size: cover;
+      }
+      &.isMarkableAsComplete {
+        opacity: 1;
+        padding: 0 !important;
+        border-radius: 0;
+        background: transparent url('../../img/icons/icon-mark.svg');
+        background-size: cover;
+      }
+      &.notMarkedComplete {
+        background: transparent url('../../img/icons/icon-mark.svg');
+        opacity: 0.7;
+        background-size: cover;
+        cursor: not-allowed;
+      }
+    }
+    #action-download {
+      background-image: url('../../img/icons/icon-download.svg');
+      background-size: 30px;
+      &.job-completed {
+        background-image: url('../../img/icons/icon-download-complete.svg');
+      }
+    }
+    #action-QR,
+    #quality-report-button {
+      /*background-image: url("../../img/icons/icon-QR-line.svg");*/
+      #quality-report {
         display: grid;
-        grid-template-columns: auto auto auto;
-        align-items: center;
-        justify-content: center;
+        background: transparent;
+        border: none !important;
+        opacity: unset;
+      }
+      #quality-report svg {
+        position: absolute;
+      }
+    }
 
-        /*.user-nolog {
+    #quality-report-button {
+      #quality-report {
+        svg {
+          .st0 {
+            fill: none;
+            stroke: #fafafa;
+          }
+
+          .st2 {
+            fill: #ffffff;
+          }
+        }
+      }
+
+      &[data-revised='true'] {
+        #quality-report {
+          &[data-vote='excellent'],
+          &[data-vote='good'],
+          &[data-vote='verygood'] {
+            svg {
+              .st0 {
+                fill: #5eb304;
+                stroke: #5eb304;
+              }
+            }
+          }
+          &[data-vote='poor'] {
+            svg {
+              .st0 {
+                fill: #ffa935;
+                stroke: #ffa935;
+              }
+            }
+          }
+          &[data-vote='acceptable'] {
+            svg {
+              .st0 {
+                fill: #eaba22;
+                stroke: #eaba22;
+              }
+            }
+          }
+
+          &[data-vote='fail'] {
+            svg {
+              .st0 {
+                fill: #e02020;
+                stroke: #e02020;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    #notifbox {
+      width: $icon-scale;
+      height: $icon-scale;
+      padding: 0 !important;
+      text-align: right;
+      opacity: 0.8;
+      &:hover {
+        opacity: 1;
+      }
+      a {
+        position: absolute;
+      }
+    }
+
+    #action-comments,
+    #mbc-history {
+      width: $icon-scale !important;
+      height: $icon-scale;
+      padding: 0 !important;
+      background-position: center;
+
+      svg {
+        opacity: 0.8;
+        &:hover {
+          opacity: 1;
+        }
+      }
+      &.open svg {
+        opacity: 1;
+      }
+
+      .badge {
+        position: absolute;
+        margin: 0;
+        top: 0;
+        padding: 1px 6px;
+        right: -4px;
+        /*background: #e02020;*/
+        background: #0bbeec;
+        color: #fff;
+        font-size: 10px;
+        text-align: center;
+        border-radius: 25px;
+        vertical-align: middle;
+        line-height: 16px;
+        height: 17px;
+      }
+
+      .mbc-history-balloon-outer {
+        background: #fff;
+        margin-top: 5px;
+        border-radius: 3px;
+        right: -136px;
+        z-index: 2;
+        .mbc-triangle-top {
+          border-left: 6px solid transparent;
+          border-right: 6px solid transparent;
+          border-bottom: 6px solid #ffffff;
+          bottom: 100%;
+          left: 50%;
+          right: auto;
+          transform: translate(-90%, 0) !important;
+          position: absolute;
+          pointer-events: none;
+        }
+
+        .mbc-thread-wrap-active {
+          border: none;
+        }
+      }
+      .mbc-history-balloon {
+        background: #fff;
+        border-radius: 3px;
+      }
+      .mbc-thread-wrap {
+        border-top: none;
+      }
+    }
+    #action-search {
+      svg {
+        circle {
+          fill: #fff;
+        }
+
+        .st1 {
+          fill: #002b5c;
+        }
+      }
+    }
+    #action-filter {
+      &.active,
+      &.open {
+        opacity: 1;
+        #filter {
+          fill: #fff;
+        }
+      }
+    }
+    #action-three-dots {
+    }
+    #action-settings {
+    }
+  }
+
+  .profile-menu {
+    display: grid;
+    grid-template-columns: auto auto auto;
+    align-items: center;
+    justify-content: center;
+
+    /*.user-nolog {
           opacity: 0.8;
           &:hover {
             opacity: 1;
           }
         }*/
 
-        .ui.user.label {
-            top:0;
-            margin-left: 10px;
-            background: none;
-            background-color: transparent;
-            border: 2px solid $translatedBlue;
-            opacity: 0.8;
-            color: $translatedBlue;
-            &:hover {
-                opacity: 1;
-            }
-        }
-
-        #action-manage {
-            opacity: 0.8;
-            &:hover {
-                opacity: 1;
-            }
-        }
-
-        a {
-            display: grid;
-            align-items:center;
-            grid-template-columns: $icon-scale;
-            grid-template-rows: $icon-scale;
-
-            img {
-                width: $icon-scale;
-            }
-        }
-
-        .position-sing-in {
-            top:0;
-            .sing-in-header {
-                padding: 0;
-                width: 44px !important;
-                height: 44px !important;
-                border:none !important;
-                background: none;
-                svg {
-                    width: 40px;
-                }
-            }
-        }
-
-        .column-separator {
-            width: 1px;
-            height:$icon-scale;
-            background: #fff;
-            margin-right: 14px;
-            margin-left: 10px;
-        }
-
-        .user-menu-container {
-            padding:0;
-            img {
-                margin-top:0;
-            }
-
-            .organization-name {
-                display: none;
-            }
-        }
+    .ui.user.label {
+      top: 0;
+      margin-left: 10px;
+      background: none;
+      background-color: transparent;
+      border: 2px solid $translatedBlue;
+      opacity: 0.8;
+      color: $translatedBlue;
+      &:hover {
+        opacity: 1;
+      }
     }
 
     #action-manage {
-        opacity: 0.8;
-        &:hover {
-            opacity: 1;
-        }
+      opacity: 0.8;
+      &:hover {
+        opacity: 1;
+      }
     }
+
+    a {
+      display: grid;
+      align-items: center;
+      grid-template-columns: $icon-scale;
+      grid-template-rows: $icon-scale;
+
+      img {
+        width: $icon-scale;
+      }
+    }
+
+    .position-sing-in {
+      top: 0;
+      .sing-in-header {
+        padding: 0;
+        width: 44px !important;
+        height: 44px !important;
+        border: none !important;
+        background: none;
+        svg {
+          width: 40px;
+        }
+      }
+    }
+
+    .column-separator {
+      width: 1px;
+      height: $icon-scale;
+      background: #fff;
+      margin-right: 14px;
+      margin-left: 10px;
+    }
+
+    .user-menu-container {
+      padding: 0;
+      img {
+        margin-top: 0;
+      }
+
+      .organization-name {
+        display: none;
+      }
+    }
+  }
+
+  #action-manage {
+    opacity: 0.8;
+    &:hover {
+      opacity: 1;
+    }
+  }
 }
 
 .topMenu {
-    width: 315px;
-    background: $light-gray;
-    z-index: 2;
-    text-align: left;
-    padding: 0;
-    font-size: 14px;
-    display: none;
-    box-shadow: none;
-    left: 135px;
-    position: fixed;
-    &.open {
-        max-height: 64%;
-        overflow-y: auto;
-        top: 64px !important;
-        display: block;
-        box-shadow: 0px 1px 12px #999;
+  width: 315px;
+  background: $light-gray;
+  z-index: 2;
+  text-align: left;
+  padding: 0;
+  font-size: 14px;
+  display: none;
+  box-shadow: none;
+  left: 135px;
+  position: fixed;
+  &.open {
+    max-height: 64%;
+    overflow-y: auto;
+    top: 64px !important;
+    display: block;
+    box-shadow: 0px 1px 12px #999;
+    border-radius: 2px;
+    z-index: 13;
+    border: solid 1px #cdd4de;
+
+    &::after {
+      content: '';
+      width: 0;
+      height: 0;
+      border-left: 6px solid transparent;
+      border-right: 6px solid transparent;
+      border-bottom: 6px solid #ffffff;
+      bottom: 100%;
+      left: 50%;
+      right: auto;
+      transform: translate(-90%, 0) !important;
+      position: absolute;
+      pointer-events: none;
+    }
+  }
+
+  .separator {
+    width: 254px;
+    height: 2px;
+    background: $gray-2;
+    align-items: center;
+    margin-left: 15px;
+  }
+
+  ul.gotocurrentsegment {
+    width: 100%;
+    line-height: 24px;
+    font-size: 16px;
+    position: relative;
+    .firstSegment {
+      height: 35px;
+      line-height: 35px;
+      padding-left: 11px;
+    }
+    .currSegment {
+      a {
+        background: $white;
+        padding: 8px 16px;
+        cursor: pointer;
+        &::before {
+          color: $medium-gray;
+          font-size: 16px;
+          margin-right: 10px;
+          padding-right: 2px;
+        }
+      }
+      .label {
+        height: auto !important;
+        margin: 0 !important;
+        width: 224px !important;
+        padding: 4px 8px !important;
         border-radius: 2px;
-        z-index: 13;
-        border: solid 1px #cdd4de;
+        float: none !important;
+        display: inline-block;
 
-        &::after {
-            content: "";
-            width: 0;
-            height: 0;
-            border-left: 6px solid transparent;
-            border-right: 6px solid transparent;
-            border-bottom: 6px solid #ffffff;
-            bottom: 100%;
-            left: 50%;
-            right: auto;
-            transform: translate(-90%, 0) !important;
-            position: absolute;
-            pointer-events: none;
+        &:hover {
+          background-color: $light-gray;
+          color: $light-blue;
         }
-
+      }
     }
 
-    .separator {
-        width: 254px;
-        height: 2px;
-        background: $gray-2;
+    .firstSegment {
+      a {
+        padding: 4px 12px;
+      }
+      .label {
+        height: auto !important;
+        margin: 0 !important;
+        width: 190px !important;
+        padding: 4px !important;
+        border-radius: 2px;
+        float: none !important;
+        font-size: 14px;
+        cursor: default;
+        pointer-events: none;
+        &:hover {
+          color: $light-blue;
+        }
+      }
+    }
+  }
+
+  ul.jobmenu-list {
+    margin-top: 0;
+    span {
+      padding: 4px 4px 0 2px;
+      &.extdoc {
+        margin: 0 !important;
+      }
+    }
+
+    li {
+      display: grid;
+      grid-template-columns: 40px auto;
+      grid-template-rows: 40px;
+      align-items: center;
+
+      font-weight: normal;
+      border-left: none;
+      font-size: 14px;
+      color: #000;
+      padding: 1px 8px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      a {
+        border-radius: 3px;
+        border-left: none;
+        padding: 6px 8px;
+        margin-right: 6px;
+        display: grid;
+        grid-template-columns: auto 18px;
         align-items: center;
-        margin-left: 15px;
+
+        &:hover {
+          color: $light-blue;
+        }
+
+        svg {
+          display: none;
+        }
+      }
+
+      &.current {
+        a {
+          background: $matecat-blue;
+          color: #ffffff;
+          font-weight: normal;
+          svg {
+            display: block;
+            width: 16px;
+          }
+        }
+      }
     }
+  }
+}
 
-    ul.gotocurrentsegment {
+.func-foo {
+  height: 44px;
+  background-color: #fafafa;
+  padding: 0 146px;
+  width: 100%;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  display: grid;
 
-        width: 100%;
-        line-height: 24px;
-        font-size: 16px;
-        position: relative;
-        .firstSegment {
-            height: 35px;
-            line-height: 35px;
-            padding-left: 11px;
-        }
-        .currSegment {
-            a {
-                background: $white;
-                padding: 8px 16px;
-                cursor: pointer;
-                &::before {
-                    color: $medium-gray;
-                    font-size: 16px;
-                    margin-right: 10px;
-                    padding-right: 2px;
-                }
-            }
-            .label {
-                height: auto !important;
-                margin: 0 !important;
-                width: 224px !important;
-                padding: 4px 8px !important;
-                border-radius: 2px;
-                float:none !important;
-                display: inline-block;
-
-                &:hover {
-                    background-color: $light-gray;
-                    color: $light-blue;
-                }
-            }
+  #pagination_box {
+    nav {
+      ul {
+        #current_page {
+          padding: 0 4px;
+          a {
+            color: $translatedBlue;
+            padding: 2px 6px;
+            border: 2px solid $translatedBlue;
+            border-radius: 25px;
+          }
         }
 
-        .firstSegment {
-            a {
-                padding: 4px 12px;
-            }
-            .label {
-                height: auto !important;
-                margin: 0 !important;
-                width: 190px !important;
-                padding: 4px !important;
-                border-radius: 2px;
-                float:none !important;
-                font-size: 14px;
-                cursor: default;
-                pointer-events: none;
-                &:hover {
-                    color: $light-blue;
-                }
-            }
-        }
-    }
-
-    ul.jobmenu-list {
-        margin-top: 0;
-        span {
-            padding: 4px 4px 0 2px;
-            &.extdoc {
-                margin:0 !important;
-            }
+        li a {
+          opacity: 0.8;
         }
 
         li {
-            display: grid;
-            grid-template-columns: 40px auto;
-            grid-template-rows: 40px;
-            align-items: center;
-
-            font-weight: normal;
-            border-left: none;
-            font-size: 14px;
+          padding: 0 8px;
+          margin: 0;
+          border-right: none;
+          a {
+            text-decoration: none;
             color: #000;
-            padding: 1px 8px;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-
-            a {
-                border-radius: 3px;
-                border-left: none;
-                padding: 6px 8px;
-                margin-right: 6px;
-                display: grid;
-                grid-template-columns: auto 18px;
-                align-items: center;
-
-                &:hover {
-                    color: $light-blue;
-                }
-
-                svg {
-                    display: none;
-                }
-            }
-
-            &.current {
-                a {
-                    background: $matecat-blue;
-                    color: #ffffff;
-                    font-weight: normal;
-                    svg {
-                        display: block;
-                        width: 16px;
-                    }
-                }
-            }
+          }
         }
+      }
     }
-}
+  }
 
-
-.func-foo {
-    height: 44px;
-    background-color: #fafafa;
-    padding: 0 146px;
-    width: 100%;
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    z-index: 2;
+  .footer-body {
     display: grid;
+    position: relative;
+    grid-column-gap: 32px;
+    grid-template-columns: auto; /* auto 0.5fr 0.5fr 0.5fr 0.5fr  */
+    align-items: center;
+    justify-content: center;
+    min-width: 616px;
 
-    #pagination_box {
-        nav {
-            ul {
-               #current_page{
-                   padding: 0 4px;
-                   a{
-                       color: $translatedBlue;
-                       padding: 2px 6px;
-                       border: 2px solid $translatedBlue;
-                       border-radius: 25px;
-                   }
-               }
-
-                li a {
-                    opacity: 0.8;
-                }
-
-                li {
-                    padding: 0 8px ;
-                    margin: 0;
-                    border-right: none;
-                    a {
-                        text-decoration: none ;
-                        color: #000;
-                    }
-                }
-            }
-        }
+    .item {
+      font-size: 16px;
+      font-weight: bold;
+      font-style: normal;
+      font-stretch: normal;
+      line-height: 1.5;
+      color: black;
     }
-
-
-    .footer-body {
-        display: grid;
-        position: relative;
-        grid-column-gap: 32px;
-        grid-template-columns: auto; /* auto 0.5fr 0.5fr 0.5fr 0.5fr  */
-        align-items: center;
-        justify-content: center;
-        min-width: 616px;
-
-        .item {
-            font-size: 16px;
-            font-weight: bold;
-            font-style: normal;
-            font-stretch: normal;
-            line-height: 1.5;
-            color: black;
-        }
-    }
+  }
 }

--- a/public/css/sass/upload-main.scss
+++ b/public/css/sass/upload-main.scss
@@ -1,12 +1,12 @@
-@import "vendor_mc/semantic/matecat_semantic";
+@import 'vendor_mc/semantic/matecat_semantic';
 
 @import 'variables';
 
-@import "commons/buttons";
-@import "commons/filter-teams";
-@import "commons/icons";
-@import "commons/nav-bar";
-@import "commons/team-member";
+@import 'commons/buttons';
+@import 'commons/filter-teams';
+@import 'commons/icons';
+@import 'commons/nav-bar';
+@import 'commons/team-member';
 
 @import 'common-main';
 @import 'popup';
@@ -15,220 +15,214 @@
 
 @import 'upload-page';
 
-
 .translation-row {
+  display: grid;
+  justify-content: center;
+
+  .translation-options,
+  #additional-input-params {
     display: grid;
-    justify-content: center;
-
-    .translation-options, #additional-input-params {
-        display: grid;
-        grid-auto-flow: column;
-        /*grid-template-columns: repeat(8,auto);*/
-        grid-column-gap: 8px;
-    }
+    grid-auto-flow: column;
+    /*grid-template-columns: repeat(8,auto);*/
+    grid-column-gap: 8px;
+  }
 }
-
 
 .translate-box.target,
 .translate-box.source,
 .translate-box.tmx-select,
 .translate-box.project-subject,
 .translate-box.project-team {
-    .dropdown {
-        height: 37px;
-        padding: 4px;
-        padding-left: 10px;
-        font-size: 16px;
-        margin: 0 0 5px 0;
-        border-radius: 2px;
-        min-height: initial;
-        cursor: pointer !important;
-    }
-    .dropdown.icon {
-        padding: 8px;
-        border: none;
-    }
-    input.search {
-        padding: inherit !important;
-        font-family: system-ui, Calibri, Arial, Helvetica, sans-serif;
-        font-size: 16px;
-    }
+  .dropdown {
+    height: 37px;
+    padding: 4px;
+    padding-left: 10px;
+    font-size: 16px;
+    margin: 0 0 5px 0;
+    border-radius: 2px;
+    min-height: initial;
+    cursor: pointer !important;
+  }
+  .dropdown.icon {
+    padding: 8px;
+    border: none;
+  }
+  input.search {
+    padding: inherit !important;
+    font-family: system-ui, Calibri, Arial, Helvetica, sans-serif;
+    font-size: 16px;
+  }
 }
 
 .translate-box.tmx-select,
 .translate-box.source,
 .translate-box.target,
 .translate-box.project-subject,
-.translate-box.project-team{
-
-    #project-subject,
-    #source-lang,
-    #target-lang {
-       /* width:164px;*/
+.translate-box.project-team {
+  #project-subject,
+  #source-lang,
+  #target-lang {
+    /* width:164px;*/
+  }
+  #target-lang {
+    .multiple-none-text {
+      width: fit-content;
+      display: inline-block;
+      margin-right: 5px;
     }
-    #target-lang {
-        .multiple-none-text {
-            width: fit-content;
-            display: inline-block;
-            margin-right: 5px;
-        }
-        .multiple-text {
-            width: fit-content;
-            display: inline-block;
-        }
+    .multiple-text {
+      width: fit-content;
+      display: inline-block;
     }
-    #tmx-select {
-        /*width: 170px;*/
-        &:hover {
-            box-shadow: none !important;
-        }
+  }
+  #tmx-select {
+    /*width: 170px;*/
+    &:hover {
+      box-shadow: none !important;
     }
-    .menu-dropdown {
-        max-height: none !important;
-        overflow: hidden !important;
+  }
+  .menu-dropdown {
+    max-height: none !important;
+    overflow: hidden !important;
+  }
+  div#add-tmx-option:hover,
+  div#add-multiple-lang:hover {
+    background: rgba(0, 0, 0, 0.05);
+  }
+  div#add-tmx-option,
+  div#add-multiple-lang {
+    cursor: pointer;
+    color: #39699a;
+    font-size: 14px;
+    margin: 0;
+    padding: 15px;
+    .icon {
+      float: right;
+      font-size: 24px;
+      margin-top: -3px;
+      margin-right: 1px;
+      color: #39699a;
     }
-    div#add-tmx-option:hover ,
-    div#add-multiple-lang:hover {
-        background: rgba(0, 0, 0, 0.05);
+  }
+  div.item {
+    width: 100%;
+    min-width: 128px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-right: 10px !important;
+    span.item-key-id {
+      color: #757575;
+      clear: both;
     }
-    div#add-tmx-option ,
-    div#add-multiple-lang {
-        cursor: pointer;
-        color: #39699a;
-        font-size: 14px;
-        margin: 0;
-        padding: 15px;
-        .icon {
-            float: right;
-            font-size: 24px;
-            margin-top: -3px;
-            margin-right: 1px;
-            color: #39699a;
-        }
+    span {
+      line-height: 17px;
     }
-    div.item {
-        width: 100%;
-        min-width: 128px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        padding-right: 10px !important;
-        span.item-key-id {
-            color: #757575;
-            clear: both;
-        }
-        span {
-            line-height: 17px;
-        }
-        .no-descr {
-            font-style: italic ;
-        }
+    .no-descr {
+      font-style: italic;
     }
-    .dropdown > span.text {
-        margin-top: 0 !important;
-        pointer-events: none;
-        line-height: 28px !important;
-        max-width: 80% !important;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        font-size: 16px;
-        .item-key-id {
-            margin-top: 0px;
-            float: none;
-        }
-        .item-key-name {
-            color: initial;
-            margin-top: 0px;
-            margin-right: 5px;
-            float: none;
-        }
+  }
+  .dropdown > span.text {
+    margin-top: 0 !important;
+    pointer-events: none;
+    line-height: 28px !important;
+    max-width: 80% !important;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 16px;
+    .item-key-id {
+      margin-top: 0px;
+      float: none;
     }
-    .divider {
-        margin: 0 !important;
+    .item-key-name {
+      color: initial;
+      margin-top: 0px;
+      margin-right: 5px;
+      float: none;
     }
-
+  }
+  .divider {
+    margin: 0 !important;
+  }
 }
 
 .wrapper-upload .translate-box.tmx-select {
-    span.text {
-        margin: 0 !important;
-        line-height: 28px !important;
-        max-width: 85% !important;
-        font-size: 16px !important;
-        i.icon-checkmark2.icon {
-            display: none;
-        }
+  span.text {
+    margin: 0 !important;
+    line-height: 28px !important;
+    max-width: 85% !important;
+    font-size: 16px !important;
+    i.icon-checkmark2.icon {
+      display: none;
     }
-    .item {
-        i.icon-checkmark2.icon {
-            color: rgba(117, 117, 117, 0.7);;
-            font-size: 20px;
-            position: absolute;
-            right: 7px;
-            display: none;
-        }
-        &.active {
-            background-color: rgba(0, 0, 0, 0.03) !important;
-            i.icon-checkmark2.icon {
-                display: block;
-            }
-        }
-
+  }
+  .item {
+    i.icon-checkmark2.icon {
+      color: rgba(117, 117, 117, 0.7);
+      font-size: 20px;
+      position: absolute;
+      right: 7px;
+      display: none;
     }
-    .item-key-id {
-        color: #757575;
-    }
-    .item-key-name {
-        color: initial;
-        max-width: 145px !important;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-    .text .multiple-tm {
+    &.active {
+      background-color: rgba(0, 0, 0, 0.03) !important;
+      i.icon-checkmark2.icon {
         display: block;
+      }
     }
-    .menu .multiple-tm {
-        display: none;
-    }
-    .multiple-tm-num {
-        margin-top: 0 !important;
-        margin-right: 4px;
-    }
-    .icon-info {
-        font-size: 19px;
-        margin-top: 1px;
-        margin-left: 5px;
-        color: rgba(117, 117, 117, 0.7);
-    }
-    .tm-tooltip {
-        text-align: left;
-    }
-    .tm-info-icon {
-        float: left;
-    }
-    .tm-info-title {
-        line-height: 16px;
-    }
-    h2 {
-        float: left;
-    }
-
+  }
+  .item-key-id {
+    color: #757575;
+  }
+  .item-key-name {
+    color: initial;
+    max-width: 145px !important;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .text .multiple-tm {
+    display: block;
+  }
+  .menu .multiple-tm {
+    display: none;
+  }
+  .multiple-tm-num {
+    margin-top: 0 !important;
+    margin-right: 4px;
+  }
+  .icon-info {
+    font-size: 19px;
+    margin-top: 1px;
+    margin-left: 5px;
+    color: rgba(117, 117, 117, 0.7);
+  }
+  .tm-tooltip {
+    text-align: left;
+  }
+  .tm-info-icon {
+    float: left;
+  }
+  .tm-info-title {
+    line-height: 16px;
+  }
+  h2 {
+    float: left;
+  }
 }
 
 @media only screen and (max-width: 1320px) {
-    .translate-box.tmx-select,
-    .translate-box.source,
-    .translate-box.target,
-    .translate-box.project-subject,
-    .translate-box.project-team{
+  .translate-box.tmx-select,
+  .translate-box.source,
+  .translate-box.target,
+  .translate-box.project-subject,
+  .translate-box.project-team {
+    .menu .header {
+      padding: 12px !important;
+    }
 
-        .menu .header {
-            padding: 12px !important;
-        }
-
-        /*#project-subject,
+    /*#project-subject,
         #source-lang,
         #target-lang {
             !*width: 127px ;*!
@@ -237,117 +231,115 @@
             }
         }*/
 
-        .ui.icon.search.input {
-            min-width: unset;
-        }
-        #target-lang {
-            .multiple-none-text {
-                display: none;
-            }
-        }
-        #tmx-select {
-         min-width: 168px;
-            &:hover {
-                box-shadow: none !important;
-            }
-            .ui.multiple.search.dropdown > .text {
-                width: 150px;
-            }
-        }
-        .menu-dropdown {
-            max-height: none !important;
-            overflow: hidden !important;
-        }
-        div#add-tmx-option:hover ,
-        div#add-multiple-lang:hover {
-            background: rgba(0, 0, 0, 0.05);
-        }
-        div#add-tmx-option ,
-        div#add-multiple-lang {
-            cursor: pointer;
-            color: #39699a;
-            font-size: 14px;
-            margin: 0;
-            padding: 15px;
-            .icon {
-                float: right;
-                font-size: 24px;
-                margin-top: -3px;
-                margin-right: 1px;
-                color: #39699a;
-            }
-        }
-        div.item {
-            width: 100%;
-            min-width: 128px;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            padding-right: 10px !important;
-            span.item-key-id {
-                color: #757575;
-                clear: both;
-            }
-            span {
-                line-height: 17px;
-            }
-            .no-descr {
-                font-style: italic ;
-            }
-        }
-        .dropdown > span.text {
-            margin-top: 0 !important;
-            pointer-events: none;
-            line-height: 28px !important;
-            max-width: 80% !important;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            .item-key-id {
-                margin-top: 0px;
-                float: none;
-            }
-            .item-key-name {
-                color: initial;
-                margin-top: 0px;
-                margin-right: 5px;
-                float: none;
-            }
-        }
-        .divider {
-            margin: 0 !important;
-        }
+    .ui.icon.search.input {
+      min-width: unset;
     }
-    .translate-box.project-name {
-        /*width: 140px;*/
-        .upload-input {
-            width: 140px;
-        }
+    #target-lang {
+      .multiple-none-text {
+        display: none;
+      }
     }
-    .translate-box.settings {
-        .more-options {
-            margin: 0;
-        }
+    #tmx-select {
+      min-width: 168px;
+      &:hover {
+        box-shadow: none !important;
+      }
+      .ui.multiple.search.dropdown > .text {
+        width: 150px;
+      }
     }
-    .translate-box.tmx-select {
-        margin-right: 0;
+    .menu-dropdown {
+      max-height: none !important;
+      overflow: hidden !important;
     }
-    .wrapper-upload{
-        .translate-box {
-          div.dropdown{
-            width:140px;
-          }
-        }
+    div#add-tmx-option:hover,
+    div#add-multiple-lang:hover {
+      background: rgba(0, 0, 0, 0.05);
     }
+    div#add-tmx-option,
+    div#add-multiple-lang {
+      cursor: pointer;
+      color: #39699a;
+      font-size: 14px;
+      margin: 0;
+      padding: 15px;
+      .icon {
+        float: right;
+        font-size: 24px;
+        margin-top: -3px;
+        margin-right: 1px;
+        color: #39699a;
+      }
+    }
+    div.item {
+      width: 100%;
+      min-width: 128px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      padding-right: 10px !important;
+      span.item-key-id {
+        color: #757575;
+        clear: both;
+      }
+      span {
+        line-height: 17px;
+      }
+      .no-descr {
+        font-style: italic;
+      }
+    }
+    .dropdown > span.text {
+      margin-top: 0 !important;
+      pointer-events: none;
+      line-height: 28px !important;
+      max-width: 80% !important;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      .item-key-id {
+        margin-top: 0px;
+        float: none;
+      }
+      .item-key-name {
+        color: initial;
+        margin-top: 0px;
+        margin-right: 5px;
+        float: none;
+      }
+    }
+    .divider {
+      margin: 0 !important;
+    }
+  }
+  .translate-box.project-name {
+    /*width: 140px;*/
+    .upload-input {
+      width: 140px;
+    }
+  }
+  .translate-box.settings {
+    .more-options {
+      margin: 0;
+    }
+  }
+  .translate-box.tmx-select {
+    margin-right: 0;
+  }
+  .wrapper-upload {
+    .translate-box {
+      div.dropdown {
+        width: 140px;
+      }
+    }
+  }
 
-    div.more-options-cont {
-        span.text {
-            display: none;
-        }
+  div.more-options-cont {
+    span.text {
+      display: none;
     }
+  }
 }
-
-
 
 /*@media only screen and (min-width: 1200px) {
     .translate-box.target {
@@ -369,126 +361,117 @@
     }
 }*/
 
-
 @media only screen and (min-width: 1600px) {
-    .wrapper-upload{
-        .translate-box{
-            input{
-                width: 200px;
-            }
-            div.dropdown{
-                width: 200px;
-                .menu{
-                    width: 280px;
-                }
-                .text {
-                    /*overflow: hidden;
+  .wrapper-upload {
+    .translate-box {
+      input {
+        width: 200px;
+      }
+      div.dropdown {
+        width: 200px;
+        .menu {
+          width: 280px;
+        }
+        .text {
+          /*overflow: hidden;
                     text-overflow: ellipsis;
                     font-size: 16px;
                     white-space: nowrap;*/
-                }
-            }
-
         }
-        #tmx-select {
-            width: 200px;
-            &:hover {
-                box-shadow: none !important;
-            }
-        }
+      }
     }
+    #tmx-select {
+      width: 200px;
+      &:hover {
+        box-shadow: none !important;
+      }
+    }
+  }
 }
 
 @media only screen and (max-width: 1599px) and (min-width: 1321px) {
-
-    .wrapper-upload{
-        .translate-box {
-            .upload-input {
-                width: 162px;
-            }
-            div.dropdown{
-                width:162px;
-                .text {
-                    /*overflow: hidden;
+  .wrapper-upload {
+    .translate-box {
+      .upload-input {
+        width: 162px;
+      }
+      div.dropdown {
+        width: 162px;
+        .text {
+          /*overflow: hidden;
                     text-overflow: ellipsis;
                     font-size: 16px;
                     white-space: nowrap;*/
-                }
-            }
-            #tmx-select {
-                width:170px;
-            }
         }
+      }
+      #tmx-select {
+        width: 170px;
+      }
     }
+  }
 }
-
 
 @media only screen and (max-width: 1199px) and (min-width: 992px) {
-    .translate-box.target {
-        #target-lang {
-            .multiple-none-text {
-                display: none;
-            }
-        }
+  .translate-box.target {
+    #target-lang {
+      .multiple-none-text {
+        display: none;
+      }
     }
+  }
 
-    .wrapper-upload{
-        .translate-box {
-            .upload-input {
-                width: 128px;
-            }
-            div.dropdown{
-                width:128px;
-                .text {
-                    /*overflow: hidden;
+  .wrapper-upload {
+    .translate-box {
+      .upload-input {
+        width: 128px;
+      }
+      div.dropdown {
+        width: 128px;
+        .text {
+          /*overflow: hidden;
                     text-overflow: ellipsis;
                     font-size: 16px;
                     white-space: nowrap;*/
-                }
-            }
-            #tmx-select {
-
-            }
         }
+      }
+      #tmx-select {
+      }
     }
+  }
 }
-
 
 @media only screen and (max-width: 991px) and (min-width: 768px) {
-    .translate-box.target {
-        #target-lang {
-            .multiple-none-text {
-                display: none;
-            }
-        }
+  .translate-box.target {
+    #target-lang {
+      .multiple-none-text {
+        display: none;
+      }
     }
+  }
 
-    .wrapper-upload{
-        .translate-box {
-            .upload-input {
-                width: 128px;
-            }
-            div.dropdown{
-                width:128px;
-            }
-            #tmx-select {
-
-            }
-        }
+  .wrapper-upload {
+    .translate-box {
+      .upload-input {
+        width: 128px;
+      }
+      div.dropdown {
+        width: 128px;
+      }
+      #tmx-select {
+      }
     }
+  }
 }
 
-
-@media only screen and (max-width: 991px){
-
-    .wrapper-upload{
-        .translate-box {
-            .upload-input {
-                width: 128px;
-            }
-            div.dropdown{
-                width:128px;
-            }
-        }
+@media only screen and (max-width: 991px) {
+  .wrapper-upload {
+    .translate-box {
+      .upload-input {
+        width: 128px;
+      }
+      div.dropdown {
+        width: 128px;
+      }
     }
+  }
 }

--- a/public/css/sass/upload-page.scss
+++ b/public/css/sass/upload-page.scss
@@ -1,8 +1,8 @@
 body {
-    margin: 0;
-    padding: 0;
-    overflow: visible;
-    min-height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: visible;
+  min-height: 100%;
 }
 
 /* Interaction states
@@ -14,9 +14,11 @@ body {
 //    color: #555555;
 //}
 
-.ui-state-default a, .ui-state-default a:link, .ui-state-default a:visited {
-    color: #555555;
-    text-decoration: none;
+.ui-state-default a,
+.ui-state-default a:link,
+.ui-state-default a:visited {
+  color: #555555;
+  text-decoration: none;
 }
 
 //.ui-state-hover, .ui-widget-content .ui-state-hover, .ui-widget-header .ui-state-hover, .ui-state-focus, .ui-widget-content .ui-state-focus, .ui-widget-header .ui-state-focus {
@@ -26,9 +28,10 @@ body {
 //    color: #212121;
 //}
 
-.ui-state-hover a, .ui-state-hover a:hover {
-    color: #212121;
-    text-decoration: none;
+.ui-state-hover a,
+.ui-state-hover a:hover {
+  color: #212121;
+  text-decoration: none;
 }
 
 //.ui-state-active, .ui-widget-content .ui-state-active, .ui-widget-header .ui-state-active {
@@ -38,13 +41,15 @@ body {
 //    color: #212121;
 //}
 
-.ui-state-active a, .ui-state-active a:link, .ui-state-active a:visited {
-    color: #212121;
-    text-decoration: none;
+.ui-state-active a,
+.ui-state-active a:link,
+.ui-state-active a:visited {
+  color: #212121;
+  text-decoration: none;
 }
 
 .ui-widget :active {
-    outline: none;
+  outline: none;
 }
 
 /* Interaction Cues
@@ -55,8 +60,10 @@ body {
 //    color: #363636;
 //}
 
-.ui-state-highlight a, .ui-widget-content .ui-state-highlight a, .ui-widget-header .ui-state-highlight a {
-    color: #363636;
+.ui-state-highlight a,
+.ui-widget-content .ui-state-highlight a,
+.ui-widget-header .ui-state-highlight a {
+  color: #363636;
 }
 
 //.ui-state-error, .ui-widget-content .ui-state-error, .ui-widget-header .ui-state-error {
@@ -65,28 +72,38 @@ body {
 //    color: #cd0a0a;
 //}
 
-.ui-state-error a, .ui-widget-content .ui-state-error a, .ui-widget-header .ui-state-error a {
-    color: #cd0a0a;
+.ui-state-error a,
+.ui-widget-content .ui-state-error a,
+.ui-widget-header .ui-state-error a {
+  color: #cd0a0a;
 }
 
-.ui-state-error-text, .ui-widget-content .ui-state-error-text, .ui-widget-header .ui-state-error-text {
-    color: #cd0a0a;
+.ui-state-error-text,
+.ui-widget-content .ui-state-error-text,
+.ui-widget-header .ui-state-error-text {
+  color: #cd0a0a;
 }
 
-.ui-priority-primary, .ui-widget-content .ui-priority-primary, .ui-widget-header .ui-priority-primary {
-    font-weight: bold;
+.ui-priority-primary,
+.ui-widget-content .ui-priority-primary,
+.ui-widget-header .ui-priority-primary {
+  font-weight: bold;
 }
 
-.ui-priority-secondary, .ui-widget-content .ui-priority-secondary, .ui-widget-header .ui-priority-secondary {
-    opacity: .7;
-    filter: Alpha(Opacity=70);
-    font-weight: normal;
+.ui-priority-secondary,
+.ui-widget-content .ui-priority-secondary,
+.ui-widget-header .ui-priority-secondary {
+  opacity: 0.7;
+  filter: Alpha(Opacity=70);
+  font-weight: normal;
 }
 
-.ui-state-disabled, .ui-widget-content .ui-state-disabled, .ui-widget-header .ui-state-disabled {
-    opacity: .35;
-    filter: Alpha(Opacity=35);
-    background-image: none;
+.ui-state-disabled,
+.ui-widget-content .ui-state-disabled,
+.ui-widget-header .ui-state-disabled {
+  opacity: 0.35;
+  filter: Alpha(Opacity=35);
+  background-image: none;
 }
 
 /* Icons
@@ -96,32 +113,44 @@ body {
 ----------------------------------*/
 
 /* Corner radius */
-.ui-corner-all, .ui-corner-top, .ui-corner-left, .ui-corner-tl {
-    -moz-border-radius-topleft: 4px;
-    -webkit-border-top-left-radius: 4px;
-    -khtml-border-top-left-radius: 4px;
-    border-top-left-radius: 4px;
+.ui-corner-all,
+.ui-corner-top,
+.ui-corner-left,
+.ui-corner-tl {
+  -moz-border-radius-topleft: 4px;
+  -webkit-border-top-left-radius: 4px;
+  -khtml-border-top-left-radius: 4px;
+  border-top-left-radius: 4px;
 }
 
-.ui-corner-all, .ui-corner-top, .ui-corner-right, .ui-corner-tr {
-    -moz-border-radius-topright: 4px;
-    -webkit-border-top-right-radius: 4px;
-    -khtml-border-top-right-radius: 4px;
-    border-top-right-radius: 4px;
+.ui-corner-all,
+.ui-corner-top,
+.ui-corner-right,
+.ui-corner-tr {
+  -moz-border-radius-topright: 4px;
+  -webkit-border-top-right-radius: 4px;
+  -khtml-border-top-right-radius: 4px;
+  border-top-right-radius: 4px;
 }
 
-.ui-corner-all, .ui-corner-bottom, .ui-corner-left, .ui-corner-bl {
-    -moz-border-radius-bottomleft: 4px;
-    -webkit-border-bottom-left-radius: 4px;
-    -khtml-border-bottom-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+.ui-corner-all,
+.ui-corner-bottom,
+.ui-corner-left,
+.ui-corner-bl {
+  -moz-border-radius-bottomleft: 4px;
+  -webkit-border-bottom-left-radius: 4px;
+  -khtml-border-bottom-left-radius: 4px;
+  border-bottom-left-radius: 4px;
 }
 
-.ui-corner-all, .ui-corner-bottom, .ui-corner-right, .ui-corner-br {
-    -moz-border-radius-bottomright: 4px;
-    -webkit-border-bottom-right-radius: 4px;
-    -khtml-border-bottom-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+.ui-corner-all,
+.ui-corner-bottom,
+.ui-corner-right,
+.ui-corner-br {
+  -moz-border-radius-bottomright: 4px;
+  -webkit-border-bottom-right-radius: 4px;
+  -khtml-border-bottom-right-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 /* Overlays */
@@ -153,81 +182,82 @@ body {
  * http://docs.jquery.com/UI/Resizable#theming
  */
 .ui-resizable {
-    position: relative;
+  position: relative;
 }
 
 .ui-resizable-handle {
-    position: absolute;
-    font-size: 0.1px;
-    display: block;
+  position: absolute;
+  font-size: 0.1px;
+  display: block;
 }
 
-.ui-resizable-disabled .ui-resizable-handle, .ui-resizable-autohide .ui-resizable-handle {
-    display: none;
+.ui-resizable-disabled .ui-resizable-handle,
+.ui-resizable-autohide .ui-resizable-handle {
+  display: none;
 }
 
 .ui-resizable-n {
-    cursor: n-resize;
-    height: 7px;
-    width: 100%;
-    top: -5px;
-    left: 0;
+  cursor: n-resize;
+  height: 7px;
+  width: 100%;
+  top: -5px;
+  left: 0;
 }
 
 .ui-resizable-s {
-    cursor: s-resize;
-    height: 7px;
-    width: 100%;
-    bottom: -5px;
-    left: 0;
+  cursor: s-resize;
+  height: 7px;
+  width: 100%;
+  bottom: -5px;
+  left: 0;
 }
 
 .ui-resizable-e {
-    cursor: e-resize;
-    width: 7px;
-    right: -5px;
-    top: 0;
-    height: 100%;
+  cursor: e-resize;
+  width: 7px;
+  right: -5px;
+  top: 0;
+  height: 100%;
 }
 
 .ui-resizable-w {
-    cursor: w-resize;
-    width: 7px;
-    left: -5px;
-    top: 0;
-    height: 100%;
+  cursor: w-resize;
+  width: 7px;
+  left: -5px;
+  top: 0;
+  height: 100%;
 }
 
 .ui-resizable-se {
-    cursor: se-resize;
-    width: 12px;
-    height: 12px;
-    right: 1px;
-    bottom: 1px;
+  cursor: se-resize;
+  width: 12px;
+  height: 12px;
+  right: 1px;
+  bottom: 1px;
 }
 
 .ui-resizable-sw {
-    cursor: sw-resize;
-    width: 9px;
-    height: 9px;
-    left: -5px;
-    bottom: -5px;
+  cursor: sw-resize;
+  width: 9px;
+  height: 9px;
+  left: -5px;
+  bottom: -5px;
 }
 
 .ui-resizable-nw {
-    cursor: nw-resize;
-    width: 9px;
-    height: 9px;
-    left: -5px;
-    top: -5px;
+  cursor: nw-resize;
+  width: 9px;
+  height: 9px;
+  left: -5px;
+  top: -5px;
 }
 
 .ui-resizable-ne {
-    cursor: ne-resize;
-    width: 9px;
-    height: 9px;
-    right: -5px;
-    top: -5px;
+  cursor: ne-resize;
+  width: 9px;
+  height: 9px;
+  right: -5px;
+  top: -5px;
 }
 
 /*!
@@ -240,9 +270,9 @@ body {
  * http://docs.jquery.com/UI/Selectable#theming
  */
 .ui-selectable-helper {
-    position: absolute;
-    z-index: 100;
-    border: 1px dotted black;
+  position: absolute;
+  z-index: 100;
+  border: 1px dotted black;
 }
 
 /*!
@@ -256,55 +286,55 @@ body {
  */
 /* IE/Win - Fix animation bug - #4615 */
 .ui-accordion {
-    width: 100%;
+  width: 100%;
 }
 
 .ui-accordion .ui-accordion-header {
-    cursor: pointer;
-    position: relative;
-    margin-top: 1px;
-    zoom: 1;
+  cursor: pointer;
+  position: relative;
+  margin-top: 1px;
+  zoom: 1;
 }
 
 .ui-accordion .ui-accordion-li-fix {
-    display: inline;
+  display: inline;
 }
 
 .ui-accordion .ui-accordion-header-active {
-    border-bottom: 0 !important;
+  border-bottom: 0 !important;
 }
 
 .ui-accordion .ui-accordion-header a {
-    display: block;
-    font-size: 1em;
-    padding: .5em .5em .5em .7em;
+  display: block;
+  font-size: 1em;
+  padding: 0.5em 0.5em 0.5em 0.7em;
 }
 
 .ui-accordion-icons .ui-accordion-header a {
-    padding-left: 2.2em;
+  padding-left: 2.2em;
 }
 
 .ui-accordion .ui-accordion-header .ui-icon {
-    position: absolute;
-    left: .5em;
-    top: 50%;
-    margin-top: -8px;
+  position: absolute;
+  left: 0.5em;
+  top: 50%;
+  margin-top: -8px;
 }
 
 .ui-accordion .ui-accordion-content {
-    padding: 1em 2.2em;
-    border-top: 0;
-    margin-top: -2px;
-    position: relative;
-    top: 1px;
-    margin-bottom: 2px;
-    overflow: auto;
-    display: none;
-    zoom: 1;
+  padding: 1em 2.2em;
+  border-top: 0;
+  margin-top: -2px;
+  position: relative;
+  top: 1px;
+  margin-bottom: 2px;
+  overflow: auto;
+  display: none;
+  zoom: 1;
 }
 
 .ui-accordion .ui-accordion-content-active {
-    display: block;
+  display: block;
 }
 
 /*!
@@ -317,13 +347,13 @@ body {
  * http://docs.jquery.com/UI/Autocomplete#theming
  */
 .ui-autocomplete {
-    position: absolute;
-    cursor: default;
+  position: absolute;
+  cursor: default;
 }
 
 /* workarounds */
 * html .ui-autocomplete {
-    width: 1px;
+  width: 1px;
 }
 
 /* without this, the menu expands to 100% in IE6 */
@@ -338,38 +368,38 @@ body {
  * http://docs.jquery.com/UI/Menu#theming
  */
 .ui-menu {
-    list-style: none;
-    padding: 2px;
-    margin: 0;
-    display: block;
-    float: left;
+  list-style: none;
+  padding: 2px;
+  margin: 0;
+  display: block;
+  float: left;
 }
 
 .ui-menu .ui-menu {
-    margin-top: -3px;
+  margin-top: -3px;
 }
 
 .ui-menu .ui-menu-item {
-    margin: 0;
-    padding: 0;
-    zoom: 1;
-    float: left;
-    clear: left;
-    width: 100%;
+  margin: 0;
+  padding: 0;
+  zoom: 1;
+  float: left;
+  clear: left;
+  width: 100%;
 }
 
 .ui-menu .ui-menu-item a {
-    text-decoration: none;
-    display: block;
-    padding: .2em .4em;
-    line-height: 1.5;
-    zoom: 1;
+  text-decoration: none;
+  display: block;
+  padding: 0.2em 0.4em;
+  line-height: 1.5;
+  zoom: 1;
 }
 
 .ui-menu .ui-menu-item a.ui-state-hover,
 .ui-menu .ui-menu-item a.ui-state-active {
-    font-weight: normal;
-    margin: -1px;
+  font-weight: normal;
+  margin: -1px;
 }
 
 /*!
@@ -382,83 +412,92 @@ body {
  * http://docs.jquery.com/UI/Button#theming
  */
 .ui-button {
-    display: inline-block;
-    position: relative;
-    padding: 0;
-    margin-right: .1em;
-    text-decoration: none !important;
-    cursor: pointer;
-    text-align: center;
-    zoom: 1;
-    overflow: visible;
+  display: inline-block;
+  position: relative;
+  padding: 0;
+  margin-right: 0.1em;
+  text-decoration: none !important;
+  cursor: pointer;
+  text-align: center;
+  zoom: 1;
+  overflow: visible;
 }
 
 /* the overflow property removes extra width in IE */
 .ui-button-icon-only {
-    width: 2.2em;
+  width: 2.2em;
 }
 
 /* to make room for the icon, a width needs to be set here */
 button.ui-button-icon-only {
-    width: 2.4em;
+  width: 2.4em;
 }
 
 /* button elements seem to need a little more width */
 .ui-button-icons-only {
-    width: 3.4em;
+  width: 3.4em;
 }
 
 table .btn {
-    padding: 0px 20px;
+  padding: 0px 20px;
 }
 
 button.ui-button-icons-only {
-    width: 3.7em;
+  width: 3.7em;
 }
 
 /*button text element */
 .ui-button .ui-button-text {
-    font-family: Calibri, Arial, Helvetica, sans-serif
+  font-family: Calibri, Arial, Helvetica, sans-serif;
 }
 
 /*button icon element(s) */
-.ui-button-icon-only .ui-icon, .ui-button-text-icon-primary .ui-icon, .ui-button-text-icon-secondary .ui-icon, .ui-button-text-icons .ui-icon, .ui-button-icons-only .ui-icon {
-    position: absolute;
-    top: 50%;
-    margin-top: -8px;
+.ui-button-icon-only .ui-icon,
+.ui-button-text-icon-primary .ui-icon,
+.ui-button-text-icon-secondary .ui-icon,
+.ui-button-text-icons .ui-icon,
+.ui-button-icons-only .ui-icon {
+  position: absolute;
+  top: 50%;
+  margin-top: -8px;
 }
 
 .ui-button-icon-only .ui-icon {
-    left: 50%;
-    margin-left: -8px;
+  left: 50%;
+  margin-left: -8px;
 }
 
-.ui-button-text-icon-primary .ui-button-icon-primary, .ui-button-text-icons .ui-button-icon-primary, .ui-button-icons-only .ui-button-icon-primary {
-    left: .5em;
+.ui-button-text-icon-primary .ui-button-icon-primary,
+.ui-button-text-icons .ui-button-icon-primary,
+.ui-button-icons-only .ui-button-icon-primary {
+  left: 0.5em;
 }
 
-.ui-button-text-icon-secondary .ui-button-icon-secondary, .ui-button-text-icons .ui-button-icon-secondary, .ui-button-icons-only .ui-button-icon-secondary {
-    right: .5em;
+.ui-button-text-icon-secondary .ui-button-icon-secondary,
+.ui-button-text-icons .ui-button-icon-secondary,
+.ui-button-icons-only .ui-button-icon-secondary {
+  right: 0.5em;
 }
 
-.ui-button-text-icons .ui-button-icon-secondary, .ui-button-icons-only .ui-button-icon-secondary {
-    right: .5em;
+.ui-button-text-icons .ui-button-icon-secondary,
+.ui-button-icons-only .ui-button-icon-secondary {
+  right: 0.5em;
 }
 
 /*button sets*/
 .ui-buttonset {
-    margin-right: 7px;
+  margin-right: 7px;
 }
 
 .ui-buttonset .ui-button {
-    margin-left: 0;
-    margin-right: -.3em;
+  margin-left: 0;
+  margin-right: -0.3em;
 }
 
 /* workarounds */
 button.ui-button::-moz-focus-inner {
-    border: 0;
-    padding: 0;
+  border: 0;
+  padding: 0;
 }
 
 /* reset extra padding in Firefox */
@@ -472,76 +511,77 @@ button.ui-button::-moz-focus-inner {
  * http://docs.jquery.com/UI/Dialog#theming
  */
 .ui-dialog {
-    position: absolute;
-    padding: .2em;
-    width: 300px;
-    overflow: hidden;
+  position: absolute;
+  padding: 0.2em;
+  width: 300px;
+  overflow: hidden;
 }
 
 .ui-dialog .ui-dialog-titlebar {
-    padding: .4em 1em;
-    position: relative;
+  padding: 0.4em 1em;
+  position: relative;
 }
 
 .ui-dialog .ui-dialog-title {
-    float: left;
-    margin: .1em 16px .1em 0;
+  float: left;
+  margin: 0.1em 16px 0.1em 0;
 }
 
 .ui-dialog .ui-dialog-titlebar-close {
-    position: absolute;
-    right: .3em;
-    top: 50%;
-    width: 19px;
-    margin: -10px 0 0 0;
-    padding: 1px;
-    height: 18px;
+  position: absolute;
+  right: 0.3em;
+  top: 50%;
+  width: 19px;
+  margin: -10px 0 0 0;
+  padding: 1px;
+  height: 18px;
 }
 
 .ui-dialog .ui-dialog-titlebar-close span {
-    display: block;
-    margin: 1px;
+  display: block;
+  margin: 1px;
 }
 
-.ui-dialog .ui-dialog-titlebar-close:hover, .ui-dialog .ui-dialog-titlebar-close:focus {
-    padding: 0;
+.ui-dialog .ui-dialog-titlebar-close:hover,
+.ui-dialog .ui-dialog-titlebar-close:focus {
+  padding: 0;
 }
 
 .ui-dialog .ui-dialog-content {
-    position: relative;
-    border: 0;
-    padding: .5em 1em;
-    background: none;
-    overflow: auto;
-    zoom: 1;
+  position: relative;
+  border: 0;
+  padding: 0.5em 1em;
+  background: none;
+  overflow: auto;
+  zoom: 1;
 }
 
 .ui-dialog .ui-dialog-buttonpane {
-    text-align: left;
-    border-width: 1px 0 0 0;
-    background-image: none;
-    margin: .5em 0 0 0;
-    padding: .3em 1em .5em .4em;
+  text-align: left;
+  border-width: 1px 0 0 0;
+  background-image: none;
+  margin: 0.5em 0 0 0;
+  padding: 0.3em 1em 0.5em 0.4em;
 }
 
 .ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset {
-    float: right;
+  float: right;
 }
 
 .ui-dialog .ui-dialog-buttonpane button {
-    margin: .5em .4em .5em 0;
-    cursor: pointer;
+  margin: 0.5em 0.4em 0.5em 0;
+  cursor: pointer;
 }
 
 .ui-dialog .ui-resizable-se {
-    width: 14px;
-    height: 14px;
-    right: 3px;
-    bottom: 3px;
+  width: 14px;
+  height: 14px;
+  right: 3px;
+  bottom: 3px;
 }
 
 .ui-draggable .ui-dialog-titlebar {
-    cursor: move;
+  cursor: move;
 }
 
 /*!
@@ -554,71 +594,71 @@ button.ui-button::-moz-focus-inner {
  * http://docs.jquery.com/UI/Slider#theming
  */
 .ui-slider {
-    position: relative;
-    text-align: left;
+  position: relative;
+  text-align: left;
 }
 
 .ui-slider .ui-slider-handle {
-    position: absolute;
-    z-index: 2;
-    width: 1.2em;
-    height: 1.2em;
-    cursor: default;
+  position: absolute;
+  z-index: 2;
+  width: 1.2em;
+  height: 1.2em;
+  cursor: default;
 }
 
 .ui-slider .ui-slider-range {
-    position: absolute;
-    z-index: 1;
-    font-size: .7em;
-    display: block;
-    border: 0;
-    background-position: 0 0;
+  position: absolute;
+  z-index: 1;
+  font-size: 0.7em;
+  display: block;
+  border: 0;
+  background-position: 0 0;
 }
 
 .ui-slider-horizontal {
-    height: .8em;
+  height: 0.8em;
 }
 
 .ui-slider-horizontal .ui-slider-handle {
-    top: -.3em;
-    margin-left: -.6em;
+  top: -0.3em;
+  margin-left: -0.6em;
 }
 
 .ui-slider-horizontal .ui-slider-range {
-    top: 0;
-    height: 100%;
+  top: 0;
+  height: 100%;
 }
 
 .ui-slider-horizontal .ui-slider-range-min {
-    left: 0;
+  left: 0;
 }
 
 .ui-slider-horizontal .ui-slider-range-max {
-    right: 0;
+  right: 0;
 }
 
 .ui-slider-vertical {
-    width: .8em;
-    height: 100px;
+  width: 0.8em;
+  height: 100px;
 }
 
 .ui-slider-vertical .ui-slider-handle {
-    left: -.3em;
-    margin-left: 0;
-    margin-bottom: -.6em;
+  left: -0.3em;
+  margin-left: 0;
+  margin-bottom: -0.6em;
 }
 
 .ui-slider-vertical .ui-slider-range {
-    left: 0;
-    width: 100%;
+  left: 0;
+  width: 100%;
 }
 
 .ui-slider-vertical .ui-slider-range-min {
-    bottom: 0;
+  bottom: 0;
 }
 
 .ui-slider-vertical .ui-slider-range-max {
-    top: 0;
+  top: 0;
 }
 
 /*!
@@ -631,57 +671,60 @@ button.ui-button::-moz-focus-inner {
  * http://docs.jquery.com/UI/Tabs#theming
  */
 .ui-tabs {
-    position: relative;
-    padding: .2em;
-    zoom: 1;
+  position: relative;
+  padding: 0.2em;
+  zoom: 1;
 }
 
 /* position: relative prevents IE scroll bug (element with position: relative inside container with overflow: auto appear as "fixed") */
 .ui-tabs .ui-tabs-nav {
-    margin: 0;
-    padding: .2em .2em 0;
+  margin: 0;
+  padding: 0.2em 0.2em 0;
 }
 
 .ui-tabs .ui-tabs-nav li {
-    list-style: none;
-    float: left;
-    position: relative;
-    top: 1px;
-    margin: 0 .2em 1px 0;
-    border-bottom: 0 !important;
-    padding: 0;
-    white-space: nowrap;
+  list-style: none;
+  float: left;
+  position: relative;
+  top: 1px;
+  margin: 0 0.2em 1px 0;
+  border-bottom: 0 !important;
+  padding: 0;
+  white-space: nowrap;
 }
 
 .ui-tabs .ui-tabs-nav li a {
-    float: left;
-    padding: .5em 1em;
-    text-decoration: none;
+  float: left;
+  padding: 0.5em 1em;
+  text-decoration: none;
 }
 
 .ui-tabs .ui-tabs-nav li.ui-tabs-selected {
-    margin-bottom: 0;
-    padding-bottom: 1px;
+  margin-bottom: 0;
+  padding-bottom: 1px;
 }
 
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a, .ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-state-processing a {
-    cursor: text;
+.ui-tabs .ui-tabs-nav li.ui-tabs-selected a,
+.ui-tabs .ui-tabs-nav li.ui-state-disabled a,
+.ui-tabs .ui-tabs-nav li.ui-state-processing a {
+  cursor: text;
 }
 
-.ui-tabs .ui-tabs-nav li a, .ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a {
-    cursor: pointer;
+.ui-tabs .ui-tabs-nav li a,
+.ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a {
+  cursor: pointer;
 }
 
 /* first selector in group seems obsolete, but required to overcome bug in Opera applying cursor: text overall if defined elsewhere... */
 .ui-tabs .ui-tabs-panel {
-    display: block;
-    border-width: 0;
-    padding: 1em 1.4em;
-    background: none;
+  display: block;
+  border-width: 0;
+  padding: 1em 1.4em;
+  background: none;
 }
 
 .ui-tabs .ui-tabs-hide {
-    display: none !important;
+  display: none !important;
 }
 
 /*!
@@ -694,227 +737,231 @@ button.ui-button::-moz-focus-inner {
  * http://docs.jquery.com/UI/Datepicker#theming
  */
 .ui-datepicker {
-    width: 17em;
-    padding: .2em .2em 0;
-    display: none;
+  width: 17em;
+  padding: 0.2em 0.2em 0;
+  display: none;
 }
 
 .ui-datepicker .ui-datepicker-header {
-    position: relative;
-    padding: .2em 0;
+  position: relative;
+  padding: 0.2em 0;
 }
 
-.ui-datepicker .ui-datepicker-prev, .ui-datepicker .ui-datepicker-next {
-    position: absolute;
-    top: 2px;
-    width: 1.8em;
-    height: 1.8em;
+.ui-datepicker .ui-datepicker-prev,
+.ui-datepicker .ui-datepicker-next {
+  position: absolute;
+  top: 2px;
+  width: 1.8em;
+  height: 1.8em;
 }
 
-.ui-datepicker .ui-datepicker-prev-hover, .ui-datepicker .ui-datepicker-next-hover {
-    top: 1px;
+.ui-datepicker .ui-datepicker-prev-hover,
+.ui-datepicker .ui-datepicker-next-hover {
+  top: 1px;
 }
 
 .ui-datepicker .ui-datepicker-prev {
-    left: 2px;
+  left: 2px;
 }
 
 .ui-datepicker .ui-datepicker-next {
-    right: 2px;
+  right: 2px;
 }
 
 .ui-datepicker .ui-datepicker-prev-hover {
-    left: 1px;
+  left: 1px;
 }
 
 .ui-datepicker .ui-datepicker-next-hover {
-    right: 1px;
+  right: 1px;
 }
 
-.ui-datepicker .ui-datepicker-prev span, .ui-datepicker .ui-datepicker-next span {
-    display: block;
-    position: absolute;
-    left: 50%;
-    margin-left: -8px;
-    top: 50%;
-    margin-top: -8px;
+.ui-datepicker .ui-datepicker-prev span,
+.ui-datepicker .ui-datepicker-next span {
+  display: block;
+  position: absolute;
+  left: 50%;
+  margin-left: -8px;
+  top: 50%;
+  margin-top: -8px;
 }
 
 .ui-datepicker .ui-datepicker-title {
-    margin: 0 2.3em;
-    line-height: 1.8em;
-    text-align: center;
+  margin: 0 2.3em;
+  line-height: 1.8em;
+  text-align: center;
 }
 
 .ui-datepicker .ui-datepicker-title select {
-    font-size: 1em;
-    margin: 1px 0;
+  font-size: 1em;
+  margin: 1px 0;
 }
 
 .ui-datepicker select.ui-datepicker-month-year {
-    width: 100%;
+  width: 100%;
 }
 
 .ui-datepicker select.ui-datepicker-month,
 .ui-datepicker select.ui-datepicker-year {
-    width: 49%;
+  width: 49%;
 }
 
 .ui-datepicker table {
-    width: 100%;
-    font-size: .9em;
-    border-collapse: collapse;
-    margin: 0 0 .4em;
+  width: 100%;
+  font-size: 0.9em;
+  border-collapse: collapse;
+  margin: 0 0 0.4em;
 }
 
 .ui-datepicker th {
-    padding: .7em .3em;
-    text-align: center;
-    font-weight: bold;
-    border: 0;
+  padding: 0.7em 0.3em;
+  text-align: center;
+  font-weight: bold;
+  border: 0;
 }
 
 .ui-datepicker td {
-    border: 0;
-    padding: 1px;
+  border: 0;
+  padding: 1px;
 }
 
-.ui-datepicker td span, .ui-datepicker td a {
-    display: block;
-    padding: .2em;
-    text-align: right;
-    text-decoration: none;
+.ui-datepicker td span,
+.ui-datepicker td a {
+  display: block;
+  padding: 0.2em;
+  text-align: right;
+  text-decoration: none;
 }
 
 .ui-datepicker .ui-datepicker-buttonpane {
-    background-image: none;
-    margin: .7em 0 0 0;
-    padding: 0 .2em;
-    border-left: 0;
-    border-right: 0;
-    border-bottom: 0;
+  background-image: none;
+  margin: 0.7em 0 0 0;
+  padding: 0 0.2em;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
 }
 
 .ui-datepicker .ui-datepicker-buttonpane button {
-    float: right;
-    margin: .5em .2em .4em;
-    cursor: pointer;
-    padding: .2em .6em .3em .6em;
-    width: auto;
-    overflow: visible;
+  float: right;
+  margin: 0.5em 0.2em 0.4em;
+  cursor: pointer;
+  padding: 0.2em 0.6em 0.3em 0.6em;
+  width: auto;
+  overflow: visible;
 }
 
 .ui-datepicker .ui-datepicker-buttonpane button.ui-datepicker-current {
-    float: left;
+  float: left;
 }
 
 /* with multiple calendars */
 .ui-datepicker.ui-datepicker-multi {
-    width: auto;
+  width: auto;
 }
 
 .ui-datepicker-multi .ui-datepicker-group {
-    float: left;
+  float: left;
 }
 
 .ui-datepicker-multi .ui-datepicker-group table {
-    width: 95%;
-    margin: 0 auto .4em;
+  width: 95%;
+  margin: 0 auto 0.4em;
 }
 
 .ui-datepicker-multi-2 .ui-datepicker-group {
-    width: 50%;
+  width: 50%;
 }
 
 .ui-datepicker-multi-3 .ui-datepicker-group {
-    width: 33.3%;
+  width: 33.3%;
 }
 
 .ui-datepicker-multi-4 .ui-datepicker-group {
-    width: 25%;
+  width: 25%;
 }
 
 .ui-datepicker-multi .ui-datepicker-group-last .ui-datepicker-header {
-    border-left-width: 0;
+  border-left-width: 0;
 }
 
 .ui-datepicker-multi .ui-datepicker-group-middle .ui-datepicker-header {
-    border-left-width: 0;
+  border-left-width: 0;
 }
 
 .ui-datepicker-multi .ui-datepicker-buttonpane {
-    clear: left;
+  clear: left;
 }
 
 .ui-datepicker-row-break {
-    clear: both;
-    width: 100%;
-    font-size: 0em;
+  clear: both;
+  width: 100%;
+  font-size: 0em;
 }
 
 /* RTL support */
 .ui-datepicker-rtl {
-    direction: rtl;
+  direction: rtl;
 }
 
 .ui-datepicker-rtl .ui-datepicker-prev {
-    right: 2px;
-    left: auto;
+  right: 2px;
+  left: auto;
 }
 
 .ui-datepicker-rtl .ui-datepicker-next {
-    left: 2px;
-    right: auto;
+  left: 2px;
+  right: auto;
 }
 
 .ui-datepicker-rtl .ui-datepicker-prev:hover {
-    right: 1px;
-    left: auto;
+  right: 1px;
+  left: auto;
 }
 
 .ui-datepicker-rtl .ui-datepicker-next:hover {
-    left: 1px;
-    right: auto;
+  left: 1px;
+  right: auto;
 }
 
 .ui-datepicker-rtl .ui-datepicker-buttonpane {
-    clear: right;
+  clear: right;
 }
 
 .ui-datepicker-rtl .ui-datepicker-buttonpane button {
-    float: left;
+  float: left;
 }
 
 .ui-datepicker-rtl .ui-datepicker-buttonpane button.ui-datepicker-current {
-    float: right;
+  float: right;
 }
 
 .ui-datepicker-rtl .ui-datepicker-group {
-    float: right;
+  float: right;
 }
 
 .ui-datepicker-rtl .ui-datepicker-group-last .ui-datepicker-header {
-    border-right-width: 0;
-    border-left-width: 1px;
+  border-right-width: 0;
+  border-left-width: 1px;
 }
 
 .ui-datepicker-rtl .ui-datepicker-group-middle .ui-datepicker-header {
-    border-right-width: 0;
-    border-left-width: 1px;
+  border-right-width: 0;
+  border-left-width: 1px;
 }
 
 /* IE6 IFRAME FIX (taken from datepicker 1.5.3 */
 .ui-datepicker-cover {
-    display: none; /*sorry for IE5*/
-    display /**/
+  display: none; /*sorry for IE5*/
+  display/**/
     : block; /*sorry for IE5*/
-    position: absolute; /*must have*/
-    z-index: -1; /*must have*/
-    filter: mask(); /*must have*/
-    top: -4px; /*must have*/
-    left: -4px; /*must have*/
-    width: 200px; /*must have*/
-    height: 200px; /*must have*/
+  position: absolute; /*must have*/
+  z-index: -1; /*must have*/
+  filter: mask(); /*must have*/
+  top: -4px; /*must have*/
+  left: -4px; /*must have*/
+  width: 200px; /*must have*/
+  height: 200px; /*must have*/
 }
 
 /*!
@@ -927,1512 +974,1542 @@ button.ui-button::-moz-focus-inner {
  * http://docs.jquery.com/UI/Progressbar#theming
  */
 .ui-progressbar {
-    height: 2em;
-    text-align: left;
-    overflow: hidden;
+  height: 2em;
+  text-align: left;
+  overflow: hidden;
 }
 
 .ui-progressbar .ui-progressbar-value {
-    height: 100%;
+  height: 100%;
 }
 
 /* files operations */
 
 .operation {
-    color: #666 !important;
-    font-size: 12px !important;
+  color: #666 !important;
+  font-size: 12px !important;
 }
 
 .converting .ui-progressbar-value {
-    background: url(../../img/progressbar-green.gif) !important;
+  background: url(../../img/progressbar-green.gif) !important;
 }
 
 /*jquery.image-gallery.min.css*/
 #gallery-loader {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    width: 128px;
-    height: 128px;
-    margin: -64px 0 0 -64px;
-    background: url(../../img/loading.gif);
-    z-index: 9999;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 128px;
+  height: 128px;
+  margin: -64px 0 0 -64px;
+  background: url(../../img/loading.gif);
+  z-index: 9999;
 }
 
 * html #gallery-loader {
-    position: absolute;
+  position: absolute;
 }
 
 .gallery-dialog .ui-dialog-content {
-    cursor: pointer;
-    text-align: center;
+  cursor: pointer;
+  text-align: center;
 }
 
-.gallery-dialog .ui-dialog-content:hover:before, .gallery-dialog .ui-dialog-content:hover:after {
-    content: '‹';
-    position: absolute;
-    top: 50%;
-    left: 25px;
-    width: 40px;
-    height: 40px;
-    margin-top: -20px;
-    font-size: 60px;
-    font-weight: 100;
-    line-height: 30px;
-    color: #ffffff;
-    text-align: center;
-    background: #222222;
-    border: 3px solid #ffffff;
-    -webkit-border-radius: 23px;
-    -moz-border-radius: 23px;
-    border-radius: 23px;
-    opacity: 0.5;
-    filter: alpha(opacity=50);
-    z-index: 1;
+.gallery-dialog .ui-dialog-content:hover:before,
+.gallery-dialog .ui-dialog-content:hover:after {
+  content: '‹';
+  position: absolute;
+  top: 50%;
+  left: 25px;
+  width: 40px;
+  height: 40px;
+  margin-top: -20px;
+  font-size: 60px;
+  font-weight: 100;
+  line-height: 30px;
+  color: #ffffff;
+  text-align: center;
+  background: #222222;
+  border: 3px solid #ffffff;
+  -webkit-border-radius: 23px;
+  -moz-border-radius: 23px;
+  border-radius: 23px;
+  opacity: 0.5;
+  filter: alpha(opacity=50);
+  z-index: 1;
 }
 
 .gallery-dialog .ui-dialog-content:hover:after {
-    content: '›';
-    left: auto;
-    right: 25px;
+  content: '›';
+  left: auto;
+  right: 25px;
 }
 
-.gallery-dialog-single .ui-dialog-content:hover:before, .gallery-dialog-single .ui-dialog-content:hover:after {
-    display: none;
+.gallery-dialog-single .ui-dialog-content:hover:before,
+.gallery-dialog-single .ui-dialog-content:hover:after {
+  display: none;
 }
 
 .gallery-dialog .ui-dialog-content img {
-    border: 0;
+  border: 0;
 }
 
 .gallery-dialog-fullscreen {
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    -webkit-box-shadow: 0 0 20px #000;
-    -moz-box-shadow: 0 0 20px #000;
-    box-shadow: 0 0 20px #000;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  -webkit-box-shadow: 0 0 20px #000;
+  -moz-box-shadow: 0 0 20px #000;
+  box-shadow: 0 0 20px #000;
 }
 
 .gallery-dialog-fullscreen .ui-dialog-titlebar {
-    display: none;
+  display: none;
 }
 
 .gallery-dialog-fullscreen .ui-dialog-content {
-    padding: 0;
-    border: 0;
-    cursor: pointer;
-    text-align: center;
+  padding: 0;
+  border: 0;
+  cursor: pointer;
+  text-align: center;
 }
 
-.gallery-dialog-fullscreen .ui-dialog-content img, .gallery-dialog-fullscreen .ui-dialog-content canvas {
-    float: left;
-    border: 0;
+.gallery-dialog-fullscreen .ui-dialog-content img,
+.gallery-dialog-fullscreen .ui-dialog-content canvas {
+  float: left;
+  border: 0;
 }
 
 * html .gallery-dialog-fullscreen .ui-dialog-content img {
-    float: none;
+  float: none;
 }
 
 .gallery-body-fullscreen .ui-widget-overlay {
-    opacity: 1;
-    filter: alpha(opacity=100);
+  opacity: 1;
+  filter: alpha(opacity=100);
 }
 
-.gallery-body .ui-effects-explode, .gallery-body .ui-effects-wrapper, .gallery-body-fullscreen .ui-effects-wrapper, .gallery-body-fullscreen .ui-effects-explode {
-    z-index: 10000 !important;
+.gallery-body .ui-effects-explode,
+.gallery-body .ui-effects-wrapper,
+.gallery-body-fullscreen .ui-effects-wrapper,
+.gallery-body-fullscreen .ui-effects-explode {
+  z-index: 10000 !important;
 }
 
-.gallery-body, .gallery-body-fullscreen {
-    overflow: hidden;
+.gallery-body,
+.gallery-body-fullscreen {
+  overflow: hidden;
 }
 
-* html .gallery-body select, * html .gallery-body-fullscreen select {
-    display: none;
+* html .gallery-body select,
+* html .gallery-body-fullscreen select {
+  display: none;
 }
 
 .memory-mgmt {
-    padding: 8px 10px 1px 10px;
-    margin-top: 7px;
-    /*
+  padding: 8px 10px 1px 10px;
+  margin-top: 7px;
+  /*
     color: #333;
     font-weight: bold;
     width: 230px;
     */
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .memory-mgmt .text {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .memory-mgmt .tm-added {
-    display: none;
+  display: none;
 }
 
 .memory-mgmt:hover {
-    /* background:#F7F7F7; */
+  /* background:#F7F7F7; */
 }
 
 .memory-mgmt i {
-    margin-right: 10px;
-    margin-top: 2px;
-    float: left;
+  margin-right: 10px;
+  margin-top: 2px;
+  float: left;
 }
 
 .tm-mgmt {
-    padding: 0;
-    margin: 0;
-    text-decoration: underline;
+  padding: 0;
+  margin: 0;
+  text-decoration: underline;
 }
 
 .fileinput-button input {
-    position: absolute;
-    top: 0;
-    left: 0;
-    margin: 0;
-    border: solid transparent;
-    border-width: 0 0 0 0;
-    /*width: 100%;*/
-    height: 100%;
-    opacity: 0;
-    filter: alpha(opacity=0);
-    -moz-transform: translate(-300px, 0) scale(4);
-    direction: ltr;
-    cursor: pointer;
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 0;
+  border: solid transparent;
+  border-width: 0 0 0 0;
+  /*width: 100%;*/
+  height: 100%;
+  opacity: 0;
+  filter: alpha(opacity=0);
+  -moz-transform: translate(-300px, 0) scale(4);
+  direction: ltr;
+  cursor: pointer;
 }
 
 .fileinput-link input {
-    position: absolute;
-    top: 0;
-    left: 0;
-    margin: 0;
-    border: solid transparent;
-    border-width: 0 0 0 0;
-    width: 0;
-    height: 0;
-    opacity: 0;
-    filter: alpha(opacity=0);
-    -moz-transform: translate(-300px, 0) scale(4);
-    direction: ltr;
-    /*cursor: pointer;*/
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin: 0;
+  border: solid transparent;
+  border-width: 0 0 0 0;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  filter: alpha(opacity=0);
+  -moz-transform: translate(-300px, 0) scale(4);
+  direction: ltr;
+  /*cursor: pointer;*/
 }
 
 .fileupload-buttonbar .fileinput-link:before {
-    display: none;
+  display: none;
 }
 
 .fileupload-buttonbar .ui-button,
 .fileupload-buttonbar .toggle {
-    margin-bottom: 5px;
+  margin-bottom: 5px;
 }
 
 .files .progress {
-    background: #fff;
+  background: #fff;
 }
 
 .files .progress,
 .fileupload-buttonbar .progress {
-    height: 15px;
-    border-radius: 10px;
+  height: 15px;
+  border-radius: 10px;
 }
 
 .files .ui-progressbar-value,
 .fileupload-buttonbar .ui-progressbar-value {
-    background: url(../../img/progressbar.gif);
+  background: url(../../img/progressbar.gif);
 }
 
 .fileupload-buttonbar .fade,
 .files .fade {
-    display: none;
+  display: none;
 }
 
 .fileupload-loading {
-    position: absolute;
-    left: 50%;
-    width: 128px;
-    height: 128px;
-    background: url(../../img/loading.gif) center no-repeat;
-    display: none;
+  position: absolute;
+  left: 50%;
+  width: 128px;
+  height: 128px;
+  background: url(../../img/loading.gif) center no-repeat;
+  display: none;
 }
 
 .fileupload-processing .fileupload-loading {
-    display: block;
+  display: block;
 }
 
 .name {
-    width: 50% !important;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-size: 16px;
+  width: 50% !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 16px;
 }
 
 .cancel-btn {
-    background: $rebuttedRed;
+  background: $rebuttedRed;
 }
 
 .cancel-btn:hover {
-    background: $rebuttedRedHover;
+  background: $rebuttedRedHover;
 }
 
 .translate-box a.tooltip {
-    text-align: center;
-    text-decoration: none !important;
-    position: relative;
-    float: left;
-    margin-top: 5px;
-    margin-left: 10px;
+  text-align: center;
+  text-decoration: none !important;
+  position: relative;
+  float: left;
+  margin-top: 5px;
+  margin-left: 10px;
 }
 
 .translate-box a.tooltip.gray span,
 .translate-box a.tooltip.gray {
-    background: #EEE;
+  background: #eee;
 }
 
 .translate-box a.tooltip.gray span:after {
-    border-top: 10px solid #eee;
+  border-top: 10px solid #eee;
 }
 
 .translate-box a.tooltip:hover span {
-    top: -70px;
+  top: -70px;
 }
 
-.cancel-btn, #clear-all-files, #clear-all-gdrive, #delete-failed-conversions {
-    background: $rebuttedRed;
+.cancel-btn,
+#clear-all-files,
+#clear-all-gdrive,
+#delete-failed-conversions {
+  background: $rebuttedRed;
 }
 
-.cancel-btn:hover, #clear-all-files:hover, #clear-all-gdrive:hover, #delete-failed-conversions:hover {
-    background: $rebuttedRedHover;
+.cancel-btn:hover,
+#clear-all-files:hover,
+#clear-all-gdrive:hover,
+#delete-failed-conversions:hover {
+  background: $rebuttedRedHover;
 }
 
 /* Fix for IE 6: */
 * html .fileinput-button {
-    margin-right: -2px;
+  margin-right: -2px;
 }
 
 * html .fileinput-button .ui-button-text {
-    line-height: 24px;
+  line-height: 24px;
 }
 
 * html .fileupload-buttonbar .ui-button {
-    margin-left: 3px;
+  margin-left: 3px;
 }
 
 /* Fix for IE 7: */
 * + html .fileinput-button {
-    margin-right: 1px;
+  margin-right: 1px;
 }
 
 * + html .fileinput-button .ui-button-text {
-    line-height: 24px;
+  line-height: 24px;
 }
 
 * + html .fileupload-buttonbar .ui-button {
-    margin-left: 3px;
+  margin-left: 3px;
 }
 
-.translate-box.settings{
-    .more-options-cont {
-        margin-top: 0;
-        /*margin-left: 10px;*/
-    }
+.translate-box.settings {
+  .more-options-cont {
+    margin-top: 0;
+    /*margin-left: 10px;*/
+  }
 }
-
 
 @media only screen and (max-width: 1320px) {
-    .translate-box.tmx-select,
-    .translate-box.source,
-    .translate-box.target,
-    .translate-box.project-subject {
-
-        #project-subject,
-        #source-lang,
-        #target-lang {
-            /*width: 150px ;*/
-        }
-        #tmx-select {
-            /*width: 150px;*/
-            &:hover {
-                box-shadow: none !important;
-            }
-        }
-        .menu-dropdown {
-            max-height: none !important;
-            overflow: hidden !important;
-        }
-        div#add-tmx-option:hover ,
-        div#add-multiple-lang:hover {
-            background: rgba(0, 0, 0, 0.05);
-        }
-        div#add-tmx-option ,
-        div#add-multiple-lang {
-            cursor: pointer;
-            color: #39699a;
-            font-size: 14px;
-            margin: 0;
-            padding: 15px;
-            .icon {
-                float: right;
-                font-size: 24px;
-                margin-top: -3px;
-                margin-right: 1px;
-                color: #39699a;
-            }
-        }
-        div.item {
-            width: 100%;
-            min-width: 150px;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            padding-right: 10px !important;
-            span.item-key-id {
-                color: #757575;
-                clear: both;
-            }
-            span {
-                line-height: 17px;
-            }
-            .no-descr {
-                font-style: italic ;
-            }
-        }
-        .dropdown > span.text {
-            margin-top: 0 !important;
-            pointer-events: none;
-            line-height: 28px !important;
-            /*max-width: 90px !important;
+  .translate-box.tmx-select,
+  .translate-box.source,
+  .translate-box.target,
+  .translate-box.project-subject {
+    #project-subject,
+    #source-lang,
+    #target-lang {
+      /*width: 150px ;*/
+    }
+    #tmx-select {
+      /*width: 150px;*/
+      &:hover {
+        box-shadow: none !important;
+      }
+    }
+    .menu-dropdown {
+      max-height: none !important;
+      overflow: hidden !important;
+    }
+    div#add-tmx-option:hover,
+    div#add-multiple-lang:hover {
+      background: rgba(0, 0, 0, 0.05);
+    }
+    div#add-tmx-option,
+    div#add-multiple-lang {
+      cursor: pointer;
+      color: #39699a;
+      font-size: 14px;
+      margin: 0;
+      padding: 15px;
+      .icon {
+        float: right;
+        font-size: 24px;
+        margin-top: -3px;
+        margin-right: 1px;
+        color: #39699a;
+      }
+    }
+    div.item {
+      width: 100%;
+      min-width: 150px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      padding-right: 10px !important;
+      span.item-key-id {
+        color: #757575;
+        clear: both;
+      }
+      span {
+        line-height: 17px;
+      }
+      .no-descr {
+        font-style: italic;
+      }
+    }
+    .dropdown > span.text {
+      margin-top: 0 !important;
+      pointer-events: none;
+      line-height: 28px !important;
+      /*max-width: 90px !important;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;*/
 
-            width: 100%;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            font-size: 16px;
-            white-space: nowrap;
+      width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: 16px;
+      white-space: nowrap;
 
-            .item-key-id {
-                margin-top: 0px;
-                float: none;
-            }
-            .item-key-name {
-                color: initial;
-                margin-top: 0px;
-                margin-right: 5px;
-                float: none;
-            }
-        }
-        .divider {
-            margin: 0 !important;
-        }
-
+      .item-key-id {
+        margin-top: 0px;
+        float: none;
+      }
+      .item-key-name {
+        color: initial;
+        margin-top: 0px;
+        margin-right: 5px;
+        float: none;
+      }
     }
+    .divider {
+      margin: 0 !important;
+    }
+  }
 }
 
-
 @media only screen and (max-height: 600px) {
-
-    .wrapper-claim {
-        height: 58px !important;
-
-    }
-    .wrapper-claim h1 {
-        font-size: 35px !important;
-    }
-    .upload-files, .gdrive-upload-file {
-        margin: 6px 71px !important;
-    }
-    #matecat-cat {
-        display: none;
-    }
+  .wrapper-claim {
+    height: 58px !important;
+  }
+  .wrapper-claim h1 {
+    font-size: 35px !important;
+  }
+  .upload-files,
+  .gdrive-upload-file {
+    margin: 6px 71px !important;
+  }
+  #matecat-cat {
+    display: none;
+  }
 }
 
 @media (max-width: 480px) {
-    .files .preview * {
-        width: 40px;
-    }
-    .files .name * {
-
-        display: inline-block;
-        word-wrap: break-word;
-    }
-    .files .progress {
-        width: 20px;
-    }
-    .files .delete {
-        width: 60px;
-    }
+  .files .preview * {
+    width: 40px;
+  }
+  .files .name * {
+    display: inline-block;
+    word-wrap: break-word;
+  }
+  .files .progress {
+    width: 20px;
+  }
+  .files .delete {
+    width: 60px;
+  }
 }
 
 /* Fix for Webkit (Safari, Chrome) */
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-    .fileinput-button {
-        margin-top: 2px;
-    }
+  .fileinput-button {
+    margin-top: 2px;
+  }
 }
 
 .translate-box.manage-link {
-    display: none;
+  display: none;
 }
 
 .translate-box {
-    float: left;
-    margin: 20px 0 0 0;
-    position: relative;
-    display: block;
+  float: left;
+  margin: 20px 0 0 0;
+  position: relative;
+  display: block;
 }
 
 .translate-box {
-    h2 {
-        color: $grey1;
-        font-weight: 100;
-    }
+  h2 {
+    color: $grey1;
+    font-weight: 100;
+  }
 }
 
 .translate-box.settings {
-    margin: 48px 0 0 0;
+  margin: 48px 0 0 0;
 }
 
 .translate-box.qa-box {
-    margin: 32px 0 0 !important;
+  margin: 32px 0 0 !important;
 }
 
 .translate-box.qa-box h2 {
-    display: inline;
+  display: inline;
 }
 
 .translate-box.qa-box img {
-    float: right;
-    width: 70px;
-    margin-left: 5px;
-    margin-top: -4px;
+  float: right;
+  width: 70px;
+  margin-left: 5px;
+  margin-top: -4px;
 }
 
-.translate-box input[type=checkbox] {
-    float: left;
-    margin-top: 5px;
+.translate-box input[type='checkbox'] {
+  float: left;
+  margin-top: 5px;
 }
 
 .manage-link {
-    margin-left: -14px
+  margin-left: -14px;
 }
 
 .translate-box.source {
-    margin-right: 0px
+  margin-right: 0px;
 }
 
 .translate-checkbox {
-    float: left;
+  float: left;
 }
 
 .tms-checkbox {
-    width: 150px;
-    height: 26px;
+  width: 150px;
+  height: 26px;
 }
 
 .tms-label {
-    float: right;
-    margin-left: 4px;
-    margin-top: 2px;
+  float: right;
+  margin-left: 4px;
+  margin-top: 2px;
 }
 
 .wrapper-upload {
-    text-align: left;
-    margin: 0 auto;
-    width: 94%;
-    min-width: 992px;
-    position: relative;
-    padding: 24px;
-    background: $grey5;
-    padding-top: 0px;
+  text-align: left;
+  margin: 0 auto;
+  width: 94%;
+  min-width: 992px;
+  position: relative;
+  padding: 24px;
+  background: $grey5;
+  padding-top: 0px;
 
-    #matecat-cat {
-        background-image: url(../../img/home-page-cat.svg);
-        background-size: cover;
-        width: 90px;
-        top: -104px;
-        position: absolute;
-        height: 130px;
-        left: 4px;
-    }
+  #matecat-cat {
+    background-image: url(../../img/home-page-cat.svg);
+    background-size: cover;
+    width: 90px;
+    top: -104px;
+    position: absolute;
+    height: 130px;
+    left: 4px;
+  }
 }
 
 .wrapper-upload h1 {
-    margin: 0;
-    padding: 0;
-    font-size: 40px;
+  margin: 0;
+  padding: 0;
+  font-size: 40px;
 
-    h2 {
-        font-weight: 100;
-    }
+  h2 {
+    font-weight: 100;
+  }
 }
 
 .wrapper-upload .translate-box h2 {
-    font-family: Calibri, Arial, Helvetica, sans-serif
+  font-family: Calibri, Arial, Helvetica, sans-serif;
 }
 
 .wrapper-claim {
-    display: grid;
-    align-items: center;
-    justify-content: center;
-    color: $darkBlue;
-    min-width: 992px;
-    /*margin: -3px 0 10px 0;*/
-    height: 175px;
-    /*background-color: #1f7ead;
+  display: grid;
+  align-items: center;
+  justify-content: center;
+  color: $darkBlue;
+  min-width: 992px;
+  /*margin: -3px 0 10px 0;*/
+  height: 175px;
+  /*background-color: #1f7ead;
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIGNvdW50PScxMDAlJyBoZWlnaHQ9JzEwMCUnPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPSc1JScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9JzUwJScgcj0nMTAlJyBmaWxsLW9wYWNpdHk9Jy4zJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPScxNSUnIGZpbGwtb3BhY2l0eT0nLjMnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PSc1MCUnIGN5PSc1MCUnIHI9JzIwJScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9JzUwJScgcj0nMjUlJyBmaWxsLW9wYWNpdHk9Jy4zJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPSczMCUnIGZpbGwtb3BhY2l0eT0nLjMnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PSc1MCUnIGN5PSc1MCUnIHI9JzM1JScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9JzUwJScgcj0nNDAlJyBmaWxsLW9wYWNpdHk9Jy4zJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPSc0NSUnIGZpbGwtb3BhY2l0eT0nLjMnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PSc1MCUnIGN5PSc1MCUnIHI9JzUwJScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzIwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzMwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzQwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzUwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzYwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzcwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzgwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzkwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzEwMCUnIGZpbGwtb3BhY2l0eT0nLjInIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScwJyBjeT0nMCcgcj0nMTAlJyBmaWxsLW9wYWNpdHk9Jy4yJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMCcgY3k9JzAnIHI9JzIwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzAnIGN5PScwJyByPSczMCUnIGZpbGwtb3BhY2l0eT0nLjInIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScwJyBjeT0nMCcgcj0nNDAlJyBmaWxsLW9wYWNpdHk9Jy4yJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMCcgY3k9JzAnIHI9JzUwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzAnIGN5PScwJyByPSc2MCUnIGZpbGwtb3BhY2l0eT0nLjInIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScwJyBjeT0nMCcgcj0nNzAlJyBmaWxsLW9wYWNpdHk9Jy4yJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzAnIHI9JzEwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScwJyByPScyMCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMCcgcj0nMzAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzAnIHI9JzQwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScwJyByPSc1MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMCcgcj0nNjAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzAnIHI9JzcwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScxMDAlJyByPScxMCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMTAwJScgcj0nMjAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzEwMCUnIHI9JzMwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScxMDAlJyByPSc0MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMTAwJScgcj0nNTAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzEwMCUnIHI9JzYwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScxMDAlJyByPSc3MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScwJScgY3k9JzEwMCUnIHI9JzEwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzAlJyBjeT0nMTAwJScgcj0nMjAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMCUnIGN5PScxMDAlJyByPSczMCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScwJScgY3k9JzEwMCUnIHI9JzQwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzAlJyBjeT0nMTAwJScgcj0nNTAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMCUnIGN5PScxMDAlJyByPSc2MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScwJScgY3k9JzEwMCUnIHI9JzcwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KPC9zdmc+');
     background-size: cover;*/
 
-    .wrapper-claim-content {
-        display: grid;
-        grid-template-columns: auto auto;
-        grid-column-gap: 16px;
-    }
+  .wrapper-claim-content {
+    display: grid;
+    grid-template-columns: auto auto;
+    grid-column-gap: 16px;
+  }
 
-    svg {
-        width: 50px;
-    }
+  svg {
+    width: 50px;
+  }
 }
 
 .wrapper-claim h1 {
-    font-size: 40px;
-    padding: 8px 0 6px;
-    margin: 0px;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
-    .highlight {
-        color:$translatedBlue;
-    }
+  font-size: 40px;
+  padding: 8px 0 6px;
+  margin: 0px;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
+  .highlight {
+    color: $translatedBlue;
+  }
 }
 
 .wrapper-bottom {
-    margin: 0 auto;
-    width: 94%;
-    min-width: 992px;
-    position: relative;
-    padding: 24px;
-    height: 200px;
+  margin: 0 auto;
+  width: 94%;
+  min-width: 992px;
+  position: relative;
+  padding: 24px;
+  height: 200px;
 }
 
 h2 {
-    margin: 0;
-    padding: 0;
-    font-size: 18px
+  margin: 0;
+  padding: 0;
+  font-size: 18px;
 }
 
 h2.payoff {
-    color: #fff !important;
-    font-weight: normal !important;
-    font-size: 24px;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
+  color: #fff !important;
+  font-weight: normal !important;
+  font-size: 24px;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
 }
 
 /*button*/
 
 .uploadbtn {
-    background: $translatedBlue;
-    font-weight: 100;
-    padding: 8px 16px;
-    width: auto !important;
-    min-width: 200px;
-    margin: -10px 0px 8px 0px;
-    -webkit-transition: all 100ms ease-in;
-    -moz-transition: all 100ms ease-in;
-    font-size: 26px !important;
-    cursor: pointer;
-    color: #fff;
-    border: none;
-    border-radius: 2px;
+  background: $translatedBlue;
+  font-weight: 100;
+  padding: 8px 16px;
+  width: auto !important;
+  min-width: 200px;
+  margin: -10px 0px 8px 0px;
+  -webkit-transition: all 100ms ease-in;
+  -moz-transition: all 100ms ease-in;
+  font-size: 26px !important;
+  cursor: pointer;
+  color: #fff;
+  border: none;
+  border-radius: 2px;
 }
 
 .uploadbtn:hover {
-    background: $translatedBlueHover;
-    color: #ffffff;
-    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  background: $translatedBlueHover;
+  color: #ffffff;
+  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.24) !important;
 }
-
 
 .uploadbtn:focus {
-    outline-color: $translatedBlueActive;
+  outline-color: $translatedBlueActive;
 }
 
-
 .uploadbtn:active {
-    box-shadow: none;
+  box-shadow: none;
 }
 
 .uploadbtn-box {
-    text-align: center;
-    float: right;
+  text-align: center;
+  float: right;
 }
 
 .uploadbtn-box p {
-    text-align: center;
-    margin: -2px 0 0 5px;
-    font-size: 13px;
-    font-weight: normal;
-    color: #999;
-    display: none;
-    text-align: center;
+  text-align: center;
+  margin: -2px 0 0 5px;
+  font-size: 13px;
+  font-weight: normal;
+  color: #999;
+  display: none;
+  text-align: center;
 }
 
 .uploadbtn-box:hover p {
-    display: block;
+  display: block;
 }
 
 /*upload table*/
-.upload-table, .gdrive-upload-table {
-    width: 100%;
-    margin: 0;
-    table-layout: fixed;
+.upload-table,
+.gdrive-upload-table {
+  width: 100%;
+  margin: 0;
+  table-layout: fixed;
 }
 
-.upload-table td, .gdrive-upload-table td {
-    height: auto;
-    padding: 5px 10px;
-    text-align: left;
-    border-bottom: 1px dashed #ccc
+.upload-table td,
+.gdrive-upload-table td {
+  height: auto;
+  padding: 5px 10px;
+  text-align: left;
+  border-bottom: 1px dashed #ccc;
 }
 
-.upload-table tr, .gdrive-upload-table tr {
-    background: #fff;
-    -webkit-transition: all 100ms ease-in;
-    -moz-transition: all 100ms ease-in;
-    border-bottom: 1px dashed #ccc
+.upload-table tr,
+.gdrive-upload-table tr {
+  background: #fff;
+  -webkit-transition: all 100ms ease-in;
+  -moz-transition: all 100ms ease-in;
+  border-bottom: 1px dashed #ccc;
 }
 
 .upload-table tr:hover {
 }
 
 .btncontinue {
-    position: absolute;
-    bottom: 0;
-    display: none;
-    float: left;
-    padding: 0px 0 0 0 !important;
-    font-size: 14px !important;
-    margin: 0px 0 0 10px !important;
+  position: absolute;
+  bottom: 0;
+  display: none;
+  float: left;
+  padding: 0px 0 0 0 !important;
+  font-size: 14px !important;
+  margin: 0px 0 0 10px !important;
 }
 
 .uploaded .btncontinue {
-    display: block;
+  display: block;
 }
 
 .btncontinue p {
-    float: left !important;
-    font-size: 14px !important;
-    margin: 0px 0 0 0 !important;
-    padding: 0;
+  float: left !important;
+  font-size: 14px !important;
+  margin: 0px 0 0 0 !important;
+  padding: 0;
 }
 
 .btncontinue .fileinput-button {
-    float: left;
-    margin: 7px 0 0 10px !important;
-    width: auto;
-    padding: 8px 10px 0px 10px !important;
-    height: 36px;
+  float: left;
+  margin: 7px 0 0 10px !important;
+  width: auto;
+  padding: 8px 10px 0px 10px !important;
+  height: 36px;
 }
 
-#add-files, #clear-all-files, #clear-all-gdrive {
-    padding: 8px 10px 0px 10px !important;
-    height: 36px;
+#add-files,
+#clear-all-files,
+#clear-all-gdrive {
+  padding: 8px 10px 0px 10px !important;
+  height: 36px;
 }
 
 .preview {
-    border-right: none !important;
-    width: 30px;
-    padding: 8px;
+  border-right: none !important;
+  width: 30px;
+  padding: 8px;
 }
 
 .preview img {
-    margin: 5px 0 0 10px
+  margin: 5px 0 0 10px;
 }
 
-.delete, .cancel {
-    border-right: none !important;
+.delete,
+.cancel {
+  border-right: none !important;
 }
 
-.delete .btn, .cancel .btn {
-    float: right;
-    font-weight: bold;
+.delete .btn,
+.cancel .btn {
+  float: right;
+  font-weight: bold;
 }
 
 /*UI buttons*/
 .fileinput-button {
-    font-size: 1.1em;
-    overflow: hidden;
-    margin: 0 auto;
-    width: 200px;
-    cursor: pointer;
-    padding: 12px 0px 4px 0;
-    background: $translatedBlue;
-    color: #fff;
-    font-weight: bold;
-    margin-bottom: 30px !important;
+  font-size: 1.1em;
+  overflow: hidden;
+  margin: 0 auto;
+  width: 200px;
+  cursor: pointer;
+  padding: 12px 0px 4px 0;
+  background: $translatedBlue;
+  color: #fff;
+  font-weight: bold;
+  margin-bottom: 30px !important;
 }
 
 /* Ovverride file-input-button to style it as a link */
 .fileinput-link {
-    font-size: 16px;
-    overflow: hidden;
-    margin: 0 auto;
-    cursor: pointer;
-    font-weight: 100;
-    margin-bottom: 30px !important;
-    background: transparent;
-    border: none !important;
-    padding: 0;
-    width: max-content;
-    text-decoration: underline !important;
-    color: $grey1 !important;
-    label {
-        font-size:24px;
-        &:hover {
-            text-decoration: underline;
-            cursor: pointer;
-        }
+  font-size: 16px;
+  overflow: hidden;
+  margin: 0 auto;
+  cursor: pointer;
+  font-weight: 100;
+  margin-bottom: 30px !important;
+  background: transparent;
+  border: none !important;
+  padding: 0;
+  width: max-content;
+  text-decoration: underline !important;
+  color: $grey1 !important;
+  label {
+    font-size: 24px;
+    &:hover {
+      text-decoration: underline;
+      cursor: pointer;
     }
+  }
 }
 
 .upload-footer .fileinput-button {
-    position: relative;
+  position: relative;
 }
 
 .fileinput-button:hover {
-    background-color: $translatedBlueHover;
-    box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  background-color: $translatedBlueHover;
+  box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12),
+    0 2px 4px rgba(0, 0, 0, 0.24) !important;
 }
 
 .fileinput-button:active {
-    box-shadow: none !important;
+  box-shadow: none !important;
 }
 
 .fileinput-button:focus {
-    box-shadow: none !important;
+  box-shadow: none !important;
 }
 
 .fileinput-link:hover,
 .fileinput-link:focus,
 .fileinput-link:active {
-    background-color: transparent;
-    box-shadow: none !important;
+  background-color: transparent;
+  box-shadow: none !important;
 }
 
 .delete .ui-button-text,
 .cancel .ui-button-text,
 .delete span,
 .cancel span {
-    display: none;
-    color: #fff;
-    text-align: left;
-    margin: 0px 0 0 10px !important
+  display: none;
+  color: #fff;
+  text-align: left;
+  margin: 0px 0 0 10px !important;
 }
 
-.delete .btn, .cancel .btn {
-    height: 35px !important;
-    font-size: 1.1em;
-    border: 0;
-    background: transparent;
+.delete .btn,
+.cancel .btn {
+  height: 35px !important;
+  font-size: 1.1em;
+  border: 0;
+  background: transparent;
 }
-.cancel button:hover, .delete button:hover {
-    background: #f26522;
-    color: #fff;
-    border: 1px solid #848689;
+.cancel button:hover,
+.delete button:hover {
+  background: #f26522;
+  color: #fff;
+  border: 1px solid #848689;
 }
 
-.cancel .ui-button-text span, .delete .ui-button-text span {
-    margin: -3px 0 0 15px !important;
-    display: block;
-    float: left;
+.cancel .ui-button-text span,
+.delete .ui-button-text span {
+  margin: -3px 0 0 15px !important;
+  display: block;
+  float: left;
 }
 
 a {
-    text-decoration: underline
+  text-decoration: underline;
 }
 
 a:hover {
-    text-decoration: none
+  text-decoration: none;
 }
 
 .translate-box a {
-    display: block;
-    font-size: 16px;
+  display: block;
+  font-size: 16px;
 }
 
 .translate-box label {
-    margin-left: 5px;
+  margin-left: 5px;
 }
 
 body {
-    font-family: Calibri, Arial, Helvetica, sans-serif;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
 }
 
-
 .translate-box select {
-    width: 257px;
-    height: 37px;
-    padding: 5px;
-    font-size: 16px;
-    border: 1px solid #ccc;
-    margin: 0 0 5px 0;
-    font-family: Calibri, Arial, Helvetica, sans-serif;
-    border-radius: 2px;
+  width: 257px;
+  height: 37px;
+  padding: 5px;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  margin: 0 0 5px 0;
+  font-family: Calibri, Arial, Helvetica, sans-serif;
+  border-radius: 2px;
 }
 
 .mgmt-table-mt select {
-    font-size: 14px;
+  font-size: 14px;
 }
 
 .upload-input {
-    width: 230px;
-    padding: 3px 5px 3px 9px;
-    font-size: 16px !important;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
-    border: 1px solid rgba(34, 36, 38, 0.15);
-    height: 37px;
-    box-shadow: inset 0 1px 3px #ddd;
+  width: 230px;
+  padding: 3px 5px 3px 9px;
+  font-size: 16px !important;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  border: 1px solid rgba(34, 36, 38, 0.15);
+  height: 37px;
+  box-shadow: inset 0 1px 3px #ddd;
 }
 
 .upload-input:hover {
-    border-color: rgba(34, 36, 38, 0.35);
-    box-shadow: none;
+  border-color: rgba(34, 36, 38, 0.35);
+  box-shadow: none;
 }
 
 #private-tm-key {
-    width: 220px;
-    height: 28px;
-    margin: 0 0 5px 0;
+  width: 220px;
+  height: 28px;
+  margin: 0 0 5px 0;
 }
 
 /* upload footer */
 .upload-footer {
-    width: 100%;
-    background: #ebebec;
-    padding: 10px 0;
-    border-top: 1px dashed #ccc;
-    margin-top: -1px
+  width: 100%;
+  background: #ebebec;
+  padding: 10px 0;
+  border-top: 1px dashed #ccc;
+  margin-top: -1px;
 }
 
 .upload-footer .btn {
-    float: left;
-    padding: 5px 10px 0 30px;
-    width: auto;
-    margin-bottom: 0px !important
+  float: left;
+  padding: 5px 10px 0 30px;
+  width: auto;
+  margin-bottom: 0px !important;
 }
 
 .upload-footer p {
-    text-align: left !important;
-    float: left;
-    margin: 5px 10px 0px 20px !important;
-    font-size: 18px !important;
-    line-height: 20px !important;
+  text-align: left !important;
+  float: left;
+  margin: 5px 10px 0px 20px !important;
+  font-size: 18px !important;
+  line-height: 20px !important;
 }
 
 .ui-progressbar-value {
-    display: none !important
+  display: none !important;
 }
 
 table .ui-progressbar-value {
-    display: block !important
+  display: block !important;
 }
 
 a {
-    color: $linkBlue;
-    &:hover {
-        color: $linkBlueHover;
-    }
+  color: $linkBlue;
+  &:hover {
+    color: $linkBlueHover;
+  }
 }
 
 .cl {
-    clear: both;
-    visibility: hidden;
+  clear: both;
+  visibility: hidden;
 }
 
 .uploadtext {
-    float: left;
-    width: 55%;
+  float: left;
+  width: 55%;
 }
 
 .uploadtext h2 {
-    margin: 15px 0 0 0;
+  margin: 15px 0 0 0;
 }
 
 .linkupload {
-    font-size: 22px;
-    font-weight: bold;
+  font-size: 22px;
+  font-weight: bold;
 }
 
 .upload-analysis {
-    border: 1px solid #ccc;
-    float: left;
-    font-size: 16px;
-    -moz-box-shadow: 0 1px 3px #ccc;
-    -webkit-box-shadow: 0 1px 3px #ccc;
-    float: left;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
-    width: 80%;
+  border: 1px solid #ccc;
+  float: left;
+  font-size: 16px;
+  -moz-box-shadow: 0 1px 3px #ccc;
+  -webkit-box-shadow: 0 1px 3px #ccc;
+  float: left;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  width: 80%;
 }
 
 .upload-analysis th {
-    padding: 10px;
-    border-bottom: 1px solid #ccc;
-    text-align: left;
-    background: #e2e4e5
+  padding: 10px;
+  border-bottom: 1px solid #ccc;
+  text-align: left;
+  background: #e2e4e5;
 }
 
 .upload-analysis td {
-    padding: 10px;
-    border-bottom: 1px solid #ccc;
-    text-align: left;
-    background: #efefef
+  padding: 10px;
+  border-bottom: 1px solid #ccc;
+  text-align: left;
+  background: #efefef;
 }
 
 .supported-files {
-    float: left;
-    font-weight: bold;
-    font-size: 16px;
-    color: $grey1;
-    margin-top: 48px;
+  float: left;
+  font-weight: bold;
+  font-size: 16px;
+  color: $grey1;
+  margin-top: 48px;
 }
 
 /*upload table*/
 
 .dragging .file-drop {
-    display: block !important
+  display: block !important;
 }
 
 .uploaded.dragging .file-drop {
-    display: none !important
+  display: none !important;
 }
 
 .uploaded .upload-footer {
-    display: block !important
+  display: block !important;
 }
 
 .file-drop {
-    margin: 40px 0 50px 0 !important
+  margin: 40px 0 50px 0 !important;
 }
 
 #fileupload {
-    margin: 0 !important; /* padding:0 !important */
+  margin: 0 !important; /* padding:0 !important */
 }
 
-.upload-files, .gdrive-upload-files {
-
-    position: relative;
-    border: 1px dashed #ccc;
-    margin: 18px 72px;
-    min-height:200px;
-    /*min-height: 270px;*/
-    -moz-border-radius: 4px;
-    border-radius: 4px;
-    background: #fff;
-    -webkit-transition: all 50ms ease-in;
-    -moz-transition: all 50ms ease-in;
+.upload-files,
+.gdrive-upload-files {
+  position: relative;
+  border: 1px dashed #ccc;
+  margin: 18px 72px;
+  min-height: 200px;
+  /*min-height: 270px;*/
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  background: #fff;
+  -webkit-transition: all 50ms ease-in;
+  -moz-transition: all 50ms ease-in;
 }
 
-.upload-files.uploaded, .gdrive-upload-files.uploaded {
-    padding-bottom: 50px !important;
-    min-height: 220px;
+.upload-files.uploaded,
+.gdrive-upload-files.uploaded {
+  padding-bottom: 50px !important;
+  min-height: 220px;
 }
 
 span.gdrive-icon {
-    background: url(../../img/logo-drive-16.png);
-    background-size: 100%;
-    width: 16px;
-    height: 14px;
-    display: block;
-    float: right;
-    margin-top: 2px;
-    margin-left: 3px;
+  background: url(../../img/logo-drive-16.png);
+  background-size: 100%;
+  width: 16px;
+  height: 14px;
+  display: block;
+  float: right;
+  margin-top: 2px;
+  margin-left: 3px;
 }
 
 .dragging {
-    background: #e2e2e3 !important;
-    border: 1px dashed #000 !important;
-    -moz-box-shadow: 0 1px 2px #ccc;
-    -webkit-box-shadow: 0 1px 2px #ccc;
+  background: #e2e2e3 !important;
+  border: 1px dashed #000 !important;
+  -moz-box-shadow: 0 1px 2px #ccc;
+  -webkit-box-shadow: 0 1px 2px #ccc;
 }
 
-.uploaded .upload-files, .uploaded .gdrive-upload-files {
-    height: auto !important;
+.uploaded .upload-files,
+.uploaded .gdrive-upload-files {
+  height: auto !important;
 }
 
 .drag {
-    text-align: center;
-    overflow: hidden;
+  text-align: center;
+  overflow: hidden;
 }
 
 .drag p {
-    text-align: center;
-    margin: 2px 0 0 0;
-    font-size: 35px;
-    line-height: 50px;
+  text-align: center;
+  margin: 2px 0 0 0;
+  font-size: 35px;
+  line-height: 50px;
 }
 
 .drag span.min {
-    font-size: 24px;
+  font-size: 24px;
 }
 
 #overlay {
-    display: none;
-    z-index: 2;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+  display: none;
+  z-index: 2;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 .dnd-hover {
-    /*
+  /*
         border: 4px solid #97e800 !important;
     */
 }
 
 .upload-files.uploaded .upload-footer,
 .gdrive-upload-files.uploaded .upload-footer {
-    display: none !important;
+  display: none !important;
 }
 
 .creating .uploadloader {
-    display: block;
+  display: block;
 }
 
 .error-content {
-    padding-left: 45px;
-    padding-right: 10px;
-    float: left;
+  padding-left: 45px;
+  padding-right: 10px;
+  float: left;
 }
 
 .error-content a {
-    color: white;
+  color: white;
 }
 
 .error-message,
 .warning-message {
-    background: #d65757;
-    color: #fff;
-    padding: 10px 0 10px 16px;
-    margin: 10px 0;
+  background: #d65757;
+  color: #fff;
+  padding: 10px 0 10px 16px;
+  margin: 10px 0;
+  float: left;
+  font-weight: bold;
+  width: 100%;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
+  border: 1px solid #c45f5f;
+  display: none;
+  .icon {
     float: left;
-    font-weight: bold;
-    width: 100%;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
-    border: 1px solid #c45f5f;
-    display: none;
-    .icon {
-        float: left;
-        font-size: 25px;
-    }
-    p {
-        line-height: 25px;
-        font-size: 16px;
-        float: left;
-        margin-left: 12px;
-    }
+    font-size: 25px;
+  }
+  p {
+    line-height: 25px;
+    font-size: 16px;
+    float: left;
+    margin-left: 12px;
+  }
 }
 
 .warning-message {
-    background: rgba(255, 250, 139, 0.38) !important;
-    border-color: #6D6E71;
-    color: #000;
+  background: rgba(255, 250, 139, 0.38) !important;
+  border-color: #6d6e71;
+  color: #000;
 }
 
 .warning-message span {
-    /*margin-left: 15px;*/
+  /*margin-left: 15px;*/
 }
 
 .file-drag {
-    transition: width 2s;
-    -moz-transition: width 2s; /* Firefox 4 */
-    -webkit-transition: width 2s; /* Safari and Chrome */
-    -o-transition: width 2s; /* Opera */
+  transition: width 2s;
+  -moz-transition: width 2s; /* Firefox 4 */
+  -webkit-transition: width 2s; /* Safari and Chrome */
+  -o-transition: width 2s; /* Opera */
 }
 
 .file-drag {
-    overflow: hidden;
-    /*height:100px;*/
-    margin: 10px auto;
-    /*cursor: pointer;*/
-    position: relative;
-    transition: all 0.1s linear;
-    -webkit-transition: all 0.1s linear;
-    -moz-transition: all 0.1s linear;
-    -o-transition: all 0.1s linear;
-    -ms-transition: all 0.1s linear;
+  overflow: hidden;
+  /*height:100px;*/
+  margin: 10px auto;
+  /*cursor: pointer;*/
+  position: relative;
+  transition: all 0.1s linear;
+  -webkit-transition: all 0.1s linear;
+  -moz-transition: all 0.1s linear;
+  -o-transition: all 0.1s linear;
+  -ms-transition: all 0.1s linear;
 }
 
 /*.dragging .file-drag,*/
-.uploaded .file-drag, .uploaded .min {
-    display: none;
+.uploaded .file-drag,
+.uploaded .min {
+  display: none;
 }
 
-.file-drop, .upload-footer, .uploaded .btn-success, .dragging .btn-success,
-.uploaded .fileinput-link, .dragging .fileinput-link,
-.uploaded .upload-icon, .dragging .upload-icon
-{
-    display: none !important;
+.file-drop,
+.upload-footer,
+.uploaded .btn-success,
+.dragging .btn-success,
+.uploaded .fileinput-link,
+.dragging .fileinput-link,
+.uploaded .upload-icon,
+.dragging .upload-icon {
+  display: none !important;
 }
 
 .progress-extended {
-    display: none
+  display: none;
 }
 
-.dragging .file-drag, .uploaded .file-drop, .uploaded .fileupload-buttonbar {
-    height: 0;
+.dragging .file-drag,
+.uploaded .file-drop,
+.uploaded .fileupload-buttonbar {
+  height: 0;
 }
 
 .dragging .min {
-    display: none;
+  display: none;
 }
 
 .name {
-    width: 230px;
+  width: 230px;
 }
 
 .size {
-    width: 100px;
-    text-align: right !important;
-    padding-right: 20px;
+  width: 100px;
+  text-align: right !important;
+  padding-right: 20px;
 }
 
 .size span {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 tr.ready .size span {
-    visibility: visible;
+  visibility: visible;
 }
 
 .advanced-box {
-    margin: 0px 0 10px 0;
-    float: left;
-    width: 96%;
-    padding: 20px;
+  margin: 0px 0 10px 0;
+  float: left;
+  width: 96%;
+  padding: 20px;
 }
 
 .advanced-box h2 {
-    font-size: 30px;
-    text-align: left;
+  font-size: 30px;
+  text-align: left;
 }
 
 .more {
-    margin-bottom: 5px;
-    float: left;
-    text-decoration: none;
+  margin-bottom: 5px;
+  float: left;
+  text-decoration: none;
 }
 
 .more span {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .more:hover span {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .translate-box .fileinput-button {
-    margin-top: 8px;
-    text-align: center;
-    padding: 4px 0px
+  margin-top: 8px;
+  text-align: center;
+  padding: 4px 0px;
 }
 
 .more-options-cont {
-    margin-top: 7px;
-    .more-options {
-        float: left ;
-        font-size: 14px;
-        &:before {
-            display: none;
-        }
+  margin-top: 7px;
+  .more-options {
+    float: left;
+    font-size: 14px;
+    &:before {
+      display: none;
     }
-    .more-options, span:hover {
-        text-decoration: none;
-        cursor: pointer;
+  }
+  .more-options,
+  span:hover {
+    text-decoration: none;
+    cursor: pointer;
+  }
+  span {
+    font-size: 14px;
+    float: left;
+    color: $linkBlue;
+    &:hover {
+      color: $linkBlueHover;
     }
-    span {
-        font-size: 14px;
-        float: left;
-        color: $linkBlue;
-        &:hover {
-            color: $linkBlueHover;
-        }
-        &.text {
-            margin-top: 2px;
-        }
+    &.text {
+      margin-top: 2px;
     }
+  }
 
-    .more-options-icon {
-        svg {
-            width: 24px;
-            height: auto;
-        }
+  .more-options-icon {
+    svg {
+      width: 24px;
+      height: auto;
     }
-
+  }
 }
 
-
 @-moz-document url-prefix() {
-
-    .translate-box .fileinput-button {
-        margin-top: 7px;
-    }
-
+  .translate-box .fileinput-button {
+    margin-top: 7px;
+  }
 }
 
 .btn {
-    height: 44px;
-    display: block;
-    border: 1px solid #848689;
-    text-decoration: none;
-    -moz-border-radius: 2px;
-    border-radius: 2px;
+  height: 44px;
+  display: block;
+  border: 1px solid #848689;
+  text-decoration: none;
+  -moz-border-radius: 2px;
+  border-radius: 2px;
 }
 
 .tm-button {
-    width: 20px;
-    display: none;
-    float: left;
-    margin-left: -10px;
-    margin-top: 35px;
+  width: 20px;
+  display: none;
+  float: left;
+  margin-left: -10px;
+  margin-top: 35px;
 }
 
-.disabled, .disabled:hover, .disabled:active {
-    cursor: default;
-    -moz-box-shadow: none;
-    -webkit-box-shadow: none;
-    border: none;
-    background: $grey2;
-    box-shadow: none !important;
+.disabled,
+.disabled:hover,
+.disabled:active {
+  cursor: default;
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+  border: none;
+  background: $grey2;
+  box-shadow: none !important;
 }
 
 header {
-    position: relative;
-    min-width: 992px;
+  position: relative;
+  min-width: 992px;
 }
 
 .wrapper {
-    width: 98%;
-    min-width: 960px;
-    margin: 0px auto 0 auto;
-    padding: 5px 0 0 0;
-    width: 92%;
-    font-size: 14px;
-    position: relative;
-    text-align: left;
+  width: 98%;
+  min-width: 960px;
+  margin: 0px auto 0 auto;
+  padding: 5px 0 0 0;
+  width: 92%;
+  font-size: 14px;
+  position: relative;
+  text-align: left;
 }
 
 .supported-formats .popup {
-    margin: auto;
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    width: 1045px;
-    height: 620px;
-    max-width: unset;
+  margin: auto;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 1045px;
+  height: 620px;
+  max-width: unset;
 }
 
 .popup-tm .popup {
-    width: 94% !important;
-    margin: 0 !important;
-    left: 3% !important;
-    top: 5%;
+  width: 94% !important;
+  margin: 0 !important;
+  left: 3% !important;
+  top: 5%;
 }
 
 .fileformat span {
-    padding: 10px 0px 10px 40px;
-    margin: 5px 0 0 0;
-    width: 60px;
-    height: 35px;
-    float: left;
-    background-size: 25px !important;
+  padding: 10px 0px 10px 40px;
+  margin: 5px 0 0 0;
+  width: 60px;
+  height: 35px;
+  float: left;
+  background-size: 25px !important;
 }
 
 .fileformat.popup-box h3 {
-    padding: 5px 17px 5px 18px !important;
+  padding: 5px 17px 5px 18px !important;
 }
 
 .fileformat.popup-box span {
-    line-height: 15px;
+  line-height: 15px;
 }
 
 .fileformat.popup-box ul li {
-    margin: 0;
-    padding: 0 5px;
-    float: left;
-    text-align: left;
+  margin: 0;
+  padding: 0 5px;
+  float: left;
+  text-align: left;
 }
 
 .fileformat .format-box ul {
-    margin: 0 auto;
-    float: none;
-    overflow: hidden;
+  margin: 0 auto;
+  float: none;
+  overflow: hidden;
 }
 
 .fileformat .format-box:first-child ul {
-    float: left;
+  float: left;
 }
 
 .fileformat .format-box:last-child ul {
-    width: 120px;
+  width: 120px;
 }
 
 .popup-tm h1 {
-    height: 50px;
+  height: 50px;
 }
 
 .popup h3 {
-    font-size: 16px;
-    margin: 10px 0 5px 0;
-    color: #333;
+  font-size: 16px;
+  margin: 10px 0 5px 0;
+  color: #333;
 }
 
 .popup .header {
-    width: 96.2%;
-    height: 20px;
-    float: left;
-    text-align: left;
-    background: #efefef;
-    border-bottom: 1px solid #ccc;
-    margin-bottom: 5px;
-    -webkit-box-shadow: inset 0 1px 1px 1px #f4f7f9;
-    box-shadow: inset 0 1px 1px 1px #f4f7f9;
-    color: #333;
-    font-size: 22px;
-    font-weight: bold;
-    padding: 5px 2.5% 10px 1.3%;
+  width: 96.2%;
+  height: 20px;
+  float: left;
+  text-align: left;
+  background: #efefef;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 5px;
+  -webkit-box-shadow: inset 0 1px 1px 1px #f4f7f9;
+  box-shadow: inset 0 1px 1px 1px #f4f7f9;
+  color: #333;
+  font-size: 22px;
+  font-weight: bold;
+  padding: 5px 2.5% 10px 1.3%;
 }
 
-
 .popup ul {
-    margin: 0px;
-    padding: 0;
-    float: left;
-    list-style: none;
-    font-size: 14px;
+  margin: 0px;
+  padding: 0;
+  float: left;
+  list-style: none;
+  font-size: 14px;
 }
 
 .format-box ul {
-    width: 100px;
+  width: 100px;
 }
 
 .popup ul li {
-    margin: 3px 0px 3px 2px;
-    padding: 1px 5px;
+  margin: 3px 0px 3px 2px;
+  padding: 1px 5px;
 }
 
-
 #deselectMultilang {
-    margin-left: 30px;
-    font-size: 70%;
-    font-weight: normal;
-    color: #fff;
+  margin-left: 30px;
+  font-size: 70%;
+  font-weight: normal;
+  color: #fff;
 }
 
 .close {
-    background: url(../../img/x.png) center 1px no-repeat;
-    width: 22px;
-    height: 20px;
-    display: block;
-    position: absolute;
-    right: 0;
-    top: 0;
+  background: url(../../img/x.png) center 1px no-repeat;
+  width: 22px;
+  height: 20px;
+  display: block;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
-.close:hover, .close:focus {
-    background: url(../../img/x.png) center -30px no-repeat;
+.close:hover,
+.close:focus {
+  background: url(../../img/x.png) center -30px no-repeat;
 }
 
 .listlang {
-    float: left;
-    padding: 0 0 0 0;
-    margin: 0 10px 50px 5px;
-    width: 220px;
-    font-size: 100%;
+  float: left;
+  padding: 0 0 0 0;
+  margin: 0 10px 50px 5px;
+  width: 220px;
+  font-size: 100%;
 }
 
 .listlang li {
-    width: 200px;
-    padding: 1px 0 1px 0;
-    overflow: hidden !important;
-    border-bottom: 1px dotted #ccc;
-    line-height: 22px;
-    text-align: left;
+  width: 200px;
+  padding: 1px 0 1px 0;
+  overflow: hidden !important;
+  border-bottom: 1px dotted #ccc;
+  line-height: 22px;
+  text-align: left;
 }
 
 .listlang li.on {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .listlang label {
-    display: inline-block;
-    cursor: pointer;
-    padding-left: 0%;
-    padding-top: 4px;
+  display: inline-block;
+  cursor: pointer;
+  padding-left: 0%;
+  padding-top: 4px;
 }
 
 .listlang input {
-    margin-top: 8px;
+  margin-top: 8px;
 }
 
 .popup .header input {
-    float: right;
-    margin: 1px 0px 0px 15px !important;
-    background: $translatedBlue;
-    font-weight: bold;
-    float: right;
-    font-size: 14px;
-    cursor: pointer;
-    color: #333;
-    border: 1px solid #ccc !important;
-    border-radius: 2px;
-    border-radius: 2px;
-    padding: 3px 12px !important;
-    min-width: 150px;
-    background: -webkit-gradient(linear, 0% 0%, 0% 100%, from(rgb(245, 245, 245)), to(rgb(211, 212, 213)));
-    background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
-    background: linear-gradient(top, $translatedBlue, #119ec4);
+  float: right;
+  margin: 1px 0px 0px 15px !important;
+  background: $translatedBlue;
+  font-weight: bold;
+  float: right;
+  font-size: 14px;
+  cursor: pointer;
+  color: #333;
+  border: 1px solid #ccc !important;
+  border-radius: 2px;
+  border-radius: 2px;
+  padding: 3px 12px !important;
+  min-width: 150px;
+  background: -webkit-gradient(
+    linear,
+    0% 0%,
+    0% 100%,
+    from(rgb(245, 245, 245)),
+    to(rgb(211, 212, 213))
+  );
+  background: -moz-linear-gradient(top, $translatedBlue, #119ec4);
+  background: linear-gradient(top, $translatedBlue, #119ec4);
 }
 
 .translate-box h2 span.extra {
-    margin-left: 10px;
+  margin-left: 10px;
 }
 
 .grayed {
-    display: none;
-    background: #000;
-    width: 100%;
-    height: 100%;
-    position: fixed;
-    top: 0;
-    left: 0;
-    opacity: 0.2;
-    z-index: 9;
+  display: none;
+  background: #000;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  opacity: 0.2;
+  z-index: 9;
 }
 
 .format-box {
-    float: left;
-    margin: 0;
-    margin-right: 2px;
+  float: left;
+  margin: 0;
+  margin-right: 2px;
 }
 
 #delete-failed-conversions {
-    display: none;
+  display: none;
 }
 
 ul.test {
-    column-count: 4;
+  column-count: 4;
 }
 
 ul.test li {
-    float: left;
-    width: 200px;
-    background: yellow;
+  float: left;
+  width: 200px;
+  background: yellow;
 }
 
 //footer{background:#6d6e71;height:27px;text-align:right;border-top:1px solid #333;color:#fff;position:fixed;bottom:0;left:0;width:100%;z-index:999999999999;}
@@ -2478,13 +2555,13 @@ ul.test li {
 }*/
 
 .fb-like.fb_iframe_widget {
-    float: left;
-    margin-top: -1px;
+  float: left;
+  margin-top: -1px;
 }
 
 #authentication {
-    float: right;
-    margin-left: 50px;
+  float: right;
+  margin-left: 50px;
 }
 
 /*#mt_engine
@@ -2493,337 +2570,332 @@ ul.test li {
 	}
 */
 #create_private_tm_btn {
-    background-image: none;
-    width: 70px;
-    margin-left: -22px;
-    padding: 8px 0 1px 0;
-    margin-top: 7px;
+  background-image: none;
+  width: 70px;
+  margin-left: -22px;
+  padding: 8px 0 1px 0;
+  margin-top: 7px;
 }
 
 #swaplang {
-    float: left;
-    display: block;
-    width: 10px;
-    text-decoration: none;
-    height: 18px;
-    margin: 52px 14px 0 5px;
-    font-size: 20px;
-    color: #ccc;
+  float: left;
+  display: block;
+  width: 10px;
+  text-decoration: none;
+  height: 18px;
+  margin: 52px 14px 0 5px;
+  font-size: 20px;
+  color: #ccc;
 }
 
 #swaplang span {
-    display: none;
+  display: none;
 }
 
 #swaplang:hover {
-    color: #ddd;
+  color: #ddd;
 }
 
 /* job list table when analyze page is not available */
 .tablestats {
-    display: none;
-    border-right: 1px solid #ccc;
-    -moz-border-radius: 4px;
-    border-radius: 4px;
-    margin-bottom: 4px !important;
-    margin-top: 20px !important;
-    float: right;
+  display: none;
+  border-right: 1px solid #ccc;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  margin-bottom: 4px !important;
+  margin-top: 20px !important;
+  float: right;
 }
 
 .tablestats th {
-    background-color: #efefef;
-    font-size: 16px;
-    border-top: 1px solid #ccc;
+  background-color: #efefef;
+  font-size: 16px;
+  border-top: 1px solid #ccc;
 }
 
-.tablestats th, .tablestats td {
-    border-bottom: 1px solid #ccc;
-    border-left: 1px solid #ccc;
-    padding: 8px;
-    margin: 1px 0;
-    text-align: left;
+.tablestats th,
+.tablestats td {
+  border-bottom: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  padding: 8px;
+  margin: 1px 0;
+  text-align: left;
 }
 
 .tablestats td {
-    font-size: 14px;
+  font-size: 14px;
 }
 
 .newProject {
-    right: 20px;
-    float: right;
+  right: 20px;
+  float: right;
 }
 
 .tablestats a.url {
-    font-size: 14px;
+  font-size: 14px;
 }
 
 .disabledLink {
-    color: gray;
-    text-decoration: none;
-    background: none;
-    cursor: default;
+  color: gray;
+  text-decoration: none;
+  background: none;
+  cursor: default;
 }
 
 .name {
-    padding: 8px 0px 5px 20px !important;
+  padding: 8px 0px 5px 20px !important;
 }
 
 /* file extensions */
 
 .preview span {
-    height: 30px;
-    width: 30px;
-    display: block;
-    background-size: 25px !important;
+  height: 30px;
+  width: 30px;
+  display: block;
+  background-size: 25px !important;
 }
 
 .error .label.label-important a {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 header .open-more {
-    color: #fff;
-    padding: 10px 5px;
-    font-size: 16px;
+  color: #fff;
+  padding: 10px 5px;
+  font-size: 16px;
 }
 
 .open-more {
-    cursor: pointer;
-    text-decoration: underline;
-    color: #fff;
-
+  cursor: pointer;
+  text-decoration: underline;
+  color: #fff;
 }
 
 .learnmore {
-    background-color: #fff;
-    padding: 20px 40px 30px 40px;
-    margin: 0 auto;
-    margin-top: -20px;
-    overflow: hidden;
-    color: #333;
-    font-size: 20px;
-
+  background-color: #fff;
+  padding: 20px 40px 30px 40px;
+  margin: 0 auto;
+  margin-top: -20px;
+  overflow: hidden;
+  color: #333;
+  font-size: 20px;
 }
 
 .learnmore h1 {
-    color: #19bdea;
-    font-size: 40px;
-    font-weight: 800;
-    margin: 0px 0 10px 0;
-    padding-bottom: 20px;
-    border-bottom: 1px solid #E9E9E9;
+  color: #19bdea;
+  font-size: 40px;
+  font-weight: 800;
+  margin: 0px 0 10px 0;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #e9e9e9;
 }
 
 .col-3 {
-    width: 25%;
-    float: left;
-    padding: 0 4%;
+  width: 25%;
+  float: left;
+  padding: 0 4%;
 }
 
 .learnmore h2 {
-    color: #333;
-    margin-top: 10px;
-    font-weight: 800;
-    font-size: 25px;
+  color: #333;
+  margin-top: 10px;
+  font-weight: 800;
+  font-size: 25px;
 }
 
 .learnmore .open-more {
-    font-size: 20px;
-    text-decoration: none;
-    font-weight: bold;
-    color: #333;
+  font-size: 20px;
+  text-decoration: none;
+  font-weight: bold;
+  color: #333;
 }
 
 .learnmore .open-more:hover {
-    color: #19bdea;
+  color: #19bdea;
 }
 
 .learnmore img {
-    width: 250px;
+  width: 250px;
 }
 
-.more, .more.minus {
-    color: #333;
+.more,
+.more.minus {
+  color: #333;
 }
 
 .bottom-lm {
-    margin-top: 20px;
-    float: left;
-    width: 100%;
+  margin-top: 20px;
+  float: left;
+  width: 100%;
 }
 
 .nobrowser {
-    display: none;
+  display: none;
 }
 
 .cat-appear-div {
-    position: absolute;
-    right: 0;
-    z-index: -1000;
+  position: absolute;
+  right: 0;
+  z-index: -1000;
 }
 
 .text-center {
-    text-align: center;
+  text-align: center;
 }
 
-.zip_internal_file /*:before*/
-{
-    /*content: "\ea58";*/
-    /* margin-left: 15px;*/
-    /*color: #555;*/
+.zip_internal_file /*:before*/ {
+  /*content: "\ea58";*/
+  /* margin-left: 15px;*/
+  /*color: #555;*/
 }
 
 span.load-gdrive {
-    display: inline-block;
-    vertical-align: top;
-    width: 200px;
-    font-family: calibri, Arial, Helvetica, sans-serif;
-    font-size: 1.1em;
-    margin: 0;
-    padding: 0.60rem 0.25rem 0.40rem 2.2rem;
-    border: 0.1rem solid #B7B9BC;
-    background: url(../../img/logo-drive-16.png) 1.3rem 0.85rem no-repeat;
-    background-color: #F5F5F5;
-    cursor: pointer;
+  display: inline-block;
+  vertical-align: top;
+  width: 200px;
+  font-family: calibri, Arial, Helvetica, sans-serif;
+  font-size: 1.1em;
+  margin: 0;
+  padding: 0.6rem 0.25rem 0.4rem 2.2rem;
+  border: 0.1rem solid #b7b9bc;
+  background: url(../../img/logo-drive-16.png) 1.3rem 0.85rem no-repeat;
+  background-color: #f5f5f5;
+  cursor: pointer;
 }
 
 span.load-gdrive:hover,
 .continue-gdrive span.load-gdrive:hover {
-    background-color: #EFEFEF;
+  background-color: #efefef;
 }
 
 .modal-gdrive {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 9999999999999;
-    background: rgba(255, 255, 255, 0.5);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 9999999999999;
+  background: rgba(255, 255, 255, 0.5);
 }
 
 .fileupload-buttonbar span.min {
-    font-size: 24px;
-    display: inline-block;
-    vertical-align: middle;
-    line-height: 42px;
-    margin: 0 1.5rem;
+  font-size: 24px;
+  display: inline-block;
+  vertical-align: middle;
+  line-height: 42px;
+  margin: 0 1.5rem;
 }
 
 span.fileinput-button {
-    display: inline-block;
-    vertical-align: top;
-    margin: 0;
+  display: inline-block;
+  vertical-align: top;
+  margin: 0;
 }
 
 div.continue-gdrive {
-    margin: 0 0 10px 10px !important;
-    display: block;
+  margin: 0 0 10px 10px !important;
+  display: block;
 }
 
 .continue-gdrive span.load-gdrive {
-    width: auto;
-    padding: 0.50rem 0.70rem 0.0rem 2.3rem;
-    background: url(../../img/logo-drive-16.png) 0.7rem 0.55rem no-repeat;
-    margin-right: 10px;
-    background-size: 20px;
-    height: 36px;
+  width: auto;
+  padding: 0.5rem 0.7rem 0rem 2.3rem;
+  background: url(../../img/logo-drive-16.png) 0.7rem 0.55rem no-repeat;
+  margin-right: 10px;
+  background-size: 20px;
+  height: 36px;
 }
 
 .continue-gdrive span.clear-gdrive {
-    float: none;
-    margin: 0 !important;
+  float: none;
+  margin: 0 !important;
 }
 
 #upload-files-list {
-    display: block;
-    padding: 24px;
+  display: block;
+  padding: 24px;
 }
 
 #gdrive-files-list {
-    display: none;
+  display: none;
 }
-
 
 .wrapper-dropdown-5 {
-    padding: 4px 16px !important;
+  padding: 4px 16px !important;
 }
 .google-login-button {
-    box-sizing: content-box;
+  box-sizing: content-box;
 }
 
 #sign-in-o-mt {
-    width: 300px !important;
+  width: 300px !important;
 }
 
 .btn-confirm-small {
-    //height: 35px;
+  //height: 35px;
 }
 
 header .nav-mc-bar .dropdown.select-org span.text {
-    line-height: 32px;
+  line-height: 32px;
 }
 
 .ui.user.label {
-    top: 0px !important;
+  top: 0px !important;
 }
 
 header .nav-mc-bar .dropdown.select-org span.text {
-    text-align: right;
-    line-height: 32px;
-    text-decoration: underline;
-    min-width: 0px;
-    padding-right: 12px;
-    max-width: 110px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    top: -1px;
+  text-align: right;
+  line-height: 32px;
+  text-decoration: underline;
+  min-width: 0px;
+  padding-right: 12px;
+  max-width: 110px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  top: -1px;
 }
 
 header .nav-mc-bar .dropdown.select-org i.dropdown.icon {
-    top: 12px;
-    margin-left: -25px !important;
+  top: 12px;
+  margin-left: -25px !important;
 }
 
 .translate-box input:focus {
-    border-color: #85B7D9;
-    background: #FFFFFF;
-    color: rgba(0, 0, 0, 0.8);
-    outline: none;
+  border-color: #85b7d9;
+  background: #ffffff;
+  color: rgba(0, 0, 0, 0.8);
+  outline: none;
 }
 
 select:focus {
-    border-color: #85B7D9;
-    background: #FFFFFF;
-    color: rgba(0, 0, 0, 0.8);
-    outline: none;
+  border-color: #85b7d9;
+  background: #ffffff;
+  color: rgba(0, 0, 0, 0.8);
+  outline: none;
 }
 
 .ui.selection.dropdown {
-    box-shadow: inset 0 1px 3px #ddd;
+  box-shadow: inset 0 1px 3px #ddd;
 }
 
 .ui.input input {
-    box-shadow: inset 0 1px 3px #ddd;
+  box-shadow: inset 0 1px 3px #ddd;
 }
 
 a.pull-left.btn-grey.canceladdtmx {
-    margin-left: 4px;
+  margin-left: 4px;
 }
 
 a.pull-right.confirmDelete {
-    margin-right: 3px;
+  margin-right: 3px;
 }
-
-
-
 
 /* Header restyling */
 
 .action-submenu {
-    opacity: 0.8;
-    &:hover {
-        opacity: 1;
-    }
+  opacity: 0.8;
+  &:hover {
+    opacity: 1;
+  }
 }

--- a/public/css/sass/variables.scss
+++ b/public/css/sass/variables.scss
@@ -1,10 +1,8 @@
-
 $approved-color: #639d5e;
 $translated-color: #0798bc;
 $rejected-color: #b02429;
 $disabled-color: #ebebeb;
 $disabled-border-color: #b3b3b3;
-
 
 /******* Notifications ***********/
 
@@ -38,14 +36,10 @@ $notification-info: #369cc7;
   transition: $args;
 }
 
-@mixin box-shadow($top, $left, $blur, $color, $inset:"") {
-  -webkit-box-shadow:$top $left $blur $color #{$inset};
-  -moz-box-shadow:$top $left $blur $color #{$inset};
-  box-shadow:$top $left $blur $color #{$inset};
+@mixin box-shadow($top, $left, $blur, $color, $inset: '') {
+  -webkit-box-shadow: $top $left $blur $color #{$inset};
+  -moz-box-shadow: $top $left $blur $color #{$inset};
+  box-shadow: $top $left $blur $color #{$inset};
 }
-
-
-
-
 
 /*********************************/

--- a/public/css/sass/vendor_mc/jquery.atwho.scss
+++ b/public/css/sass/vendor_mc/jquery.atwho.scss
@@ -1,72 +1,72 @@
 .atwho-view {
-    position:absolute;
-    top: 0;
-    left: 0;
-    display: none;
-    margin-top: 18px;
-    background: white;
-    color: black;
-    border: 1px solid #DDD;
-    border-radius: 3px;
-    box-shadow: 0 0 4px rgba(0,0,0,0.1);
-    min-width: 120px;
-    text-align: left;
-    z-index: 11110 !important;
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: none;
+  margin-top: 18px;
+  background: white;
+  color: black;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.1);
+  min-width: 120px;
+  text-align: left;
+  z-index: 11110 !important;
 }
 
 .atwho-view .atwho-header {
-    padding: 5px;
-    margin: 5px;
-    cursor: pointer;
-    border-bottom: solid 1px #eaeff1;
-    color: #6f8092;
-    font-size: 11px;
-    font-weight: bold;
+  padding: 5px;
+  margin: 5px;
+  cursor: pointer;
+  border-bottom: solid 1px #eaeff1;
+  color: #6f8092;
+  font-size: 11px;
+  font-weight: bold;
 }
 
 .atwho-view .atwho-header .small {
-    color: #6f8092;
-    float: right;
-    padding-top: 2px;
-    margin-right: -5px;
-    font-size: 12px;
-    font-weight: normal;
+  color: #6f8092;
+  float: right;
+  padding-top: 2px;
+  margin-right: -5px;
+  font-size: 12px;
+  font-weight: normal;
 }
 
 .atwho-view .atwho-header:hover {
-    cursor: default;
+  cursor: default;
 }
 
 .atwho-view .cur {
-    /*background: #3366FF;*/
-    background: #f2f2f2;
-    /*color: white;*/
+  /*background: #3366FF;*/
+  background: #f2f2f2;
+  /*color: white;*/
 }
 .atwho-view .cur small {
-    /*color: white;*/
+  /*color: white;*/
 }
 .atwho-view strong {
-    color: #3366FF;
+  color: #3366ff;
 }
 .atwho-view .cur strong {
-    /*color: white;*/
-    font:bold;
+  /*color: white;*/
+  font: bold;
 }
 .atwho-view ul {
-    /* width: 100px; */
-    list-style:none;
-    padding:0;
-    margin:auto;
-    max-height: 250px;
-    overflow-y: auto;
+  /* width: 100px; */
+  list-style: none;
+  padding: 0;
+  margin: auto;
+  max-height: 250px;
+  overflow-y: auto;
 }
 .atwho-view ul li {
-    display: block;
-    padding: 5px 10px;
-    cursor: pointer;
+  display: block;
+  padding: 5px 10px;
+  cursor: pointer;
 }
 .atwho-view small {
-    font-size: smaller;
-    color: #777;
-    font-weight: normal;
+  font-size: smaller;
+  color: #777;
+  font-weight: normal;
 }

--- a/public/css/sass/vendor_mc/semantic/_semantic_overrides.scss
+++ b/public/css/sass/vendor_mc/semantic/_semantic_overrides.scss
@@ -1,107 +1,106 @@
-
 /******** Overwrite Semantic CSS  *********/
 
 .ui.basic.buttons .active.button,
 .ui.basic.active.button {
-    box-shadow: rgba(34, 36, 38, 0.35);
+  box-shadow: rgba(34, 36, 38, 0.35);
 }
 .ui.basic.buttons .active.button {
-    box-shadow: rgba(34, 36, 38, 0.35) inset;
+  box-shadow: rgba(34, 36, 38, 0.35) inset;
 }
 
 /*--- Blue ---*/
 
 .ui.blue.buttons .button,
 .ui.blue.button {
-    background-color: $translatedBlue;
+  background-color: $translatedBlue;
 }
 .ui.blue.buttons .button:hover,
 .ui.blue.button:hover {
-    background-color: $translatedBlueHover;
+  background-color: $translatedBlueHover;
 }
 /* Basic */
 
 .ui.basic.blue.buttons .button,
 .ui.basic.blue.button {
-    box-shadow: 0px 0px 0px 1px $translatedBlue inset !important;
-    color: $translatedBlue !important;
+  box-shadow: 0px 0px 0px 1px $translatedBlue inset !important;
+  color: $translatedBlue !important;
 }
 
 .ui.basic.blue.buttons .button:hover,
 .ui.basic.blue.button:hover {
-    color: $translatedBlueHover !important;
+  color: $translatedBlueHover !important;
 }
 
 .ui.basic.blue.buttons .button:focus,
 .ui.basic.blue.button:focus {
-    color: $translatedBlueHover !important;
+  color: $translatedBlueHover !important;
 }
 
 /*--- Green ---*/
 
 .ui.green.buttons .button,
 .ui.green.button {
-    background-color: $greenDefault;
-    transition: 0.3s ease;
+  background-color: $greenDefault;
+  transition: 0.3s ease;
 }
 
 .ui.green.buttons .button:hover,
 .ui.green.button:hover {
-    background-color: $greenDefaultHover;
-    //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  background-color: $greenDefaultHover;
+  //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
 }
 
 .ui.green.buttons .button:focus,
 .ui.green.button:focus {
-    background-color: $greenDefaultHover;
-    box-shadow: none !important;
+  background-color: $greenDefaultHover;
+  box-shadow: none !important;
 }
 
 .ui.green.buttons .button:active,
 .ui.green.button:active {
-    background-color: $greenDefaultHover;
-    box-shadow: none !important;
-    transition: none !important;
+  background-color: $greenDefaultHover;
+  box-shadow: none !important;
+  transition: none !important;
 }
 
 .ui.green.buttons .active.button,
 .ui.green.buttons .active.button:active,
 .ui.green.active.button,
 .ui.green.button .active.button:active {
-    box-shadow: none !important;
-    transition: none !important;
+  box-shadow: none !important;
+  transition: none !important;
 }
 /*--- Red ---*/
 
 .ui.red.buttons .button,
 .ui.red.button {
-    background-color: $redDefault;
+  background-color: $redDefault;
 }
 
 .ui.red.buttons .button:hover,
 .ui.red.button:hover {
-    background-color: $redDefaultHover;
-    //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  background-color: $redDefaultHover;
+  //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
 }
 
 .ui.red.buttons .button:focus,
 .ui.red.button:focus {
-    background-color: $redDefaultHover;
-    box-shadow: none !important;
+  background-color: $redDefaultHover;
+  box-shadow: none !important;
 }
 
 .ui.red.buttons .button:active,
 .ui.red.button:active {
-    background-color: $redDefaultHover;
-    box-shadow: none !important;
+  background-color: $redDefaultHover;
+  box-shadow: none !important;
 }
 
 .ui.red.buttons .active.button,
 .ui.red.buttons .active.button:active,
 .ui.red.active.button,
 .ui.red.button .active.button:active {
-    background-color: $redDefaultHover;
-    box-shadow: none !important;
+  background-color: $redDefaultHover;
+  box-shadow: none !important;
 }
 
 /*-------------------
@@ -112,52 +111,52 @@
 
 .ui.primary.buttons .button,
 .ui.primary.button {
-    background-color: $translatedBlue;
-    transition: 0.3s ease;
+  background-color: $translatedBlue;
+  transition: 0.3s ease;
 }
 
 .ui.primary.buttons .button:hover,
 .ui.primary.button:hover {
-    background-color: $translatedBlueHover;
-    //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
+  background-color: $translatedBlueHover;
+  //box-shadow: 0 0 0 #e0e0e0, 0 0 2px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.24) !important;
 }
 
 .ui.primary.buttons .button:focus,
 .ui.primary.button:focus {
-    background-color: $translatedBlueActive;
-    box-shadow: none !important;
+  background-color: $translatedBlueActive;
+  box-shadow: none !important;
 }
 
 .ui.primary.buttons .button:active,
 .ui.primary.button:active {
-    background-color: $translatedBlueActive;
-    box-shadow: none !important;
-    transition: none;
+  background-color: $translatedBlueActive;
+  box-shadow: none !important;
+  transition: none;
 }
 
 .ui.primary.buttons .active.button,
 .ui.primary.buttons .active.button:active,
 .ui.primary.active.button,
 .ui.primary.button .active.button:active {
-    transition: none;
+  transition: none;
 }
 
 /* Basic */
 
 .ui.basic.primary.buttons .button,
 .ui.basic.primary.button {
-    box-shadow: 0px 0px 0px 1px $translatedBlue inset !important;
-    color: $translatedBlue !important;
+  box-shadow: 0px 0px 0px 1px $translatedBlue inset !important;
+  color: $translatedBlue !important;
 }
 
 .ui.basic.primary.buttons .button:hover,
 .ui.basic.primary.button:hover {
-    color: $translatedBlueHover !important;
+  color: $translatedBlueHover !important;
 }
 
 .ui.basic.primary.buttons .button:focus,
 .ui.basic.primary.button:focus {
-    color: $translatedBlueActive !important;
+  color: $translatedBlueActive !important;
 }
 
 /*---------------
@@ -168,7 +167,7 @@
 
 .ui.positive.buttons .button:hover,
 .ui.positive.button:hover {
-    background-color: #85b742;
+  background-color: #85b742;
 }
 
 /*---------------
@@ -179,51 +178,50 @@
 
 .ui.negative.buttons .button,
 .ui.negative.button {
-    background-color: #f26522;
+  background-color: #f26522;
 }
 
 .ui.negative.buttons .button:hover,
 .ui.negative.button:hover {
-    background-color: #d1581c;
+  background-color: #d1581c;
 }
 /**********/
 i.flag.mm:before,
 i.flag.myanmar:before,
 i.flag.burma:before {
-    background-position: -36px -1717px;
+  background-position: -36px -1717px;
 }
-
 
 /* Blue */
 
 i.blue.icon {
-    color: $translatedBlue !important;
+  color: $translatedBlue !important;
 }
 
 i.inverted.blue.icon {
-    color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 i.inverted.bordered.blue.icon,
 i.inverted.circular.blue.icon {
-    background-color: $translatedBlue !important;
-    color: #FFFFFF !important;
+  background-color: $translatedBlue !important;
+  color: #ffffff !important;
 }
 
 /*--- Blue ---*/
 
 .ui.blue.labels .label,
 .ui.blue.label {
-    background-color: $translatedBlue !important;
-    border-color: $translatedBlue !important;
+  background-color: $translatedBlue !important;
+  border-color: $translatedBlue !important;
 }
 
 /* Link */
 
 .ui.blue.labels .label:hover,
 a.ui.blue.label:hover {
-    background-color: $translatedBlueHover !important;
-    border-color: $translatedBlueHover !important;
+  background-color: $translatedBlueHover !important;
+  border-color: $translatedBlueHover !important;
 }
 
 /* Ribbon */
@@ -231,14 +229,14 @@ a.ui.blue.label:hover {
 /* Basic */
 
 .ui.basic.blue.label {
-    color: $translatedBlue !important;
-    border-color: $translatedBlue !important;
+  color: $translatedBlue !important;
+  border-color: $translatedBlue !important;
 }
 
 .ui.basic.blue.labels a.label:hover,
 a.ui.basic.blue.label:hover {
-    color: $translatedBlueHover !important;
-    border-color: $translatedBlueHover !important;
+  color: $translatedBlueHover !important;
+  border-color: $translatedBlueHover !important;
 }
 
 /* Colors */
@@ -246,13 +244,12 @@ a.ui.basic.blue.label:hover {
 /* Blue */
 
 .ui.blue.segment:not(.inverted) {
-    border-top: 2px solid $translatedBlue;
+  border-top: 2px solid $translatedBlue;
 }
 
 .ui.inverted.blue.segment {
-    background-color: $translatedBlue !important;
+  background-color: $translatedBlue !important;
 }
-
 
 /*----------------------
          Colored
@@ -261,7 +258,7 @@ a.ui.basic.blue.label:hover {
 .ui.grid > .blue.row,
 .ui.grid > .blue.column,
 .ui.grid > .row > .blue.column {
-    background-color: $translatedBlue !important;
+  background-color: $translatedBlue !important;
 }
 
 /*--------------
@@ -271,8 +268,8 @@ a.ui.basic.blue.label:hover {
 /*--- Standard Colors  ---*/
 .ui.menu .blue.active.item,
 .ui.blue.menu .active.item {
-    border-color: $translatedBlue !important;
-    color: $translatedBlue !important;
+  border-color: $translatedBlue !important;
+  color: $translatedBlue !important;
 }
 /*--------------
     Inverted
@@ -282,23 +279,22 @@ a.ui.basic.blue.label:hover {
 
 .ui.inverted.menu .red.active.item,
 .ui.inverted.red.menu {
-    background-color: #f26522;
+  background-color: #f26522;
 }
 /* Blue */
 
 .ui.inverted.menu .blue.active.item,
 .ui.inverted.blue.menu {
-    background-color: $translatedBlue;
+  background-color: $translatedBlue;
 }
-
 
 /* Colors Message */
 
 .ui.blue.message {
-    color: $translatedBlue;
-    box-shadow: 0px 0px 0px 1px $translatedBlue inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  color: $translatedBlue;
+  box-shadow: 0px 0px 0px 1px $translatedBlue inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
-
 
 /*--------------
    Single Line
@@ -309,38 +305,36 @@ a.ui.basic.blue.label:hover {
 /* Blue */
 
 .ui.blue.table {
-    border-top: 0.2em solid $translatedBlue;
+  border-top: 0.2em solid $translatedBlue;
 }
 
 .ui.inverted.blue.table {
-    background-color: $translatedBlue !important;
+  background-color: $translatedBlue !important;
 }
-
 
 /* Blue */
 
 .ui.blue.cards > .card,
 .ui.cards > .blue.card,
 .ui.blue.card {
-    box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px $translatedBlue, 0px 1px 3px 0px #D4D4D5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px $translatedBlue,
+    0px 1px 3px 0px #d4d4d5;
 }
-
 
 .ui.blue.statistics .statistic > .value,
 .ui.statistics .blue.statistic > .value,
 .ui.blue.statistic > .value {
-    color: $translatedBlue;
+  color: $translatedBlue;
 }
-
 
 .ui.toggle.checkbox input:checked ~ .box:before,
 .ui.toggle.checkbox input:checked ~ label:before {
-    background-color: $translatedBlue !important;
+  background-color: $translatedBlue !important;
 }
 
 .ui.scrolling.dropdown .menu .item.item.item,
 .ui.dropdown .scrolling.menu > .item.item.item {
-    padding-right: calc( 1.14285714rem  +  17px ) !important;
+  padding-right: calc(1.14285714rem + 17px) !important;
 }
 
 /*--------------
@@ -350,22 +344,21 @@ a.ui.basic.blue.label:hover {
 /* Red */
 
 .ui.red.progress .bar {
-    background-color: #f26522;
+  background-color: #f26522;
 }
 /* Blue */
 
 .ui.blue.progress .bar {
-    background-color: $translatedBlue;
+  background-color: $translatedBlue;
 }
 
 /********************************************/
 
 .ui.popup {
-    overflow: initial !important;
-    z-index: 20000000000000;
+  overflow: initial !important;
+  z-index: 20000000000000;
 }
 
-
-.ui.grid.border-box *{
-    box-sizing: border-box;
+.ui.grid.border-box * {
+  box-sizing: border-box;
 }

--- a/public/css/sass/vendor_mc/semantic/matecat_semantic.scss
+++ b/public/css/sass/vendor_mc/semantic/matecat_semantic.scss
@@ -1,15 +1,15 @@
-
-@import "semantic";
-@import "../../commons/colors";
-@import "semantic_overrides";
+@import 'semantic';
+@import '../../commons/colors';
+@import 'semantic_overrides';
 
 @font-face {
   font-family: 'Icons';
-  src:  url('../../fonts/icomoon.eot?13r8r1');
-  src:  url('../../fonts/icomoon.eot?13r8r1#iefix') format('embedded-opentype'),
-  url('../../fonts/icomoon.ttf?13r8r1') format('truetype'),
-  url('../../fonts/icomoon.woff?13r8r1') format('woff'),
-  url('../../fonts/icomoon.svg?13r8r1#icomoon') format('svg');font-style: normal;
+  src: url('../../fonts/icomoon.eot?13r8r1');
+  src: url('../../fonts/icomoon.eot?13r8r1#iefix') format('embedded-opentype'),
+    url('../../fonts/icomoon.ttf?13r8r1') format('truetype'),
+    url('../../fonts/icomoon.woff?13r8r1') format('woff'),
+    url('../../fonts/icomoon.svg?13r8r1#icomoon') format('svg');
+  font-style: normal;
   font-weight: normal;
   font-variant: normal;
   text-decoration: inherit;
@@ -17,11 +17,11 @@
 }
 
 a {
-    color: $linkBlue;
-    &:hover{
-        color: $linkBlueHover;
-    }
-    &:active {
-        color: $linkBlueActive;
-    }
+  color: $linkBlue;
+  &:hover {
+    color: $linkBlueHover;
+  }
+  &:active {
+    color: $linkBlueActive;
+  }
 }

--- a/public/css/sass/vendor_mc/semantic/semantic.css
+++ b/public/css/sass/vendor_mc/semantic/semantic.css
@@ -1,4 +1,4 @@
- /*
+/*
  * # Semantic UI - 2.4.2
  * https://github.com/Semantic-Org/Semantic-UI
  * http://www.semantic-ui.com/
@@ -39,10 +39,10 @@ html {
 
 /* iPad Input Shadows */
 
-input[type="text"],
-input[type="email"],
-input[type="search"],
-input[type="password"] {
+input[type='text'],
+input[type='email'],
+input[type='search'],
+input[type='password'] {
   -webkit-appearance: none;
   -moz-appearance: none;
   /* mobile firefox too! */
@@ -349,9 +349,9 @@ select {
  */
 
 button,
-html [type="button"],
-[type="reset"],
-[type="submit"] {
+html [type='button'],
+[type='reset'],
+[type='submit'] {
   -webkit-appearance: button;
   /* 2 */
 }
@@ -361,9 +361,9 @@ html [type="button"],
  */
 
 button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
+[type='button']::-moz-focus-inner,
+[type='reset']::-moz-focus-inner,
+[type='submit']::-moz-focus-inner {
   border-style: none;
   padding: 0;
 }
@@ -373,9 +373,9 @@ button::-moz-focus-inner,
  */
 
 button:-moz-focusring,
-[type="button"]:-moz-focusring,
-[type="reset"]:-moz-focusring,
-[type="submit"]:-moz-focusring {
+[type='button']:-moz-focusring,
+[type='reset']:-moz-focusring,
+[type='submit']:-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 
@@ -435,8 +435,8 @@ textarea {
  * 2. Remove the padding in IE 10-.
  */
 
-[type="checkbox"],
-[type="radio"] {
+[type='checkbox'],
+[type='radio'] {
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
   /* 1 */
@@ -448,8 +448,8 @@ textarea {
  * Correct the cursor style of increment and decrement buttons in Chrome.
  */
 
-[type="number"]::-webkit-inner-spin-button,
-[type="number"]::-webkit-outer-spin-button {
+[type='number']::-webkit-inner-spin-button,
+[type='number']::-webkit-outer-spin-button {
   height: auto;
 }
 
@@ -458,7 +458,7 @@ textarea {
  * 2. Correct the outline style in Safari.
  */
 
-[type="search"] {
+[type='search'] {
   -webkit-appearance: textfield;
   /* 1 */
   outline-offset: -2px;
@@ -469,8 +469,8 @@ textarea {
  * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
  */
 
-[type="search"]::-webkit-search-cancel-button,
-[type="search"]::-webkit-search-decoration {
+[type='search']::-webkit-search-cancel-button,
+[type='search']::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
@@ -568,7 +568,7 @@ body {
   padding: 0px;
   overflow-x: hidden;
   min-width: 320px;
-  background: #FFFFFF;
+  background: #ffffff;
   font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
   font-size: 14px;
   line-height: 1.4285em;
@@ -587,7 +587,7 @@ h4,
 h5 {
   font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
   line-height: 1.28571429em;
-  margin: calc(2rem -  0.14285714em ) 0em 1rem;
+  margin: calc(2rem - 0.14285714em) 0em 1rem;
   font-weight: bold;
   padding: 0em;
 }
@@ -651,7 +651,7 @@ p:last-child {
 --------------------*/
 
 a {
-  color: #4183C4;
+  color: #4183c4;
   text-decoration: none;
 }
 
@@ -671,17 +671,17 @@ a:hover {
 /* Site */
 
 ::-webkit-selection {
-  background-color: #CCE2FF;
+  background-color: #cce2ff;
   color: rgba(0, 0, 0, 0.87);
 }
 
 ::-moz-selection {
-  background-color: #CCE2FF;
+  background-color: #cce2ff;
   color: rgba(0, 0, 0, 0.87);
 }
 
 ::selection {
-  background-color: #CCE2FF;
+  background-color: #cce2ff;
   color: rgba(0, 0, 0, 0.87);
 }
 
@@ -780,7 +780,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   outline: none;
   border: none;
   vertical-align: baseline;
-  background: #E0E1E2 none;
+  background: #e0e1e2 none;
   color: rgba(0, 0, 0, 0.6);
   font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
   margin: 0em 0.25em 0em 0em;
@@ -793,16 +793,22 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   text-align: center;
   text-decoration: none;
   border-radius: 0.28571429rem;
-  -webkit-box-shadow: 0px 0px 0px 1px transparent inset, 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 0px 0px 1px transparent inset, 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 0px 0px 1px transparent inset,
+    0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 0px 0px 1px transparent inset,
+    0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  -webkit-transition: opacity 0.1s ease, background-color 0.1s ease, color 0.1s ease, background 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: opacity 0.1s ease, background-color 0.1s ease, color 0.1s ease, background 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: opacity 0.1s ease, background-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, background 0.1s ease;
-  transition: opacity 0.1s ease, background-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, background 0.1s ease, -webkit-box-shadow 0.1s ease;
+  -webkit-transition: opacity 0.1s ease, background-color 0.1s ease,
+    color 0.1s ease, background 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: opacity 0.1s ease, background-color 0.1s ease, color 0.1s ease,
+    background 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: opacity 0.1s ease, background-color 0.1s ease, color 0.1s ease,
+    box-shadow 0.1s ease, background 0.1s ease;
+  transition: opacity 0.1s ease, background-color 0.1s ease, color 0.1s ease,
+    box-shadow 0.1s ease, background 0.1s ease, -webkit-box-shadow 0.1s ease;
   will-change: '';
   -webkit-tap-highlight-color: transparent;
 }
@@ -816,10 +822,12 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 ---------------*/
 
 .ui.button:hover {
-  background-color: #CACBCD;
+  background-color: #cacbcd;
   background-image: none;
-  -webkit-box-shadow: 0px 0px 0px 1px transparent inset, 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 0px 0px 1px transparent inset, 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 0px 0px 1px transparent inset,
+    0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 0px 0px 1px transparent inset,
+    0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
   color: rgba(0, 0, 0, 0.8);
 }
 
@@ -832,7 +840,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 ---------------*/
 
 .ui.button:focus {
-  background-color: #CACBCD;
+  background-color: #cacbcd;
   color: rgba(0, 0, 0, 0.8);
   background-image: '' !important;
   -webkit-box-shadow: '' !important;
@@ -849,7 +857,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.button:active,
 .ui.active.button:active {
-  background-color: #BABBBC;
+  background-color: #babbbc;
   background-image: '';
   color: rgba(0, 0, 0, 0.9);
   -webkit-box-shadow: 0px 0px 0px 1px transparent inset, none;
@@ -861,7 +869,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 ---------------*/
 
 .ui.active.button {
-  background-color: #C0C1C2;
+  background-color: #c0c1c2;
   background-image: none;
   -webkit-box-shadow: 0px 0px 0px 1px transparent inset;
   box-shadow: 0px 0px 0px 1px transparent inset;
@@ -869,13 +877,13 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 }
 
 .ui.active.button:hover {
-  background-color: #C0C1C2;
+  background-color: #c0c1c2;
   background-image: none;
   color: rgba(0, 0, 0, 0.95);
 }
 
 .ui.active.button:active {
-  background-color: #C0C1C2;
+  background-color: #c0c1c2;
   background-image: none;
 }
 
@@ -921,7 +929,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   -webkit-animation-iteration-count: infinite;
   animation-iteration-count: infinite;
   border-radius: 500rem;
-  border-color: #FFFFFF transparent transparent;
+  border-color: #ffffff transparent transparent;
   border-style: solid;
   border-width: 0.2em;
   -webkit-box-shadow: 0px 0px 0px 1px transparent;
@@ -1093,7 +1101,8 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   -webkit-transition: opacity 0.3s ease, -webkit-transform 0.3s ease;
   transition: opacity 0.3s ease, -webkit-transform 0.3s ease;
   transition: opacity 0.3s ease, transform 0.3s ease;
-  transition: opacity 0.3s ease, transform 0.3s ease, -webkit-transform 0.3s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease,
+    -webkit-transform 0.3s ease;
 }
 
 .ui.fade.animated.button .visible.content {
@@ -1135,10 +1144,10 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 --------------------*/
 
 .ui.inverted.button {
-  -webkit-box-shadow: 0px 0px 0px 2px #FFFFFF inset !important;
-  box-shadow: 0px 0px 0px 2px #FFFFFF inset !important;
+  -webkit-box-shadow: 0px 0px 0px 2px #ffffff inset !important;
+  box-shadow: 0px 0px 0px 2px #ffffff inset !important;
   background: transparent none;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none !important;
 }
 
@@ -1165,9 +1174,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 /* Hover */
 
 .ui.inverted.button:hover {
-  background: #FFFFFF;
-  -webkit-box-shadow: 0px 0px 0px 2px #FFFFFF inset !important;
-  box-shadow: 0px 0px 0px 2px #FFFFFF inset !important;
+  background: #ffffff;
+  -webkit-box-shadow: 0px 0px 0px 2px #ffffff inset !important;
+  box-shadow: 0px 0px 0px 2px #ffffff inset !important;
   color: rgba(0, 0, 0, 0.8);
 }
 
@@ -1175,18 +1184,18 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.inverted.button:focus,
 .ui.inverted.button.active {
-  background: #FFFFFF;
-  -webkit-box-shadow: 0px 0px 0px 2px #FFFFFF inset !important;
-  box-shadow: 0px 0px 0px 2px #FFFFFF inset !important;
+  background: #ffffff;
+  -webkit-box-shadow: 0px 0px 0px 2px #ffffff inset !important;
+  box-shadow: 0px 0px 0px 2px #ffffff inset !important;
   color: rgba(0, 0, 0, 0.8);
 }
 
 /* Active Focus */
 
 .ui.inverted.button.active:focus {
-  background: #DCDDDE;
-  -webkit-box-shadow: 0px 0px 0px 2px #DCDDDE inset !important;
-  box-shadow: 0px 0px 0px 2px #DCDDDE inset !important;
+  background: #dcddde;
+  -webkit-box-shadow: 0px 0px 0px 2px #dcddde inset !important;
+  box-shadow: 0px 0px 0px 2px #dcddde inset !important;
   color: rgba(0, 0, 0, 0.8);
 }
 
@@ -1235,24 +1244,24 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 /* Right */
 
-.ui.labeled.button:not([class*="left labeled"]) > .button {
+.ui.labeled.button:not([class*='left labeled']) > .button {
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;
 }
 
-.ui.labeled.button:not([class*="left labeled"]) > .label {
+.ui.labeled.button:not([class*='left labeled']) > .label {
   border-top-left-radius: 0px;
   border-bottom-left-radius: 0px;
 }
 
 /* Left Side */
 
-.ui[class*="left labeled"].button > .button {
+.ui[class*='left labeled'].button > .button {
   border-top-left-radius: 0px;
   border-bottom-left-radius: 0px;
 }
 
-.ui[class*="left labeled"].button > .label {
+.ui[class*='left labeled'].button > .label {
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;
 }
@@ -1264,8 +1273,8 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 /* Facebook */
 
 .ui.facebook.button {
-  background-color: #3B5998;
-  color: #FFFFFF;
+  background-color: #3b5998;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
   -webkit-box-shadow: 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
@@ -1274,21 +1283,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.facebook.button:hover {
   background-color: #304d8a;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.facebook.button:active {
   background-color: #2d4373;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 /* Twitter */
 
 .ui.twitter.button {
-  background-color: #55ACEE;
-  color: #FFFFFF;
+  background-color: #55acee;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
   -webkit-box-shadow: 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
@@ -1297,21 +1306,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.twitter.button:hover {
   background-color: #35a2f4;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.twitter.button:active {
   background-color: #2795e9;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 /* Google Plus */
 
 .ui.google.plus.button {
-  background-color: #DD4B39;
-  color: #FFFFFF;
+  background-color: #dd4b39;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
   -webkit-box-shadow: 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
@@ -1320,41 +1329,41 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.google.plus.button:hover {
   background-color: #e0321c;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.google.plus.button:active {
   background-color: #c23321;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 /* Linked In */
 
 .ui.linkedin.button {
-  background-color: #1F88BE;
-  color: #FFFFFF;
+  background-color: #1f88be;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.linkedin.button:hover {
   background-color: #147baf;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.linkedin.button:active {
   background-color: #186992;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 /* YouTube */
 
 .ui.youtube.button {
-  background-color: #FF0000;
-  color: #FFFFFF;
+  background-color: #ff0000;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
   -webkit-box-shadow: 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
@@ -1363,21 +1372,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.youtube.button:hover {
   background-color: #e60000;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.youtube.button:active {
   background-color: #cc0000;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 /* Instagram */
 
 .ui.instagram.button {
-  background-color: #49769C;
-  color: #FFFFFF;
+  background-color: #49769c;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
   -webkit-box-shadow: 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
@@ -1386,21 +1395,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.instagram.button:hover {
   background-color: #3d698e;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.instagram.button:active {
   background-color: #395c79;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 /* Pinterest */
 
 .ui.pinterest.button {
-  background-color: #BD081C;
-  color: #FFFFFF;
+  background-color: #bd081c;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
   -webkit-box-shadow: 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
@@ -1409,21 +1418,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.pinterest.button:hover {
   background-color: #ac0013;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.pinterest.button:active {
   background-color: #8c0615;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 /* VK */
 
 .ui.vk.button {
-  background-color: #4D7198;
-  color: #FFFFFF;
+  background-color: #4d7198;
+  color: #ffffff;
   background-image: none;
   -webkit-box-shadow: 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
   box-shadow: 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
@@ -1431,12 +1440,12 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.vk.button:hover {
   background-color: #41648a;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.vk.button:active {
   background-color: #3c5876;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 /*--------------
@@ -1469,15 +1478,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
        Floated
 --------------------*/
 
-.ui[class*="left floated"].buttons,
-.ui[class*="left floated"].button {
+.ui[class*='left floated'].buttons,
+.ui[class*='left floated'].button {
   float: left;
   margin-left: 0em;
   margin-right: 0.25em;
 }
 
-.ui[class*="right floated"].buttons,
-.ui[class*="right floated"].button {
+.ui[class*='right floated'].buttons,
+.ui[class*='right floated'].button {
   float: right;
   margin-right: 0em;
   margin-left: 0.25em;
@@ -1599,26 +1608,32 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.buttons .button:hover,
 .ui.basic.button:hover {
-  background: #FFFFFF !important;
+  background: #ffffff !important;
   color: rgba(0, 0, 0, 0.8) !important;
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset, 0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset, 0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset,
+    0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset,
+    0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset;
 }
 
 .ui.basic.buttons .button:focus,
 .ui.basic.button:focus {
-  background: #FFFFFF !important;
+  background: #ffffff !important;
   color: rgba(0, 0, 0, 0.8) !important;
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset, 0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset, 0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset,
+    0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset,
+    0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset;
 }
 
 .ui.basic.buttons .button:active,
 .ui.basic.button:active {
-  background: #F8F8F8 !important;
+  background: #f8f8f8 !important;
   color: rgba(0, 0, 0, 0.9) !important;
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.15) inset, 0px 1px 4px 0px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.15) inset, 0px 1px 4px 0px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.15) inset,
+    0px 1px 4px 0px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.15) inset,
+    0px 1px 4px 0px rgba(34, 36, 38, 0.15) inset;
 }
 
 .ui.basic.buttons .active.button,
@@ -1637,13 +1652,17 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 /* Vertical */
 
 .ui.basic.buttons .button:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset, 0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset inset;
-  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset, 0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset inset;
+  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset,
+    0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset inset;
+  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.35) inset,
+    0px 0px 0px 0px rgba(34, 36, 38, 0.15) inset inset;
 }
 
 .ui.basic.buttons .button:active {
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.15) inset, 0px 1px 4px 0px rgba(34, 36, 38, 0.15) inset inset;
-  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.15) inset, 0px 1px 4px 0px rgba(34, 36, 38, 0.15) inset inset;
+  -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.15) inset,
+    0px 1px 4px 0px rgba(34, 36, 38, 0.15) inset inset;
+  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.15) inset,
+    0px 1px 4px 0px rgba(34, 36, 38, 0.15) inset inset;
 }
 
 .ui.basic.buttons .active.button {
@@ -1656,21 +1675,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.basic.inverted.buttons .button,
 .ui.basic.inverted.button {
   background-color: transparent !important;
-  color: #F9FAFB !important;
+  color: #f9fafb !important;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
 }
 
 .ui.basic.inverted.buttons .button:hover,
 .ui.basic.inverted.button:hover {
-  color: #FFFFFF !important;
+  color: #ffffff !important;
   -webkit-box-shadow: 0px 0px 0px 2px #ffffff inset !important;
   box-shadow: 0px 0px 0px 2px #ffffff inset !important;
 }
 
 .ui.basic.inverted.buttons .button:focus,
 .ui.basic.inverted.button:focus {
-  color: #FFFFFF !important;
+  color: #ffffff !important;
   -webkit-box-shadow: 0px 0px 0px 2px #ffffff inset !important;
   box-shadow: 0px 0px 0px 2px #ffffff inset !important;
 }
@@ -1678,7 +1697,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.basic.inverted.buttons .button:active,
 .ui.basic.inverted.button:active {
   background-color: rgba(255, 255, 255, 0.08) !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.9) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.9) inset !important;
 }
@@ -1686,7 +1705,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.basic.inverted.buttons .active.button,
 .ui.basic.inverted.active.button {
   background-color: rgba(255, 255, 255, 0.08);
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.7) inset;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.7) inset;
@@ -1760,12 +1779,12 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 /* Right Labeled */
 
-.ui[class*="right labeled"].icon.button {
+.ui[class*='right labeled'].icon.button {
   padding-right: 4.07142857em !important;
   padding-left: 1.5em !important;
 }
 
-.ui[class*="right labeled"].icon.button > .icon {
+.ui[class*='right labeled'].icon.button > .icon {
   left: auto;
   right: 0em;
   border-radius: 0px;
@@ -1814,8 +1833,8 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 /* Fluid Labeled */
 
-.ui.fluid[class*="left labeled"].icon.button,
-.ui.fluid[class*="right labeled"].icon.button {
+.ui.fluid[class*='left labeled'].icon.button,
+.ui.fluid[class*='right labeled'].icon.button {
   padding-left: 1.5em !important;
   padding-right: 1.5em !important;
 }
@@ -1829,17 +1848,17 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.toggle.buttons .active.button,
 .ui.buttons .button.toggle.active,
 .ui.button.toggle.active {
-  background-color: #21BA45 !important;
+  background-color: #21ba45 !important;
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
   text-shadow: none;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.button.toggle.active:hover {
   background-color: #16ab39 !important;
   text-shadow: none;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /*--------------
@@ -1873,7 +1892,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   content: 'or';
   top: 50%;
   left: 50%;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   text-shadow: none;
   margin-top: -0.89285714em;
   margin-left: -0.89285714em;
@@ -1971,35 +1990,35 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 /* Top / Bottom */
 
-.ui[class*="top attached"].buttons {
+.ui[class*='top attached'].buttons {
   margin-bottom: -1px;
   border-radius: 0.28571429rem 0.28571429rem 0em 0em;
 }
 
-.ui[class*="top attached"].buttons .button:first-child {
+.ui[class*='top attached'].buttons .button:first-child {
   border-radius: 0.28571429rem 0em 0em 0em;
 }
 
-.ui[class*="top attached"].buttons .button:last-child {
+.ui[class*='top attached'].buttons .button:last-child {
   border-radius: 0em 0.28571429rem 0em 0em;
 }
 
-.ui[class*="bottom attached"].buttons {
+.ui[class*='bottom attached'].buttons {
   margin-top: -1px;
   border-radius: 0em 0em 0.28571429rem 0.28571429rem;
 }
 
-.ui[class*="bottom attached"].buttons .button:first-child {
+.ui[class*='bottom attached'].buttons .button:first-child {
   border-radius: 0em 0em 0em 0.28571429rem;
 }
 
-.ui[class*="bottom attached"].buttons .button:last-child {
+.ui[class*='bottom attached'].buttons .button:last-child {
   border-radius: 0em 0em 0.28571429rem 0em;
 }
 
 /* Left / Right */
 
-.ui[class*="left attached"].buttons {
+.ui[class*='left attached'].buttons {
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
   display: inline-flex;
@@ -2008,17 +2027,17 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   border-radius: 0em 0.28571429rem 0.28571429rem 0em;
 }
 
-.ui[class*="left attached"].buttons .button:first-child {
+.ui[class*='left attached'].buttons .button:first-child {
   margin-left: -1px;
   border-radius: 0em 0.28571429rem 0em 0em;
 }
 
-.ui[class*="left attached"].buttons .button:last-child {
+.ui[class*='left attached'].buttons .button:last-child {
   margin-left: -1px;
   border-radius: 0em 0em 0.28571429rem 0em;
 }
 
-.ui[class*="right attached"].buttons {
+.ui[class*='right attached'].buttons {
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
   display: inline-flex;
@@ -2027,12 +2046,12 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   border-radius: 0.28571429rem 0em 0em 0.28571429rem;
 }
 
-.ui[class*="right attached"].buttons .button:first-child {
+.ui[class*='right attached'].buttons .button:first-child {
   margin-left: -1px;
   border-radius: 0.28571429rem 0em 0em 0em;
 }
 
-.ui[class*="right attached"].buttons .button:last-child {
+.ui[class*='right attached'].buttons .button:last-child {
   margin-left: -1px;
   border-radius: 0em 0em 0em 0.28571429rem;
 }
@@ -2200,8 +2219,8 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.black.buttons .button,
 .ui.black.button {
-  background-color: #1B1C1D;
-  color: #FFFFFF;
+  background-color: #1b1c1d;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -2214,21 +2233,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.black.buttons .button:hover,
 .ui.black.button:hover {
   background-color: #27292a;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.black.buttons .button:focus,
 .ui.black.button:focus {
   background-color: #2f3032;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.black.buttons .button:active,
 .ui.black.button:active {
   background-color: #343637;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2237,7 +2256,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.black.active.button,
 .ui.black.button .active.button:active {
   background-color: #0f0f10;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2245,9 +2264,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.black.buttons .button,
 .ui.basic.black.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #1B1C1D inset !important;
-  box-shadow: 0px 0px 0px 1px #1B1C1D inset !important;
-  color: #1B1C1D !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #1b1c1d inset !important;
+  box-shadow: 0px 0px 0px 1px #1b1c1d inset !important;
+  color: #1b1c1d !important;
 }
 
 .ui.basic.black.buttons .button:hover,
@@ -2290,9 +2309,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.black.buttons .button,
 .ui.inverted.black.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #D4D4D5 inset !important;
-  box-shadow: 0px 0px 0px 2px #D4D4D5 inset !important;
-  color: #FFFFFF;
+  -webkit-box-shadow: 0px 0px 0px 2px #d4d4d5 inset !important;
+  box-shadow: 0px 0px 0px 2px #d4d4d5 inset !important;
+  color: #ffffff;
 }
 
 .ui.inverted.black.buttons .button:hover,
@@ -2305,7 +2324,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.black.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.black.buttons .button:hover,
@@ -2336,7 +2355,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.black.basic.buttons .button:hover,
@@ -2344,7 +2363,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.black.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #000000 inset !important;
   box-shadow: 0px 0px 0px 2px #000000 inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.black.basic.buttons .button:focus,
@@ -2360,7 +2379,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.black.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #000000 inset !important;
   box-shadow: 0px 0px 0px 2px #000000 inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.black.basic.buttons .button:active,
@@ -2368,7 +2387,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.black.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #000000 inset !important;
   box-shadow: 0px 0px 0px 2px #000000 inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /*--- Grey ---*/
@@ -2376,7 +2395,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.grey.buttons .button,
 .ui.grey.button {
   background-color: #767676;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -2389,21 +2408,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.grey.buttons .button:hover,
 .ui.grey.button:hover {
   background-color: #838383;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.grey.buttons .button:focus,
 .ui.grey.button:focus {
   background-color: #8a8a8a;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.grey.buttons .button:active,
 .ui.grey.button:active {
   background-color: #909090;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2412,7 +2431,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.grey.active.button,
 .ui.grey.button .active.button:active {
   background-color: #696969;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2465,9 +2484,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.grey.buttons .button,
 .ui.inverted.grey.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #D4D4D5 inset !important;
-  box-shadow: 0px 0px 0px 2px #D4D4D5 inset !important;
-  color: #FFFFFF;
+  -webkit-box-shadow: 0px 0px 0px 2px #d4d4d5 inset !important;
+  box-shadow: 0px 0px 0px 2px #d4d4d5 inset !important;
+  color: #ffffff;
 }
 
 .ui.inverted.grey.buttons .button:hover,
@@ -2511,7 +2530,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.grey.basic.buttons .button:hover,
@@ -2519,7 +2538,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.grey.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #cfd0d2 inset !important;
   box-shadow: 0px 0px 0px 2px #cfd0d2 inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.grey.basic.buttons .button:focus,
@@ -2527,7 +2546,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.grey.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #c7c9cb inset !important;
   box-shadow: 0px 0px 0px 2px #c7c9cb inset !important;
-  color: #DCDDDE !important;
+  color: #dcddde !important;
 }
 
 .ui.inverted.grey.basic.buttons .active.button,
@@ -2535,7 +2554,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.grey.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #cfd0d2 inset !important;
   box-shadow: 0px 0px 0px 2px #cfd0d2 inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.grey.basic.buttons .button:active,
@@ -2543,15 +2562,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.grey.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #c2c4c5 inset !important;
   box-shadow: 0px 0px 0px 2px #c2c4c5 inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /*--- Brown ---*/
 
 .ui.brown.buttons .button,
 .ui.brown.button {
-  background-color: #A5673F;
-  color: #FFFFFF;
+  background-color: #a5673f;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -2564,21 +2583,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.brown.buttons .button:hover,
 .ui.brown.button:hover {
   background-color: #975b33;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.brown.buttons .button:focus,
 .ui.brown.button:focus {
   background-color: #90532b;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.brown.buttons .button:active,
 .ui.brown.button:active {
   background-color: #805031;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2587,7 +2606,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.brown.active.button,
 .ui.brown.button .active.button:active {
   background-color: #995a31;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2595,9 +2614,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.brown.buttons .button,
 .ui.basic.brown.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #A5673F inset !important;
-  box-shadow: 0px 0px 0px 1px #A5673F inset !important;
-  color: #A5673F !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #a5673f inset !important;
+  box-shadow: 0px 0px 0px 1px #a5673f inset !important;
+  color: #a5673f !important;
 }
 
 .ui.basic.brown.buttons .button:hover,
@@ -2640,9 +2659,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.brown.buttons .button,
 .ui.inverted.brown.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #D67C1C inset !important;
-  box-shadow: 0px 0px 0px 2px #D67C1C inset !important;
-  color: #D67C1C;
+  -webkit-box-shadow: 0px 0px 0px 2px #d67c1c inset !important;
+  box-shadow: 0px 0px 0px 2px #d67c1c inset !important;
+  color: #d67c1c;
 }
 
 .ui.inverted.brown.buttons .button:hover,
@@ -2655,7 +2674,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.brown.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.brown.buttons .button:hover,
@@ -2686,7 +2705,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.brown.basic.buttons .button:hover,
@@ -2694,7 +2713,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.brown.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #c86f11 inset !important;
   box-shadow: 0px 0px 0px 2px #c86f11 inset !important;
-  color: #D67C1C !important;
+  color: #d67c1c !important;
 }
 
 .ui.inverted.brown.basic.buttons .button:focus,
@@ -2702,7 +2721,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.brown.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #c16808 inset !important;
   box-shadow: 0px 0px 0px 2px #c16808 inset !important;
-  color: #D67C1C !important;
+  color: #d67c1c !important;
 }
 
 .ui.inverted.brown.basic.buttons .active.button,
@@ -2710,7 +2729,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.brown.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #cc6f0d inset !important;
   box-shadow: 0px 0px 0px 2px #cc6f0d inset !important;
-  color: #D67C1C !important;
+  color: #d67c1c !important;
 }
 
 .ui.inverted.brown.basic.buttons .button:active,
@@ -2718,15 +2737,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.brown.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #a96216 inset !important;
   box-shadow: 0px 0px 0px 2px #a96216 inset !important;
-  color: #D67C1C !important;
+  color: #d67c1c !important;
 }
 
 /*--- Blue ---*/
 
 .ui.blue.buttons .button,
 .ui.blue.button {
-  background-color: #2185D0;
-  color: #FFFFFF;
+  background-color: #2185d0;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -2739,21 +2758,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.blue.buttons .button:hover,
 .ui.blue.button:hover {
   background-color: #1678c2;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.blue.buttons .button:focus,
 .ui.blue.button:focus {
   background-color: #0d71bb;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.blue.buttons .button:active,
 .ui.blue.button:active {
   background-color: #1a69a4;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2762,7 +2781,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.blue.active.button,
 .ui.blue.button .active.button:active {
   background-color: #1279c6;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2770,9 +2789,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.blue.buttons .button,
 .ui.basic.blue.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #2185D0 inset !important;
-  box-shadow: 0px 0px 0px 1px #2185D0 inset !important;
-  color: #2185D0 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #2185d0 inset !important;
+  box-shadow: 0px 0px 0px 1px #2185d0 inset !important;
+  color: #2185d0 !important;
 }
 
 .ui.basic.blue.buttons .button:hover,
@@ -2815,9 +2834,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.blue.buttons .button,
 .ui.inverted.blue.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #54C8FF inset !important;
-  box-shadow: 0px 0px 0px 2px #54C8FF inset !important;
-  color: #54C8FF;
+  -webkit-box-shadow: 0px 0px 0px 2px #54c8ff inset !important;
+  box-shadow: 0px 0px 0px 2px #54c8ff inset !important;
+  color: #54c8ff;
 }
 
 .ui.inverted.blue.buttons .button:hover,
@@ -2830,7 +2849,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.blue.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.blue.buttons .button:hover,
@@ -2861,7 +2880,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.blue.basic.buttons .button:hover,
@@ -2869,7 +2888,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.blue.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #3ac0ff inset !important;
   box-shadow: 0px 0px 0px 2px #3ac0ff inset !important;
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 .ui.inverted.blue.basic.buttons .button:focus,
@@ -2877,7 +2896,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.blue.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #2bbbff inset !important;
   box-shadow: 0px 0px 0px 2px #2bbbff inset !important;
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 .ui.inverted.blue.basic.buttons .active.button,
@@ -2885,7 +2904,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.blue.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #3ac0ff inset !important;
   box-shadow: 0px 0px 0px 2px #3ac0ff inset !important;
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 .ui.inverted.blue.basic.buttons .button:active,
@@ -2893,15 +2912,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.blue.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #21b8ff inset !important;
   box-shadow: 0px 0px 0px 2px #21b8ff inset !important;
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 /*--- Green ---*/
 
 .ui.green.buttons .button,
 .ui.green.button {
-  background-color: #21BA45;
-  color: #FFFFFF;
+  background-color: #21ba45;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -2914,21 +2933,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.green.buttons .button:hover,
 .ui.green.button:hover {
   background-color: #16ab39;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.green.buttons .button:focus,
 .ui.green.button:focus {
   background-color: #0ea432;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.green.buttons .button:active,
 .ui.green.button:active {
   background-color: #198f35;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2937,7 +2956,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.green.active.button,
 .ui.green.button .active.button:active {
   background-color: #13ae38;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -2945,9 +2964,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.green.buttons .button,
 .ui.basic.green.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #21BA45 inset !important;
-  box-shadow: 0px 0px 0px 1px #21BA45 inset !important;
-  color: #21BA45 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #21ba45 inset !important;
+  box-shadow: 0px 0px 0px 1px #21ba45 inset !important;
+  color: #21ba45 !important;
 }
 
 .ui.basic.green.buttons .button:hover,
@@ -2990,9 +3009,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.green.buttons .button,
 .ui.inverted.green.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #2ECC40 inset !important;
-  box-shadow: 0px 0px 0px 2px #2ECC40 inset !important;
-  color: #2ECC40;
+  -webkit-box-shadow: 0px 0px 0px 2px #2ecc40 inset !important;
+  box-shadow: 0px 0px 0px 2px #2ecc40 inset !important;
+  color: #2ecc40;
 }
 
 .ui.inverted.green.buttons .button:hover,
@@ -3005,7 +3024,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.green.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.green.buttons .button:hover,
@@ -3036,7 +3055,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.green.basic.buttons .button:hover,
@@ -3044,7 +3063,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.green.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #22be34 inset !important;
   box-shadow: 0px 0px 0px 2px #22be34 inset !important;
-  color: #2ECC40 !important;
+  color: #2ecc40 !important;
 }
 
 .ui.inverted.green.basic.buttons .button:focus,
@@ -3052,7 +3071,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.green.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #19b82b inset !important;
   box-shadow: 0px 0px 0px 2px #19b82b inset !important;
-  color: #2ECC40 !important;
+  color: #2ecc40 !important;
 }
 
 .ui.inverted.green.basic.buttons .active.button,
@@ -3060,7 +3079,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.green.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #1fc231 inset !important;
   box-shadow: 0px 0px 0px 2px #1fc231 inset !important;
-  color: #2ECC40 !important;
+  color: #2ecc40 !important;
 }
 
 .ui.inverted.green.basic.buttons .button:active,
@@ -3068,15 +3087,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.green.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #25a233 inset !important;
   box-shadow: 0px 0px 0px 2px #25a233 inset !important;
-  color: #2ECC40 !important;
+  color: #2ecc40 !important;
 }
 
 /*--- Orange ---*/
 
 .ui.orange.buttons .button,
 .ui.orange.button {
-  background-color: #F2711C;
-  color: #FFFFFF;
+  background-color: #f2711c;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -3089,21 +3108,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.orange.buttons .button:hover,
 .ui.orange.button:hover {
   background-color: #f26202;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.orange.buttons .button:focus,
 .ui.orange.button:focus {
   background-color: #e55b00;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.orange.buttons .button:active,
 .ui.orange.button:active {
   background-color: #cf590c;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3112,7 +3131,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.orange.active.button,
 .ui.orange.button .active.button:active {
   background-color: #f56100;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3120,9 +3139,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.orange.buttons .button,
 .ui.basic.orange.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #F2711C inset !important;
-  box-shadow: 0px 0px 0px 1px #F2711C inset !important;
-  color: #F2711C !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #f2711c inset !important;
+  box-shadow: 0px 0px 0px 1px #f2711c inset !important;
+  color: #f2711c !important;
 }
 
 .ui.basic.orange.buttons .button:hover,
@@ -3165,9 +3184,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.orange.buttons .button,
 .ui.inverted.orange.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #FF851B inset !important;
-  box-shadow: 0px 0px 0px 2px #FF851B inset !important;
-  color: #FF851B;
+  -webkit-box-shadow: 0px 0px 0px 2px #ff851b inset !important;
+  box-shadow: 0px 0px 0px 2px #ff851b inset !important;
+  color: #ff851b;
 }
 
 .ui.inverted.orange.buttons .button:hover,
@@ -3180,7 +3199,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.orange.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.orange.buttons .button:hover,
@@ -3211,7 +3230,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.orange.basic.buttons .button:hover,
@@ -3219,7 +3238,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.orange.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #ff7701 inset !important;
   box-shadow: 0px 0px 0px 2px #ff7701 inset !important;
-  color: #FF851B !important;
+  color: #ff851b !important;
 }
 
 .ui.inverted.orange.basic.buttons .button:focus,
@@ -3227,7 +3246,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.orange.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #f17000 inset !important;
   box-shadow: 0px 0px 0px 2px #f17000 inset !important;
-  color: #FF851B !important;
+  color: #ff851b !important;
 }
 
 .ui.inverted.orange.basic.buttons .active.button,
@@ -3235,7 +3254,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.orange.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #ff7701 inset !important;
   box-shadow: 0px 0px 0px 2px #ff7701 inset !important;
-  color: #FF851B !important;
+  color: #ff851b !important;
 }
 
 .ui.inverted.orange.basic.buttons .button:active,
@@ -3243,15 +3262,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.orange.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #e76b00 inset !important;
   box-shadow: 0px 0px 0px 2px #e76b00 inset !important;
-  color: #FF851B !important;
+  color: #ff851b !important;
 }
 
 /*--- Pink ---*/
 
 .ui.pink.buttons .button,
 .ui.pink.button {
-  background-color: #E03997;
-  color: #FFFFFF;
+  background-color: #e03997;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -3264,21 +3283,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.pink.buttons .button:hover,
 .ui.pink.button:hover {
   background-color: #e61a8d;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.pink.buttons .button:focus,
 .ui.pink.button:focus {
   background-color: #e10f85;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.pink.buttons .button:active,
 .ui.pink.button:active {
   background-color: #c71f7e;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3287,7 +3306,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.pink.active.button,
 .ui.pink.button .active.button:active {
   background-color: #ea158d;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3295,9 +3314,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.pink.buttons .button,
 .ui.basic.pink.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #E03997 inset !important;
-  box-shadow: 0px 0px 0px 1px #E03997 inset !important;
-  color: #E03997 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #e03997 inset !important;
+  box-shadow: 0px 0px 0px 1px #e03997 inset !important;
+  color: #e03997 !important;
 }
 
 .ui.basic.pink.buttons .button:hover,
@@ -3340,9 +3359,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.pink.buttons .button,
 .ui.inverted.pink.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #FF8EDF inset !important;
-  box-shadow: 0px 0px 0px 2px #FF8EDF inset !important;
-  color: #FF8EDF;
+  -webkit-box-shadow: 0px 0px 0px 2px #ff8edf inset !important;
+  box-shadow: 0px 0px 0px 2px #ff8edf inset !important;
+  color: #ff8edf;
 }
 
 .ui.inverted.pink.buttons .button:hover,
@@ -3355,7 +3374,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.pink.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.pink.buttons .button:hover,
@@ -3386,7 +3405,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.pink.basic.buttons .button:hover,
@@ -3394,7 +3413,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.pink.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #ff74d8 inset !important;
   box-shadow: 0px 0px 0px 2px #ff74d8 inset !important;
-  color: #FF8EDF !important;
+  color: #ff8edf !important;
 }
 
 .ui.inverted.pink.basic.buttons .button:focus,
@@ -3402,7 +3421,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.pink.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #ff65d3 inset !important;
   box-shadow: 0px 0px 0px 2px #ff65d3 inset !important;
-  color: #FF8EDF !important;
+  color: #ff8edf !important;
 }
 
 .ui.inverted.pink.basic.buttons .active.button,
@@ -3410,7 +3429,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.pink.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #ff74d8 inset !important;
   box-shadow: 0px 0px 0px 2px #ff74d8 inset !important;
-  color: #FF8EDF !important;
+  color: #ff8edf !important;
 }
 
 .ui.inverted.pink.basic.buttons .button:active,
@@ -3418,15 +3437,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.pink.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #ff5bd1 inset !important;
   box-shadow: 0px 0px 0px 2px #ff5bd1 inset !important;
-  color: #FF8EDF !important;
+  color: #ff8edf !important;
 }
 
 /*--- Violet ---*/
 
 .ui.violet.buttons .button,
 .ui.violet.button {
-  background-color: #6435C9;
-  color: #FFFFFF;
+  background-color: #6435c9;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -3439,21 +3458,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.violet.buttons .button:hover,
 .ui.violet.button:hover {
   background-color: #5829bb;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.violet.buttons .button:focus,
 .ui.violet.button:focus {
   background-color: #4f20b5;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.violet.buttons .button:active,
 .ui.violet.button:active {
   background-color: #502aa1;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3462,7 +3481,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.violet.active.button,
 .ui.violet.button .active.button:active {
   background-color: #5626bf;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3470,9 +3489,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.violet.buttons .button,
 .ui.basic.violet.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #6435C9 inset !important;
-  box-shadow: 0px 0px 0px 1px #6435C9 inset !important;
-  color: #6435C9 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #6435c9 inset !important;
+  box-shadow: 0px 0px 0px 1px #6435c9 inset !important;
+  color: #6435c9 !important;
 }
 
 .ui.basic.violet.buttons .button:hover,
@@ -3515,9 +3534,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.violet.buttons .button,
 .ui.inverted.violet.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #A291FB inset !important;
-  box-shadow: 0px 0px 0px 2px #A291FB inset !important;
-  color: #A291FB;
+  -webkit-box-shadow: 0px 0px 0px 2px #a291fb inset !important;
+  box-shadow: 0px 0px 0px 2px #a291fb inset !important;
+  color: #a291fb;
 }
 
 .ui.inverted.violet.buttons .button:hover,
@@ -3530,7 +3549,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.violet.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.violet.buttons .button:hover,
@@ -3561,7 +3580,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.violet.basic.buttons .button:hover,
@@ -3569,7 +3588,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.violet.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #8a73ff inset !important;
   box-shadow: 0px 0px 0px 2px #8a73ff inset !important;
-  color: #A291FB !important;
+  color: #a291fb !important;
 }
 
 .ui.inverted.violet.basic.buttons .button:focus,
@@ -3577,7 +3596,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.violet.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #7d64ff inset !important;
   box-shadow: 0px 0px 0px 2px #7d64ff inset !important;
-  color: #A291FB !important;
+  color: #a291fb !important;
 }
 
 .ui.inverted.violet.basic.buttons .active.button,
@@ -3585,7 +3604,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.violet.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #8a73ff inset !important;
   box-shadow: 0px 0px 0px 2px #8a73ff inset !important;
-  color: #A291FB !important;
+  color: #a291fb !important;
 }
 
 .ui.inverted.violet.basic.buttons .button:active,
@@ -3593,15 +3612,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.violet.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #7860f9 inset !important;
   box-shadow: 0px 0px 0px 2px #7860f9 inset !important;
-  color: #A291FB !important;
+  color: #a291fb !important;
 }
 
 /*--- Purple ---*/
 
 .ui.purple.buttons .button,
 .ui.purple.button {
-  background-color: #A333C8;
-  color: #FFFFFF;
+  background-color: #a333c8;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -3614,21 +3633,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.purple.buttons .button:hover,
 .ui.purple.button:hover {
   background-color: #9627ba;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.purple.buttons .button:focus,
 .ui.purple.button:focus {
   background-color: #8f1eb4;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.purple.buttons .button:active,
 .ui.purple.button:active {
   background-color: #82299f;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3637,7 +3656,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.purple.active.button,
 .ui.purple.button .active.button:active {
   background-color: #9724be;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3645,9 +3664,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.purple.buttons .button,
 .ui.basic.purple.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #A333C8 inset !important;
-  box-shadow: 0px 0px 0px 1px #A333C8 inset !important;
-  color: #A333C8 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #a333c8 inset !important;
+  box-shadow: 0px 0px 0px 1px #a333c8 inset !important;
+  color: #a333c8 !important;
 }
 
 .ui.basic.purple.buttons .button:hover,
@@ -3690,9 +3709,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.purple.buttons .button,
 .ui.inverted.purple.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #DC73FF inset !important;
-  box-shadow: 0px 0px 0px 2px #DC73FF inset !important;
-  color: #DC73FF;
+  -webkit-box-shadow: 0px 0px 0px 2px #dc73ff inset !important;
+  box-shadow: 0px 0px 0px 2px #dc73ff inset !important;
+  color: #dc73ff;
 }
 
 .ui.inverted.purple.buttons .button:hover,
@@ -3705,7 +3724,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.purple.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.purple.buttons .button:hover,
@@ -3736,7 +3755,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.purple.basic.buttons .button:hover,
@@ -3744,7 +3763,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.purple.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #d65aff inset !important;
   box-shadow: 0px 0px 0px 2px #d65aff inset !important;
-  color: #DC73FF !important;
+  color: #dc73ff !important;
 }
 
 .ui.inverted.purple.basic.buttons .button:focus,
@@ -3752,7 +3771,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.purple.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #d24aff inset !important;
   box-shadow: 0px 0px 0px 2px #d24aff inset !important;
-  color: #DC73FF !important;
+  color: #dc73ff !important;
 }
 
 .ui.inverted.purple.basic.buttons .active.button,
@@ -3760,7 +3779,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.purple.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #d65aff inset !important;
   box-shadow: 0px 0px 0px 2px #d65aff inset !important;
-  color: #DC73FF !important;
+  color: #dc73ff !important;
 }
 
 .ui.inverted.purple.basic.buttons .button:active,
@@ -3768,15 +3787,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.purple.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #cf40ff inset !important;
   box-shadow: 0px 0px 0px 2px #cf40ff inset !important;
-  color: #DC73FF !important;
+  color: #dc73ff !important;
 }
 
 /*--- Red ---*/
 
 .ui.red.buttons .button,
 .ui.red.button {
-  background-color: #DB2828;
-  color: #FFFFFF;
+  background-color: #db2828;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -3789,21 +3808,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.red.buttons .button:hover,
 .ui.red.button:hover {
   background-color: #d01919;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.red.buttons .button:focus,
 .ui.red.button:focus {
   background-color: #ca1010;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.red.buttons .button:active,
 .ui.red.button:active {
   background-color: #b21e1e;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3812,7 +3831,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.red.active.button,
 .ui.red.button .active.button:active {
   background-color: #d41515;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3820,9 +3839,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.red.buttons .button,
 .ui.basic.red.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #DB2828 inset !important;
-  box-shadow: 0px 0px 0px 1px #DB2828 inset !important;
-  color: #DB2828 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #db2828 inset !important;
+  box-shadow: 0px 0px 0px 1px #db2828 inset !important;
+  color: #db2828 !important;
 }
 
 .ui.basic.red.buttons .button:hover,
@@ -3865,9 +3884,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.red.buttons .button,
 .ui.inverted.red.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #FF695E inset !important;
-  box-shadow: 0px 0px 0px 2px #FF695E inset !important;
-  color: #FF695E;
+  -webkit-box-shadow: 0px 0px 0px 2px #ff695e inset !important;
+  box-shadow: 0px 0px 0px 2px #ff695e inset !important;
+  color: #ff695e;
 }
 
 .ui.inverted.red.buttons .button:hover,
@@ -3880,7 +3899,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.red.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.red.buttons .button:hover,
@@ -3911,7 +3930,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.red.basic.buttons .button:hover,
@@ -3919,7 +3938,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.red.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #ff5144 inset !important;
   box-shadow: 0px 0px 0px 2px #ff5144 inset !important;
-  color: #FF695E !important;
+  color: #ff695e !important;
 }
 
 .ui.inverted.red.basic.buttons .button:focus,
@@ -3927,7 +3946,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.red.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #ff4335 inset !important;
   box-shadow: 0px 0px 0px 2px #ff4335 inset !important;
-  color: #FF695E !important;
+  color: #ff695e !important;
 }
 
 .ui.inverted.red.basic.buttons .active.button,
@@ -3935,7 +3954,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.red.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #ff5144 inset !important;
   box-shadow: 0px 0px 0px 2px #ff5144 inset !important;
-  color: #FF695E !important;
+  color: #ff695e !important;
 }
 
 .ui.inverted.red.basic.buttons .button:active,
@@ -3943,15 +3962,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.red.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #ff392b inset !important;
   box-shadow: 0px 0px 0px 2px #ff392b inset !important;
-  color: #FF695E !important;
+  color: #ff695e !important;
 }
 
 /*--- Teal ---*/
 
 .ui.teal.buttons .button,
 .ui.teal.button {
-  background-color: #00B5AD;
-  color: #FFFFFF;
+  background-color: #00b5ad;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -3964,21 +3983,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.teal.buttons .button:hover,
 .ui.teal.button:hover {
   background-color: #009c95;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.teal.buttons .button:focus,
 .ui.teal.button:focus {
   background-color: #008c86;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.teal.buttons .button:active,
 .ui.teal.button:active {
   background-color: #00827c;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3987,7 +4006,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.teal.active.button,
 .ui.teal.button .active.button:active {
   background-color: #009c95;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -3995,9 +4014,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.teal.buttons .button,
 .ui.basic.teal.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #00B5AD inset !important;
-  box-shadow: 0px 0px 0px 1px #00B5AD inset !important;
-  color: #00B5AD !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #00b5ad inset !important;
+  box-shadow: 0px 0px 0px 1px #00b5ad inset !important;
+  color: #00b5ad !important;
 }
 
 .ui.basic.teal.buttons .button:hover,
@@ -4040,9 +4059,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.teal.buttons .button,
 .ui.inverted.teal.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #6DFFFF inset !important;
-  box-shadow: 0px 0px 0px 2px #6DFFFF inset !important;
-  color: #6DFFFF;
+  -webkit-box-shadow: 0px 0px 0px 2px #6dffff inset !important;
+  box-shadow: 0px 0px 0px 2px #6dffff inset !important;
+  color: #6dffff;
 }
 
 .ui.inverted.teal.buttons .button:hover,
@@ -4086,7 +4105,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.teal.basic.buttons .button:hover,
@@ -4094,7 +4113,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.teal.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #54ffff inset !important;
   box-shadow: 0px 0px 0px 2px #54ffff inset !important;
-  color: #6DFFFF !important;
+  color: #6dffff !important;
 }
 
 .ui.inverted.teal.basic.buttons .button:focus,
@@ -4102,7 +4121,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.teal.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #44ffff inset !important;
   box-shadow: 0px 0px 0px 2px #44ffff inset !important;
-  color: #6DFFFF !important;
+  color: #6dffff !important;
 }
 
 .ui.inverted.teal.basic.buttons .active.button,
@@ -4110,7 +4129,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.teal.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #54ffff inset !important;
   box-shadow: 0px 0px 0px 2px #54ffff inset !important;
-  color: #6DFFFF !important;
+  color: #6dffff !important;
 }
 
 .ui.inverted.teal.basic.buttons .button:active,
@@ -4118,15 +4137,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.teal.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #3affff inset !important;
   box-shadow: 0px 0px 0px 2px #3affff inset !important;
-  color: #6DFFFF !important;
+  color: #6dffff !important;
 }
 
 /*--- Olive ---*/
 
 .ui.olive.buttons .button,
 .ui.olive.button {
-  background-color: #B5CC18;
-  color: #FFFFFF;
+  background-color: #b5cc18;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -4139,21 +4158,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.olive.buttons .button:hover,
 .ui.olive.button:hover {
   background-color: #a7bd0d;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.olive.buttons .button:focus,
 .ui.olive.button:focus {
   background-color: #a0b605;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.olive.buttons .button:active,
 .ui.olive.button:active {
   background-color: #8d9e13;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4162,7 +4181,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.olive.active.button,
 .ui.olive.button .active.button:active {
   background-color: #aac109;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4170,9 +4189,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.olive.buttons .button,
 .ui.basic.olive.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #B5CC18 inset !important;
-  box-shadow: 0px 0px 0px 1px #B5CC18 inset !important;
-  color: #B5CC18 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #b5cc18 inset !important;
+  box-shadow: 0px 0px 0px 1px #b5cc18 inset !important;
+  color: #b5cc18 !important;
 }
 
 .ui.basic.olive.buttons .button:hover,
@@ -4215,9 +4234,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.olive.buttons .button,
 .ui.inverted.olive.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #D9E778 inset !important;
-  box-shadow: 0px 0px 0px 2px #D9E778 inset !important;
-  color: #D9E778;
+  -webkit-box-shadow: 0px 0px 0px 2px #d9e778 inset !important;
+  box-shadow: 0px 0px 0px 2px #d9e778 inset !important;
+  color: #d9e778;
 }
 
 .ui.inverted.olive.buttons .button:hover,
@@ -4261,7 +4280,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.olive.basic.buttons .button:hover,
@@ -4269,7 +4288,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.olive.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #d8ea5c inset !important;
   box-shadow: 0px 0px 0px 2px #d8ea5c inset !important;
-  color: #D9E778 !important;
+  color: #d9e778 !important;
 }
 
 .ui.inverted.olive.basic.buttons .button:focus,
@@ -4277,7 +4296,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.olive.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #daef47 inset !important;
   box-shadow: 0px 0px 0px 2px #daef47 inset !important;
-  color: #D9E778 !important;
+  color: #d9e778 !important;
 }
 
 .ui.inverted.olive.basic.buttons .active.button,
@@ -4285,7 +4304,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.olive.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #daed59 inset !important;
   box-shadow: 0px 0px 0px 2px #daed59 inset !important;
-  color: #D9E778 !important;
+  color: #d9e778 !important;
 }
 
 .ui.inverted.olive.basic.buttons .button:active,
@@ -4293,15 +4312,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.olive.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #cddf4d inset !important;
   box-shadow: 0px 0px 0px 2px #cddf4d inset !important;
-  color: #D9E778 !important;
+  color: #d9e778 !important;
 }
 
 /*--- Yellow ---*/
 
 .ui.yellow.buttons .button,
 .ui.yellow.button {
-  background-color: #FBBD08;
-  color: #FFFFFF;
+  background-color: #fbbd08;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -4314,21 +4333,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.yellow.buttons .button:hover,
 .ui.yellow.button:hover {
   background-color: #eaae00;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.yellow.buttons .button:focus,
 .ui.yellow.button:focus {
   background-color: #daa300;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.yellow.buttons .button:active,
 .ui.yellow.button:active {
   background-color: #cd9903;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4337,7 +4356,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.yellow.active.button,
 .ui.yellow.button .active.button:active {
   background-color: #eaae00;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4345,9 +4364,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.yellow.buttons .button,
 .ui.basic.yellow.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #FBBD08 inset !important;
-  box-shadow: 0px 0px 0px 1px #FBBD08 inset !important;
-  color: #FBBD08 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #fbbd08 inset !important;
+  box-shadow: 0px 0px 0px 1px #fbbd08 inset !important;
+  color: #fbbd08 !important;
 }
 
 .ui.basic.yellow.buttons .button:hover,
@@ -4390,9 +4409,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.yellow.buttons .button,
 .ui.inverted.yellow.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #FFE21F inset !important;
-  box-shadow: 0px 0px 0px 2px #FFE21F inset !important;
-  color: #FFE21F;
+  -webkit-box-shadow: 0px 0px 0px 2px #ffe21f inset !important;
+  box-shadow: 0px 0px 0px 2px #ffe21f inset !important;
+  color: #ffe21f;
 }
 
 .ui.inverted.yellow.buttons .button:hover,
@@ -4436,7 +4455,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.yellow.basic.buttons .button:hover,
@@ -4444,7 +4463,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.yellow.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #ffdf05 inset !important;
   box-shadow: 0px 0px 0px 2px #ffdf05 inset !important;
-  color: #FFE21F !important;
+  color: #ffe21f !important;
 }
 
 .ui.inverted.yellow.basic.buttons .button:focus,
@@ -4452,7 +4471,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.yellow.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #f5d500 inset !important;
   box-shadow: 0px 0px 0px 2px #f5d500 inset !important;
-  color: #FFE21F !important;
+  color: #ffe21f !important;
 }
 
 .ui.inverted.yellow.basic.buttons .active.button,
@@ -4460,7 +4479,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.yellow.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #ffdf05 inset !important;
   box-shadow: 0px 0px 0px 2px #ffdf05 inset !important;
-  color: #FFE21F !important;
+  color: #ffe21f !important;
 }
 
 .ui.inverted.yellow.basic.buttons .button:active,
@@ -4468,7 +4487,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.yellow.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #ebcd00 inset !important;
   box-shadow: 0px 0px 0px 2px #ebcd00 inset !important;
-  color: #FFE21F !important;
+  color: #ffe21f !important;
 }
 
 /*-------------------
@@ -4479,8 +4498,8 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.primary.buttons .button,
 .ui.primary.button {
-  background-color: #2185D0;
-  color: #FFFFFF;
+  background-color: #2185d0;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -4493,21 +4512,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.primary.buttons .button:hover,
 .ui.primary.button:hover {
   background-color: #1678c2;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.primary.buttons .button:focus,
 .ui.primary.button:focus {
   background-color: #0d71bb;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.primary.buttons .button:active,
 .ui.primary.button:active {
   background-color: #1a69a4;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4516,7 +4535,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.primary.active.button,
 .ui.primary.button .active.button:active {
   background-color: #1279c6;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4524,9 +4543,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.primary.buttons .button,
 .ui.basic.primary.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #2185D0 inset !important;
-  box-shadow: 0px 0px 0px 1px #2185D0 inset !important;
-  color: #2185D0 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #2185d0 inset !important;
+  box-shadow: 0px 0px 0px 1px #2185d0 inset !important;
+  color: #2185d0 !important;
 }
 
 .ui.basic.primary.buttons .button:hover,
@@ -4569,9 +4588,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.primary.buttons .button,
 .ui.inverted.primary.button {
   background-color: transparent;
-  -webkit-box-shadow: 0px 0px 0px 2px #54C8FF inset !important;
-  box-shadow: 0px 0px 0px 2px #54C8FF inset !important;
-  color: #54C8FF;
+  -webkit-box-shadow: 0px 0px 0px 2px #54c8ff inset !important;
+  box-shadow: 0px 0px 0px 2px #54c8ff inset !important;
+  color: #54c8ff;
 }
 
 .ui.inverted.primary.buttons .button:hover,
@@ -4584,7 +4603,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.primary.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.primary.buttons .button:hover,
@@ -4615,7 +4634,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.primary.basic.buttons .button:hover,
@@ -4623,7 +4642,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.primary.basic.button:hover {
   -webkit-box-shadow: 0px 0px 0px 2px #3ac0ff inset !important;
   box-shadow: 0px 0px 0px 2px #3ac0ff inset !important;
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 .ui.inverted.primary.basic.buttons .button:focus,
@@ -4631,7 +4650,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.primary.basic.button:focus {
   -webkit-box-shadow: 0px 0px 0px 2px #2bbbff inset !important;
   box-shadow: 0px 0px 0px 2px #2bbbff inset !important;
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 .ui.inverted.primary.basic.buttons .active.button,
@@ -4639,7 +4658,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.primary.basic.active.button {
   -webkit-box-shadow: 0px 0px 0px 2px #3ac0ff inset !important;
   box-shadow: 0px 0px 0px 2px #3ac0ff inset !important;
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 .ui.inverted.primary.basic.buttons .button:active,
@@ -4647,7 +4666,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.primary.basic.button:active {
   -webkit-box-shadow: 0px 0px 0px 2px #21b8ff inset !important;
   box-shadow: 0px 0px 0px 2px #21b8ff inset !important;
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 /*-------------------
@@ -4658,8 +4677,8 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.secondary.buttons .button,
 .ui.secondary.button {
-  background-color: #1B1C1D;
-  color: #FFFFFF;
+  background-color: #1b1c1d;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -4672,21 +4691,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.secondary.buttons .button:hover,
 .ui.secondary.button:hover {
   background-color: #27292a;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.secondary.buttons .button:focus,
 .ui.secondary.button:focus {
   background-color: #2e3032;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.secondary.buttons .button:active,
 .ui.secondary.button:active {
   background-color: #343637;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4695,7 +4714,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.secondary.active.button,
 .ui.secondary.button .active.button:active {
   background-color: #27292a;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4703,9 +4722,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.secondary.buttons .button,
 .ui.basic.secondary.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #1B1C1D inset !important;
-  box-shadow: 0px 0px 0px 1px #1B1C1D inset !important;
-  color: #1B1C1D !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #1b1c1d inset !important;
+  box-shadow: 0px 0px 0px 1px #1b1c1d inset !important;
+  color: #1b1c1d !important;
 }
 
 .ui.basic.secondary.buttons .button:hover,
@@ -4763,7 +4782,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.inverted.secondary.button:active {
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.secondary.buttons .button:hover,
@@ -4794,7 +4813,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   background-color: transparent;
   -webkit-box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
   box-shadow: 0px 0px 0px 2px rgba(255, 255, 255, 0.5) inset !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.secondary.basic.buttons .button:hover,
@@ -4837,8 +4856,8 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.positive.buttons .button,
 .ui.positive.button {
-  background-color: #21BA45;
-  color: #FFFFFF;
+  background-color: #21ba45;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -4851,21 +4870,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.positive.buttons .button:hover,
 .ui.positive.button:hover {
   background-color: #16ab39;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.positive.buttons .button:focus,
 .ui.positive.button:focus {
   background-color: #0ea432;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.positive.buttons .button:active,
 .ui.positive.button:active {
   background-color: #198f35;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4874,7 +4893,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.positive.active.button,
 .ui.positive.button .active.button:active {
   background-color: #13ae38;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4882,9 +4901,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.positive.buttons .button,
 .ui.basic.positive.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #21BA45 inset !important;
-  box-shadow: 0px 0px 0px 1px #21BA45 inset !important;
-  color: #21BA45 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #21ba45 inset !important;
+  box-shadow: 0px 0px 0px 1px #21ba45 inset !important;
+  color: #21ba45 !important;
 }
 
 .ui.basic.positive.buttons .button:hover,
@@ -4930,8 +4949,8 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.negative.buttons .button,
 .ui.negative.button {
-  background-color: #DB2828;
-  color: #FFFFFF;
+  background-color: #db2828;
+  color: #ffffff;
   text-shadow: none;
   background-image: none;
 }
@@ -4944,21 +4963,21 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.negative.buttons .button:hover,
 .ui.negative.button:hover {
   background-color: #d01919;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.negative.buttons .button:focus,
 .ui.negative.button:focus {
   background-color: #ca1010;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
 .ui.negative.buttons .button:active,
 .ui.negative.button:active {
   background-color: #b21e1e;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4967,7 +4986,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.negative.active.button,
 .ui.negative.button .active.button:active {
   background-color: #d41515;
-  color: #FFFFFF;
+  color: #ffffff;
   text-shadow: none;
 }
 
@@ -4975,9 +4994,9 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.basic.negative.buttons .button,
 .ui.basic.negative.button {
-  -webkit-box-shadow: 0px 0px 0px 1px #DB2828 inset !important;
-  box-shadow: 0px 0px 0px 1px #DB2828 inset !important;
-  color: #DB2828 !important;
+  -webkit-box-shadow: 0px 0px 0px 1px #db2828 inset !important;
+  box-shadow: 0px 0px 0px 1px #db2828 inset !important;
+  color: #db2828 !important;
 }
 
 .ui.basic.negative.buttons .button:hover,
@@ -5040,7 +5059,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 /* Clearfix */
 
 .ui.buttons:after {
-  content: ".";
+  content: '.';
   display: block;
   height: 0;
   clear: both;
@@ -5060,8 +5079,10 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 
 .ui.buttons > .ui.button:not(.basic):not(.inverted),
 .ui.buttons:not(.basic):not(.inverted) > .button {
-  -webkit-box-shadow: 0px 0px 0px 1px transparent inset, 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 0px 0px 1px transparent inset, 0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 0px 0px 1px transparent inset,
+    0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 0px 0px 1px transparent inset,
+    0px 0em 0px 0px rgba(34, 36, 38, 0.15) inset;
 }
 
 .ui.buttons .button:first-child {
@@ -5173,15 +5194,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   }
 
   .ui.grid.container {
-    width: calc( 723px  +  2rem ) !important;
+    width: calc(723px + 2rem) !important;
   }
 
   .ui.relaxed.grid.container {
-    width: calc( 723px  +  3rem ) !important;
+    width: calc(723px + 3rem) !important;
   }
 
   .ui.very.relaxed.grid.container {
-    width: calc( 723px  +  5rem ) !important;
+    width: calc(723px + 5rem) !important;
   }
 }
 
@@ -5195,15 +5216,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   }
 
   .ui.grid.container {
-    width: calc( 933px  +  2rem ) !important;
+    width: calc(933px + 2rem) !important;
   }
 
   .ui.relaxed.grid.container {
-    width: calc( 933px  +  3rem ) !important;
+    width: calc(933px + 3rem) !important;
   }
 
   .ui.very.relaxed.grid.container {
-    width: calc( 933px  +  5rem ) !important;
+    width: calc(933px + 5rem) !important;
   }
 }
 
@@ -5217,15 +5238,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   }
 
   .ui.grid.container {
-    width: calc( 1127px  +  2rem ) !important;
+    width: calc(1127px + 2rem) !important;
   }
 
   .ui.relaxed.grid.container {
-    width: calc( 1127px  +  3rem ) !important;
+    width: calc(1127px + 3rem) !important;
   }
 
   .ui.very.relaxed.grid.container {
-    width: calc( 1127px  +  5rem ) !important;
+    width: calc(1127px + 5rem) !important;
   }
 }
 
@@ -5255,15 +5276,15 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
            Variations
 *******************************/
 
-.ui[class*="left aligned"].container {
+.ui[class*='left aligned'].container {
   text-align: left;
 }
 
-.ui[class*="center aligned"].container {
+.ui[class*='center aligned'].container {
   text-align: center;
 }
 
-.ui[class*="right aligned"].container {
+.ui[class*='right aligned'].container {
   text-align: right;
 }
 
@@ -5389,7 +5410,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
   border-left: 1px solid rgba(34, 36, 38, 0.15);
   border-right: 1px solid rgba(255, 255, 255, 0.1);
   width: 0%;
-  height: calc(100% -  1rem );
+  height: calc(100% - 1rem);
 }
 
 .ui.vertical.divider:before {
@@ -5482,7 +5503,7 @@ body .ui.inverted::-webkit-scrollbar-thumb:hover {
 .ui.divider.inverted,
 .ui.vertical.inverted.divider,
 .ui.horizontal.inverted.divider {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.divider.inverted,
@@ -5581,7 +5602,7 @@ i.flag:not(.icon) {
 i.flag:not(.icon):before {
   display: inline-block;
   content: '';
-  background: url("./themes/default/assets/images/flags.png") no-repeat -108px -1976px;
+  background: url('./themes/default/assets/images/flags.png') no-repeat -108px -1976px;
   width: 16px;
   height: 11px;
 }
@@ -6843,7 +6864,7 @@ i.flag.zimbabwe:before {
 
 .ui.header {
   border: none;
-  margin: calc(2rem -  0.14285714em ) 0em 1rem;
+  margin: calc(2rem - 0.14285714em) 0em 1rem;
   padding: 0em 0em;
   font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
   font-weight: bold;
@@ -7153,7 +7174,7 @@ h5.ui.header .sub.header {
 --------------------*/
 
 .ui.inverted.header {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.header .sub.header {
@@ -7188,7 +7209,7 @@ h5.ui.header .sub.header {
 /*--- Red ---*/
 
 .ui.red.header {
-  color: #DB2828 !important;
+  color: #db2828 !important;
 }
 
 a.ui.red.header:hover {
@@ -7196,13 +7217,13 @@ a.ui.red.header:hover {
 }
 
 .ui.red.dividing.header {
-  border-bottom: 2px solid #DB2828;
+  border-bottom: 2px solid #db2828;
 }
 
 /* Inverted */
 
 .ui.inverted.red.header {
-  color: #FF695E !important;
+  color: #ff695e !important;
 }
 
 a.ui.inverted.red.header:hover {
@@ -7212,7 +7233,7 @@ a.ui.inverted.red.header:hover {
 /*--- Orange ---*/
 
 .ui.orange.header {
-  color: #F2711C !important;
+  color: #f2711c !important;
 }
 
 a.ui.orange.header:hover {
@@ -7220,13 +7241,13 @@ a.ui.orange.header:hover {
 }
 
 .ui.orange.dividing.header {
-  border-bottom: 2px solid #F2711C;
+  border-bottom: 2px solid #f2711c;
 }
 
 /* Inverted */
 
 .ui.inverted.orange.header {
-  color: #FF851B !important;
+  color: #ff851b !important;
 }
 
 a.ui.inverted.orange.header:hover {
@@ -7236,7 +7257,7 @@ a.ui.inverted.orange.header:hover {
 /*--- Olive ---*/
 
 .ui.olive.header {
-  color: #B5CC18 !important;
+  color: #b5cc18 !important;
 }
 
 a.ui.olive.header:hover {
@@ -7244,13 +7265,13 @@ a.ui.olive.header:hover {
 }
 
 .ui.olive.dividing.header {
-  border-bottom: 2px solid #B5CC18;
+  border-bottom: 2px solid #b5cc18;
 }
 
 /* Inverted */
 
 .ui.inverted.olive.header {
-  color: #D9E778 !important;
+  color: #d9e778 !important;
 }
 
 a.ui.inverted.olive.header:hover {
@@ -7260,7 +7281,7 @@ a.ui.inverted.olive.header:hover {
 /*--- Yellow ---*/
 
 .ui.yellow.header {
-  color: #FBBD08 !important;
+  color: #fbbd08 !important;
 }
 
 a.ui.yellow.header:hover {
@@ -7268,13 +7289,13 @@ a.ui.yellow.header:hover {
 }
 
 .ui.yellow.dividing.header {
-  border-bottom: 2px solid #FBBD08;
+  border-bottom: 2px solid #fbbd08;
 }
 
 /* Inverted */
 
 .ui.inverted.yellow.header {
-  color: #FFE21F !important;
+  color: #ffe21f !important;
 }
 
 a.ui.inverted.yellow.header:hover {
@@ -7284,7 +7305,7 @@ a.ui.inverted.yellow.header:hover {
 /*--- Green ---*/
 
 .ui.green.header {
-  color: #21BA45 !important;
+  color: #21ba45 !important;
 }
 
 a.ui.green.header:hover {
@@ -7292,13 +7313,13 @@ a.ui.green.header:hover {
 }
 
 .ui.green.dividing.header {
-  border-bottom: 2px solid #21BA45;
+  border-bottom: 2px solid #21ba45;
 }
 
 /* Inverted */
 
 .ui.inverted.green.header {
-  color: #2ECC40 !important;
+  color: #2ecc40 !important;
 }
 
 a.ui.inverted.green.header:hover {
@@ -7308,7 +7329,7 @@ a.ui.inverted.green.header:hover {
 /*--- Teal ---*/
 
 .ui.teal.header {
-  color: #00B5AD !important;
+  color: #00b5ad !important;
 }
 
 a.ui.teal.header:hover {
@@ -7316,13 +7337,13 @@ a.ui.teal.header:hover {
 }
 
 .ui.teal.dividing.header {
-  border-bottom: 2px solid #00B5AD;
+  border-bottom: 2px solid #00b5ad;
 }
 
 /* Inverted */
 
 .ui.inverted.teal.header {
-  color: #6DFFFF !important;
+  color: #6dffff !important;
 }
 
 a.ui.inverted.teal.header:hover {
@@ -7332,7 +7353,7 @@ a.ui.inverted.teal.header:hover {
 /*--- Blue ---*/
 
 .ui.blue.header {
-  color: #2185D0 !important;
+  color: #2185d0 !important;
 }
 
 a.ui.blue.header:hover {
@@ -7340,13 +7361,13 @@ a.ui.blue.header:hover {
 }
 
 .ui.blue.dividing.header {
-  border-bottom: 2px solid #2185D0;
+  border-bottom: 2px solid #2185d0;
 }
 
 /* Inverted */
 
 .ui.inverted.blue.header {
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 a.ui.inverted.blue.header:hover {
@@ -7356,7 +7377,7 @@ a.ui.inverted.blue.header:hover {
 /*--- Violet ---*/
 
 .ui.violet.header {
-  color: #6435C9 !important;
+  color: #6435c9 !important;
 }
 
 a.ui.violet.header:hover {
@@ -7364,13 +7385,13 @@ a.ui.violet.header:hover {
 }
 
 .ui.violet.dividing.header {
-  border-bottom: 2px solid #6435C9;
+  border-bottom: 2px solid #6435c9;
 }
 
 /* Inverted */
 
 .ui.inverted.violet.header {
-  color: #A291FB !important;
+  color: #a291fb !important;
 }
 
 a.ui.inverted.violet.header:hover {
@@ -7380,7 +7401,7 @@ a.ui.inverted.violet.header:hover {
 /*--- Purple ---*/
 
 .ui.purple.header {
-  color: #A333C8 !important;
+  color: #a333c8 !important;
 }
 
 a.ui.purple.header:hover {
@@ -7388,13 +7409,13 @@ a.ui.purple.header:hover {
 }
 
 .ui.purple.dividing.header {
-  border-bottom: 2px solid #A333C8;
+  border-bottom: 2px solid #a333c8;
 }
 
 /* Inverted */
 
 .ui.inverted.purple.header {
-  color: #DC73FF !important;
+  color: #dc73ff !important;
 }
 
 a.ui.inverted.purple.header:hover {
@@ -7404,7 +7425,7 @@ a.ui.inverted.purple.header:hover {
 /*--- Pink ---*/
 
 .ui.pink.header {
-  color: #E03997 !important;
+  color: #e03997 !important;
 }
 
 a.ui.pink.header:hover {
@@ -7412,13 +7433,13 @@ a.ui.pink.header:hover {
 }
 
 .ui.pink.dividing.header {
-  border-bottom: 2px solid #E03997;
+  border-bottom: 2px solid #e03997;
 }
 
 /* Inverted */
 
 .ui.inverted.pink.header {
-  color: #FF8EDF !important;
+  color: #ff8edf !important;
 }
 
 a.ui.inverted.pink.header:hover {
@@ -7428,7 +7449,7 @@ a.ui.inverted.pink.header:hover {
 /*--- Brown ---*/
 
 .ui.brown.header {
-  color: #A5673F !important;
+  color: #a5673f !important;
 }
 
 a.ui.brown.header:hover {
@@ -7436,13 +7457,13 @@ a.ui.brown.header:hover {
 }
 
 .ui.brown.dividing.header {
-  border-bottom: 2px solid #A5673F;
+  border-bottom: 2px solid #a5673f;
 }
 
 /* Inverted */
 
 .ui.inverted.brown.header {
-  color: #D67C1C !important;
+  color: #d67c1c !important;
 }
 
 a.ui.inverted.brown.header:hover {
@@ -7466,7 +7487,7 @@ a.ui.grey.header:hover {
 /* Inverted */
 
 .ui.inverted.grey.header {
-  color: #DCDDDE !important;
+  color: #dcddde !important;
 }
 
 a.ui.inverted.grey.header:hover {
@@ -7505,13 +7526,13 @@ a.ui.inverted.grey.header:hover {
 --------------------*/
 
 .ui.floated.header,
-.ui[class*="left floated"].header {
+.ui[class*='left floated'].header {
   float: left;
   margin-top: 0em;
   margin-right: 0.5em;
 }
 
-.ui[class*="right floated"].header {
+.ui[class*='right floated'].header {
   float: right;
   margin-top: 0em;
   margin-left: 0.5em;
@@ -7551,11 +7572,11 @@ a.ui.inverted.grey.header:hover {
 --------------------*/
 
 .ui.block.header {
-  background: #F3F4F5;
+  background: #f3f4f5;
   padding: 0.78571429rem 1rem;
   -webkit-box-shadow: none;
   box-shadow: none;
-  border: 1px solid #D4D4D5;
+  border: 1px solid #d4d4d5;
   border-radius: 0.28571429rem;
 }
 
@@ -7584,17 +7605,17 @@ a.ui.inverted.grey.header:hover {
 --------------------*/
 
 .ui.attached.header {
-  background: #FFFFFF;
+  background: #ffffff;
   padding: 0.78571429rem 1rem;
   margin-left: -1px;
   margin-right: -1px;
   -webkit-box-shadow: none;
   box-shadow: none;
-  border: 1px solid #D4D4D5;
+  border: 1px solid #d4d4d5;
 }
 
 .ui.attached.block.header {
-  background: #F3F4F5;
+  background: #f3f4f5;
 }
 
 .ui.attached:not(.top):not(.bottom).header {
@@ -7668,8 +7689,13 @@ a.ui.inverted.grey.header:hover {
 
 @font-face {
   font-family: 'Icons';
-  src: url("./themes/default/assets/fonts/icons.eot");
-  src: url("./themes/default/assets/fonts/icons.eot?#iefix") format('embedded-opentype'), url("./themes/default/assets/fonts/icons.woff2") format('woff2'), url("./themes/default/assets/fonts/icons.woff") format('woff'), url("./themes/default/assets/fonts/icons.ttf") format('truetype'), url("./themes/default/assets/fonts/icons.svg#icons") format('svg');
+  src: url('./themes/default/assets/fonts/icons.eot');
+  src: url('./themes/default/assets/fonts/icons.eot?#iefix')
+      format('embedded-opentype'),
+    url('./themes/default/assets/fonts/icons.woff2') format('woff2'),
+    url('./themes/default/assets/fonts/icons.woff') format('woff'),
+    url('./themes/default/assets/fonts/icons.ttf') format('truetype'),
+    url('./themes/default/assets/fonts/icons.svg#icons') format('svg');
   font-style: normal;
   font-weight: normal;
   font-variant: normal;
@@ -7869,12 +7895,12 @@ i.bordered.inverted.icon {
 
 i.inverted.bordered.icon,
 i.inverted.circular.icon {
-  background-color: #1B1C1D !important;
-  color: #FFFFFF !important;
+  background-color: #1b1c1d !important;
+  color: #ffffff !important;
 }
 
 i.inverted.icon {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 /*-------------------
@@ -7884,177 +7910,177 @@ i.inverted.icon {
 /* Red */
 
 i.red.icon {
-  color: #DB2828 !important;
+  color: #db2828 !important;
 }
 
 i.inverted.red.icon {
-  color: #FF695E !important;
+  color: #ff695e !important;
 }
 
 i.inverted.bordered.red.icon,
 i.inverted.circular.red.icon {
-  background-color: #DB2828 !important;
-  color: #FFFFFF !important;
+  background-color: #db2828 !important;
+  color: #ffffff !important;
 }
 
 /* Orange */
 
 i.orange.icon {
-  color: #F2711C !important;
+  color: #f2711c !important;
 }
 
 i.inverted.orange.icon {
-  color: #FF851B !important;
+  color: #ff851b !important;
 }
 
 i.inverted.bordered.orange.icon,
 i.inverted.circular.orange.icon {
-  background-color: #F2711C !important;
-  color: #FFFFFF !important;
+  background-color: #f2711c !important;
+  color: #ffffff !important;
 }
 
 /* Yellow */
 
 i.yellow.icon {
-  color: #FBBD08 !important;
+  color: #fbbd08 !important;
 }
 
 i.inverted.yellow.icon {
-  color: #FFE21F !important;
+  color: #ffe21f !important;
 }
 
 i.inverted.bordered.yellow.icon,
 i.inverted.circular.yellow.icon {
-  background-color: #FBBD08 !important;
-  color: #FFFFFF !important;
+  background-color: #fbbd08 !important;
+  color: #ffffff !important;
 }
 
 /* Olive */
 
 i.olive.icon {
-  color: #B5CC18 !important;
+  color: #b5cc18 !important;
 }
 
 i.inverted.olive.icon {
-  color: #D9E778 !important;
+  color: #d9e778 !important;
 }
 
 i.inverted.bordered.olive.icon,
 i.inverted.circular.olive.icon {
-  background-color: #B5CC18 !important;
-  color: #FFFFFF !important;
+  background-color: #b5cc18 !important;
+  color: #ffffff !important;
 }
 
 /* Green */
 
 i.green.icon {
-  color: #21BA45 !important;
+  color: #21ba45 !important;
 }
 
 i.inverted.green.icon {
-  color: #2ECC40 !important;
+  color: #2ecc40 !important;
 }
 
 i.inverted.bordered.green.icon,
 i.inverted.circular.green.icon {
-  background-color: #21BA45 !important;
-  color: #FFFFFF !important;
+  background-color: #21ba45 !important;
+  color: #ffffff !important;
 }
 
 /* Teal */
 
 i.teal.icon {
-  color: #00B5AD !important;
+  color: #00b5ad !important;
 }
 
 i.inverted.teal.icon {
-  color: #6DFFFF !important;
+  color: #6dffff !important;
 }
 
 i.inverted.bordered.teal.icon,
 i.inverted.circular.teal.icon {
-  background-color: #00B5AD !important;
-  color: #FFFFFF !important;
+  background-color: #00b5ad !important;
+  color: #ffffff !important;
 }
 
 /* Blue */
 
 i.blue.icon {
-  color: #2185D0 !important;
+  color: #2185d0 !important;
 }
 
 i.inverted.blue.icon {
-  color: #54C8FF !important;
+  color: #54c8ff !important;
 }
 
 i.inverted.bordered.blue.icon,
 i.inverted.circular.blue.icon {
-  background-color: #2185D0 !important;
-  color: #FFFFFF !important;
+  background-color: #2185d0 !important;
+  color: #ffffff !important;
 }
 
 /* Violet */
 
 i.violet.icon {
-  color: #6435C9 !important;
+  color: #6435c9 !important;
 }
 
 i.inverted.violet.icon {
-  color: #A291FB !important;
+  color: #a291fb !important;
 }
 
 i.inverted.bordered.violet.icon,
 i.inverted.circular.violet.icon {
-  background-color: #6435C9 !important;
-  color: #FFFFFF !important;
+  background-color: #6435c9 !important;
+  color: #ffffff !important;
 }
 
 /* Purple */
 
 i.purple.icon {
-  color: #A333C8 !important;
+  color: #a333c8 !important;
 }
 
 i.inverted.purple.icon {
-  color: #DC73FF !important;
+  color: #dc73ff !important;
 }
 
 i.inverted.bordered.purple.icon,
 i.inverted.circular.purple.icon {
-  background-color: #A333C8 !important;
-  color: #FFFFFF !important;
+  background-color: #a333c8 !important;
+  color: #ffffff !important;
 }
 
 /* Pink */
 
 i.pink.icon {
-  color: #E03997 !important;
+  color: #e03997 !important;
 }
 
 i.inverted.pink.icon {
-  color: #FF8EDF !important;
+  color: #ff8edf !important;
 }
 
 i.inverted.bordered.pink.icon,
 i.inverted.circular.pink.icon {
-  background-color: #E03997 !important;
-  color: #FFFFFF !important;
+  background-color: #e03997 !important;
+  color: #ffffff !important;
 }
 
 /* Brown */
 
 i.brown.icon {
-  color: #A5673F !important;
+  color: #a5673f !important;
 }
 
 i.inverted.brown.icon {
-  color: #D67C1C !important;
+  color: #d67c1c !important;
 }
 
 i.inverted.bordered.brown.icon,
 i.inverted.circular.brown.icon {
-  background-color: #A5673F !important;
-  color: #FFFFFF !important;
+  background-color: #a5673f !important;
+  color: #ffffff !important;
 }
 
 /* Grey */
@@ -8064,19 +8090,19 @@ i.grey.icon {
 }
 
 i.inverted.grey.icon {
-  color: #DCDDDE !important;
+  color: #dcddde !important;
 }
 
 i.inverted.bordered.grey.icon,
 i.inverted.circular.grey.icon {
   background-color: #767676 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Black */
 
 i.black.icon {
-  color: #1B1C1D !important;
+  color: #1b1c1d !important;
 }
 
 i.inverted.black.icon {
@@ -8085,8 +8111,8 @@ i.inverted.black.icon {
 
 i.inverted.bordered.black.icon,
 i.inverted.circular.black.icon {
-  background-color: #1B1C1D !important;
-  color: #FFFFFF !important;
+  background-color: #1b1c1d !important;
+  color: #ffffff !important;
 }
 
 /*-------------------
@@ -8184,7 +8210,8 @@ i.icons .corner.icon {
   -webkit-transform: none;
   transform: none;
   font-size: 0.45em;
-  text-shadow: -1px -1px 0 #FFFFFF, 1px -1px 0 #FFFFFF, -1px 1px 0 #FFFFFF, 1px 1px 0 #FFFFFF;
+  text-shadow: -1px -1px 0 #ffffff, 1px -1px 0 #ffffff, -1px 1px 0 #ffffff,
+    1px 1px 0 #ffffff;
 }
 
 i.icons .top.right.corner.icon {
@@ -8216,7 +8243,8 @@ i.icons .bottom.right.corner.icon {
 }
 
 i.icons .inverted.corner.icon {
-  text-shadow: -1px -1px 0 #1B1C1D, 1px -1px 0 #1B1C1D, -1px 1px 0 #1B1C1D, 1px 1px 0 #1B1C1D;
+  text-shadow: -1px -1px 0 #1b1c1d, 1px -1px 0 #1b1c1d, -1px 1px 0 #1b1c1d,
+    1px 1px 0 #1b1c1d;
 }
 
 /*
@@ -8254,4687 +8282,4687 @@ for instance `lemon icon` not `lemon outline icon` since there is only one lemon
 /* Deprecated *In/Out Naming Conflict) */
 
 i.icon.linkedin.in:before {
-  content: "\f0e1";
+  content: '\f0e1';
 }
 
 i.icon.zoom.in:before {
-  content: "\f00e";
+  content: '\f00e';
 }
 
 i.icon.zoom.out:before {
-  content: "\f010";
+  content: '\f010';
 }
 
 i.icon.sign.in:before {
-  content: "\f2f6";
+  content: '\f2f6';
 }
 
 i.icon.in.cart:before {
-  content: "\f218";
+  content: '\f218';
 }
 
 i.icon.log.out:before {
-  content: "\f2f5";
+  content: '\f2f5';
 }
 
 i.icon.sign.out:before {
-  content: "\f2f5";
+  content: '\f2f5';
 }
 
 /* Icons */
 
 i.icon.\35 00px:before {
-  content: "\f26e";
+  content: '\f26e';
 }
 
 i.icon.accessible.icon:before {
-  content: "\f368";
+  content: '\f368';
 }
 
 i.icon.accusoft:before {
-  content: "\f369";
+  content: '\f369';
 }
 
 i.icon.address.book:before {
-  content: "\f2b9";
+  content: '\f2b9';
 }
 
 i.icon.address.card:before {
-  content: "\f2bb";
+  content: '\f2bb';
 }
 
 i.icon.adjust:before {
-  content: "\f042";
+  content: '\f042';
 }
 
 i.icon.adn:before {
-  content: "\f170";
+  content: '\f170';
 }
 
 i.icon.adversal:before {
-  content: "\f36a";
+  content: '\f36a';
 }
 
 i.icon.affiliatetheme:before {
-  content: "\f36b";
+  content: '\f36b';
 }
 
 i.icon.algolia:before {
-  content: "\f36c";
+  content: '\f36c';
 }
 
 i.icon.align.center:before {
-  content: "\f037";
+  content: '\f037';
 }
 
 i.icon.align.justify:before {
-  content: "\f039";
+  content: '\f039';
 }
 
 i.icon.align.left:before {
-  content: "\f036";
+  content: '\f036';
 }
 
 i.icon.align.right:before {
-  content: "\f038";
+  content: '\f038';
 }
 
 i.icon.amazon:before {
-  content: "\f270";
+  content: '\f270';
 }
 
 i.icon.amazon.pay:before {
-  content: "\f42c";
+  content: '\f42c';
 }
 
 i.icon.ambulance:before {
-  content: "\f0f9";
+  content: '\f0f9';
 }
 
 i.icon.american.sign.language.interpreting:before {
-  content: "\f2a3";
+  content: '\f2a3';
 }
 
 i.icon.amilia:before {
-  content: "\f36d";
+  content: '\f36d';
 }
 
 i.icon.anchor:before {
-  content: "\f13d";
+  content: '\f13d';
 }
 
 i.icon.android:before {
-  content: "\f17b";
+  content: '\f17b';
 }
 
 i.icon.angellist:before {
-  content: "\f209";
+  content: '\f209';
 }
 
 i.icon.angle.double.down:before {
-  content: "\f103";
+  content: '\f103';
 }
 
 i.icon.angle.double.left:before {
-  content: "\f100";
+  content: '\f100';
 }
 
 i.icon.angle.double.right:before {
-  content: "\f101";
+  content: '\f101';
 }
 
 i.icon.angle.double.up:before {
-  content: "\f102";
+  content: '\f102';
 }
 
 i.icon.angle.down:before {
-  content: "\f107";
+  content: '\f107';
 }
 
 i.icon.angle.left:before {
-  content: "\f104";
+  content: '\f104';
 }
 
 i.icon.angle.right:before {
-  content: "\f105";
+  content: '\f105';
 }
 
 i.icon.angle.up:before {
-  content: "\f106";
+  content: '\f106';
 }
 
 i.icon.angrycreative:before {
-  content: "\f36e";
+  content: '\f36e';
 }
 
 i.icon.angular:before {
-  content: "\f420";
+  content: '\f420';
 }
 
 i.icon.app.store:before {
-  content: "\f36f";
+  content: '\f36f';
 }
 
 i.icon.app.store.ios:before {
-  content: "\f370";
+  content: '\f370';
 }
 
 i.icon.apper:before {
-  content: "\f371";
+  content: '\f371';
 }
 
 i.icon.apple:before {
-  content: "\f179";
+  content: '\f179';
 }
 
 i.icon.apple.pay:before {
-  content: "\f415";
+  content: '\f415';
 }
 
 i.icon.archive:before {
-  content: "\f187";
+  content: '\f187';
 }
 
 i.icon.arrow.alternate.circle.down:before {
-  content: "\f358";
+  content: '\f358';
 }
 
 i.icon.arrow.alternate.circle.left:before {
-  content: "\f359";
+  content: '\f359';
 }
 
 i.icon.arrow.alternate.circle.right:before {
-  content: "\f35a";
+  content: '\f35a';
 }
 
 i.icon.arrow.alternate.circle.up:before {
-  content: "\f35b";
+  content: '\f35b';
 }
 
 i.icon.arrow.circle.down:before {
-  content: "\f0ab";
+  content: '\f0ab';
 }
 
 i.icon.arrow.circle.left:before {
-  content: "\f0a8";
+  content: '\f0a8';
 }
 
 i.icon.arrow.circle.right:before {
-  content: "\f0a9";
+  content: '\f0a9';
 }
 
 i.icon.arrow.circle.up:before {
-  content: "\f0aa";
+  content: '\f0aa';
 }
 
 i.icon.arrow.down:before {
-  content: "\f063";
+  content: '\f063';
 }
 
 i.icon.arrow.left:before {
-  content: "\f060";
+  content: '\f060';
 }
 
 i.icon.arrow.right:before {
-  content: "\f061";
+  content: '\f061';
 }
 
 i.icon.arrow.up:before {
-  content: "\f062";
+  content: '\f062';
 }
 
 i.icon.arrows.alternate:before {
-  content: "\f0b2";
+  content: '\f0b2';
 }
 
 i.icon.arrows.alternate.horizontal:before {
-  content: "\f337";
+  content: '\f337';
 }
 
 i.icon.arrows.alternate.vertical:before {
-  content: "\f338";
+  content: '\f338';
 }
 
 i.icon.assistive.listening.systems:before {
-  content: "\f2a2";
+  content: '\f2a2';
 }
 
 i.icon.asterisk:before {
-  content: "\f069";
+  content: '\f069';
 }
 
 i.icon.asymmetrik:before {
-  content: "\f372";
+  content: '\f372';
 }
 
 i.icon.at:before {
-  content: "\f1fa";
+  content: '\f1fa';
 }
 
 i.icon.audible:before {
-  content: "\f373";
+  content: '\f373';
 }
 
 i.icon.audio.description:before {
-  content: "\f29e";
+  content: '\f29e';
 }
 
 i.icon.autoprefixer:before {
-  content: "\f41c";
+  content: '\f41c';
 }
 
 i.icon.avianex:before {
-  content: "\f374";
+  content: '\f374';
 }
 
 i.icon.aviato:before {
-  content: "\f421";
+  content: '\f421';
 }
 
 i.icon.aws:before {
-  content: "\f375";
+  content: '\f375';
 }
 
 i.icon.backward:before {
-  content: "\f04a";
+  content: '\f04a';
 }
 
 i.icon.balance.scale:before {
-  content: "\f24e";
+  content: '\f24e';
 }
 
 i.icon.ban:before {
-  content: "\f05e";
+  content: '\f05e';
 }
 
 i.icon.band.aid:before {
-  content: "\f462";
+  content: '\f462';
 }
 
 i.icon.bandcamp:before {
-  content: "\f2d5";
+  content: '\f2d5';
 }
 
 i.icon.barcode:before {
-  content: "\f02a";
+  content: '\f02a';
 }
 
 i.icon.bars:before {
-  content: "\f0c9";
+  content: '\f0c9';
 }
 
 i.icon.baseball.ball:before {
-  content: "\f433";
+  content: '\f433';
 }
 
 i.icon.basketball.ball:before {
-  content: "\f434";
+  content: '\f434';
 }
 
 i.icon.bath:before {
-  content: "\f2cd";
+  content: '\f2cd';
 }
 
 i.icon.battery.empty:before {
-  content: "\f244";
+  content: '\f244';
 }
 
 i.icon.battery.full:before {
-  content: "\f240";
+  content: '\f240';
 }
 
 i.icon.battery.half:before {
-  content: "\f242";
+  content: '\f242';
 }
 
 i.icon.battery.quarter:before {
-  content: "\f243";
+  content: '\f243';
 }
 
 i.icon.battery.three.quarters:before {
-  content: "\f241";
+  content: '\f241';
 }
 
 i.icon.bed:before {
-  content: "\f236";
+  content: '\f236';
 }
 
 i.icon.beer:before {
-  content: "\f0fc";
+  content: '\f0fc';
 }
 
 i.icon.behance:before {
-  content: "\f1b4";
+  content: '\f1b4';
 }
 
 i.icon.behance.square:before {
-  content: "\f1b5";
+  content: '\f1b5';
 }
 
 i.icon.bell:before {
-  content: "\f0f3";
+  content: '\f0f3';
 }
 
 i.icon.bell.slash:before {
-  content: "\f1f6";
+  content: '\f1f6';
 }
 
 i.icon.bicycle:before {
-  content: "\f206";
+  content: '\f206';
 }
 
 i.icon.bimobject:before {
-  content: "\f378";
+  content: '\f378';
 }
 
 i.icon.binoculars:before {
-  content: "\f1e5";
+  content: '\f1e5';
 }
 
 i.icon.birthday.cake:before {
-  content: "\f1fd";
+  content: '\f1fd';
 }
 
 i.icon.bitbucket:before {
-  content: "\f171";
+  content: '\f171';
 }
 
 i.icon.bitcoin:before {
-  content: "\f379";
+  content: '\f379';
 }
 
 i.icon.bity:before {
-  content: "\f37a";
+  content: '\f37a';
 }
 
 i.icon.black.tie:before {
-  content: "\f27e";
+  content: '\f27e';
 }
 
 i.icon.blackberry:before {
-  content: "\f37b";
+  content: '\f37b';
 }
 
 i.icon.blind:before {
-  content: "\f29d";
+  content: '\f29d';
 }
 
 i.icon.blogger:before {
-  content: "\f37c";
+  content: '\f37c';
 }
 
 i.icon.blogger.b:before {
-  content: "\f37d";
+  content: '\f37d';
 }
 
 i.icon.bluetooth:before {
-  content: "\f293";
+  content: '\f293';
 }
 
 i.icon.bluetooth.b:before {
-  content: "\f294";
+  content: '\f294';
 }
 
 i.icon.bold:before {
-  content: "\f032";
+  content: '\f032';
 }
 
 i.icon.bolt:before {
-  content: "\f0e7";
+  content: '\f0e7';
 }
 
 i.icon.bomb:before {
-  content: "\f1e2";
+  content: '\f1e2';
 }
 
 i.icon.book:before {
-  content: "\f02d";
+  content: '\f02d';
 }
 
 i.icon.bookmark:before {
-  content: "\f02e";
+  content: '\f02e';
 }
 
 i.icon.bowling.ball:before {
-  content: "\f436";
+  content: '\f436';
 }
 
 i.icon.box:before {
-  content: "\f466";
+  content: '\f466';
 }
 
 i.icon.boxes:before {
-  content: "\f468";
+  content: '\f468';
 }
 
 i.icon.braille:before {
-  content: "\f2a1";
+  content: '\f2a1';
 }
 
 i.icon.briefcase:before {
-  content: "\f0b1";
+  content: '\f0b1';
 }
 
 i.icon.btc:before {
-  content: "\f15a";
+  content: '\f15a';
 }
 
 i.icon.bug:before {
-  content: "\f188";
+  content: '\f188';
 }
 
 i.icon.building:before {
-  content: "\f1ad";
+  content: '\f1ad';
 }
 
 i.icon.bullhorn:before {
-  content: "\f0a1";
+  content: '\f0a1';
 }
 
 i.icon.bullseye:before {
-  content: "\f140";
+  content: '\f140';
 }
 
 i.icon.buromobelexperte:before {
-  content: "\f37f";
+  content: '\f37f';
 }
 
 i.icon.bus:before {
-  content: "\f207";
+  content: '\f207';
 }
 
 i.icon.buysellads:before {
-  content: "\f20d";
+  content: '\f20d';
 }
 
 i.icon.calculator:before {
-  content: "\f1ec";
+  content: '\f1ec';
 }
 
 i.icon.calendar:before {
-  content: "\f133";
+  content: '\f133';
 }
 
 i.icon.calendar.alternate:before {
-  content: "\f073";
+  content: '\f073';
 }
 
 i.icon.calendar.check:before {
-  content: "\f274";
+  content: '\f274';
 }
 
 i.icon.calendar.minus:before {
-  content: "\f272";
+  content: '\f272';
 }
 
 i.icon.calendar.plus:before {
-  content: "\f271";
+  content: '\f271';
 }
 
 i.icon.calendar.times:before {
-  content: "\f273";
+  content: '\f273';
 }
 
 i.icon.camera:before {
-  content: "\f030";
+  content: '\f030';
 }
 
 i.icon.camera.retro:before {
-  content: "\f083";
+  content: '\f083';
 }
 
 i.icon.car:before {
-  content: "\f1b9";
+  content: '\f1b9';
 }
 
 i.icon.caret.down:before {
-  content: "\f0d7";
+  content: '\f0d7';
 }
 
 i.icon.caret.left:before {
-  content: "\f0d9";
+  content: '\f0d9';
 }
 
 i.icon.caret.right:before {
-  content: "\f0da";
+  content: '\f0da';
 }
 
 i.icon.caret.square.down:before {
-  content: "\f150";
+  content: '\f150';
 }
 
 i.icon.caret.square.left:before {
-  content: "\f191";
+  content: '\f191';
 }
 
 i.icon.caret.square.right:before {
-  content: "\f152";
+  content: '\f152';
 }
 
 i.icon.caret.square.up:before {
-  content: "\f151";
+  content: '\f151';
 }
 
 i.icon.caret.up:before {
-  content: "\f0d8";
+  content: '\f0d8';
 }
 
 i.icon.cart.arrow.down:before {
-  content: "\f218";
+  content: '\f218';
 }
 
 i.icon.cart.plus:before {
-  content: "\f217";
+  content: '\f217';
 }
 
 i.icon.cc.amazon.pay:before {
-  content: "\f42d";
+  content: '\f42d';
 }
 
 i.icon.cc.amex:before {
-  content: "\f1f3";
+  content: '\f1f3';
 }
 
 i.icon.cc.apple.pay:before {
-  content: "\f416";
+  content: '\f416';
 }
 
 i.icon.cc.diners.club:before {
-  content: "\f24c";
+  content: '\f24c';
 }
 
 i.icon.cc.discover:before {
-  content: "\f1f2";
+  content: '\f1f2';
 }
 
 i.icon.cc.jcb:before {
-  content: "\f24b";
+  content: '\f24b';
 }
 
 i.icon.cc.mastercard:before {
-  content: "\f1f1";
+  content: '\f1f1';
 }
 
 i.icon.cc.paypal:before {
-  content: "\f1f4";
+  content: '\f1f4';
 }
 
 i.icon.cc.stripe:before {
-  content: "\f1f5";
+  content: '\f1f5';
 }
 
 i.icon.cc.visa:before {
-  content: "\f1f0";
+  content: '\f1f0';
 }
 
 i.icon.centercode:before {
-  content: "\f380";
+  content: '\f380';
 }
 
 i.icon.certificate:before {
-  content: "\f0a3";
+  content: '\f0a3';
 }
 
 i.icon.chart.area:before {
-  content: "\f1fe";
+  content: '\f1fe';
 }
 
 i.icon.chart.bar:before {
-  content: "\f080";
+  content: '\f080';
 }
 
 i.icon.chart.line:before {
-  content: "\f201";
+  content: '\f201';
 }
 
 i.icon.chart.pie:before {
-  content: "\f200";
+  content: '\f200';
 }
 
 i.icon.check:before {
-  content: "\f00c";
+  content: '\f00c';
 }
 
 i.icon.check.circle:before {
-  content: "\f058";
+  content: '\f058';
 }
 
 i.icon.check.square:before {
-  content: "\f14a";
+  content: '\f14a';
 }
 
 i.icon.chess:before {
-  content: "\f439";
+  content: '\f439';
 }
 
 i.icon.chess.bishop:before {
-  content: "\f43a";
+  content: '\f43a';
 }
 
 i.icon.chess.board:before {
-  content: "\f43c";
+  content: '\f43c';
 }
 
 i.icon.chess.king:before {
-  content: "\f43f";
+  content: '\f43f';
 }
 
 i.icon.chess.knight:before {
-  content: "\f441";
+  content: '\f441';
 }
 
 i.icon.chess.pawn:before {
-  content: "\f443";
+  content: '\f443';
 }
 
 i.icon.chess.queen:before {
-  content: "\f445";
+  content: '\f445';
 }
 
 i.icon.chess.rook:before {
-  content: "\f447";
+  content: '\f447';
 }
 
 i.icon.chevron.circle.down:before {
-  content: "\f13a";
+  content: '\f13a';
 }
 
 i.icon.chevron.circle.left:before {
-  content: "\f137";
+  content: '\f137';
 }
 
 i.icon.chevron.circle.right:before {
-  content: "\f138";
+  content: '\f138';
 }
 
 i.icon.chevron.circle.up:before {
-  content: "\f139";
+  content: '\f139';
 }
 
 i.icon.chevron.down:before {
-  content: "\f078";
+  content: '\f078';
 }
 
 i.icon.chevron.left:before {
-  content: "\f053";
+  content: '\f053';
 }
 
 i.icon.chevron.right:before {
-  content: "\f054";
+  content: '\f054';
 }
 
 i.icon.chevron.up:before {
-  content: "\f077";
+  content: '\f077';
 }
 
 i.icon.child:before {
-  content: "\f1ae";
+  content: '\f1ae';
 }
 
 i.icon.chrome:before {
-  content: "\f268";
+  content: '\f268';
 }
 
 i.icon.circle:before {
-  content: "\f111";
+  content: '\f111';
 }
 
 i.icon.circle.notch:before {
-  content: "\f1ce";
+  content: '\f1ce';
 }
 
 i.icon.clipboard:before {
-  content: "\f328";
+  content: '\f328';
 }
 
 i.icon.clipboard.check:before {
-  content: "\f46c";
+  content: '\f46c';
 }
 
 i.icon.clipboard.list:before {
-  content: "\f46d";
+  content: '\f46d';
 }
 
 i.icon.clock:before {
-  content: "\f017";
+  content: '\f017';
 }
 
 i.icon.clone:before {
-  content: "\f24d";
+  content: '\f24d';
 }
 
 i.icon.closed.captioning:before {
-  content: "\f20a";
+  content: '\f20a';
 }
 
 i.icon.cloud:before {
-  content: "\f0c2";
+  content: '\f0c2';
 }
 
 i.icon.cloudscale:before {
-  content: "\f383";
+  content: '\f383';
 }
 
 i.icon.cloudsmith:before {
-  content: "\f384";
+  content: '\f384';
 }
 
 i.icon.cloudversify:before {
-  content: "\f385";
+  content: '\f385';
 }
 
 i.icon.code:before {
-  content: "\f121";
+  content: '\f121';
 }
 
 i.icon.code.branch:before {
-  content: "\f126";
+  content: '\f126';
 }
 
 i.icon.codepen:before {
-  content: "\f1cb";
+  content: '\f1cb';
 }
 
 i.icon.codiepie:before {
-  content: "\f284";
+  content: '\f284';
 }
 
 i.icon.coffee:before {
-  content: "\f0f4";
+  content: '\f0f4';
 }
 
 i.icon.cog:before {
-  content: "\f013";
+  content: '\f013';
 }
 
 i.icon.cogs:before {
-  content: "\f085";
+  content: '\f085';
 }
 
 i.icon.columns:before {
-  content: "\f0db";
+  content: '\f0db';
 }
 
 i.icon.comment:before {
-  content: "\f075";
+  content: '\f075';
 }
 
 i.icon.comment.alternate:before {
-  content: "\f27a";
+  content: '\f27a';
 }
 
 i.icon.comments:before {
-  content: "\f086";
+  content: '\f086';
 }
 
 i.icon.compass:before {
-  content: "\f14e";
+  content: '\f14e';
 }
 
 i.icon.compress:before {
-  content: "\f066";
+  content: '\f066';
 }
 
 i.icon.connectdevelop:before {
-  content: "\f20e";
+  content: '\f20e';
 }
 
 i.icon.contao:before {
-  content: "\f26d";
+  content: '\f26d';
 }
 
 i.icon.copy:before {
-  content: "\f0c5";
+  content: '\f0c5';
 }
 
 i.icon.copyright:before {
-  content: "\f1f9";
+  content: '\f1f9';
 }
 
 i.icon.cpanel:before {
-  content: "\f388";
+  content: '\f388';
 }
 
 i.icon.creative.commons:before {
-  content: "\f25e";
+  content: '\f25e';
 }
 
 i.icon.credit.card:before {
-  content: "\f09d";
+  content: '\f09d';
 }
 
 i.icon.crop:before {
-  content: "\f125";
+  content: '\f125';
 }
 
 i.icon.crosshairs:before {
-  content: "\f05b";
+  content: '\f05b';
 }
 
 i.icon.css3:before {
-  content: "\f13c";
+  content: '\f13c';
 }
 
 i.icon.css3.alternate:before {
-  content: "\f38b";
+  content: '\f38b';
 }
 
 i.icon.cube:before {
-  content: "\f1b2";
+  content: '\f1b2';
 }
 
 i.icon.cubes:before {
-  content: "\f1b3";
+  content: '\f1b3';
 }
 
 i.icon.cut:before {
-  content: "\f0c4";
+  content: '\f0c4';
 }
 
 i.icon.cuttlefish:before {
-  content: "\f38c";
+  content: '\f38c';
 }
 
 i.icon.d.and.d:before {
-  content: "\f38d";
+  content: '\f38d';
 }
 
 i.icon.dashcube:before {
-  content: "\f210";
+  content: '\f210';
 }
 
 i.icon.database:before {
-  content: "\f1c0";
+  content: '\f1c0';
 }
 
 i.icon.deaf:before {
-  content: "\f2a4";
+  content: '\f2a4';
 }
 
 i.icon.delicious:before {
-  content: "\f1a5";
+  content: '\f1a5';
 }
 
 i.icon.deploydog:before {
-  content: "\f38e";
+  content: '\f38e';
 }
 
 i.icon.deskpro:before {
-  content: "\f38f";
+  content: '\f38f';
 }
 
 i.icon.desktop:before {
-  content: "\f108";
+  content: '\f108';
 }
 
 i.icon.deviantart:before {
-  content: "\f1bd";
+  content: '\f1bd';
 }
 
 i.icon.digg:before {
-  content: "\f1a6";
+  content: '\f1a6';
 }
 
 i.icon.digital.ocean:before {
-  content: "\f391";
+  content: '\f391';
 }
 
 i.icon.discord:before {
-  content: "\f392";
+  content: '\f392';
 }
 
 i.icon.discourse:before {
-  content: "\f393";
+  content: '\f393';
 }
 
 i.icon.dna:before {
-  content: "\f471";
+  content: '\f471';
 }
 
 i.icon.dochub:before {
-  content: "\f394";
+  content: '\f394';
 }
 
 i.icon.docker:before {
-  content: "\f395";
+  content: '\f395';
 }
 
 i.icon.dollar.sign:before {
-  content: "\f155";
+  content: '\f155';
 }
 
 i.icon.dolly:before {
-  content: "\f472";
+  content: '\f472';
 }
 
 i.icon.dolly.flatbed:before {
-  content: "\f474";
+  content: '\f474';
 }
 
 i.icon.dot.circle:before {
-  content: "\f192";
+  content: '\f192';
 }
 
 i.icon.download:before {
-  content: "\f019";
+  content: '\f019';
 }
 
 i.icon.draft2digital:before {
-  content: "\f396";
+  content: '\f396';
 }
 
 i.icon.dribbble:before {
-  content: "\f17d";
+  content: '\f17d';
 }
 
 i.icon.dribbble.square:before {
-  content: "\f397";
+  content: '\f397';
 }
 
 i.icon.dropbox:before {
-  content: "\f16b";
+  content: '\f16b';
 }
 
 i.icon.drupal:before {
-  content: "\f1a9";
+  content: '\f1a9';
 }
 
 i.icon.dyalog:before {
-  content: "\f399";
+  content: '\f399';
 }
 
 i.icon.earlybirds:before {
-  content: "\f39a";
+  content: '\f39a';
 }
 
 i.icon.edge:before {
-  content: "\f282";
+  content: '\f282';
 }
 
 i.icon.edit:before {
-  content: "\f044";
+  content: '\f044';
 }
 
 i.icon.eject:before {
-  content: "\f052";
+  content: '\f052';
 }
 
 i.icon.elementor:before {
-  content: "\f430";
+  content: '\f430';
 }
 
 i.icon.ellipsis.horizontal:before {
-  content: "\f141";
+  content: '\f141';
 }
 
 i.icon.ellipsis.vertical:before {
-  content: "\f142";
+  content: '\f142';
 }
 
 i.icon.ember:before {
-  content: "\f423";
+  content: '\f423';
 }
 
 i.icon.empire:before {
-  content: "\f1d1";
+  content: '\f1d1';
 }
 
 i.icon.envelope:before {
-  content: "\f0e0";
+  content: '\f0e0';
 }
 
 i.icon.envelope.open:before {
-  content: "\f2b6";
+  content: '\f2b6';
 }
 
 i.icon.envelope.square:before {
-  content: "\f199";
+  content: '\f199';
 }
 
 i.icon.envira:before {
-  content: "\f299";
+  content: '\f299';
 }
 
 i.icon.eraser:before {
-  content: "\f12d";
+  content: '\f12d';
 }
 
 i.icon.erlang:before {
-  content: "\f39d";
+  content: '\f39d';
 }
 
 i.icon.ethereum:before {
-  content: "\f42e";
+  content: '\f42e';
 }
 
 i.icon.etsy:before {
-  content: "\f2d7";
+  content: '\f2d7';
 }
 
 i.icon.euro.sign:before {
-  content: "\f153";
+  content: '\f153';
 }
 
 i.icon.exchange.alternate:before {
-  content: "\f362";
+  content: '\f362';
 }
 
 i.icon.exclamation:before {
-  content: "\f12a";
+  content: '\f12a';
 }
 
 i.icon.exclamation.circle:before {
-  content: "\f06a";
+  content: '\f06a';
 }
 
 i.icon.exclamation.triangle:before {
-  content: "\f071";
+  content: '\f071';
 }
 
 i.icon.expand:before {
-  content: "\f065";
+  content: '\f065';
 }
 
 i.icon.expand.arrows.alternate:before {
-  content: "\f31e";
+  content: '\f31e';
 }
 
 i.icon.expeditedssl:before {
-  content: "\f23e";
+  content: '\f23e';
 }
 
 i.icon.external.alternate:before {
-  content: "\f35d";
+  content: '\f35d';
 }
 
 i.icon.external.square.alternate:before {
-  content: "\f360";
+  content: '\f360';
 }
 
 i.icon.eye:before {
-  content: "\f06e";
+  content: '\f06e';
 }
 
 i.icon.eye.dropper:before {
-  content: "\f1fb";
+  content: '\f1fb';
 }
 
 i.icon.eye.slash:before {
-  content: "\f070";
+  content: '\f070';
 }
 
 i.icon.facebook:before {
-  content: "\f09a";
+  content: '\f09a';
 }
 
 i.icon.facebook.f:before {
-  content: "\f39e";
+  content: '\f39e';
 }
 
 i.icon.facebook.messenger:before {
-  content: "\f39f";
+  content: '\f39f';
 }
 
 i.icon.facebook.square:before {
-  content: "\f082";
+  content: '\f082';
 }
 
 i.icon.fast.backward:before {
-  content: "\f049";
+  content: '\f049';
 }
 
 i.icon.fast.forward:before {
-  content: "\f050";
+  content: '\f050';
 }
 
 i.icon.fax:before {
-  content: "\f1ac";
+  content: '\f1ac';
 }
 
 i.icon.female:before {
-  content: "\f182";
+  content: '\f182';
 }
 
 i.icon.fighter.jet:before {
-  content: "\f0fb";
+  content: '\f0fb';
 }
 
 i.icon.file:before {
-  content: "\f15b";
+  content: '\f15b';
 }
 
 i.icon.file.alternate:before {
-  content: "\f15c";
+  content: '\f15c';
 }
 
 i.icon.file.archive:before {
-  content: "\f1c6";
+  content: '\f1c6';
 }
 
 i.icon.file.audio:before {
-  content: "\f1c7";
+  content: '\f1c7';
 }
 
 i.icon.file.code:before {
-  content: "\f1c9";
+  content: '\f1c9';
 }
 
 i.icon.file.excel:before {
-  content: "\f1c3";
+  content: '\f1c3';
 }
 
 i.icon.file.image:before {
-  content: "\f1c5";
+  content: '\f1c5';
 }
 
 i.icon.file.pdf:before {
-  content: "\f1c1";
+  content: '\f1c1';
 }
 
 i.icon.file.powerpoint:before {
-  content: "\f1c4";
+  content: '\f1c4';
 }
 
 i.icon.file.video:before {
-  content: "\f1c8";
+  content: '\f1c8';
 }
 
 i.icon.file.word:before {
-  content: "\f1c2";
+  content: '\f1c2';
 }
 
 i.icon.film:before {
-  content: "\f008";
+  content: '\f008';
 }
 
 i.icon.filter:before {
-  content: "\f0b0";
+  content: '\f0b0';
 }
 
 i.icon.fire:before {
-  content: "\f06d";
+  content: '\f06d';
 }
 
 i.icon.fire.extinguisher:before {
-  content: "\f134";
+  content: '\f134';
 }
 
 i.icon.firefox:before {
-  content: "\f269";
+  content: '\f269';
 }
 
 i.icon.first.aid:before {
-  content: "\f479";
+  content: '\f479';
 }
 
 i.icon.first.order:before {
-  content: "\f2b0";
+  content: '\f2b0';
 }
 
 i.icon.firstdraft:before {
-  content: "\f3a1";
+  content: '\f3a1';
 }
 
 i.icon.flag:before {
-  content: "\f024";
+  content: '\f024';
 }
 
 i.icon.flag.checkered:before {
-  content: "\f11e";
+  content: '\f11e';
 }
 
 i.icon.flask:before {
-  content: "\f0c3";
+  content: '\f0c3';
 }
 
 i.icon.flickr:before {
-  content: "\f16e";
+  content: '\f16e';
 }
 
 i.icon.flipboard:before {
-  content: "\f44d";
+  content: '\f44d';
 }
 
 i.icon.fly:before {
-  content: "\f417";
+  content: '\f417';
 }
 
 i.icon.folder:before {
-  content: "\f07b";
+  content: '\f07b';
 }
 
 i.icon.folder.open:before {
-  content: "\f07c";
+  content: '\f07c';
 }
 
 i.icon.font:before {
-  content: "\f031";
+  content: '\f031';
 }
 
 i.icon.font.awesome:before {
-  content: "\f2b4";
+  content: '\f2b4';
 }
 
 i.icon.font.awesome.alternate:before {
-  content: "\f35c";
+  content: '\f35c';
 }
 
 i.icon.font.awesome.flag:before {
-  content: "\f425";
+  content: '\f425';
 }
 
 i.icon.fonticons:before {
-  content: "\f280";
+  content: '\f280';
 }
 
 i.icon.fonticons.fi:before {
-  content: "\f3a2";
+  content: '\f3a2';
 }
 
 i.icon.football.ball:before {
-  content: "\f44e";
+  content: '\f44e';
 }
 
 i.icon.fort.awesome:before {
-  content: "\f286";
+  content: '\f286';
 }
 
 i.icon.fort.awesome.alternate:before {
-  content: "\f3a3";
+  content: '\f3a3';
 }
 
 i.icon.forumbee:before {
-  content: "\f211";
+  content: '\f211';
 }
 
 i.icon.forward:before {
-  content: "\f04e";
+  content: '\f04e';
 }
 
 i.icon.foursquare:before {
-  content: "\f180";
+  content: '\f180';
 }
 
 i.icon.free.code.camp:before {
-  content: "\f2c5";
+  content: '\f2c5';
 }
 
 i.icon.freebsd:before {
-  content: "\f3a4";
+  content: '\f3a4';
 }
 
 i.icon.frown:before {
-  content: "\f119";
+  content: '\f119';
 }
 
 i.icon.futbol:before {
-  content: "\f1e3";
+  content: '\f1e3';
 }
 
 i.icon.gamepad:before {
-  content: "\f11b";
+  content: '\f11b';
 }
 
 i.icon.gavel:before {
-  content: "\f0e3";
+  content: '\f0e3';
 }
 
 i.icon.gem:before {
-  content: "\f3a5";
+  content: '\f3a5';
 }
 
 i.icon.genderless:before {
-  content: "\f22d";
+  content: '\f22d';
 }
 
 i.icon.get.pocket:before {
-  content: "\f265";
+  content: '\f265';
 }
 
 i.icon.gg:before {
-  content: "\f260";
+  content: '\f260';
 }
 
 i.icon.gg.circle:before {
-  content: "\f261";
+  content: '\f261';
 }
 
 i.icon.gift:before {
-  content: "\f06b";
+  content: '\f06b';
 }
 
 i.icon.git:before {
-  content: "\f1d3";
+  content: '\f1d3';
 }
 
 i.icon.git.square:before {
-  content: "\f1d2";
+  content: '\f1d2';
 }
 
 i.icon.github:before {
-  content: "\f09b";
+  content: '\f09b';
 }
 
 i.icon.github.alternate:before {
-  content: "\f113";
+  content: '\f113';
 }
 
 i.icon.github.square:before {
-  content: "\f092";
+  content: '\f092';
 }
 
 i.icon.gitkraken:before {
-  content: "\f3a6";
+  content: '\f3a6';
 }
 
 i.icon.gitlab:before {
-  content: "\f296";
+  content: '\f296';
 }
 
 i.icon.gitter:before {
-  content: "\f426";
+  content: '\f426';
 }
 
 i.icon.glass.martini:before {
-  content: "\f000";
+  content: '\f000';
 }
 
 i.icon.glide:before {
-  content: "\f2a5";
+  content: '\f2a5';
 }
 
 i.icon.glide.g:before {
-  content: "\f2a6";
+  content: '\f2a6';
 }
 
 i.icon.globe:before {
-  content: "\f0ac";
+  content: '\f0ac';
 }
 
 i.icon.gofore:before {
-  content: "\f3a7";
+  content: '\f3a7';
 }
 
 i.icon.golf.ball:before {
-  content: "\f450";
+  content: '\f450';
 }
 
 i.icon.goodreads:before {
-  content: "\f3a8";
+  content: '\f3a8';
 }
 
 i.icon.goodreads.g:before {
-  content: "\f3a9";
+  content: '\f3a9';
 }
 
 i.icon.google:before {
-  content: "\f1a0";
+  content: '\f1a0';
 }
 
 i.icon.google.drive:before {
-  content: "\f3aa";
+  content: '\f3aa';
 }
 
 i.icon.google.play:before {
-  content: "\f3ab";
+  content: '\f3ab';
 }
 
 i.icon.google.plus:before {
-  content: "\f2b3";
+  content: '\f2b3';
 }
 
 i.icon.google.plus.g:before {
-  content: "\f0d5";
+  content: '\f0d5';
 }
 
 i.icon.google.plus.square:before {
-  content: "\f0d4";
+  content: '\f0d4';
 }
 
 i.icon.google.wallet:before {
-  content: "\f1ee";
+  content: '\f1ee';
 }
 
 i.icon.graduation.cap:before {
-  content: "\f19d";
+  content: '\f19d';
 }
 
 i.icon.gratipay:before {
-  content: "\f184";
+  content: '\f184';
 }
 
 i.icon.grav:before {
-  content: "\f2d6";
+  content: '\f2d6';
 }
 
 i.icon.gripfire:before {
-  content: "\f3ac";
+  content: '\f3ac';
 }
 
 i.icon.grunt:before {
-  content: "\f3ad";
+  content: '\f3ad';
 }
 
 i.icon.gulp:before {
-  content: "\f3ae";
+  content: '\f3ae';
 }
 
 i.icon.h.square:before {
-  content: "\f0fd";
+  content: '\f0fd';
 }
 
 i.icon.hacker.news:before {
-  content: "\f1d4";
+  content: '\f1d4';
 }
 
 i.icon.hacker.news.square:before {
-  content: "\f3af";
+  content: '\f3af';
 }
 
 i.icon.hand.lizard:before {
-  content: "\f258";
+  content: '\f258';
 }
 
 i.icon.hand.paper:before {
-  content: "\f256";
+  content: '\f256';
 }
 
 i.icon.hand.peace:before {
-  content: "\f25b";
+  content: '\f25b';
 }
 
 i.icon.hand.point.down:before {
-  content: "\f0a7";
+  content: '\f0a7';
 }
 
 i.icon.hand.point.left:before {
-  content: "\f0a5";
+  content: '\f0a5';
 }
 
 i.icon.hand.point.right:before {
-  content: "\f0a4";
+  content: '\f0a4';
 }
 
 i.icon.hand.point.up:before {
-  content: "\f0a6";
+  content: '\f0a6';
 }
 
 i.icon.hand.pointer:before {
-  content: "\f25a";
+  content: '\f25a';
 }
 
 i.icon.hand.rock:before {
-  content: "\f255";
+  content: '\f255';
 }
 
 i.icon.hand.scissors:before {
-  content: "\f257";
+  content: '\f257';
 }
 
 i.icon.hand.spock:before {
-  content: "\f259";
+  content: '\f259';
 }
 
 i.icon.handshake:before {
-  content: "\f2b5";
+  content: '\f2b5';
 }
 
 i.icon.hashtag:before {
-  content: "\f292";
+  content: '\f292';
 }
 
 i.icon.hdd:before {
-  content: "\f0a0";
+  content: '\f0a0';
 }
 
 i.icon.heading:before {
-  content: "\f1dc";
+  content: '\f1dc';
 }
 
 i.icon.headphones:before {
-  content: "\f025";
+  content: '\f025';
 }
 
 i.icon.heart:before {
-  content: "\f004";
+  content: '\f004';
 }
 
 i.icon.heartbeat:before {
-  content: "\f21e";
+  content: '\f21e';
 }
 
 i.icon.hips:before {
-  content: "\f452";
+  content: '\f452';
 }
 
 i.icon.hire.a.helper:before {
-  content: "\f3b0";
+  content: '\f3b0';
 }
 
 i.icon.history:before {
-  content: "\f1da";
+  content: '\f1da';
 }
 
 i.icon.hockey.puck:before {
-  content: "\f453";
+  content: '\f453';
 }
 
 i.icon.home:before {
-  content: "\f015";
+  content: '\f015';
 }
 
 i.icon.hooli:before {
-  content: "\f427";
+  content: '\f427';
 }
 
 i.icon.hospital:before {
-  content: "\f0f8";
+  content: '\f0f8';
 }
 
 i.icon.hospital.symbol:before {
-  content: "\f47e";
+  content: '\f47e';
 }
 
 i.icon.hotjar:before {
-  content: "\f3b1";
+  content: '\f3b1';
 }
 
 i.icon.hourglass:before {
-  content: "\f254";
+  content: '\f254';
 }
 
 i.icon.hourglass.end:before {
-  content: "\f253";
+  content: '\f253';
 }
 
 i.icon.hourglass.half:before {
-  content: "\f252";
+  content: '\f252';
 }
 
 i.icon.hourglass.start:before {
-  content: "\f251";
+  content: '\f251';
 }
 
 i.icon.houzz:before {
-  content: "\f27c";
+  content: '\f27c';
 }
 
 i.icon.html5:before {
-  content: "\f13b";
+  content: '\f13b';
 }
 
 i.icon.hubspot:before {
-  content: "\f3b2";
+  content: '\f3b2';
 }
 
 i.icon.i.cursor:before {
-  content: "\f246";
+  content: '\f246';
 }
 
 i.icon.id.badge:before {
-  content: "\f2c1";
+  content: '\f2c1';
 }
 
 i.icon.id.card:before {
-  content: "\f2c2";
+  content: '\f2c2';
 }
 
 i.icon.image:before {
-  content: "\f03e";
+  content: '\f03e';
 }
 
 i.icon.images:before {
-  content: "\f302";
+  content: '\f302';
 }
 
 i.icon.imdb:before {
-  content: "\f2d8";
+  content: '\f2d8';
 }
 
 i.icon.inbox:before {
-  content: "\f01c";
+  content: '\f01c';
 }
 
 i.icon.indent:before {
-  content: "\f03c";
+  content: '\f03c';
 }
 
 i.icon.industry:before {
-  content: "\f275";
+  content: '\f275';
 }
 
 i.icon.info:before {
-  content: "\f129";
+  content: '\f129';
 }
 
 i.icon.info.circle:before {
-  content: "\f05a";
+  content: '\f05a';
 }
 
 i.icon.instagram:before {
-  content: "\f16d";
+  content: '\f16d';
 }
 
 i.icon.internet.explorer:before {
-  content: "\f26b";
+  content: '\f26b';
 }
 
 i.icon.ioxhost:before {
-  content: "\f208";
+  content: '\f208';
 }
 
 i.icon.italic:before {
-  content: "\f033";
+  content: '\f033';
 }
 
 i.icon.itunes:before {
-  content: "\f3b4";
+  content: '\f3b4';
 }
 
 i.icon.itunes.note:before {
-  content: "\f3b5";
+  content: '\f3b5';
 }
 
 i.icon.jenkins:before {
-  content: "\f3b6";
+  content: '\f3b6';
 }
 
 i.icon.joget:before {
-  content: "\f3b7";
+  content: '\f3b7';
 }
 
 i.icon.joomla:before {
-  content: "\f1aa";
+  content: '\f1aa';
 }
 
 i.icon.js:before {
-  content: "\f3b8";
+  content: '\f3b8';
 }
 
 i.icon.js.square:before {
-  content: "\f3b9";
+  content: '\f3b9';
 }
 
 i.icon.jsfiddle:before {
-  content: "\f1cc";
+  content: '\f1cc';
 }
 
 i.icon.key:before {
-  content: "\f084";
+  content: '\f084';
 }
 
 i.icon.keyboard:before {
-  content: "\f11c";
+  content: '\f11c';
 }
 
 i.icon.keycdn:before {
-  content: "\f3ba";
+  content: '\f3ba';
 }
 
 i.icon.kickstarter:before {
-  content: "\f3bb";
+  content: '\f3bb';
 }
 
 i.icon.kickstarter.k:before {
-  content: "\f3bc";
+  content: '\f3bc';
 }
 
 i.icon.korvue:before {
-  content: "\f42f";
+  content: '\f42f';
 }
 
 i.icon.language:before {
-  content: "\f1ab";
+  content: '\f1ab';
 }
 
 i.icon.laptop:before {
-  content: "\f109";
+  content: '\f109';
 }
 
 i.icon.laravel:before {
-  content: "\f3bd";
+  content: '\f3bd';
 }
 
 i.icon.lastfm:before {
-  content: "\f202";
+  content: '\f202';
 }
 
 i.icon.lastfm.square:before {
-  content: "\f203";
+  content: '\f203';
 }
 
 i.icon.leaf:before {
-  content: "\f06c";
+  content: '\f06c';
 }
 
 i.icon.leanpub:before {
-  content: "\f212";
+  content: '\f212';
 }
 
 i.icon.lemon:before {
-  content: "\f094";
+  content: '\f094';
 }
 
 i.icon.less:before {
-  content: "\f41d";
+  content: '\f41d';
 }
 
 i.icon.level.down.alternate:before {
-  content: "\f3be";
+  content: '\f3be';
 }
 
 i.icon.level.up.alternate:before {
-  content: "\f3bf";
+  content: '\f3bf';
 }
 
 i.icon.life.ring:before {
-  content: "\f1cd";
+  content: '\f1cd';
 }
 
 i.icon.lightbulb:before {
-  content: "\f0eb";
+  content: '\f0eb';
 }
 
 i.icon.linechat:before {
-  content: "\f3c0";
+  content: '\f3c0';
 }
 
 i.icon.linkify:before {
-  content: "\f0c1";
+  content: '\f0c1';
 }
 
 i.icon.linkedin:before {
-  content: "\f08c";
+  content: '\f08c';
 }
 
 i.icon.linkedin.alt:before {
-  content: "\f0e1";
+  content: '\f0e1';
 }
 
 i.icon.linode:before {
-  content: "\f2b8";
+  content: '\f2b8';
 }
 
 i.icon.linux:before {
-  content: "\f17c";
+  content: '\f17c';
 }
 
 i.icon.lira.sign:before {
-  content: "\f195";
+  content: '\f195';
 }
 
 i.icon.list:before {
-  content: "\f03a";
+  content: '\f03a';
 }
 
 i.icon.list.alternate:before {
-  content: "\f022";
+  content: '\f022';
 }
 
 i.icon.list.ol:before {
-  content: "\f0cb";
+  content: '\f0cb';
 }
 
 i.icon.list.ul:before {
-  content: "\f0ca";
+  content: '\f0ca';
 }
 
 i.icon.location.arrow:before {
-  content: "\f124";
+  content: '\f124';
 }
 
 i.icon.lock:before {
-  content: "\f023";
+  content: '\f023';
 }
 
 i.icon.lock.open:before {
-  content: "\f3c1";
+  content: '\f3c1';
 }
 
 i.icon.long.arrow.alternate.down:before {
-  content: "\f309";
+  content: '\f309';
 }
 
 i.icon.long.arrow.alternate.left:before {
-  content: "\f30a";
+  content: '\f30a';
 }
 
 i.icon.long.arrow.alternate.right:before {
-  content: "\f30b";
+  content: '\f30b';
 }
 
 i.icon.long.arrow.alternate.up:before {
-  content: "\f30c";
+  content: '\f30c';
 }
 
 i.icon.low.vision:before {
-  content: "\f2a8";
+  content: '\f2a8';
 }
 
 i.icon.lyft:before {
-  content: "\f3c3";
+  content: '\f3c3';
 }
 
 i.icon.magento:before {
-  content: "\f3c4";
+  content: '\f3c4';
 }
 
 i.icon.magic:before {
-  content: "\f0d0";
+  content: '\f0d0';
 }
 
 i.icon.magnet:before {
-  content: "\f076";
+  content: '\f076';
 }
 
 i.icon.male:before {
-  content: "\f183";
+  content: '\f183';
 }
 
 i.icon.map:before {
-  content: "\f279";
+  content: '\f279';
 }
 
 i.icon.map.marker:before {
-  content: "\f041";
+  content: '\f041';
 }
 
 i.icon.map.marker.alternate:before {
-  content: "\f3c5";
+  content: '\f3c5';
 }
 
 i.icon.map.pin:before {
-  content: "\f276";
+  content: '\f276';
 }
 
 i.icon.map.signs:before {
-  content: "\f277";
+  content: '\f277';
 }
 
 i.icon.mars:before {
-  content: "\f222";
+  content: '\f222';
 }
 
 i.icon.mars.double:before {
-  content: "\f227";
+  content: '\f227';
 }
 
 i.icon.mars.stroke:before {
-  content: "\f229";
+  content: '\f229';
 }
 
 i.icon.mars.stroke.horizontal:before {
-  content: "\f22b";
+  content: '\f22b';
 }
 
 i.icon.mars.stroke.vertical:before {
-  content: "\f22a";
+  content: '\f22a';
 }
 
 i.icon.maxcdn:before {
-  content: "\f136";
+  content: '\f136';
 }
 
 i.icon.medapps:before {
-  content: "\f3c6";
+  content: '\f3c6';
 }
 
 i.icon.medium:before {
-  content: "\f23a";
+  content: '\f23a';
 }
 
 i.icon.medium.m:before {
-  content: "\f3c7";
+  content: '\f3c7';
 }
 
 i.icon.medkit:before {
-  content: "\f0fa";
+  content: '\f0fa';
 }
 
 i.icon.medrt:before {
-  content: "\f3c8";
+  content: '\f3c8';
 }
 
 i.icon.meetup:before {
-  content: "\f2e0";
+  content: '\f2e0';
 }
 
 i.icon.meh:before {
-  content: "\f11a";
+  content: '\f11a';
 }
 
 i.icon.mercury:before {
-  content: "\f223";
+  content: '\f223';
 }
 
 i.icon.microchip:before {
-  content: "\f2db";
+  content: '\f2db';
 }
 
 i.icon.microphone:before {
-  content: "\f130";
+  content: '\f130';
 }
 
 i.icon.microphone.slash:before {
-  content: "\f131";
+  content: '\f131';
 }
 
 i.icon.microsoft:before {
-  content: "\f3ca";
+  content: '\f3ca';
 }
 
 i.icon.minus:before {
-  content: "\f068";
+  content: '\f068';
 }
 
 i.icon.minus.circle:before {
-  content: "\f056";
+  content: '\f056';
 }
 
 i.icon.minus.square:before {
-  content: "\f146";
+  content: '\f146';
 }
 
 i.icon.mix:before {
-  content: "\f3cb";
+  content: '\f3cb';
 }
 
 i.icon.mixcloud:before {
-  content: "\f289";
+  content: '\f289';
 }
 
 i.icon.mizuni:before {
-  content: "\f3cc";
+  content: '\f3cc';
 }
 
 i.icon.mobile:before {
-  content: "\f10b";
+  content: '\f10b';
 }
 
 i.icon.mobile.alternate:before {
-  content: "\f3cd";
+  content: '\f3cd';
 }
 
 i.icon.modx:before {
-  content: "\f285";
+  content: '\f285';
 }
 
 i.icon.monero:before {
-  content: "\f3d0";
+  content: '\f3d0';
 }
 
 i.icon.money.bill.alternate:before {
-  content: "\f3d1";
+  content: '\f3d1';
 }
 
 i.icon.moon:before {
-  content: "\f186";
+  content: '\f186';
 }
 
 i.icon.motorcycle:before {
-  content: "\f21c";
+  content: '\f21c';
 }
 
 i.icon.mouse.pointer:before {
-  content: "\f245";
+  content: '\f245';
 }
 
 i.icon.music:before {
-  content: "\f001";
+  content: '\f001';
 }
 
 i.icon.napster:before {
-  content: "\f3d2";
+  content: '\f3d2';
 }
 
 i.icon.neuter:before {
-  content: "\f22c";
+  content: '\f22c';
 }
 
 i.icon.newspaper:before {
-  content: "\f1ea";
+  content: '\f1ea';
 }
 
 i.icon.nintendo.switch:before {
-  content: "\f418";
+  content: '\f418';
 }
 
 i.icon.node:before {
-  content: "\f419";
+  content: '\f419';
 }
 
 i.icon.node.js:before {
-  content: "\f3d3";
+  content: '\f3d3';
 }
 
 i.icon.npm:before {
-  content: "\f3d4";
+  content: '\f3d4';
 }
 
 i.icon.ns8:before {
-  content: "\f3d5";
+  content: '\f3d5';
 }
 
 i.icon.nutritionix:before {
-  content: "\f3d6";
+  content: '\f3d6';
 }
 
 i.icon.object.group:before {
-  content: "\f247";
+  content: '\f247';
 }
 
 i.icon.object.ungroup:before {
-  content: "\f248";
+  content: '\f248';
 }
 
 i.icon.odnoklassniki:before {
-  content: "\f263";
+  content: '\f263';
 }
 
 i.icon.odnoklassniki.square:before {
-  content: "\f264";
+  content: '\f264';
 }
 
 i.icon.opencart:before {
-  content: "\f23d";
+  content: '\f23d';
 }
 
 i.icon.openid:before {
-  content: "\f19b";
+  content: '\f19b';
 }
 
 i.icon.opera:before {
-  content: "\f26a";
+  content: '\f26a';
 }
 
 i.icon.optin.monster:before {
-  content: "\f23c";
+  content: '\f23c';
 }
 
 i.icon.osi:before {
-  content: "\f41a";
+  content: '\f41a';
 }
 
 i.icon.outdent:before {
-  content: "\f03b";
+  content: '\f03b';
 }
 
 i.icon.page4:before {
-  content: "\f3d7";
+  content: '\f3d7';
 }
 
 i.icon.pagelines:before {
-  content: "\f18c";
+  content: '\f18c';
 }
 
 i.icon.paint.brush:before {
-  content: "\f1fc";
+  content: '\f1fc';
 }
 
 i.icon.palfed:before {
-  content: "\f3d8";
+  content: '\f3d8';
 }
 
 i.icon.pallet:before {
-  content: "\f482";
+  content: '\f482';
 }
 
 i.icon.paper.plane:before {
-  content: "\f1d8";
+  content: '\f1d8';
 }
 
 i.icon.paperclip:before {
-  content: "\f0c6";
+  content: '\f0c6';
 }
 
 i.icon.paragraph:before {
-  content: "\f1dd";
+  content: '\f1dd';
 }
 
 i.icon.paste:before {
-  content: "\f0ea";
+  content: '\f0ea';
 }
 
 i.icon.patreon:before {
-  content: "\f3d9";
+  content: '\f3d9';
 }
 
 i.icon.pause:before {
-  content: "\f04c";
+  content: '\f04c';
 }
 
 i.icon.pause.circle:before {
-  content: "\f28b";
+  content: '\f28b';
 }
 
 i.icon.paw:before {
-  content: "\f1b0";
+  content: '\f1b0';
 }
 
 i.icon.paypal:before {
-  content: "\f1ed";
+  content: '\f1ed';
 }
 
 i.icon.pen.square:before {
-  content: "\f14b";
+  content: '\f14b';
 }
 
 i.icon.pencil.alternate:before {
-  content: "\f303";
+  content: '\f303';
 }
 
 i.icon.percent:before {
-  content: "\f295";
+  content: '\f295';
 }
 
 i.icon.periscope:before {
-  content: "\f3da";
+  content: '\f3da';
 }
 
 i.icon.phabricator:before {
-  content: "\f3db";
+  content: '\f3db';
 }
 
 i.icon.phoenix.framework:before {
-  content: "\f3dc";
+  content: '\f3dc';
 }
 
 i.icon.phone:before {
-  content: "\f095";
+  content: '\f095';
 }
 
 i.icon.phone.square:before {
-  content: "\f098";
+  content: '\f098';
 }
 
 i.icon.phone.volume:before {
-  content: "\f2a0";
+  content: '\f2a0';
 }
 
 i.icon.php:before {
-  content: "\f457";
+  content: '\f457';
 }
 
 i.icon.pied.piper:before {
-  content: "\f2ae";
+  content: '\f2ae';
 }
 
 i.icon.pied.piper.alternate:before {
-  content: "\f1a8";
+  content: '\f1a8';
 }
 
 i.icon.pied.piper.pp:before {
-  content: "\f1a7";
+  content: '\f1a7';
 }
 
 i.icon.pills:before {
-  content: "\f484";
+  content: '\f484';
 }
 
 i.icon.pinterest:before {
-  content: "\f0d2";
+  content: '\f0d2';
 }
 
 i.icon.pinterest.p:before {
-  content: "\f231";
+  content: '\f231';
 }
 
 i.icon.pinterest.square:before {
-  content: "\f0d3";
+  content: '\f0d3';
 }
 
 i.icon.plane:before {
-  content: "\f072";
+  content: '\f072';
 }
 
 i.icon.play:before {
-  content: "\f04b";
+  content: '\f04b';
 }
 
 i.icon.play.circle:before {
-  content: "\f144";
+  content: '\f144';
 }
 
 i.icon.playstation:before {
-  content: "\f3df";
+  content: '\f3df';
 }
 
 i.icon.plug:before {
-  content: "\f1e6";
+  content: '\f1e6';
 }
 
 i.icon.plus:before {
-  content: "\f067";
+  content: '\f067';
 }
 
 i.icon.plus.circle:before {
-  content: "\f055";
+  content: '\f055';
 }
 
 i.icon.plus.square:before {
-  content: "\f0fe";
+  content: '\f0fe';
 }
 
 i.icon.podcast:before {
-  content: "\f2ce";
+  content: '\f2ce';
 }
 
 i.icon.pound.sign:before {
-  content: "\f154";
+  content: '\f154';
 }
 
 i.icon.power.off:before {
-  content: "\f011";
+  content: '\f011';
 }
 
 i.icon.print:before {
-  content: "\f02f";
+  content: '\f02f';
 }
 
 i.icon.product.hunt:before {
-  content: "\f288";
+  content: '\f288';
 }
 
 i.icon.pushed:before {
-  content: "\f3e1";
+  content: '\f3e1';
 }
 
 i.icon.puzzle.piece:before {
-  content: "\f12e";
+  content: '\f12e';
 }
 
 i.icon.python:before {
-  content: "\f3e2";
+  content: '\f3e2';
 }
 
 i.icon.qq:before {
-  content: "\f1d6";
+  content: '\f1d6';
 }
 
 i.icon.qrcode:before {
-  content: "\f029";
+  content: '\f029';
 }
 
 i.icon.question:before {
-  content: "\f128";
+  content: '\f128';
 }
 
 i.icon.question.circle:before {
-  content: "\f059";
+  content: '\f059';
 }
 
 i.icon.quidditch:before {
-  content: "\f458";
+  content: '\f458';
 }
 
 i.icon.quinscape:before {
-  content: "\f459";
+  content: '\f459';
 }
 
 i.icon.quora:before {
-  content: "\f2c4";
+  content: '\f2c4';
 }
 
 i.icon.quote.left:before {
-  content: "\f10d";
+  content: '\f10d';
 }
 
 i.icon.quote.right:before {
-  content: "\f10e";
+  content: '\f10e';
 }
 
 i.icon.random:before {
-  content: "\f074";
+  content: '\f074';
 }
 
 i.icon.ravelry:before {
-  content: "\f2d9";
+  content: '\f2d9';
 }
 
 i.icon.react:before {
-  content: "\f41b";
+  content: '\f41b';
 }
 
 i.icon.rebel:before {
-  content: "\f1d0";
+  content: '\f1d0';
 }
 
 i.icon.recycle:before {
-  content: "\f1b8";
+  content: '\f1b8';
 }
 
 i.icon.redriver:before {
-  content: "\f3e3";
+  content: '\f3e3';
 }
 
 i.icon.reddit:before {
-  content: "\f1a1";
+  content: '\f1a1';
 }
 
 i.icon.reddit.alien:before {
-  content: "\f281";
+  content: '\f281';
 }
 
 i.icon.reddit.square:before {
-  content: "\f1a2";
+  content: '\f1a2';
 }
 
 i.icon.redo:before {
-  content: "\f01e";
+  content: '\f01e';
 }
 
 i.icon.redo.alternate:before {
-  content: "\f2f9";
+  content: '\f2f9';
 }
 
 i.icon.registered:before {
-  content: "\f25d";
+  content: '\f25d';
 }
 
 i.icon.rendact:before {
-  content: "\f3e4";
+  content: '\f3e4';
 }
 
 i.icon.renren:before {
-  content: "\f18b";
+  content: '\f18b';
 }
 
 i.icon.reply:before {
-  content: "\f3e5";
+  content: '\f3e5';
 }
 
 i.icon.reply.all:before {
-  content: "\f122";
+  content: '\f122';
 }
 
 i.icon.replyd:before {
-  content: "\f3e6";
+  content: '\f3e6';
 }
 
 i.icon.resolving:before {
-  content: "\f3e7";
+  content: '\f3e7';
 }
 
 i.icon.retweet:before {
-  content: "\f079";
+  content: '\f079';
 }
 
 i.icon.road:before {
-  content: "\f018";
+  content: '\f018';
 }
 
 i.icon.rocket:before {
-  content: "\f135";
+  content: '\f135';
 }
 
 i.icon.rocketchat:before {
-  content: "\f3e8";
+  content: '\f3e8';
 }
 
 i.icon.rockrms:before {
-  content: "\f3e9";
+  content: '\f3e9';
 }
 
 i.icon.rss:before {
-  content: "\f09e";
+  content: '\f09e';
 }
 
 i.icon.rss.square:before {
-  content: "\f143";
+  content: '\f143';
 }
 
 i.icon.ruble.sign:before {
-  content: "\f158";
+  content: '\f158';
 }
 
 i.icon.rupee.sign:before {
-  content: "\f156";
+  content: '\f156';
 }
 
 i.icon.safari:before {
-  content: "\f267";
+  content: '\f267';
 }
 
 i.icon.sass:before {
-  content: "\f41e";
+  content: '\f41e';
 }
 
 i.icon.save:before {
-  content: "\f0c7";
+  content: '\f0c7';
 }
 
 i.icon.schlix:before {
-  content: "\f3ea";
+  content: '\f3ea';
 }
 
 i.icon.scribd:before {
-  content: "\f28a";
+  content: '\f28a';
 }
 
 i.icon.search:before {
-  content: "\f002";
+  content: '\f002';
 }
 
 i.icon.search.minus:before {
-  content: "\f010";
+  content: '\f010';
 }
 
 i.icon.search.plus:before {
-  content: "\f00e";
+  content: '\f00e';
 }
 
 i.icon.searchengin:before {
-  content: "\f3eb";
+  content: '\f3eb';
 }
 
 i.icon.sellcast:before {
-  content: "\f2da";
+  content: '\f2da';
 }
 
 i.icon.sellsy:before {
-  content: "\f213";
+  content: '\f213';
 }
 
 i.icon.server:before {
-  content: "\f233";
+  content: '\f233';
 }
 
 i.icon.servicestack:before {
-  content: "\f3ec";
+  content: '\f3ec';
 }
 
 i.icon.share:before {
-  content: "\f064";
+  content: '\f064';
 }
 
 i.icon.share.alternate:before {
-  content: "\f1e0";
+  content: '\f1e0';
 }
 
 i.icon.share.alternate.square:before {
-  content: "\f1e1";
+  content: '\f1e1';
 }
 
 i.icon.share.square:before {
-  content: "\f14d";
+  content: '\f14d';
 }
 
 i.icon.shekel.sign:before {
-  content: "\f20b";
+  content: '\f20b';
 }
 
 i.icon.shield.alternate:before {
-  content: "\f3ed";
+  content: '\f3ed';
 }
 
 i.icon.ship:before {
-  content: "\f21a";
+  content: '\f21a';
 }
 
 i.icon.shipping.fast:before {
-  content: "\f48b";
+  content: '\f48b';
 }
 
 i.icon.shirtsinbulk:before {
-  content: "\f214";
+  content: '\f214';
 }
 
 i.icon.shopping.bag:before {
-  content: "\f290";
+  content: '\f290';
 }
 
 i.icon.shopping.basket:before {
-  content: "\f291";
+  content: '\f291';
 }
 
 i.icon.shopping.cart:before {
-  content: "\f07a";
+  content: '\f07a';
 }
 
 i.icon.shower:before {
-  content: "\f2cc";
+  content: '\f2cc';
 }
 
 i.icon.sign.language:before {
-  content: "\f2a7";
+  content: '\f2a7';
 }
 
 i.icon.signal:before {
-  content: "\f012";
+  content: '\f012';
 }
 
 i.icon.simplybuilt:before {
-  content: "\f215";
+  content: '\f215';
 }
 
 i.icon.sistrix:before {
-  content: "\f3ee";
+  content: '\f3ee';
 }
 
 i.icon.sitemap:before {
-  content: "\f0e8";
+  content: '\f0e8';
 }
 
 i.icon.skyatlas:before {
-  content: "\f216";
+  content: '\f216';
 }
 
 i.icon.skype:before {
-  content: "\f17e";
+  content: '\f17e';
 }
 
 i.icon.slack:before {
-  content: "\f198";
+  content: '\f198';
 }
 
 i.icon.slack.hash:before {
-  content: "\f3ef";
+  content: '\f3ef';
 }
 
 i.icon.sliders.horizontal:before {
-  content: "\f1de";
+  content: '\f1de';
 }
 
 i.icon.slideshare:before {
-  content: "\f1e7";
+  content: '\f1e7';
 }
 
 i.icon.smile:before {
-  content: "\f118";
+  content: '\f118';
 }
 
 i.icon.snapchat:before {
-  content: "\f2ab";
+  content: '\f2ab';
 }
 
 i.icon.snapchat.ghost:before {
-  content: "\f2ac";
+  content: '\f2ac';
 }
 
 i.icon.snapchat.square:before {
-  content: "\f2ad";
+  content: '\f2ad';
 }
 
 i.icon.snowflake:before {
-  content: "\f2dc";
+  content: '\f2dc';
 }
 
 i.icon.sort:before {
-  content: "\f0dc";
+  content: '\f0dc';
 }
 
 i.icon.sort.alphabet.down:before {
-  content: "\f15d";
+  content: '\f15d';
 }
 
 i.icon.sort.alphabet.up:before {
-  content: "\f15e";
+  content: '\f15e';
 }
 
 i.icon.sort.amount.down:before {
-  content: "\f160";
+  content: '\f160';
 }
 
 i.icon.sort.amount.up:before {
-  content: "\f161";
+  content: '\f161';
 }
 
 i.icon.sort.down:before {
-  content: "\f0dd";
+  content: '\f0dd';
 }
 
 i.icon.sort.numeric.down:before {
-  content: "\f162";
+  content: '\f162';
 }
 
 i.icon.sort.numeric.up:before {
-  content: "\f163";
+  content: '\f163';
 }
 
 i.icon.sort.up:before {
-  content: "\f0de";
+  content: '\f0de';
 }
 
 i.icon.soundcloud:before {
-  content: "\f1be";
+  content: '\f1be';
 }
 
 i.icon.space.shuttle:before {
-  content: "\f197";
+  content: '\f197';
 }
 
 i.icon.speakap:before {
-  content: "\f3f3";
+  content: '\f3f3';
 }
 
 i.icon.spinner:before {
-  content: "\f110";
+  content: '\f110';
 }
 
 i.icon.spotify:before {
-  content: "\f1bc";
+  content: '\f1bc';
 }
 
 i.icon.square:before {
-  content: "\f0c8";
+  content: '\f0c8';
 }
 
 i.icon.square.full:before {
-  content: "\f45c";
+  content: '\f45c';
 }
 
 i.icon.stack.exchange:before {
-  content: "\f18d";
+  content: '\f18d';
 }
 
 i.icon.stack.overflow:before {
-  content: "\f16c";
+  content: '\f16c';
 }
 
 i.icon.star:before {
-  content: "\f005";
+  content: '\f005';
 }
 
 i.icon.star.half:before {
-  content: "\f089";
+  content: '\f089';
 }
 
 i.icon.staylinked:before {
-  content: "\f3f5";
+  content: '\f3f5';
 }
 
 i.icon.steam:before {
-  content: "\f1b6";
+  content: '\f1b6';
 }
 
 i.icon.steam.square:before {
-  content: "\f1b7";
+  content: '\f1b7';
 }
 
 i.icon.steam.symbol:before {
-  content: "\f3f6";
+  content: '\f3f6';
 }
 
 i.icon.step.backward:before {
-  content: "\f048";
+  content: '\f048';
 }
 
 i.icon.step.forward:before {
-  content: "\f051";
+  content: '\f051';
 }
 
 i.icon.stethoscope:before {
-  content: "\f0f1";
+  content: '\f0f1';
 }
 
 i.icon.sticker.mule:before {
-  content: "\f3f7";
+  content: '\f3f7';
 }
 
 i.icon.sticky.note:before {
-  content: "\f249";
+  content: '\f249';
 }
 
 i.icon.stop:before {
-  content: "\f04d";
+  content: '\f04d';
 }
 
 i.icon.stop.circle:before {
-  content: "\f28d";
+  content: '\f28d';
 }
 
 i.icon.stopwatch:before {
-  content: "\f2f2";
+  content: '\f2f2';
 }
 
 i.icon.strava:before {
-  content: "\f428";
+  content: '\f428';
 }
 
 i.icon.street.view:before {
-  content: "\f21d";
+  content: '\f21d';
 }
 
 i.icon.strikethrough:before {
-  content: "\f0cc";
+  content: '\f0cc';
 }
 
 i.icon.stripe:before {
-  content: "\f429";
+  content: '\f429';
 }
 
 i.icon.stripe.s:before {
-  content: "\f42a";
+  content: '\f42a';
 }
 
 i.icon.studiovinari:before {
-  content: "\f3f8";
+  content: '\f3f8';
 }
 
 i.icon.stumbleupon:before {
-  content: "\f1a4";
+  content: '\f1a4';
 }
 
 i.icon.stumbleupon.circle:before {
-  content: "\f1a3";
+  content: '\f1a3';
 }
 
 i.icon.subscript:before {
-  content: "\f12c";
+  content: '\f12c';
 }
 
 i.icon.subway:before {
-  content: "\f239";
+  content: '\f239';
 }
 
 i.icon.suitcase:before {
-  content: "\f0f2";
+  content: '\f0f2';
 }
 
 i.icon.sun:before {
-  content: "\f185";
+  content: '\f185';
 }
 
 i.icon.superpowers:before {
-  content: "\f2dd";
+  content: '\f2dd';
 }
 
 i.icon.superscript:before {
-  content: "\f12b";
+  content: '\f12b';
 }
 
 i.icon.supple:before {
-  content: "\f3f9";
+  content: '\f3f9';
 }
 
 i.icon.sync:before {
-  content: "\f021";
+  content: '\f021';
 }
 
 i.icon.sync.alternate:before {
-  content: "\f2f1";
+  content: '\f2f1';
 }
 
 i.icon.syringe:before {
-  content: "\f48e";
+  content: '\f48e';
 }
 
 i.icon.table:before {
-  content: "\f0ce";
+  content: '\f0ce';
 }
 
 i.icon.table.tennis:before {
-  content: "\f45d";
+  content: '\f45d';
 }
 
 i.icon.tablet:before {
-  content: "\f10a";
+  content: '\f10a';
 }
 
 i.icon.tablet.alternate:before {
-  content: "\f3fa";
+  content: '\f3fa';
 }
 
 i.icon.tachometer.alternate:before {
-  content: "\f3fd";
+  content: '\f3fd';
 }
 
 i.icon.tag:before {
-  content: "\f02b";
+  content: '\f02b';
 }
 
 i.icon.tags:before {
-  content: "\f02c";
+  content: '\f02c';
 }
 
 i.icon.tasks:before {
-  content: "\f0ae";
+  content: '\f0ae';
 }
 
 i.icon.taxi:before {
-  content: "\f1ba";
+  content: '\f1ba';
 }
 
 i.icon.telegram:before {
-  content: "\f2c6";
+  content: '\f2c6';
 }
 
 i.icon.telegram.plane:before {
-  content: "\f3fe";
+  content: '\f3fe';
 }
 
 i.icon.tencent.weibo:before {
-  content: "\f1d5";
+  content: '\f1d5';
 }
 
 i.icon.terminal:before {
-  content: "\f120";
+  content: '\f120';
 }
 
 i.icon.text.height:before {
-  content: "\f034";
+  content: '\f034';
 }
 
 i.icon.text.width:before {
-  content: "\f035";
+  content: '\f035';
 }
 
 i.icon.th:before {
-  content: "\f00a";
+  content: '\f00a';
 }
 
 i.icon.th.large:before {
-  content: "\f009";
+  content: '\f009';
 }
 
 i.icon.th.list:before {
-  content: "\f00b";
+  content: '\f00b';
 }
 
 i.icon.themeisle:before {
-  content: "\f2b2";
+  content: '\f2b2';
 }
 
 i.icon.thermometer:before {
-  content: "\f491";
+  content: '\f491';
 }
 
 i.icon.thermometer.empty:before {
-  content: "\f2cb";
+  content: '\f2cb';
 }
 
 i.icon.thermometer.full:before {
-  content: "\f2c7";
+  content: '\f2c7';
 }
 
 i.icon.thermometer.half:before {
-  content: "\f2c9";
+  content: '\f2c9';
 }
 
 i.icon.thermometer.quarter:before {
-  content: "\f2ca";
+  content: '\f2ca';
 }
 
 i.icon.thermometer.three.quarters:before {
-  content: "\f2c8";
+  content: '\f2c8';
 }
 
 i.icon.thumbs.down:before {
-  content: "\f165";
+  content: '\f165';
 }
 
 i.icon.thumbs.up:before {
-  content: "\f164";
+  content: '\f164';
 }
 
 i.icon.thumbtack:before {
-  content: "\f08d";
+  content: '\f08d';
 }
 
 i.icon.ticket.alternate:before {
-  content: "\f3ff";
+  content: '\f3ff';
 }
 
 i.icon.times:before {
-  content: "\f00d";
+  content: '\f00d';
 }
 
 i.icon.times.circle:before {
-  content: "\f057";
+  content: '\f057';
 }
 
 i.icon.tint:before {
-  content: "\f043";
+  content: '\f043';
 }
 
 i.icon.toggle.off:before {
-  content: "\f204";
+  content: '\f204';
 }
 
 i.icon.toggle.on:before {
-  content: "\f205";
+  content: '\f205';
 }
 
 i.icon.trademark:before {
-  content: "\f25c";
+  content: '\f25c';
 }
 
 i.icon.train:before {
-  content: "\f238";
+  content: '\f238';
 }
 
 i.icon.transgender:before {
-  content: "\f224";
+  content: '\f224';
 }
 
 i.icon.transgender.alternate:before {
-  content: "\f225";
+  content: '\f225';
 }
 
 i.icon.trash:before {
-  content: "\f1f8";
+  content: '\f1f8';
 }
 
 i.icon.trash.alternate:before {
-  content: "\f2ed";
+  content: '\f2ed';
 }
 
 i.icon.tree:before {
-  content: "\f1bb";
+  content: '\f1bb';
 }
 
 i.icon.trello:before {
-  content: "\f181";
+  content: '\f181';
 }
 
 i.icon.tripadvisor:before {
-  content: "\f262";
+  content: '\f262';
 }
 
 i.icon.trophy:before {
-  content: "\f091";
+  content: '\f091';
 }
 
 i.icon.truck:before {
-  content: "\f0d1";
+  content: '\f0d1';
 }
 
 i.icon.tty:before {
-  content: "\f1e4";
+  content: '\f1e4';
 }
 
 i.icon.tumblr:before {
-  content: "\f173";
+  content: '\f173';
 }
 
 i.icon.tumblr.square:before {
-  content: "\f174";
+  content: '\f174';
 }
 
 i.icon.tv:before {
-  content: "\f26c";
+  content: '\f26c';
 }
 
 i.icon.twitch:before {
-  content: "\f1e8";
+  content: '\f1e8';
 }
 
 i.icon.twitter:before {
-  content: "\f099";
+  content: '\f099';
 }
 
 i.icon.twitter.square:before {
-  content: "\f081";
+  content: '\f081';
 }
 
 i.icon.typo3:before {
-  content: "\f42b";
+  content: '\f42b';
 }
 
 i.icon.uber:before {
-  content: "\f402";
+  content: '\f402';
 }
 
 i.icon.uikit:before {
-  content: "\f403";
+  content: '\f403';
 }
 
 i.icon.umbrella:before {
-  content: "\f0e9";
+  content: '\f0e9';
 }
 
 i.icon.underline:before {
-  content: "\f0cd";
+  content: '\f0cd';
 }
 
 i.icon.undo:before {
-  content: "\f0e2";
+  content: '\f0e2';
 }
 
 i.icon.undo.alternate:before {
-  content: "\f2ea";
+  content: '\f2ea';
 }
 
 i.icon.uniregistry:before {
-  content: "\f404";
+  content: '\f404';
 }
 
 i.icon.universal.access:before {
-  content: "\f29a";
+  content: '\f29a';
 }
 
 i.icon.university:before {
-  content: "\f19c";
+  content: '\f19c';
 }
 
 i.icon.unlink:before {
-  content: "\f127";
+  content: '\f127';
 }
 
 i.icon.unlock:before {
-  content: "\f09c";
+  content: '\f09c';
 }
 
 i.icon.unlock.alternate:before {
-  content: "\f13e";
+  content: '\f13e';
 }
 
 i.icon.untappd:before {
-  content: "\f405";
+  content: '\f405';
 }
 
 i.icon.upload:before {
-  content: "\f093";
+  content: '\f093';
 }
 
 i.icon.usb:before {
-  content: "\f287";
+  content: '\f287';
 }
 
 i.icon.user:before {
-  content: "\f007";
+  content: '\f007';
 }
 
 i.icon.user.circle:before {
-  content: "\f2bd";
+  content: '\f2bd';
 }
 
 i.icon.user.md:before {
-  content: "\f0f0";
+  content: '\f0f0';
 }
 
 i.icon.user.plus:before {
-  content: "\f234";
+  content: '\f234';
 }
 
 i.icon.user.secret:before {
-  content: "\f21b";
+  content: '\f21b';
 }
 
 i.icon.user.times:before {
-  content: "\f235";
+  content: '\f235';
 }
 
 i.icon.users:before {
-  content: "\f0c0";
+  content: '\f0c0';
 }
 
 i.icon.ussunnah:before {
-  content: "\f407";
+  content: '\f407';
 }
 
 i.icon.utensil.spoon:before {
-  content: "\f2e5";
+  content: '\f2e5';
 }
 
 i.icon.utensils:before {
-  content: "\f2e7";
+  content: '\f2e7';
 }
 
 i.icon.vaadin:before {
-  content: "\f408";
+  content: '\f408';
 }
 
 i.icon.venus:before {
-  content: "\f221";
+  content: '\f221';
 }
 
 i.icon.venus.double:before {
-  content: "\f226";
+  content: '\f226';
 }
 
 i.icon.venus.mars:before {
-  content: "\f228";
+  content: '\f228';
 }
 
 i.icon.viacoin:before {
-  content: "\f237";
+  content: '\f237';
 }
 
 i.icon.viadeo:before {
-  content: "\f2a9";
+  content: '\f2a9';
 }
 
 i.icon.viadeo.square:before {
-  content: "\f2aa";
+  content: '\f2aa';
 }
 
 i.icon.viber:before {
-  content: "\f409";
+  content: '\f409';
 }
 
 i.icon.video:before {
-  content: "\f03d";
+  content: '\f03d';
 }
 
 i.icon.vimeo:before {
-  content: "\f40a";
+  content: '\f40a';
 }
 
 i.icon.vimeo.square:before {
-  content: "\f194";
+  content: '\f194';
 }
 
 i.icon.vimeo.v:before {
-  content: "\f27d";
+  content: '\f27d';
 }
 
 i.icon.vine:before {
-  content: "\f1ca";
+  content: '\f1ca';
 }
 
 i.icon.vk:before {
-  content: "\f189";
+  content: '\f189';
 }
 
 i.icon.vnv:before {
-  content: "\f40b";
+  content: '\f40b';
 }
 
 i.icon.volleyball.ball:before {
-  content: "\f45f";
+  content: '\f45f';
 }
 
 i.icon.volume.down:before {
-  content: "\f027";
+  content: '\f027';
 }
 
 i.icon.volume.off:before {
-  content: "\f026";
+  content: '\f026';
 }
 
 i.icon.volume.up:before {
-  content: "\f028";
+  content: '\f028';
 }
 
 i.icon.vuejs:before {
-  content: "\f41f";
+  content: '\f41f';
 }
 
 i.icon.warehouse:before {
-  content: "\f494";
+  content: '\f494';
 }
 
 i.icon.weibo:before {
-  content: "\f18a";
+  content: '\f18a';
 }
 
 i.icon.weight:before {
-  content: "\f496";
+  content: '\f496';
 }
 
 i.icon.weixin:before {
-  content: "\f1d7";
+  content: '\f1d7';
 }
 
 i.icon.whatsapp:before {
-  content: "\f232";
+  content: '\f232';
 }
 
 i.icon.whatsapp.square:before {
-  content: "\f40c";
+  content: '\f40c';
 }
 
 i.icon.wheelchair:before {
-  content: "\f193";
+  content: '\f193';
 }
 
 i.icon.whmcs:before {
-  content: "\f40d";
+  content: '\f40d';
 }
 
 i.icon.wifi:before {
-  content: "\f1eb";
+  content: '\f1eb';
 }
 
 i.icon.wikipedia.w:before {
-  content: "\f266";
+  content: '\f266';
 }
 
 i.icon.window.close:before {
-  content: "\f410";
+  content: '\f410';
 }
 
 i.icon.window.maximize:before {
-  content: "\f2d0";
+  content: '\f2d0';
 }
 
 i.icon.window.minimize:before {
-  content: "\f2d1";
+  content: '\f2d1';
 }
 
 i.icon.window.restore:before {
-  content: "\f2d2";
+  content: '\f2d2';
 }
 
 i.icon.windows:before {
-  content: "\f17a";
+  content: '\f17a';
 }
 
 i.icon.won.sign:before {
-  content: "\f159";
+  content: '\f159';
 }
 
 i.icon.wordpress:before {
-  content: "\f19a";
+  content: '\f19a';
 }
 
 i.icon.wordpress.simple:before {
-  content: "\f411";
+  content: '\f411';
 }
 
 i.icon.wpbeginner:before {
-  content: "\f297";
+  content: '\f297';
 }
 
 i.icon.wpexplorer:before {
-  content: "\f2de";
+  content: '\f2de';
 }
 
 i.icon.wpforms:before {
-  content: "\f298";
+  content: '\f298';
 }
 
 i.icon.wrench:before {
-  content: "\f0ad";
+  content: '\f0ad';
 }
 
 i.icon.xbox:before {
-  content: "\f412";
+  content: '\f412';
 }
 
 i.icon.xing:before {
-  content: "\f168";
+  content: '\f168';
 }
 
 i.icon.xing.square:before {
-  content: "\f169";
+  content: '\f169';
 }
 
 i.icon.y.combinator:before {
-  content: "\f23b";
+  content: '\f23b';
 }
 
 i.icon.yahoo:before {
-  content: "\f19e";
+  content: '\f19e';
 }
 
 i.icon.yandex:before {
-  content: "\f413";
+  content: '\f413';
 }
 
 i.icon.yandex.international:before {
-  content: "\f414";
+  content: '\f414';
 }
 
 i.icon.yelp:before {
-  content: "\f1e9";
+  content: '\f1e9';
 }
 
 i.icon.yen.sign:before {
-  content: "\f157";
+  content: '\f157';
 }
 
 i.icon.yoast:before {
-  content: "\f2b1";
+  content: '\f2b1';
 }
 
 i.icon.youtube:before {
-  content: "\f167";
+  content: '\f167';
 }
 
 i.icon.youtube.square:before {
-  content: "\f431";
+  content: '\f431';
 }
 
 /* Aliases */
 
 i.icon.chess.rock:before {
-  content: "\f447";
+  content: '\f447';
 }
 
 i.icon.ordered.list:before {
-  content: "\f0cb";
+  content: '\f0cb';
 }
 
 i.icon.unordered.list:before {
-  content: "\f0ca";
+  content: '\f0ca';
 }
 
 i.icon.user.doctor:before {
-  content: "\f0f0";
+  content: '\f0f0';
 }
 
 i.icon.shield:before {
-  content: "\f3ed";
+  content: '\f3ed';
 }
 
 i.icon.puzzle:before {
-  content: "\f12e";
+  content: '\f12e';
 }
 
 i.icon.credit.card.amazon.pay:before {
-  content: "\f42d";
+  content: '\f42d';
 }
 
 i.icon.credit.card.american.express:before {
-  content: "\f1f3";
+  content: '\f1f3';
 }
 
 i.icon.credit.card.diners.club:before {
-  content: "\f24c";
+  content: '\f24c';
 }
 
 i.icon.credit.card.discover:before {
-  content: "\f1f2";
+  content: '\f1f2';
 }
 
 i.icon.credit.card.jcb:before {
-  content: "\f24b";
+  content: '\f24b';
 }
 
 i.icon.credit.card.mastercard:before {
-  content: "\f1f1";
+  content: '\f1f1';
 }
 
 i.icon.credit.card.paypal:before {
-  content: "\f1f4";
+  content: '\f1f4';
 }
 
 i.icon.credit.card.stripe:before {
-  content: "\f1f5";
+  content: '\f1f5';
 }
 
 i.icon.credit.card.visa:before {
-  content: "\f1f0";
+  content: '\f1f0';
 }
 
 i.icon.add.circle:before {
-  content: "\f055";
+  content: '\f055';
 }
 
 i.icon.add.square:before {
-  content: "\f0fe";
+  content: '\f0fe';
 }
 
 i.icon.add.to.calendar:before {
-  content: "\f271";
+  content: '\f271';
 }
 
 i.icon.add.to.cart:before {
-  content: "\f217";
+  content: '\f217';
 }
 
 i.icon.add.user:before {
-  content: "\f234";
+  content: '\f234';
 }
 
 i.icon.add:before {
-  content: "\f067";
+  content: '\f067';
 }
 
 i.icon.alarm.mute:before {
-  content: "\f1f6";
+  content: '\f1f6';
 }
 
 i.icon.alarm:before {
-  content: "\f0f3";
+  content: '\f0f3';
 }
 
 i.icon.ald:before {
-  content: "\f2a2";
+  content: '\f2a2';
 }
 
 i.icon.als:before {
-  content: "\f2a2";
+  content: '\f2a2';
 }
 
 i.icon.american.express.card:before {
-  content: "\f1f3";
+  content: '\f1f3';
 }
 
 i.icon.american.express:before {
-  content: "\f1f3";
+  content: '\f1f3';
 }
 
 i.icon.amex:before {
-  content: "\f1f3";
+  content: '\f1f3';
 }
 
 i.icon.announcement:before {
-  content: "\f0a1";
+  content: '\f0a1';
 }
 
 i.icon.area.chart:before {
-  content: "\f1fe";
+  content: '\f1fe';
 }
 
 i.icon.area.graph:before {
-  content: "\f1fe";
+  content: '\f1fe';
 }
 
 i.icon.arrow.down.cart:before {
-  content: "\f218";
+  content: '\f218';
 }
 
 i.icon.asexual:before {
-  content: "\f22d";
+  content: '\f22d';
 }
 
 i.icon.asl.interpreting:before {
-  content: "\f2a3";
+  content: '\f2a3';
 }
 
 i.icon.asl:before {
-  content: "\f2a3";
+  content: '\f2a3';
 }
 
 i.icon.assistive.listening.devices:before {
-  content: "\f2a2";
+  content: '\f2a2';
 }
 
 i.icon.attach:before {
-  content: "\f0c6";
+  content: '\f0c6';
 }
 
 i.icon.attention:before {
-  content: "\f06a";
+  content: '\f06a';
 }
 
 i.icon.balance:before {
-  content: "\f24e";
+  content: '\f24e';
 }
 
 i.icon.bar:before {
-  content: "\f0fc";
+  content: '\f0fc';
 }
 
 i.icon.bathtub:before {
-  content: "\f2cd";
+  content: '\f2cd';
 }
 
 i.icon.battery.four:before {
-  content: "\f240";
+  content: '\f240';
 }
 
 i.icon.battery.high:before {
-  content: "\f241";
+  content: '\f241';
 }
 
 i.icon.battery.low:before {
-  content: "\f243";
+  content: '\f243';
 }
 
 i.icon.battery.medium:before {
-  content: "\f242";
+  content: '\f242';
 }
 
 i.icon.battery.one:before {
-  content: "\f243";
+  content: '\f243';
 }
 
 i.icon.battery.three:before {
-  content: "\f241";
+  content: '\f241';
 }
 
 i.icon.battery.two:before {
-  content: "\f242";
+  content: '\f242';
 }
 
 i.icon.battery.zero:before {
-  content: "\f244";
+  content: '\f244';
 }
 
 i.icon.birthday:before {
-  content: "\f1fd";
+  content: '\f1fd';
 }
 
 i.icon.block.layout:before {
-  content: "\f009";
+  content: '\f009';
 }
 
 i.icon.bluetooth.alternative:before {
-  content: "\f294";
+  content: '\f294';
 }
 
 i.icon.broken.chain:before {
-  content: "\f127";
+  content: '\f127';
 }
 
 i.icon.browser:before {
-  content: "\f022";
+  content: '\f022';
 }
 
 i.icon.call.square:before {
-  content: "\f098";
+  content: '\f098';
 }
 
 i.icon.call:before {
-  content: "\f095";
+  content: '\f095';
 }
 
 i.icon.cancel:before {
-  content: "\f00d";
+  content: '\f00d';
 }
 
 i.icon.cart:before {
-  content: "\f07a";
+  content: '\f07a';
 }
 
 i.icon.cc:before {
-  content: "\f20a";
+  content: '\f20a';
 }
 
 i.icon.chain:before {
-  content: "\f0c1";
+  content: '\f0c1';
 }
 
 i.icon.chat:before {
-  content: "\f075";
+  content: '\f075';
 }
 
 i.icon.checked.calendar:before {
-  content: "\f274";
+  content: '\f274';
 }
 
 i.icon.checkmark:before {
-  content: "\f00c";
+  content: '\f00c';
 }
 
 i.icon.circle.notched:before {
-  content: "\f1ce";
+  content: '\f1ce';
 }
 
 i.icon.close:before {
-  content: "\f00d";
+  content: '\f00d';
 }
 
 i.icon.cny:before {
-  content: "\f157";
+  content: '\f157';
 }
 
 i.icon.cocktail:before {
-  content: "\f000";
+  content: '\f000';
 }
 
 i.icon.commenting:before {
-  content: "\f27a";
+  content: '\f27a';
 }
 
 i.icon.computer:before {
-  content: "\f108";
+  content: '\f108';
 }
 
 i.icon.configure:before {
-  content: "\f0ad";
+  content: '\f0ad';
 }
 
 i.icon.content:before {
-  content: "\f0c9";
+  content: '\f0c9';
 }
 
 i.icon.deafness:before {
-  content: "\f2a4";
+  content: '\f2a4';
 }
 
 i.icon.delete.calendar:before {
-  content: "\f273";
+  content: '\f273';
 }
 
 i.icon.delete:before {
-  content: "\f00d";
+  content: '\f00d';
 }
 
 i.icon.detective:before {
-  content: "\f21b";
+  content: '\f21b';
 }
 
 i.icon.diners.club.card:before {
-  content: "\f24c";
+  content: '\f24c';
 }
 
 i.icon.diners.club:before {
-  content: "\f24c";
+  content: '\f24c';
 }
 
 i.icon.discover.card:before {
-  content: "\f1f2";
+  content: '\f1f2';
 }
 
 i.icon.discover:before {
-  content: "\f1f2";
+  content: '\f1f2';
 }
 
 i.icon.discussions:before {
-  content: "\f086";
+  content: '\f086';
 }
 
 i.icon.doctor:before {
-  content: "\f0f0";
+  content: '\f0f0';
 }
 
 i.icon.dollar:before {
-  content: "\f155";
+  content: '\f155';
 }
 
 i.icon.dont:before {
-  content: "\f05e";
+  content: '\f05e';
 }
 
 i.icon.dribble:before {
-  content: "\f17d";
+  content: '\f17d';
 }
 
 i.icon.drivers.license:before {
-  content: "\f2c2";
+  content: '\f2c2';
 }
 
 i.icon.dropdown:before {
-  content: "\f0d7";
+  content: '\f0d7';
 }
 
 i.icon.eercast:before {
-  content: "\f2da";
+  content: '\f2da';
 }
 
 i.icon.emergency:before {
-  content: "\f0f9";
+  content: '\f0f9';
 }
 
 i.icon.envira.gallery:before {
-  content: "\f299";
+  content: '\f299';
 }
 
 i.icon.erase:before {
-  content: "\f12d";
+  content: '\f12d';
 }
 
 i.icon.eur:before {
-  content: "\f153";
+  content: '\f153';
 }
 
 i.icon.euro:before {
-  content: "\f153";
+  content: '\f153';
 }
 
 i.icon.eyedropper:before {
-  content: "\f1fb";
+  content: '\f1fb';
 }
 
 i.icon.fa:before {
-  content: "\f2b4";
+  content: '\f2b4';
 }
 
 i.icon.factory:before {
-  content: "\f275";
+  content: '\f275';
 }
 
 i.icon.favorite:before {
-  content: "\f005";
+  content: '\f005';
 }
 
 i.icon.feed:before {
-  content: "\f09e";
+  content: '\f09e';
 }
 
 i.icon.female.homosexual:before {
-  content: "\f226";
+  content: '\f226';
 }
 
 i.icon.file.text:before {
-  content: "\f15c";
+  content: '\f15c';
 }
 
 i.icon.find:before {
-  content: "\f1e5";
+  content: '\f1e5';
 }
 
 i.icon.first.aid:before {
-  content: "\f0fa";
+  content: '\f0fa';
 }
 
 i.icon.five.hundred.pixels:before {
-  content: "\f26e";
+  content: '\f26e';
 }
 
 i.icon.fork:before {
-  content: "\f126";
+  content: '\f126';
 }
 
 i.icon.game:before {
-  content: "\f11b";
+  content: '\f11b';
 }
 
 i.icon.gay:before {
-  content: "\f227";
+  content: '\f227';
 }
 
 i.icon.gbp:before {
-  content: "\f154";
+  content: '\f154';
 }
 
 i.icon.gittip:before {
-  content: "\f184";
+  content: '\f184';
 }
 
 i.icon.google.plus.circle:before {
-  content: "\f2b3";
+  content: '\f2b3';
 }
 
 i.icon.google.plus.official:before {
-  content: "\f2b3";
+  content: '\f2b3';
 }
 
 i.icon.grab:before {
-  content: "\f255";
+  content: '\f255';
 }
 
 i.icon.graduation:before {
-  content: "\f19d";
+  content: '\f19d';
 }
 
 i.icon.grid.layout:before {
-  content: "\f00a";
+  content: '\f00a';
 }
 
 i.icon.group:before {
-  content: "\f0c0";
+  content: '\f0c0';
 }
 
 i.icon.h:before {
-  content: "\f0fd";
+  content: '\f0fd';
 }
 
 i.icon.hand.victory:before {
-  content: "\f25b";
+  content: '\f25b';
 }
 
 i.icon.handicap:before {
-  content: "\f193";
+  content: '\f193';
 }
 
 i.icon.hard.of.hearing:before {
-  content: "\f2a4";
+  content: '\f2a4';
 }
 
 i.icon.header:before {
-  content: "\f1dc";
+  content: '\f1dc';
 }
 
 i.icon.help.circle:before {
-  content: "\f059";
+  content: '\f059';
 }
 
 i.icon.help:before {
-  content: "\f128";
+  content: '\f128';
 }
 
 i.icon.heterosexual:before {
-  content: "\f228";
+  content: '\f228';
 }
 
 i.icon.hide:before {
-  content: "\f070";
+  content: '\f070';
 }
 
 i.icon.hotel:before {
-  content: "\f236";
+  content: '\f236';
 }
 
 i.icon.hourglass.four:before {
-  content: "\f254";
+  content: '\f254';
 }
 
 i.icon.hourglass.full:before {
-  content: "\f254";
+  content: '\f254';
 }
 
 i.icon.hourglass.one:before {
-  content: "\f251";
+  content: '\f251';
 }
 
 i.icon.hourglass.three:before {
-  content: "\f253";
+  content: '\f253';
 }
 
 i.icon.hourglass.two:before {
-  content: "\f252";
+  content: '\f252';
 }
 
 i.icon.idea:before {
-  content: "\f0eb";
+  content: '\f0eb';
 }
 
 i.icon.ils:before {
-  content: "\f20b";
+  content: '\f20b';
 }
 
 i.icon.in-cart:before {
-  content: "\f218";
+  content: '\f218';
 }
 
 i.icon.inr:before {
-  content: "\f156";
+  content: '\f156';
 }
 
 i.icon.intergender:before {
-  content: "\f224";
+  content: '\f224';
 }
 
 i.icon.intersex:before {
-  content: "\f224";
+  content: '\f224';
 }
 
 i.icon.japan.credit.bureau.card:before {
-  content: "\f24b";
+  content: '\f24b';
 }
 
 i.icon.japan.credit.bureau:before {
-  content: "\f24b";
+  content: '\f24b';
 }
 
 i.icon.jcb:before {
-  content: "\f24b";
+  content: '\f24b';
 }
 
 i.icon.jpy:before {
-  content: "\f157";
+  content: '\f157';
 }
 
 i.icon.krw:before {
-  content: "\f159";
+  content: '\f159';
 }
 
 i.icon.lab:before {
-  content: "\f0c3";
+  content: '\f0c3';
 }
 
 i.icon.law:before {
-  content: "\f24e";
+  content: '\f24e';
 }
 
 i.icon.legal:before {
-  content: "\f0e3";
+  content: '\f0e3';
 }
 
 i.icon.lesbian:before {
-  content: "\f226";
+  content: '\f226';
 }
 
 i.icon.lightning:before {
-  content: "\f0e7";
+  content: '\f0e7';
 }
 
 i.icon.like:before {
-  content: "\f004";
+  content: '\f004';
 }
 
 i.icon.line.graph:before {
-  content: "\f201";
+  content: '\f201';
 }
 
 i.icon.linkedin.square:before {
-  content: "\f08c";
+  content: '\f08c';
 }
 
 i.icon.linkify:before {
-  content: "\f0c1";
+  content: '\f0c1';
 }
 
 i.icon.lira:before {
-  content: "\f195";
+  content: '\f195';
 }
 
 i.icon.list.layout:before {
-  content: "\f00b";
+  content: '\f00b';
 }
 
 i.icon.magnify:before {
-  content: "\f00e";
+  content: '\f00e';
 }
 
 i.icon.mail.forward:before {
-  content: "\f064";
+  content: '\f064';
 }
 
 i.icon.mail.square:before {
-  content: "\f199";
+  content: '\f199';
 }
 
 i.icon.mail:before {
-  content: "\f0e0";
+  content: '\f0e0';
 }
 
 i.icon.male.homosexual:before {
-  content: "\f227";
+  content: '\f227';
 }
 
 i.icon.man:before {
-  content: "\f222";
+  content: '\f222';
 }
 
 i.icon.marker:before {
-  content: "\f041";
+  content: '\f041';
 }
 
 i.icon.mars.alternate:before {
-  content: "\f229";
+  content: '\f229';
 }
 
 i.icon.mars.horizontal:before {
-  content: "\f22b";
+  content: '\f22b';
 }
 
 i.icon.mars.vertical:before {
-  content: "\f22a";
+  content: '\f22a';
 }
 
 i.icon.mastercard.card:before {
-  content: "\f1f1";
+  content: '\f1f1';
 }
 
 i.icon.mastercard:before {
-  content: "\f1f1";
+  content: '\f1f1';
 }
 
 i.icon.microsoft.edge:before {
-  content: "\f282";
+  content: '\f282';
 }
 
 i.icon.military:before {
-  content: "\f0fb";
+  content: '\f0fb';
 }
 
 i.icon.ms.edge:before {
-  content: "\f282";
+  content: '\f282';
 }
 
 i.icon.mute:before {
-  content: "\f131";
+  content: '\f131';
 }
 
 i.icon.new.pied.piper:before {
-  content: "\f2ae";
+  content: '\f2ae';
 }
 
 i.icon.non.binary.transgender:before {
-  content: "\f223";
+  content: '\f223';
 }
 
 i.icon.numbered.list:before {
-  content: "\f0cb";
+  content: '\f0cb';
 }
 
 i.icon.optinmonster:before {
-  content: "\f23c";
+  content: '\f23c';
 }
 
 i.icon.options:before {
-  content: "\f1de";
+  content: '\f1de';
 }
 
 i.icon.other.gender.horizontal:before {
-  content: "\f22b";
+  content: '\f22b';
 }
 
 i.icon.other.gender.vertical:before {
-  content: "\f22a";
+  content: '\f22a';
 }
 
 i.icon.other.gender:before {
-  content: "\f229";
+  content: '\f229';
 }
 
 i.icon.payment:before {
-  content: "\f09d";
+  content: '\f09d';
 }
 
 i.icon.paypal.card:before {
-  content: "\f1f4";
+  content: '\f1f4';
 }
 
 i.icon.pencil.square:before {
-  content: "\f14b";
+  content: '\f14b';
 }
 
 i.icon.photo:before {
-  content: "\f030";
+  content: '\f030';
 }
 
 i.icon.picture:before {
-  content: "\f03e";
+  content: '\f03e';
 }
 
 i.icon.pie.chart:before {
-  content: "\f200";
+  content: '\f200';
 }
 
 i.icon.pie.graph:before {
-  content: "\f200";
+  content: '\f200';
 }
 
 i.icon.pied.piper.hat:before {
-  content: "\f2ae";
+  content: '\f2ae';
 }
 
 i.icon.pin:before {
-  content: "\f08d";
+  content: '\f08d';
 }
 
 i.icon.plus.cart:before {
-  content: "\f217";
+  content: '\f217';
 }
 
 i.icon.pocket:before {
-  content: "\f265";
+  content: '\f265';
 }
 
 i.icon.point:before {
-  content: "\f041";
+  content: '\f041';
 }
 
 i.icon.pointing.down:before {
-  content: "\f0a7";
+  content: '\f0a7';
 }
 
 i.icon.pointing.left:before {
-  content: "\f0a5";
+  content: '\f0a5';
 }
 
 i.icon.pointing.right:before {
-  content: "\f0a4";
+  content: '\f0a4';
 }
 
 i.icon.pointing.up:before {
-  content: "\f0a6";
+  content: '\f0a6';
 }
 
 i.icon.pound:before {
-  content: "\f154";
+  content: '\f154';
 }
 
 i.icon.power.cord:before {
-  content: "\f1e6";
+  content: '\f1e6';
 }
 
 i.icon.power:before {
-  content: "\f011";
+  content: '\f011';
 }
 
 i.icon.privacy:before {
-  content: "\f084";
+  content: '\f084';
 }
 
 i.icon.r.circle:before {
-  content: "\f25d";
+  content: '\f25d';
 }
 
 i.icon.rain:before {
-  content: "\f0e9";
+  content: '\f0e9';
 }
 
 i.icon.record:before {
-  content: "\f03d";
+  content: '\f03d';
 }
 
 i.icon.refresh:before {
-  content: "\f021";
+  content: '\f021';
 }
 
 i.icon.remove.circle:before {
-  content: "\f057";
+  content: '\f057';
 }
 
 i.icon.remove.from.calendar:before {
-  content: "\f272";
+  content: '\f272';
 }
 
 i.icon.remove.user:before {
-  content: "\f235";
+  content: '\f235';
 }
 
 i.icon.remove:before {
-  content: "\f00d";
+  content: '\f00d';
 }
 
 i.icon.repeat:before {
-  content: "\f01e";
+  content: '\f01e';
 }
 
 i.icon.rmb:before {
-  content: "\f157";
+  content: '\f157';
 }
 
 i.icon.rouble:before {
-  content: "\f158";
+  content: '\f158';
 }
 
 i.icon.rub:before {
-  content: "\f158";
+  content: '\f158';
 }
 
 i.icon.ruble:before {
-  content: "\f158";
+  content: '\f158';
 }
 
 i.icon.rupee:before {
-  content: "\f156";
+  content: '\f156';
 }
 
 i.icon.s15:before {
-  content: "\f2cd";
+  content: '\f2cd';
 }
 
 i.icon.selected.radio:before {
-  content: "\f192";
+  content: '\f192';
 }
 
 i.icon.send:before {
-  content: "\f1d8";
+  content: '\f1d8';
 }
 
 i.icon.setting:before {
-  content: "\f013";
+  content: '\f013';
 }
 
 i.icon.settings:before {
-  content: "\f085";
+  content: '\f085';
 }
 
 i.icon.shekel:before {
-  content: "\f20b";
+  content: '\f20b';
 }
 
 i.icon.sheqel:before {
-  content: "\f20b";
+  content: '\f20b';
 }
 
 i.icon.shipping:before {
-  content: "\f0d1";
+  content: '\f0d1';
 }
 
 i.icon.shop:before {
-  content: "\f07a";
+  content: '\f07a';
 }
 
 i.icon.shuffle:before {
-  content: "\f074";
+  content: '\f074';
 }
 
 i.icon.shutdown:before {
-  content: "\f011";
+  content: '\f011';
 }
 
 i.icon.sidebar:before {
-  content: "\f0c9";
+  content: '\f0c9';
 }
 
 i.icon.signing:before {
-  content: "\f2a7";
+  content: '\f2a7';
 }
 
 i.icon.signup:before {
-  content: "\f044";
+  content: '\f044';
 }
 
 i.icon.sliders:before {
-  content: "\f1de";
+  content: '\f1de';
 }
 
 i.icon.soccer:before {
-  content: "\f1e3";
+  content: '\f1e3';
 }
 
 i.icon.sort.alphabet.ascending:before {
-  content: "\f15d";
+  content: '\f15d';
 }
 
 i.icon.sort.alphabet.descending:before {
-  content: "\f15e";
+  content: '\f15e';
 }
 
 i.icon.sort.ascending:before {
-  content: "\f0de";
+  content: '\f0de';
 }
 
 i.icon.sort.content.ascending:before {
-  content: "\f160";
+  content: '\f160';
 }
 
 i.icon.sort.content.descending:before {
-  content: "\f161";
+  content: '\f161';
 }
 
 i.icon.sort.descending:before {
-  content: "\f0dd";
+  content: '\f0dd';
 }
 
 i.icon.sort.numeric.ascending:before {
-  content: "\f162";
+  content: '\f162';
 }
 
 i.icon.sort.numeric.descending:before {
-  content: "\f163";
+  content: '\f163';
 }
 
 i.icon.sound:before {
-  content: "\f025";
+  content: '\f025';
 }
 
 i.icon.spy:before {
-  content: "\f21b";
+  content: '\f21b';
 }
 
 i.icon.stripe.card:before {
-  content: "\f1f5";
+  content: '\f1f5';
 }
 
 i.icon.student:before {
-  content: "\f19d";
+  content: '\f19d';
 }
 
 i.icon.talk:before {
-  content: "\f27a";
+  content: '\f27a';
 }
 
 i.icon.target:before {
-  content: "\f140";
+  content: '\f140';
 }
 
 i.icon.teletype:before {
-  content: "\f1e4";
+  content: '\f1e4';
 }
 
 i.icon.television:before {
-  content: "\f26c";
+  content: '\f26c';
 }
 
 i.icon.text.cursor:before {
-  content: "\f246";
+  content: '\f246';
 }
 
 i.icon.text.telephone:before {
-  content: "\f1e4";
+  content: '\f1e4';
 }
 
 i.icon.theme.isle:before {
-  content: "\f2b2";
+  content: '\f2b2';
 }
 
 i.icon.theme:before {
-  content: "\f043";
+  content: '\f043';
 }
 
 i.icon.thermometer:before {
-  content: "\f2c7";
+  content: '\f2c7';
 }
 
 i.icon.thumb.tack:before {
-  content: "\f08d";
+  content: '\f08d';
 }
 
 i.icon.time:before {
-  content: "\f017";
+  content: '\f017';
 }
 
 i.icon.tm:before {
-  content: "\f25c";
+  content: '\f25c';
 }
 
 i.icon.toggle.down:before {
-  content: "\f150";
+  content: '\f150';
 }
 
 i.icon.toggle.left:before {
-  content: "\f191";
+  content: '\f191';
 }
 
 i.icon.toggle.right:before {
-  content: "\f152";
+  content: '\f152';
 }
 
 i.icon.toggle.up:before {
-  content: "\f151";
+  content: '\f151';
 }
 
 i.icon.translate:before {
-  content: "\f1ab";
+  content: '\f1ab';
 }
 
 i.icon.travel:before {
-  content: "\f0b1";
+  content: '\f0b1';
 }
 
 i.icon.treatment:before {
-  content: "\f0f1";
+  content: '\f0f1';
 }
 
 i.icon.triangle.down:before {
-  content: "\f0d7";
+  content: '\f0d7';
 }
 
 i.icon.triangle.left:before {
-  content: "\f0d9";
+  content: '\f0d9';
 }
 
 i.icon.triangle.right:before {
-  content: "\f0da";
+  content: '\f0da';
 }
 
 i.icon.triangle.up:before {
-  content: "\f0d8";
+  content: '\f0d8';
 }
 
 i.icon.try:before {
-  content: "\f195";
+  content: '\f195';
 }
 
 i.icon.unhide:before {
-  content: "\f06e";
+  content: '\f06e';
 }
 
 i.icon.unlinkify:before {
-  content: "\f127";
+  content: '\f127';
 }
 
 i.icon.unmute:before {
-  content: "\f130";
+  content: '\f130';
 }
 
 i.icon.usd:before {
-  content: "\f155";
+  content: '\f155';
 }
 
 i.icon.user.cancel:before {
-  content: "\f235";
+  content: '\f235';
 }
 
 i.icon.user.close:before {
-  content: "\f235";
+  content: '\f235';
 }
 
 i.icon.user.delete:before {
-  content: "\f235";
+  content: '\f235';
 }
 
 i.icon.user.x:before {
-  content: "\f235";
+  content: '\f235';
 }
 
 i.icon.vcard:before {
-  content: "\f2bb";
+  content: '\f2bb';
 }
 
 i.icon.video.camera:before {
-  content: "\f03d";
+  content: '\f03d';
 }
 
 i.icon.video.play:before {
-  content: "\f144";
+  content: '\f144';
 }
 
 i.icon.visa.card:before {
-  content: "\f1f0";
+  content: '\f1f0';
 }
 
 i.icon.visa:before {
-  content: "\f1f0";
+  content: '\f1f0';
 }
 
 i.icon.volume.control.phone:before {
-  content: "\f2a0";
+  content: '\f2a0';
 }
 
 i.icon.wait:before {
-  content: "\f017";
+  content: '\f017';
 }
 
 i.icon.warning.circle:before {
-  content: "\f06a";
+  content: '\f06a';
 }
 
 i.icon.warning.sign:before {
-  content: "\f071";
+  content: '\f071';
 }
 
 i.icon.warning:before {
-  content: "\f12a";
+  content: '\f12a';
 }
 
 i.icon.wechat:before {
-  content: "\f1d7";
+  content: '\f1d7';
 }
 
 i.icon.wi-fi:before {
-  content: "\f1eb";
+  content: '\f1eb';
 }
 
 i.icon.wikipedia:before {
-  content: "\f266";
+  content: '\f266';
 }
 
 i.icon.winner:before {
-  content: "\f091";
+  content: '\f091';
 }
 
 i.icon.wizard:before {
-  content: "\f0d0";
+  content: '\f0d0';
 }
 
 i.icon.woman:before {
-  content: "\f221";
+  content: '\f221';
 }
 
 i.icon.won:before {
-  content: "\f159";
+  content: '\f159';
 }
 
 i.icon.wordpress.beginner:before {
-  content: "\f297";
+  content: '\f297';
 }
 
 i.icon.wordpress.forms:before {
-  content: "\f298";
+  content: '\f298';
 }
 
 i.icon.world:before {
-  content: "\f0ac";
+  content: '\f0ac';
 }
 
 i.icon.write.square:before {
-  content: "\f14b";
+  content: '\f14b';
 }
 
 i.icon.x:before {
-  content: "\f00d";
+  content: '\f00d';
 }
 
 i.icon.yc:before {
-  content: "\f23b";
+  content: '\f23b';
 }
 
 i.icon.ycombinator:before {
-  content: "\f23b";
+  content: '\f23b';
 }
 
 i.icon.yen:before {
-  content: "\f157";
+  content: '\f157';
 }
 
 i.icon.zip:before {
-  content: "\f187";
+  content: '\f187';
 }
 
 i.icon.zoom-in:before {
-  content: "\f00e";
+  content: '\f00e';
 }
 
 i.icon.zoom-out:before {
-  content: "\f010";
+  content: '\f010';
 }
 
 i.icon.zoom:before {
-  content: "\f00e";
+  content: '\f00e';
 }
 
 i.icon.bitbucket.square:before {
-  content: "\f171";
+  content: '\f171';
 }
 
 i.icon.checkmark.box:before {
-  content: "\f14a";
+  content: '\f14a';
 }
 
 i.icon.circle.thin:before {
-  content: "\f111";
+  content: '\f111';
 }
 
 i.icon.cloud.download:before {
-  content: "\f381";
+  content: '\f381';
 }
 
 i.icon.cloud.upload:before {
-  content: "\f382";
+  content: '\f382';
 }
 
 i.icon.compose:before {
-  content: "\f303";
+  content: '\f303';
 }
 
 i.icon.conversation:before {
-  content: "\f086";
+  content: '\f086';
 }
 
 i.icon.credit.card.alternative:before {
-  content: "\f09d";
+  content: '\f09d';
 }
 
 i.icon.currency:before {
-  content: "\f3d1";
+  content: '\f3d1';
 }
 
 i.icon.dashboard:before {
-  content: "\f3fd";
+  content: '\f3fd';
 }
 
 i.icon.diamond:before {
-  content: "\f3a5";
+  content: '\f3a5';
 }
 
 i.icon.disk:before {
-  content: "\f0a0";
+  content: '\f0a0';
 }
 
 i.icon.exchange:before {
-  content: "\f362";
+  content: '\f362';
 }
 
 i.icon.external.share:before {
-  content: "\f14d";
+  content: '\f14d';
 }
 
 i.icon.external.square:before {
-  content: "\f360";
+  content: '\f360';
 }
 
 i.icon.external:before {
-  content: "\f35d";
+  content: '\f35d';
 }
 
 i.icon.facebook.official:before {
-  content: "\f082";
+  content: '\f082';
 }
 
 i.icon.food:before {
-  content: "\f2e7";
+  content: '\f2e7';
 }
 
 i.icon.hourglass.zero:before {
-  content: "\f253";
+  content: '\f253';
 }
 
 i.icon.level.down:before {
-  content: "\f3be";
+  content: '\f3be';
 }
 
 i.icon.level.up:before {
-  content: "\f3bf";
+  content: '\f3bf';
 }
 
 i.icon.logout:before {
-  content: "\f2f5";
+  content: '\f2f5';
 }
 
 i.icon.meanpath:before {
-  content: "\f0c8";
+  content: '\f0c8';
 }
 
 i.icon.money:before {
-  content: "\f3d1";
+  content: '\f3d1';
 }
 
 i.icon.move:before {
-  content: "\f0b2";
+  content: '\f0b2';
 }
 
 i.icon.pencil:before {
-  content: "\f303";
+  content: '\f303';
 }
 
 i.icon.protect:before {
-  content: "\f023";
+  content: '\f023';
 }
 
 i.icon.radio:before {
-  content: "\f192";
+  content: '\f192';
 }
 
 i.icon.remove.bookmark:before {
-  content: "\f02e";
+  content: '\f02e';
 }
 
 i.icon.resize.horizontal:before {
-  content: "\f337";
+  content: '\f337';
 }
 
 i.icon.resize.vertical:before {
-  content: "\f338";
+  content: '\f338';
 }
 
 i.icon.sign-in:before {
-  content: "\f2f6";
+  content: '\f2f6';
 }
 
 i.icon.sign-out:before {
-  content: "\f2f5";
+  content: '\f2f5';
 }
 
 i.icon.spoon:before {
-  content: "\f2e5";
+  content: '\f2e5';
 }
 
 i.icon.star.half.empty:before {
-  content: "\f089";
+  content: '\f089';
 }
 
 i.icon.star.half.full:before {
-  content: "\f089";
+  content: '\f089';
 }
 
 i.icon.ticket:before {
-  content: "\f3ff";
+  content: '\f3ff';
 }
 
 i.icon.times.rectangle:before {
-  content: "\f410";
+  content: '\f410';
 }
 
 i.icon.write:before {
-  content: "\f303";
+  content: '\f303';
 }
 
 i.icon.youtube.play:before {
-  content: "\f167";
+  content: '\f167';
 }
 
 /*******************************
@@ -12947,8 +12975,13 @@ i.icon.youtube.play:before {
 
 @font-face {
   font-family: 'outline-icons';
-  src: url("./themes/default/assets/fonts/outline-icons.eot");
-  src: url("./themes/default/assets/fonts/outline-icons.eot?#iefix") format('embedded-opentype'), url("./themes/default/assets/fonts/outline-icons.woff2") format('woff2'), url("./themes/default/assets/fonts/outline-icons.woff") format('woff'), url("./themes/default/assets/fonts/outline-icons.ttf") format('truetype'), url("./themes/default/assets/fonts/outline-icons.svg#icons") format('svg');
+  src: url('./themes/default/assets/fonts/outline-icons.eot');
+  src: url('./themes/default/assets/fonts/outline-icons.eot?#iefix')
+      format('embedded-opentype'),
+    url('./themes/default/assets/fonts/outline-icons.woff2') format('woff2'),
+    url('./themes/default/assets/fonts/outline-icons.woff') format('woff'),
+    url('./themes/default/assets/fonts/outline-icons.ttf') format('truetype'),
+    url('./themes/default/assets/fonts/outline-icons.svg#icons') format('svg');
   font-style: normal;
   font-weight: normal;
   font-variant: normal;
@@ -12963,473 +12996,473 @@ i.icon.outline {
 /* Icon Definitions */
 
 i.icon.address.book.outline:before {
-  content: "\f2b9";
+  content: '\f2b9';
 }
 
 i.icon.address.card.outline:before {
-  content: "\f2bb";
+  content: '\f2bb';
 }
 
 i.icon.arrow.alternate.circle.down.outline:before {
-  content: "\f358";
+  content: '\f358';
 }
 
 i.icon.arrow.alternate.circle.left.outline:before {
-  content: "\f359";
+  content: '\f359';
 }
 
 i.icon.arrow.alternate.circle.right.outline:before {
-  content: "\f35a";
+  content: '\f35a';
 }
 
 i.icon.arrow.alternate.circle.up.outline:before {
-  content: "\f35b";
+  content: '\f35b';
 }
 
 i.icon.bell.outline:before {
-  content: "\f0f3";
+  content: '\f0f3';
 }
 
 i.icon.bell.slash.outline:before {
-  content: "\f1f6";
+  content: '\f1f6';
 }
 
 i.icon.bookmark.outline:before {
-  content: "\f02e";
+  content: '\f02e';
 }
 
 i.icon.building.outline:before {
-  content: "\f1ad";
+  content: '\f1ad';
 }
 
 i.icon.calendar.outline:before {
-  content: "\f133";
+  content: '\f133';
 }
 
 i.icon.calendar.alternate.outline:before {
-  content: "\f073";
+  content: '\f073';
 }
 
 i.icon.calendar.check.outline:before {
-  content: "\f274";
+  content: '\f274';
 }
 
 i.icon.calendar.minus.outline:before {
-  content: "\f272";
+  content: '\f272';
 }
 
 i.icon.calendar.plus.outline:before {
-  content: "\f271";
+  content: '\f271';
 }
 
 i.icon.calendar.times.outline:before {
-  content: "\f273";
+  content: '\f273';
 }
 
 i.icon.caret.square.down.outline:before {
-  content: "\f150";
+  content: '\f150';
 }
 
 i.icon.caret.square.left.outline:before {
-  content: "\f191";
+  content: '\f191';
 }
 
 i.icon.caret.square.right.outline:before {
-  content: "\f152";
+  content: '\f152';
 }
 
 i.icon.caret.square.up.outline:before {
-  content: "\f151";
+  content: '\f151';
 }
 
 i.icon.chart.bar.outline:before {
-  content: "\f080";
+  content: '\f080';
 }
 
 i.icon.check.circle.outline:before {
-  content: "\f058";
+  content: '\f058';
 }
 
 i.icon.check.square.outline:before {
-  content: "\f14a";
+  content: '\f14a';
 }
 
 i.icon.circle.outline:before {
-  content: "\f111";
+  content: '\f111';
 }
 
 i.icon.clipboard.outline:before {
-  content: "\f328";
+  content: '\f328';
 }
 
 i.icon.clock.outline:before {
-  content: "\f017";
+  content: '\f017';
 }
 
 i.icon.clone.outline:before {
-  content: "\f24d";
+  content: '\f24d';
 }
 
 i.icon.closed.captioning.outline:before {
-  content: "\f20a";
+  content: '\f20a';
 }
 
 i.icon.comment.outline:before {
-  content: "\f075";
+  content: '\f075';
 }
 
 i.icon.comment.alternate.outline:before {
-  content: "\f27a";
+  content: '\f27a';
 }
 
 i.icon.comments.outline:before {
-  content: "\f086";
+  content: '\f086';
 }
 
 i.icon.compass.outline:before {
-  content: "\f14e";
+  content: '\f14e';
 }
 
 i.icon.copy.outline:before {
-  content: "\f0c5";
+  content: '\f0c5';
 }
 
 i.icon.copyright.outline:before {
-  content: "\f1f9";
+  content: '\f1f9';
 }
 
 i.icon.credit.card.outline:before {
-  content: "\f09d";
+  content: '\f09d';
 }
 
 i.icon.dot.circle.outline:before {
-  content: "\f192";
+  content: '\f192';
 }
 
 i.icon.edit.outline:before {
-  content: "\f044";
+  content: '\f044';
 }
 
 i.icon.envelope.outline:before {
-  content: "\f0e0";
+  content: '\f0e0';
 }
 
 i.icon.envelope.open.outline:before {
-  content: "\f2b6";
+  content: '\f2b6';
 }
 
 i.icon.eye.slash.outline:before {
-  content: "\f070";
+  content: '\f070';
 }
 
 i.icon.file.outline:before {
-  content: "\f15b";
+  content: '\f15b';
 }
 
 i.icon.file.alternate.outline:before {
-  content: "\f15c";
+  content: '\f15c';
 }
 
 i.icon.file.archive.outline:before {
-  content: "\f1c6";
+  content: '\f1c6';
 }
 
 i.icon.file.audio.outline:before {
-  content: "\f1c7";
+  content: '\f1c7';
 }
 
 i.icon.file.code.outline:before {
-  content: "\f1c9";
+  content: '\f1c9';
 }
 
 i.icon.file.excel.outline:before {
-  content: "\f1c3";
+  content: '\f1c3';
 }
 
 i.icon.file.image.outline:before {
-  content: "\f1c5";
+  content: '\f1c5';
 }
 
 i.icon.file.pdf.outline:before {
-  content: "\f1c1";
+  content: '\f1c1';
 }
 
 i.icon.file.powerpoint.outline:before {
-  content: "\f1c4";
+  content: '\f1c4';
 }
 
 i.icon.file.video.outline:before {
-  content: "\f1c8";
+  content: '\f1c8';
 }
 
 i.icon.file.word.outline:before {
-  content: "\f1c2";
+  content: '\f1c2';
 }
 
 i.icon.flag.outline:before {
-  content: "\f024";
+  content: '\f024';
 }
 
 i.icon.folder.outline:before {
-  content: "\f07b";
+  content: '\f07b';
 }
 
 i.icon.folder.open.outline:before {
-  content: "\f07c";
+  content: '\f07c';
 }
 
 i.icon.frown.outline:before {
-  content: "\f119";
+  content: '\f119';
 }
 
 i.icon.futbol.outline:before {
-  content: "\f1e3";
+  content: '\f1e3';
 }
 
 i.icon.gem.outline:before {
-  content: "\f3a5";
+  content: '\f3a5';
 }
 
 i.icon.hand.lizard.outline:before {
-  content: "\f258";
+  content: '\f258';
 }
 
 i.icon.hand.paper.outline:before {
-  content: "\f256";
+  content: '\f256';
 }
 
 i.icon.hand.peace.outline:before {
-  content: "\f25b";
+  content: '\f25b';
 }
 
 i.icon.hand.point.down.outline:before {
-  content: "\f0a7";
+  content: '\f0a7';
 }
 
 i.icon.hand.point.left.outline:before {
-  content: "\f0a5";
+  content: '\f0a5';
 }
 
 i.icon.hand.point.right.outline:before {
-  content: "\f0a4";
+  content: '\f0a4';
 }
 
 i.icon.hand.point.up.outline:before {
-  content: "\f0a6";
+  content: '\f0a6';
 }
 
 i.icon.hand.pointer.outline:before {
-  content: "\f25a";
+  content: '\f25a';
 }
 
 i.icon.hand.rock.outline:before {
-  content: "\f255";
+  content: '\f255';
 }
 
 i.icon.hand.scissors.outline:before {
-  content: "\f257";
+  content: '\f257';
 }
 
 i.icon.hand.spock.outline:before {
-  content: "\f259";
+  content: '\f259';
 }
 
 i.icon.handshake.outline:before {
-  content: "\f2b5";
+  content: '\f2b5';
 }
 
 i.icon.hdd.outline:before {
-  content: "\f0a0";
+  content: '\f0a0';
 }
 
 i.icon.heart.outline:before {
-  content: "\f004";
+  content: '\f004';
 }
 
 i.icon.hospital.outline:before {
-  content: "\f0f8";
+  content: '\f0f8';
 }
 
 i.icon.hourglass.outline:before {
-  content: "\f254";
+  content: '\f254';
 }
 
 i.icon.id.badge.outline:before {
-  content: "\f2c1";
+  content: '\f2c1';
 }
 
 i.icon.id.card.outline:before {
-  content: "\f2c2";
+  content: '\f2c2';
 }
 
 i.icon.image.outline:before {
-  content: "\f03e";
+  content: '\f03e';
 }
 
 i.icon.images.outline:before {
-  content: "\f302";
+  content: '\f302';
 }
 
 i.icon.keyboard.outline:before {
-  content: "\f11c";
+  content: '\f11c';
 }
 
 i.icon.lemon.outline:before {
-  content: "\f094";
+  content: '\f094';
 }
 
 i.icon.life.ring.outline:before {
-  content: "\f1cd";
+  content: '\f1cd';
 }
 
 i.icon.lightbulb.outline:before {
-  content: "\f0eb";
+  content: '\f0eb';
 }
 
 i.icon.list.alternate.outline:before {
-  content: "\f022";
+  content: '\f022';
 }
 
 i.icon.map.outline:before {
-  content: "\f279";
+  content: '\f279';
 }
 
 i.icon.meh.outline:before {
-  content: "\f11a";
+  content: '\f11a';
 }
 
 i.icon.minus.square.outline:before {
-  content: "\f146";
+  content: '\f146';
 }
 
 i.icon.money.bill.alternate.outline:before {
-  content: "\f3d1";
+  content: '\f3d1';
 }
 
 i.icon.moon.outline:before {
-  content: "\f186";
+  content: '\f186';
 }
 
 i.icon.newspaper.outline:before {
-  content: "\f1ea";
+  content: '\f1ea';
 }
 
 i.icon.object.group.outline:before {
-  content: "\f247";
+  content: '\f247';
 }
 
 i.icon.object.ungroup.outline:before {
-  content: "\f248";
+  content: '\f248';
 }
 
 i.icon.paper.plane.outline:before {
-  content: "\f1d8";
+  content: '\f1d8';
 }
 
 i.icon.pause.circle.outline:before {
-  content: "\f28b";
+  content: '\f28b';
 }
 
 i.icon.play.circle.outline:before {
-  content: "\f144";
+  content: '\f144';
 }
 
 i.icon.plus.square.outline:before {
-  content: "\f0fe";
+  content: '\f0fe';
 }
 
 i.icon.question.circle.outline:before {
-  content: "\f059";
+  content: '\f059';
 }
 
 i.icon.registered.outline:before {
-  content: "\f25d";
+  content: '\f25d';
 }
 
 i.icon.save.outline:before {
-  content: "\f0c7";
+  content: '\f0c7';
 }
 
 i.icon.share.square.outline:before {
-  content: "\f14d";
+  content: '\f14d';
 }
 
 i.icon.smile.outline:before {
-  content: "\f118";
+  content: '\f118';
 }
 
 i.icon.snowflake.outline:before {
-  content: "\f2dc";
+  content: '\f2dc';
 }
 
 i.icon.square.outline:before {
-  content: "\f0c8";
+  content: '\f0c8';
 }
 
 i.icon.star.outline:before {
-  content: "\f005";
+  content: '\f005';
 }
 
 i.icon.star.half.outline:before {
-  content: "\f089";
+  content: '\f089';
 }
 
 i.icon.sticky.note.outline:before {
-  content: "\f249";
+  content: '\f249';
 }
 
 i.icon.stop.circle.outline:before {
-  content: "\f28d";
+  content: '\f28d';
 }
 
 i.icon.sun.outline:before {
-  content: "\f185";
+  content: '\f185';
 }
 
 i.icon.thumbs.down.outline:before {
-  content: "\f165";
+  content: '\f165';
 }
 
 i.icon.thumbs.up.outline:before {
-  content: "\f164";
+  content: '\f164';
 }
 
 i.icon.times.circle.outline:before {
-  content: "\f057";
+  content: '\f057';
 }
 
 i.icon.trash.alternate.outline:before {
-  content: "\f2ed";
+  content: '\f2ed';
 }
 
 i.icon.user.outline:before {
-  content: "\f007";
+  content: '\f007';
 }
 
 i.icon.user.circle.outline:before {
-  content: "\f2bd";
+  content: '\f2bd';
 }
 
 i.icon.window.close.outline:before {
-  content: "\f410";
+  content: '\f410';
 }
 
 i.icon.window.maximize.outline:before {
-  content: "\f2d0";
+  content: '\f2d0';
 }
 
 i.icon.window.minimize.outline:before {
-  content: "\f2d1";
+  content: '\f2d1';
 }
 
 i.icon.window.restore.outline:before {
-  content: "\f2d2";
+  content: '\f2d2';
 }
 
 /* Outline Aliases */
 
 i.icon.disk.outline:before {
-  content: "\f0a0";
+  content: '\f0a0';
 }
 
 i.icon.heart.empty,
@@ -13438,11 +13471,11 @@ i.icon.star.empty {
 }
 
 i.icon.heart.empty:before {
-  content: "\f004";
+  content: '\f004';
 }
 
 i.icon.star.empty:before {
-  content: "\f089";
+  content: '\f089';
 }
 
 /*******************************
@@ -13453,8 +13486,13 @@ i.icon.star.empty:before {
 
 @font-face {
   font-family: 'brand-icons';
-  src: url("./themes/default/assets/fonts/brand-icons.eot");
-  src: url("./themes/default/assets/fonts/brand-icons.eot?#iefix") format('embedded-opentype'), url("./themes/default/assets/fonts/brand-icons.woff2") format('woff2'), url("./themes/default/assets/fonts/brand-icons.woff") format('woff'), url("./themes/default/assets/fonts/brand-icons.ttf") format('truetype'), url("./themes/default/assets/fonts/brand-icons.svg#icons") format('svg');
+  src: url('./themes/default/assets/fonts/brand-icons.eot');
+  src: url('./themes/default/assets/fonts/brand-icons.eot?#iefix')
+      format('embedded-opentype'),
+    url('./themes/default/assets/fonts/brand-icons.woff2') format('woff2'),
+    url('./themes/default/assets/fonts/brand-icons.woff') format('woff'),
+    url('./themes/default/assets/fonts/brand-icons.ttf') format('truetype'),
+    url('./themes/default/assets/fonts/brand-icons.svg#icons') format('svg');
   font-style: normal;
   font-weight: normal;
   font-variant: normal;
@@ -13987,12 +14025,12 @@ img.ui.bordered.image {
   margin-right: 0.5em;
 }
 
-.ui[class*="left spaced"].image {
+.ui[class*='left spaced'].image {
   margin-left: 0.5em;
   margin-right: 0em;
 }
 
-.ui[class*="right spaced"].image {
+.ui[class*='right spaced'].image {
   margin-left: 0em;
   margin-right: 0.5em;
 }
@@ -14166,14 +14204,15 @@ img.ui.bordered.image {
   line-height: 1.21428571em;
   font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
   padding: 0.67857143em 1em;
-  background: #FFFFFF;
+  background: #ffffff;
   border: 1px solid rgba(34, 36, 38, 0.15);
   color: rgba(0, 0, 0, 0.87);
   border-radius: 0.28571429rem;
   -webkit-transition: border-color 0.1s ease, -webkit-box-shadow 0.1s ease;
   transition: border-color 0.1s ease, -webkit-box-shadow 0.1s ease;
   transition: box-shadow 0.1s ease, border-color 0.1s ease;
-  transition: box-shadow 0.1s ease, border-color 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: box-shadow 0.1s ease, border-color 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
   -webkit-box-shadow: none;
   box-shadow: none;
 }
@@ -14221,7 +14260,7 @@ img.ui.bordered.image {
 .ui.input > input:active,
 .ui.input.down input {
   border-color: rgba(0, 0, 0, 0.3);
-  background: #FAFAFA;
+  background: #fafafa;
   color: rgba(0, 0, 0, 0.87);
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -14269,8 +14308,8 @@ img.ui.bordered.image {
 
 .ui.input.focus > input,
 .ui.input > input:focus {
-  border-color: #85B7D9;
-  background: #FFFFFF;
+  border-color: #85b7d9;
+  background: #ffffff;
   color: rgba(0, 0, 0, 0.8);
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -14296,9 +14335,9 @@ img.ui.bordered.image {
 ---------------------*/
 
 .ui.input.error > input {
-  background-color: #FFF6F6;
-  border-color: #E0B4B4;
-  color: #9F3A38;
+  background-color: #fff6f6;
+  border-color: #e0b4b4;
+  color: #9f3a38;
   -webkit-box-shadow: none;
   box-shadow: none;
 }
@@ -14359,7 +14398,7 @@ img.ui.bordered.image {
   padding-right: 2em !important;
 }
 
-.ui.transparent[class*="left icon"].input > input {
+.ui.transparent[class*='left icon'].input > input {
   padding-left: 2em !important;
   padding-right: 0em !important;
 }
@@ -14367,7 +14406,7 @@ img.ui.bordered.image {
 /* Transparent Inverted */
 
 .ui.transparent.inverted.input {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.transparent.inverted.input > input {
@@ -14435,18 +14474,18 @@ img.ui.bordered.image {
 
 /* Left Icon Input */
 
-.ui[class*="left icon"].input > i.icon {
+.ui[class*='left icon'].input > i.icon {
   right: auto;
   left: 1px;
   border-radius: 0.28571429rem 0em 0em 0.28571429rem;
 }
 
-.ui[class*="left icon"].input > i.circular.icon {
+.ui[class*='left icon'].input > i.circular.icon {
   right: auto;
   left: 0.5em;
 }
 
-.ui[class*="left icon"].input > input {
+.ui[class*='left icon'].input > input {
   padding-left: 2.67142857em !important;
   padding-right: 1em !important;
 }
@@ -14478,36 +14517,38 @@ img.ui.bordered.image {
 
 /* Regular Label on Left */
 
-.ui.labeled.input:not([class*="corner labeled"]) .label:first-child {
+.ui.labeled.input:not([class*='corner labeled']) .label:first-child {
   border-top-right-radius: 0px;
   border-bottom-right-radius: 0px;
 }
 
-.ui.labeled.input:not([class*="corner labeled"]) .label:first-child + input {
+.ui.labeled.input:not([class*='corner labeled']) .label:first-child + input {
   border-top-left-radius: 0px;
   border-bottom-left-radius: 0px;
   border-left-color: transparent;
 }
 
-.ui.labeled.input:not([class*="corner labeled"]) .label:first-child + input:focus {
-  border-left-color: #85B7D9;
+.ui.labeled.input:not([class*='corner labeled'])
+  .label:first-child
+  + input:focus {
+  border-left-color: #85b7d9;
 }
 
 /* Regular Label on Right */
 
-.ui[class*="right labeled"].input > input {
+.ui[class*='right labeled'].input > input {
   border-top-right-radius: 0px !important;
   border-bottom-right-radius: 0px !important;
   border-right-color: transparent !important;
 }
 
-.ui[class*="right labeled"].input > input + .label {
+.ui[class*='right labeled'].input > input + .label {
   border-top-left-radius: 0px;
   border-bottom-left-radius: 0px;
 }
 
-.ui[class*="right labeled"].input > input:focus {
-  border-right-color: #85B7D9 !important;
+.ui[class*='right labeled'].input > input:focus {
+  border-right-color: #85b7d9 !important;
 }
 
 /* Corner Label */
@@ -14521,29 +14562,32 @@ img.ui.bordered.image {
 
 /* Spacing with corner label */
 
-.ui[class*="corner labeled"]:not([class*="left corner labeled"]).labeled.input > input {
+.ui[class*='corner labeled']:not([class*='left corner labeled']).labeled.input
+  > input {
   padding-right: 2.5em !important;
 }
 
-.ui[class*="corner labeled"].icon.input:not([class*="left corner labeled"]) > input {
+.ui[class*='corner labeled'].icon.input:not([class*='left corner labeled'])
+  > input {
   padding-right: 3.25em !important;
 }
 
-.ui[class*="corner labeled"].icon.input:not([class*="left corner labeled"]) > .icon {
+.ui[class*='corner labeled'].icon.input:not([class*='left corner labeled'])
+  > .icon {
   margin-right: 1.25em;
 }
 
 /* Left Labeled */
 
-.ui[class*="left corner labeled"].labeled.input > input {
+.ui[class*='left corner labeled'].labeled.input > input {
   padding-left: 2.5em !important;
 }
 
-.ui[class*="left corner labeled"].icon.input > input {
+.ui[class*='left corner labeled'].icon.input > input {
   padding-left: 3.25em !important;
 }
 
-.ui[class*="left corner labeled"].icon.input > .icon {
+.ui[class*='left corner labeled'].icon.input > .icon {
   margin-left: 1.25em;
 }
 
@@ -14585,54 +14629,56 @@ img.ui.bordered.image {
 
 /* Button on Right */
 
-.ui.action.input:not([class*="left action"]) > input {
+.ui.action.input:not([class*='left action']) > input {
   border-top-right-radius: 0px !important;
   border-bottom-right-radius: 0px !important;
   border-right-color: transparent !important;
 }
 
-.ui.action.input:not([class*="left action"]) > .dropdown:not(:first-child),
-.ui.action.input:not([class*="left action"]) > .button:not(:first-child),
-.ui.action.input:not([class*="left action"]) > .buttons:not(:first-child) > .button {
+.ui.action.input:not([class*='left action']) > .dropdown:not(:first-child),
+.ui.action.input:not([class*='left action']) > .button:not(:first-child),
+.ui.action.input:not([class*='left action'])
+  > .buttons:not(:first-child)
+  > .button {
   border-radius: 0px;
 }
 
-.ui.action.input:not([class*="left action"]) > .dropdown:last-child,
-.ui.action.input:not([class*="left action"]) > .button:last-child,
-.ui.action.input:not([class*="left action"]) > .buttons:last-child > .button {
+.ui.action.input:not([class*='left action']) > .dropdown:last-child,
+.ui.action.input:not([class*='left action']) > .button:last-child,
+.ui.action.input:not([class*='left action']) > .buttons:last-child > .button {
   border-radius: 0px 0.28571429rem 0.28571429rem 0px;
 }
 
 /* Input Focus */
 
-.ui.action.input:not([class*="left action"]) > input:focus {
-  border-right-color: #85B7D9 !important;
+.ui.action.input:not([class*='left action']) > input:focus {
+  border-right-color: #85b7d9 !important;
 }
 
 /* Button on Left */
 
-.ui[class*="left action"].input > input {
+.ui[class*='left action'].input > input {
   border-top-left-radius: 0px !important;
   border-bottom-left-radius: 0px !important;
   border-left-color: transparent !important;
 }
 
-.ui[class*="left action"].input > .dropdown,
-.ui[class*="left action"].input > .button,
-.ui[class*="left action"].input > .buttons > .button {
+.ui[class*='left action'].input > .dropdown,
+.ui[class*='left action'].input > .button,
+.ui[class*='left action'].input > .buttons > .button {
   border-radius: 0px;
 }
 
-.ui[class*="left action"].input > .dropdown:first-child,
-.ui[class*="left action"].input > .button:first-child,
-.ui[class*="left action"].input > .buttons:first-child > .button {
+.ui[class*='left action'].input > .dropdown:first-child,
+.ui[class*='left action'].input > .button:first-child,
+.ui[class*='left action'].input > .buttons:first-child > .button {
   border-radius: 0.28571429rem 0px 0px 0.28571429rem;
 }
 
 /* Input Focus */
 
-.ui[class*="left action"].input > input:focus {
-  border-left-color: #85B7D9 !important;
+.ui[class*='left action'].input > input:focus {
+  border-left-color: #85b7d9 !important;
 }
 
 /*--------------------
@@ -14717,7 +14763,7 @@ img.ui.bordered.image {
   line-height: 1;
   vertical-align: baseline;
   margin: 0em 0.14285714em;
-  background-color: #E8E8E8;
+  background-color: #e8e8e8;
   background-image: none;
   padding: 0.5833em 0.833em;
   color: rgba(0, 0, 0, 0.6);
@@ -14842,7 +14888,7 @@ a.ui.label {
 /* Padding on next content after a label */
 
 .ui.top.attached.label:first-child + :not(.attached),
-.ui.top.attached.label + [class*="right floated"] + * {
+.ui.top.attached.label + [class*='right floated'] + * {
   margin-top: 2rem !important;
 }
 
@@ -14862,7 +14908,7 @@ a.ui.label {
   max-width: 9999px;
   vertical-align: baseline;
   text-transform: none;
-  background: #E8E8E8;
+  background: #e8e8e8;
   padding: 0.5833em 0.833em 0.5833em 0.5em;
   border-radius: 0.28571429rem;
   -webkit-box-shadow: none;
@@ -14922,7 +14968,7 @@ a.ui.label {
   top: 50%;
   left: -0.25em;
   margin-top: -0.25em;
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   width: 0.5em;
   height: 0.5em;
   -webkit-box-shadow: 0 -1px 1px 0 rgba(0, 0, 0, 0.3);
@@ -14941,7 +14987,7 @@ a.ui.label {
   margin: 0em;
   padding: 0em;
   text-align: center;
-  border-color: #E8E8E8;
+  border-color: #e8e8e8;
   width: 4em;
   height: 4em;
   z-index: 1;
@@ -14957,7 +15003,7 @@ a.ui.label {
 
 .ui.corner.label:after {
   position: absolute;
-  content: "";
+  content: '';
   right: 0em;
   top: 0em;
   z-index: -1;
@@ -15051,7 +15097,7 @@ a.ui.label {
   padding-right: 1.2em;
 }
 
-.ui[class*="right ribbon"].label {
+.ui[class*='right ribbon'].label {
   left: calc(100% + 1rem + 1.2em);
   padding-left: 1.2em;
   padding-right: calc(1rem + 1.2em);
@@ -15059,14 +15105,14 @@ a.ui.label {
 
 /* Right Ribbon */
 
-.ui[class*="right ribbon"].label {
+.ui[class*='right ribbon'].label {
   text-align: left;
   -webkit-transform: translateX(-100%);
   transform: translateX(-100%);
   border-radius: 0.28571429rem 0em 0em 0.28571429rem;
 }
 
-.ui[class*="right ribbon"].label:after {
+.ui[class*='right ribbon'].label:after {
   left: auto;
   right: 0%;
   border-style: solid;
@@ -15088,8 +15134,8 @@ a.ui.label {
   left: calc(--0.05rem - 1.2em);
 }
 
-.ui.card .image > .ui[class*="right ribbon"].label,
-.ui.image > .ui[class*="right ribbon"].label {
+.ui.card .image > .ui[class*='right ribbon'].label,
+.ui.image > .ui[class*='right ribbon'].label {
   left: calc(100% + -0.05rem + 1.2em);
   padding-left: 0.833em;
 }
@@ -15100,7 +15146,7 @@ a.ui.label {
   left: calc(-0.78571429em - 1.2em);
 }
 
-.ui.table td > .ui[class*="right ribbon"].label {
+.ui.table td > .ui[class*='right ribbon'].label {
   left: calc(100% + 0.78571429em + 1.2em);
   padding-left: 0.833em;
 }
@@ -15109,7 +15155,7 @@ a.ui.label {
       Attached
 --------------------*/
 
-.ui[class*="top attached"].label,
+.ui[class*='top attached'].label,
 .ui.attached.label {
   width: 100%;
   position: absolute;
@@ -15120,33 +15166,33 @@ a.ui.label {
   border-radius: 0.21428571rem 0.21428571rem 0em 0em;
 }
 
-.ui[class*="bottom attached"].label {
+.ui[class*='bottom attached'].label {
   top: auto;
   bottom: 0em;
   border-radius: 0em 0em 0.21428571rem 0.21428571rem;
 }
 
-.ui[class*="top left attached"].label {
+.ui[class*='top left attached'].label {
   width: auto;
   margin-top: 0em !important;
   border-radius: 0.21428571rem 0em 0.28571429rem 0em;
 }
 
-.ui[class*="top right attached"].label {
+.ui[class*='top right attached'].label {
   width: auto;
   left: auto;
   right: 0em;
   border-radius: 0em 0.21428571rem 0em 0.28571429rem;
 }
 
-.ui[class*="bottom left attached"].label {
+.ui[class*='bottom left attached'].label {
   width: auto;
   top: auto;
   bottom: 0em;
   border-radius: 0em 0.28571429rem 0em 0.21428571rem;
 }
 
-.ui[class*="bottom right attached"].label {
+.ui[class*='bottom right attached'].label {
   top: auto;
   bottom: 0em;
   left: auto;
@@ -15173,8 +15219,8 @@ a.ui.label {
 
 a.ui.labels .label:hover,
 a.ui.label:hover {
-  background-color: #E0E0E0;
-  border-color: #E0E0E0;
+  background-color: #e0e0e0;
+  border-color: #e0e0e0;
   background-image: none;
   color: rgba(0, 0, 0, 0.8);
 }
@@ -15189,14 +15235,14 @@ a.ui.label:hover:before {
 --------------------*/
 
 .ui.active.label {
-  background-color: #D0D0D0;
-  border-color: #D0D0D0;
+  background-color: #d0d0d0;
+  border-color: #d0d0d0;
   background-image: none;
   color: rgba(0, 0, 0, 0.95);
 }
 
 .ui.active.label:before {
-  background-color: #D0D0D0;
+  background-color: #d0d0d0;
   background-image: none;
   color: rgba(0, 0, 0, 0.95);
 }
@@ -15207,15 +15253,15 @@ a.ui.label:hover:before {
 
 a.ui.labels .active.label:hover,
 a.ui.active.label:hover {
-  background-color: #C8C8C8;
-  border-color: #C8C8C8;
+  background-color: #c8c8c8;
+  border-color: #c8c8c8;
   background-image: none;
   color: rgba(0, 0, 0, 0.95);
 }
 
-.ui.labels a.active.label:ActiveHover:before,
-a.ui.active.label:ActiveHover:before {
-  background-color: #C8C8C8;
+.ui.labels a.active.label:activehover:before,
+a.ui.active.label:activehover:before {
+  background-color: #c8c8c8;
   background-image: none;
   color: rgba(0, 0, 0, 0.95);
 }
@@ -15250,9 +15296,9 @@ a.ui.active.label:ActiveHover:before {
 
 .ui.red.labels .label,
 .ui.red.label {
-  background-color: #DB2828 !important;
-  border-color: #DB2828 !important;
-  color: #FFFFFF !important;
+  background-color: #db2828 !important;
+  border-color: #db2828 !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15261,7 +15307,7 @@ a.ui.active.label:ActiveHover:before {
 a.ui.red.label:hover {
   background-color: #d01919 !important;
   border-color: #d01919 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15280,14 +15326,14 @@ a.ui.red.label:hover {
 /* Basic */
 
 .ui.basic.red.label {
-  background: none #FFFFFF !important;
-  color: #DB2828 !important;
-  border-color: #DB2828 !important;
+  background: none #ffffff !important;
+  color: #db2828 !important;
+  border-color: #db2828 !important;
 }
 
 .ui.basic.red.labels a.label:hover,
 a.ui.basic.red.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #d01919 !important;
   border-color: #d01919 !important;
 }
@@ -15296,9 +15342,9 @@ a.ui.basic.red.label:hover {
 
 .ui.orange.labels .label,
 .ui.orange.label {
-  background-color: #F2711C !important;
-  border-color: #F2711C !important;
-  color: #FFFFFF !important;
+  background-color: #f2711c !important;
+  border-color: #f2711c !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15307,7 +15353,7 @@ a.ui.basic.red.label:hover {
 a.ui.orange.label:hover {
   background-color: #f26202 !important;
   border-color: #f26202 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15326,14 +15372,14 @@ a.ui.orange.label:hover {
 /* Basic */
 
 .ui.basic.orange.label {
-  background: none #FFFFFF !important;
-  color: #F2711C !important;
-  border-color: #F2711C !important;
+  background: none #ffffff !important;
+  color: #f2711c !important;
+  border-color: #f2711c !important;
 }
 
 .ui.basic.orange.labels a.label:hover,
 a.ui.basic.orange.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #f26202 !important;
   border-color: #f26202 !important;
 }
@@ -15342,9 +15388,9 @@ a.ui.basic.orange.label:hover {
 
 .ui.yellow.labels .label,
 .ui.yellow.label {
-  background-color: #FBBD08 !important;
-  border-color: #FBBD08 !important;
-  color: #FFFFFF !important;
+  background-color: #fbbd08 !important;
+  border-color: #fbbd08 !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15353,7 +15399,7 @@ a.ui.basic.orange.label:hover {
 a.ui.yellow.label:hover {
   background-color: #eaae00 !important;
   border-color: #eaae00 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15372,14 +15418,14 @@ a.ui.yellow.label:hover {
 /* Basic */
 
 .ui.basic.yellow.label {
-  background: none #FFFFFF !important;
-  color: #FBBD08 !important;
-  border-color: #FBBD08 !important;
+  background: none #ffffff !important;
+  color: #fbbd08 !important;
+  border-color: #fbbd08 !important;
 }
 
 .ui.basic.yellow.labels a.label:hover,
 a.ui.basic.yellow.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #eaae00 !important;
   border-color: #eaae00 !important;
 }
@@ -15388,9 +15434,9 @@ a.ui.basic.yellow.label:hover {
 
 .ui.olive.labels .label,
 .ui.olive.label {
-  background-color: #B5CC18 !important;
-  border-color: #B5CC18 !important;
-  color: #FFFFFF !important;
+  background-color: #b5cc18 !important;
+  border-color: #b5cc18 !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15399,7 +15445,7 @@ a.ui.basic.yellow.label:hover {
 a.ui.olive.label:hover {
   background-color: #a7bd0d !important;
   border-color: #a7bd0d !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15418,14 +15464,14 @@ a.ui.olive.label:hover {
 /* Basic */
 
 .ui.basic.olive.label {
-  background: none #FFFFFF !important;
-  color: #B5CC18 !important;
-  border-color: #B5CC18 !important;
+  background: none #ffffff !important;
+  color: #b5cc18 !important;
+  border-color: #b5cc18 !important;
 }
 
 .ui.basic.olive.labels a.label:hover,
 a.ui.basic.olive.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #a7bd0d !important;
   border-color: #a7bd0d !important;
 }
@@ -15434,9 +15480,9 @@ a.ui.basic.olive.label:hover {
 
 .ui.green.labels .label,
 .ui.green.label {
-  background-color: #21BA45 !important;
-  border-color: #21BA45 !important;
-  color: #FFFFFF !important;
+  background-color: #21ba45 !important;
+  border-color: #21ba45 !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15445,7 +15491,7 @@ a.ui.basic.olive.label:hover {
 a.ui.green.label:hover {
   background-color: #16ab39 !important;
   border-color: #16ab39 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15464,14 +15510,14 @@ a.ui.green.label:hover {
 /* Basic */
 
 .ui.basic.green.label {
-  background: none #FFFFFF !important;
-  color: #21BA45 !important;
-  border-color: #21BA45 !important;
+  background: none #ffffff !important;
+  color: #21ba45 !important;
+  border-color: #21ba45 !important;
 }
 
 .ui.basic.green.labels a.label:hover,
 a.ui.basic.green.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #16ab39 !important;
   border-color: #16ab39 !important;
 }
@@ -15480,9 +15526,9 @@ a.ui.basic.green.label:hover {
 
 .ui.teal.labels .label,
 .ui.teal.label {
-  background-color: #00B5AD !important;
-  border-color: #00B5AD !important;
-  color: #FFFFFF !important;
+  background-color: #00b5ad !important;
+  border-color: #00b5ad !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15491,7 +15537,7 @@ a.ui.basic.green.label:hover {
 a.ui.teal.label:hover {
   background-color: #009c95 !important;
   border-color: #009c95 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15510,14 +15556,14 @@ a.ui.teal.label:hover {
 /* Basic */
 
 .ui.basic.teal.label {
-  background: none #FFFFFF !important;
-  color: #00B5AD !important;
-  border-color: #00B5AD !important;
+  background: none #ffffff !important;
+  color: #00b5ad !important;
+  border-color: #00b5ad !important;
 }
 
 .ui.basic.teal.labels a.label:hover,
 a.ui.basic.teal.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #009c95 !important;
   border-color: #009c95 !important;
 }
@@ -15526,9 +15572,9 @@ a.ui.basic.teal.label:hover {
 
 .ui.blue.labels .label,
 .ui.blue.label {
-  background-color: #2185D0 !important;
-  border-color: #2185D0 !important;
-  color: #FFFFFF !important;
+  background-color: #2185d0 !important;
+  border-color: #2185d0 !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15537,7 +15583,7 @@ a.ui.basic.teal.label:hover {
 a.ui.blue.label:hover {
   background-color: #1678c2 !important;
   border-color: #1678c2 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15556,14 +15602,14 @@ a.ui.blue.label:hover {
 /* Basic */
 
 .ui.basic.blue.label {
-  background: none #FFFFFF !important;
-  color: #2185D0 !important;
-  border-color: #2185D0 !important;
+  background: none #ffffff !important;
+  color: #2185d0 !important;
+  border-color: #2185d0 !important;
 }
 
 .ui.basic.blue.labels a.label:hover,
 a.ui.basic.blue.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #1678c2 !important;
   border-color: #1678c2 !important;
 }
@@ -15572,9 +15618,9 @@ a.ui.basic.blue.label:hover {
 
 .ui.violet.labels .label,
 .ui.violet.label {
-  background-color: #6435C9 !important;
-  border-color: #6435C9 !important;
-  color: #FFFFFF !important;
+  background-color: #6435c9 !important;
+  border-color: #6435c9 !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15583,7 +15629,7 @@ a.ui.basic.blue.label:hover {
 a.ui.violet.label:hover {
   background-color: #5829bb !important;
   border-color: #5829bb !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15602,14 +15648,14 @@ a.ui.violet.label:hover {
 /* Basic */
 
 .ui.basic.violet.label {
-  background: none #FFFFFF !important;
-  color: #6435C9 !important;
-  border-color: #6435C9 !important;
+  background: none #ffffff !important;
+  color: #6435c9 !important;
+  border-color: #6435c9 !important;
 }
 
 .ui.basic.violet.labels a.label:hover,
 a.ui.basic.violet.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #5829bb !important;
   border-color: #5829bb !important;
 }
@@ -15618,9 +15664,9 @@ a.ui.basic.violet.label:hover {
 
 .ui.purple.labels .label,
 .ui.purple.label {
-  background-color: #A333C8 !important;
-  border-color: #A333C8 !important;
-  color: #FFFFFF !important;
+  background-color: #a333c8 !important;
+  border-color: #a333c8 !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15629,7 +15675,7 @@ a.ui.basic.violet.label:hover {
 a.ui.purple.label:hover {
   background-color: #9627ba !important;
   border-color: #9627ba !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15648,14 +15694,14 @@ a.ui.purple.label:hover {
 /* Basic */
 
 .ui.basic.purple.label {
-  background: none #FFFFFF !important;
-  color: #A333C8 !important;
-  border-color: #A333C8 !important;
+  background: none #ffffff !important;
+  color: #a333c8 !important;
+  border-color: #a333c8 !important;
 }
 
 .ui.basic.purple.labels a.label:hover,
 a.ui.basic.purple.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #9627ba !important;
   border-color: #9627ba !important;
 }
@@ -15664,9 +15710,9 @@ a.ui.basic.purple.label:hover {
 
 .ui.pink.labels .label,
 .ui.pink.label {
-  background-color: #E03997 !important;
-  border-color: #E03997 !important;
-  color: #FFFFFF !important;
+  background-color: #e03997 !important;
+  border-color: #e03997 !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15675,7 +15721,7 @@ a.ui.basic.purple.label:hover {
 a.ui.pink.label:hover {
   background-color: #e61a8d !important;
   border-color: #e61a8d !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15694,14 +15740,14 @@ a.ui.pink.label:hover {
 /* Basic */
 
 .ui.basic.pink.label {
-  background: none #FFFFFF !important;
-  color: #E03997 !important;
-  border-color: #E03997 !important;
+  background: none #ffffff !important;
+  color: #e03997 !important;
+  border-color: #e03997 !important;
 }
 
 .ui.basic.pink.labels a.label:hover,
 a.ui.basic.pink.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #e61a8d !important;
   border-color: #e61a8d !important;
 }
@@ -15710,9 +15756,9 @@ a.ui.basic.pink.label:hover {
 
 .ui.brown.labels .label,
 .ui.brown.label {
-  background-color: #A5673F !important;
-  border-color: #A5673F !important;
-  color: #FFFFFF !important;
+  background-color: #a5673f !important;
+  border-color: #a5673f !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15721,7 +15767,7 @@ a.ui.basic.pink.label:hover {
 a.ui.brown.label:hover {
   background-color: #975b33 !important;
   border-color: #975b33 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15740,14 +15786,14 @@ a.ui.brown.label:hover {
 /* Basic */
 
 .ui.basic.brown.label {
-  background: none #FFFFFF !important;
-  color: #A5673F !important;
-  border-color: #A5673F !important;
+  background: none #ffffff !important;
+  color: #a5673f !important;
+  border-color: #a5673f !important;
 }
 
 .ui.basic.brown.labels a.label:hover,
 a.ui.basic.brown.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #975b33 !important;
   border-color: #975b33 !important;
 }
@@ -15758,7 +15804,7 @@ a.ui.basic.brown.label:hover {
 .ui.grey.label {
   background-color: #767676 !important;
   border-color: #767676 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15767,7 +15813,7 @@ a.ui.basic.brown.label:hover {
 a.ui.grey.label:hover {
   background-color: #838383 !important;
   border-color: #838383 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15786,14 +15832,14 @@ a.ui.grey.label:hover {
 /* Basic */
 
 .ui.basic.grey.label {
-  background: none #FFFFFF !important;
+  background: none #ffffff !important;
   color: #767676 !important;
   border-color: #767676 !important;
 }
 
 .ui.basic.grey.labels a.label:hover,
 a.ui.basic.grey.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #838383 !important;
   border-color: #838383 !important;
 }
@@ -15802,9 +15848,9 @@ a.ui.basic.grey.label:hover {
 
 .ui.black.labels .label,
 .ui.black.label {
-  background-color: #1B1C1D !important;
-  border-color: #1B1C1D !important;
-  color: #FFFFFF !important;
+  background-color: #1b1c1d !important;
+  border-color: #1b1c1d !important;
+  color: #ffffff !important;
 }
 
 /* Link */
@@ -15813,7 +15859,7 @@ a.ui.basic.grey.label:hover {
 a.ui.black.label:hover {
   background-color: #27292a !important;
   border-color: #27292a !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Corner */
@@ -15832,14 +15878,14 @@ a.ui.black.label:hover {
 /* Basic */
 
 .ui.basic.black.label {
-  background: none #FFFFFF !important;
-  color: #1B1C1D !important;
-  border-color: #1B1C1D !important;
+  background: none #ffffff !important;
+  color: #1b1c1d !important;
+  border-color: #1b1c1d !important;
 }
 
 .ui.basic.black.labels a.label:hover,
 a.ui.basic.black.label:hover {
-  background-color: #FFFFFF !important;
+  background-color: #ffffff !important;
   color: #27292a !important;
   border-color: #27292a !important;
 }
@@ -15849,7 +15895,7 @@ a.ui.basic.black.label:hover {
 --------------------*/
 
 .ui.basic.label {
-  background: none #FFFFFF;
+  background: none #ffffff;
   border: 1px solid rgba(34, 36, 38, 0.15);
   color: rgba(0, 0, 0, 0.87);
   -webkit-box-shadow: none;
@@ -15860,7 +15906,7 @@ a.ui.basic.black.label:hover {
 
 a.ui.basic.label:hover {
   text-decoration: none;
-  background: none #FFFFFF;
+  background: none #ffffff;
   color: #1e70bf;
   -webkit-box-shadow: 1px solid rgba(34, 36, 38, 0.15);
   box-shadow: 1px solid rgba(34, 36, 38, 0.15);
@@ -15968,12 +16014,12 @@ a.ui.basic.label:hover {
 /*--- Above ---*/
 
 .ui.pointing.label,
-.ui[class*="pointing above"].label {
+.ui[class*='pointing above'].label {
   margin-top: 1em;
 }
 
 .ui.pointing.label:before,
-.ui[class*="pointing above"].label:before {
+.ui[class*='pointing above'].label:before {
   border-width: 1px 0px 0px 1px;
   -webkit-transform: translateX(-50%) translateY(-50%) rotate(45deg);
   transform: translateX(-50%) translateY(-50%) rotate(45deg);
@@ -15983,14 +16029,14 @@ a.ui.basic.label:hover {
 
 /*--- Below ---*/
 
-.ui[class*="bottom pointing"].label,
-.ui[class*="pointing below"].label {
+.ui[class*='bottom pointing'].label,
+.ui[class*='pointing below'].label {
   margin-top: 0em;
   margin-bottom: 1em;
 }
 
-.ui[class*="bottom pointing"].label:before,
-.ui[class*="pointing below"].label:before {
+.ui[class*='bottom pointing'].label:before,
+.ui[class*='pointing below'].label:before {
   border-width: 0px 1px 1px 0px;
   top: auto;
   right: auto;
@@ -16002,12 +16048,12 @@ a.ui.basic.label:hover {
 
 /*--- Left ---*/
 
-.ui[class*="left pointing"].label {
+.ui[class*='left pointing'].label {
   margin-top: 0em;
   margin-left: 0.6666em;
 }
 
-.ui[class*="left pointing"].label:before {
+.ui[class*='left pointing'].label:before {
   border-width: 0px 0px 1px 1px;
   -webkit-transform: translateX(-50%) translateY(-50%) rotate(45deg);
   transform: translateX(-50%) translateY(-50%) rotate(45deg);
@@ -16019,12 +16065,12 @@ a.ui.basic.label:hover {
 
 /*--- Right ---*/
 
-.ui[class*="right pointing"].label {
+.ui[class*='right pointing'].label {
   margin-top: 0em;
   margin-right: 0.6666em;
 }
 
-.ui[class*="right pointing"].label:before {
+.ui[class*='right pointing'].label:before {
   border-width: 1px 1px 0px 0px;
   -webkit-transform: translateX(50%) translateY(-50%) rotate(45deg);
   transform: translateX(50%) translateY(-50%) rotate(45deg);
@@ -16039,14 +16085,14 @@ a.ui.basic.label:hover {
 /*--- Above ---*/
 
 .ui.basic.pointing.label:before,
-.ui.basic[class*="pointing above"].label:before {
+.ui.basic[class*='pointing above'].label:before {
   margin-top: -1px;
 }
 
 /*--- Below ---*/
 
-.ui.basic[class*="bottom pointing"].label:before,
-.ui.basic[class*="pointing below"].label:before {
+.ui.basic[class*='bottom pointing'].label:before,
+.ui.basic[class*='pointing below'].label:before {
   bottom: auto;
   top: 100%;
   margin-top: 1px;
@@ -16054,14 +16100,14 @@ a.ui.basic.label:hover {
 
 /*--- Left ---*/
 
-.ui.basic[class*="left pointing"].label:before {
+.ui.basic[class*='left pointing'].label:before {
   top: 50%;
   left: -1px;
 }
 
 /*--- Right ---*/
 
-.ui.basic[class*="right pointing"].label:before {
+.ui.basic[class*='right pointing'].label:before {
   top: 50%;
   right: -1px;
 }
@@ -16333,7 +16379,7 @@ ol.ui.list ol li,
 .ui.list .list > a.item,
 .ui.list > a.item {
   cursor: pointer;
-  color: #4183C4;
+  color: #4183c4;
 }
 
 .ui.list .list > a.item:hover,
@@ -16353,7 +16399,7 @@ ol.ui.list ol li,
 .ui.list .list > .item a.header,
 .ui.list > .item a.header {
   cursor: pointer;
-  color: #4183C4 !important;
+  color: #4183c4 !important;
 }
 
 .ui.list .list > .item a.header:hover,
@@ -16363,22 +16409,22 @@ ol.ui.list ol li,
 
 /* Floated Content */
 
-.ui[class*="left floated"].list {
+.ui[class*='left floated'].list {
   float: left;
 }
 
-.ui[class*="right floated"].list {
+.ui[class*='right floated'].list {
   float: right;
 }
 
-.ui.list .list > .item [class*="left floated"],
-.ui.list > .item [class*="left floated"] {
+.ui.list .list > .item [class*='left floated'],
+.ui.list > .item [class*='left floated'] {
   float: left;
   margin: 0em 1em 0em 0em;
 }
 
-.ui.list .list > .item [class*="right floated"],
-.ui.list > .item [class*="right floated"] {
+.ui.list .list > .item [class*='right floated'],
+.ui.list > .item [class*='right floated'] {
   float: right;
   margin: 0em 0em 0em 1em;
 }
@@ -16551,21 +16597,21 @@ ol.ui.list ol li,
        Aligned
 --------------------*/
 
-.ui.list[class*="top aligned"] .image,
-.ui.list[class*="top aligned"] .content,
-.ui.list [class*="top aligned"] {
+.ui.list[class*='top aligned'] .image,
+.ui.list[class*='top aligned'] .content,
+.ui.list [class*='top aligned'] {
   vertical-align: top !important;
 }
 
-.ui.list[class*="middle aligned"] .image,
-.ui.list[class*="middle aligned"] .content,
-.ui.list [class*="middle aligned"] {
+.ui.list[class*='middle aligned'] .image,
+.ui.list[class*='middle aligned'] .content,
+.ui.list [class*='middle aligned'] {
   vertical-align: middle !important;
 }
 
-.ui.list[class*="bottom aligned"] .image,
-.ui.list[class*="bottom aligned"] .content,
-.ui.list [class*="bottom aligned"] {
+.ui.list[class*='bottom aligned'] .image,
+.ui.list[class*='bottom aligned'] .content,
+.ui.list [class*='bottom aligned'] {
   vertical-align: bottom !important;
 }
 
@@ -16631,8 +16677,10 @@ ol.ui.list ol li,
   margin: 0em;
   color: rgba(0, 0, 0, 0.4);
   border-radius: 0.5em;
-  -webkit-transition: 0.1s color ease, 0.1s padding-left ease, 0.1s background-color ease;
-  transition: 0.1s color ease, 0.1s padding-left ease, 0.1s background-color ease;
+  -webkit-transition: 0.1s color ease, 0.1s padding-left ease,
+    0.1s background-color ease;
+  transition: 0.1s color ease, 0.1s padding-left ease,
+    0.1s background-color ease;
 }
 
 .ui.selection.list .list > .item:last-child,
@@ -16698,8 +16746,10 @@ ol.ui.list ol li,
 --------------------*/
 
 .ui.animated.list > .item {
-  -webkit-transition: 0.25s color ease 0.1s, 0.25s padding-left ease 0.1s, 0.25s background-color ease 0.1s;
-  transition: 0.25s color ease 0.1s, 0.25s padding-left ease 0.1s, 0.25s background-color ease 0.1s;
+  -webkit-transition: 0.25s color ease 0.1s, 0.25s padding-left ease 0.1s,
+    0.25s background-color ease 0.1s;
+  transition: 0.25s color ease 0.1s, 0.25s padding-left ease 0.1s,
+    0.25s background-color ease 0.1s;
 }
 
 .ui.animated.list:not(.horizontal) > .item:hover {
@@ -16827,7 +16877,7 @@ ol.ui.list li:before,
   pointer-events: none;
   margin-left: -1.25rem;
   counter-increment: ordered;
-  content: counters(ordered, ".") " ";
+  content: counters(ordered, '.') ' ';
   text-align: right;
   color: rgba(0, 0, 0, 0.87);
   vertical-align: middle;
@@ -17107,21 +17157,21 @@ ol.ui.horizontal.list li:before,
 
 /* Very Relaxed */
 
-.ui[class*="very relaxed"].list:not(.horizontal) > .item:not(:first-child) {
+.ui[class*='very relaxed'].list:not(.horizontal) > .item:not(:first-child) {
   padding-top: 0.85714286em;
 }
 
-.ui[class*="very relaxed"].list:not(.horizontal) > .item:not(:last-child) {
+.ui[class*='very relaxed'].list:not(.horizontal) > .item:not(:last-child) {
   padding-bottom: 0.85714286em;
 }
 
-.ui.horizontal[class*="very relaxed"].list .list > .item:not(:first-child),
-.ui.horizontal[class*="very relaxed"].list > .item:not(:first-child) {
+.ui.horizontal[class*='very relaxed'].list .list > .item:not(:first-child),
+.ui.horizontal[class*='very relaxed'].list > .item:not(:first-child) {
   padding-left: 1.5rem;
 }
 
-.ui.horizontal[class*="very relaxed"].list .list > .item:not(:last-child),
-.ui.horizontal[class*="very relaxed"].list > .item:not(:last-child) {
+.ui.horizontal[class*='very relaxed'].list .list > .item:not(:last-child),
+.ui.horizontal[class*='very relaxed'].list > .item:not(:last-child) {
   padding-right: 1.5rem;
 }
 
@@ -17375,7 +17425,7 @@ ol.ui.horizontal.list li:before,
 }
 
 .ui.dimmer .ui.loader:after {
-  border-color: #FFFFFF transparent transparent;
+  border-color: #ffffff transparent transparent;
 }
 
 /* White Dimmer (Inverted) */
@@ -17548,7 +17598,7 @@ ol.ui.horizontal.list li:before,
 }
 
 .ui.inverted.loader:after {
-  border-top-color: #FFFFFF;
+  border-top-color: #ffffff;
 }
 
 /*-------------------
@@ -17607,10 +17657,27 @@ ol.ui.horizontal.list li:before,
   animation: placeholderShimmer 2s linear;
   -webkit-animation-iteration-count: infinite;
   animation-iteration-count: infinite;
-  background-color: #FFFFFF;
-  background-image: -webkit-gradient(linear, left top, right top, from(rgba(0, 0, 0, 0.08)), color-stop(15%, rgba(0, 0, 0, 0.15)), color-stop(30%, rgba(0, 0, 0, 0.08)));
-  background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.08) 0%, rgba(0, 0, 0, 0.15) 15%, rgba(0, 0, 0, 0.08) 30%);
-  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.08) 0%, rgba(0, 0, 0, 0.15) 15%, rgba(0, 0, 0, 0.08) 30%);
+  background-color: #ffffff;
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right top,
+    from(rgba(0, 0, 0, 0.08)),
+    color-stop(15%, rgba(0, 0, 0, 0.15)),
+    color-stop(30%, rgba(0, 0, 0, 0.08))
+  );
+  background-image: -webkit-linear-gradient(
+    left,
+    rgba(0, 0, 0, 0.08) 0%,
+    rgba(0, 0, 0, 0.15) 15%,
+    rgba(0, 0, 0, 0.08) 30%
+  );
+  background-image: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.08) 0%,
+    rgba(0, 0, 0, 0.15) 15%,
+    rgba(0, 0, 0, 0.08) 30%
+  );
   background-size: 1200px 100%;
   max-width: 30rem;
 }
@@ -17654,7 +17721,11 @@ ol.ui.horizontal.list li:before,
   animation-delay: 0.45s;
 }
 
-.ui.placeholder + .ui.placeholder + .ui.placeholder + .ui.placeholder + .ui.placeholder {
+.ui.placeholder
+  + .ui.placeholder
+  + .ui.placeholder
+  + .ui.placeholder
+  + .ui.placeholder {
   -webkit-animation-delay: 0.6s;
   animation-delay: 0.6s;
 }
@@ -17664,7 +17735,7 @@ ol.ui.horizontal.list li:before,
 .ui.placeholder .image.header:after,
 .ui.placeholder .line,
 .ui.placeholder .line:after {
-  background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
 /* Image */
@@ -17813,9 +17884,26 @@ ol.ui.horizontal.list li:before,
 /* Inverted Content Loader */
 
 .ui.inverted.placeholder {
-  background-image: -webkit-gradient(linear, left top, right top, from(rgba(255, 255, 255, 0.08)), color-stop(15%, rgba(255, 255, 255, 0.14)), color-stop(30%, rgba(255, 255, 255, 0.08)));
-  background-image: -webkit-linear-gradient(left, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0.14) 15%, rgba(255, 255, 255, 0.08) 30%);
-  background-image: linear-gradient(to right, rgba(255, 255, 255, 0.08) 0%, rgba(255, 255, 255, 0.14) 15%, rgba(255, 255, 255, 0.08) 30%);
+  background-image: -webkit-gradient(
+    linear,
+    left top,
+    right top,
+    from(rgba(255, 255, 255, 0.08)),
+    color-stop(15%, rgba(255, 255, 255, 0.14)),
+    color-stop(30%, rgba(255, 255, 255, 0.08))
+  );
+  background-image: -webkit-linear-gradient(
+    left,
+    rgba(255, 255, 255, 0.08) 0%,
+    rgba(255, 255, 255, 0.14) 15%,
+    rgba(255, 255, 255, 0.08) 30%
+  );
+  background-image: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0.08) 0%,
+    rgba(255, 255, 255, 0.14) 15%,
+    rgba(255, 255, 255, 0.08) 30%
+  );
 }
 
 .ui.inverted.placeholder,
@@ -17823,7 +17911,7 @@ ol.ui.horizontal.list li:before,
 .ui.inverted.placeholder .image.header:after,
 .ui.inverted.placeholder .line,
 .ui.inverted.placeholder .line:after {
-  background-color: #1B1C1D;
+  background-color: #1b1c1d;
 }
 
 /*******************************
@@ -17947,7 +18035,7 @@ ol.ui.horizontal.list li:before,
 ---------------*/
 
 .ui.close.rail {
-  width: calc( 300px  +  1em );
+  width: calc(300px + 1em);
 }
 
 .ui.close.left.rail {
@@ -17961,7 +18049,7 @@ ol.ui.horizontal.list li:before,
 }
 
 .ui.very.close.rail {
-  width: calc( 300px  +  0.5em );
+  width: calc(300px + 0.5em);
 }
 
 .ui.very.close.left.rail {
@@ -18202,10 +18290,12 @@ ol.ui.horizontal.list li:before,
   float: left;
   white-space: normal;
   margin: 0em;
-  -webkit-transition: -webkit-transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1) 0.1s;
+  -webkit-transition: -webkit-transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1)
+    0.1s;
   transition: -webkit-transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1) 0.1s;
   transition: transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1) 0.1s;
-  transition: transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1) 0.1s, -webkit-transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1) 0.1s;
+  transition: transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1) 0.1s,
+    -webkit-transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1) 0.1s;
 }
 
 .ui.move.reveal > .visible.content {
@@ -18358,7 +18448,7 @@ ol.ui.horizontal.list li:before,
 
 .ui.segment {
   position: relative;
-  background: #FFFFFF;
+  background: #ffffff;
   -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
   box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
   margin: 1rem 0em;
@@ -18400,27 +18490,27 @@ ol.ui.horizontal.list li:before,
 /* Header */
 
 .ui.inverted.segment > .ui.header {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 /* Label */
 
-.ui[class*="bottom attached"].segment > [class*="top attached"].label {
+.ui[class*='bottom attached'].segment > [class*='top attached'].label {
   border-top-left-radius: 0em;
   border-top-right-radius: 0em;
 }
 
-.ui[class*="top attached"].segment > [class*="bottom attached"].label {
+.ui[class*='top attached'].segment > [class*='bottom attached'].label {
   border-bottom-left-radius: 0em;
   border-bottom-right-radius: 0em;
 }
 
-.ui.attached.segment:not(.top):not(.bottom) > [class*="top attached"].label {
+.ui.attached.segment:not(.top):not(.bottom) > [class*='top attached'].label {
   border-top-left-radius: 0em;
   border-top-right-radius: 0em;
 }
 
-.ui.attached.segment:not(.top):not(.bottom) > [class*="bottom attached"].label {
+.ui.attached.segment:not(.top):not(.bottom) > [class*='bottom attached'].label {
   border-bottom-left-radius: 0em;
   border-bottom-right-radius: 0em;
 }
@@ -18442,13 +18532,13 @@ ol.ui.horizontal.list li:before,
 /* Table */
 
 .ui.basic.table.segment {
-  background: #FFFFFF;
+  background: #ffffff;
   border: 1px solid rgba(34, 36, 38, 0.15);
   -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
   box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
 }
 
-.ui[class*="very basic"].table.segment {
+.ui[class*='very basic'].table.segment {
   padding: 1em 1em;
 }
 
@@ -18480,7 +18570,7 @@ ol.ui.horizontal.list li:before,
   overflow: visible;
   padding: 1em 1em;
   min-height: 18rem;
-  background: #F9FAFB;
+  background: #f9fafb;
   border-color: rgba(34, 36, 38, 0.15);
   -webkit-box-shadow: 0px 2px 25px 0 rgba(34, 36, 38, 0.05) inset;
   box-shadow: 0px 2px 25px 0 rgba(34, 36, 38, 0.05) inset;
@@ -18548,7 +18638,7 @@ ol.ui.horizontal.list li:before,
 .ui.piled.segments:before,
 .ui.piled.segment:after,
 .ui.piled.segment:before {
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   visibility: visible;
   content: '';
   display: block;
@@ -18579,21 +18669,21 @@ ol.ui.horizontal.list li:before,
 
 /* Piled Attached */
 
-.ui[class*="top attached"].piled.segment {
+.ui[class*='top attached'].piled.segment {
   margin-top: 3em;
   margin-bottom: 0em;
 }
 
-.ui.piled.segment[class*="top attached"]:first-child {
+.ui.piled.segment[class*='top attached']:first-child {
   margin-top: 0em;
 }
 
-.ui.piled.segment[class*="bottom attached"] {
+.ui.piled.segment[class*='bottom attached'] {
   margin-top: 0em;
   margin-bottom: 3em;
 }
 
-.ui.piled.segment[class*="bottom attached"]:last-child {
+.ui.piled.segment[class*='bottom attached']:last-child {
   margin-bottom: 0em;
 }
 
@@ -18651,14 +18741,14 @@ ol.ui.horizontal.list li:before,
   padding: 1.5em;
 }
 
-.ui[class*="very padded"].segment {
+.ui[class*='very padded'].segment {
   padding: 3em;
 }
 
 /* Padded vertical */
 
 .ui.padded.segment.vertical.segment,
-.ui[class*="very padded"].vertical.segment {
+.ui[class*='very padded'].vertical.segment {
   padding-left: 0px;
   padding-right: 0px;
 }
@@ -18705,8 +18795,10 @@ ol.ui.horizontal.list li:before,
 
 .ui.raised.segments,
 .ui.raised.segment {
-  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
 }
 
 /*******************************
@@ -18805,7 +18897,7 @@ ol.ui.horizontal.list li:before,
   background-color: transparent;
   border-radius: 0px;
   padding: 0em;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
   box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
   margin: 1rem 0em;
@@ -18958,7 +19050,7 @@ ol.ui.horizontal.list li:before,
 --------------------*/
 
 .ui.clearing.segment:after {
-  content: ".";
+  content: '.';
   display: block;
   height: 0;
   clear: both;
@@ -18972,122 +19064,122 @@ ol.ui.horizontal.list li:before,
 /* Red */
 
 .ui.red.segment:not(.inverted) {
-  border-top: 2px solid #DB2828 !important;
+  border-top: 2px solid #db2828 !important;
 }
 
 .ui.inverted.red.segment {
-  background-color: #DB2828 !important;
-  color: #FFFFFF !important;
+  background-color: #db2828 !important;
+  color: #ffffff !important;
 }
 
 /* Orange */
 
 .ui.orange.segment:not(.inverted) {
-  border-top: 2px solid #F2711C !important;
+  border-top: 2px solid #f2711c !important;
 }
 
 .ui.inverted.orange.segment {
-  background-color: #F2711C !important;
-  color: #FFFFFF !important;
+  background-color: #f2711c !important;
+  color: #ffffff !important;
 }
 
 /* Yellow */
 
 .ui.yellow.segment:not(.inverted) {
-  border-top: 2px solid #FBBD08 !important;
+  border-top: 2px solid #fbbd08 !important;
 }
 
 .ui.inverted.yellow.segment {
-  background-color: #FBBD08 !important;
-  color: #FFFFFF !important;
+  background-color: #fbbd08 !important;
+  color: #ffffff !important;
 }
 
 /* Olive */
 
 .ui.olive.segment:not(.inverted) {
-  border-top: 2px solid #B5CC18 !important;
+  border-top: 2px solid #b5cc18 !important;
 }
 
 .ui.inverted.olive.segment {
-  background-color: #B5CC18 !important;
-  color: #FFFFFF !important;
+  background-color: #b5cc18 !important;
+  color: #ffffff !important;
 }
 
 /* Green */
 
 .ui.green.segment:not(.inverted) {
-  border-top: 2px solid #21BA45 !important;
+  border-top: 2px solid #21ba45 !important;
 }
 
 .ui.inverted.green.segment {
-  background-color: #21BA45 !important;
-  color: #FFFFFF !important;
+  background-color: #21ba45 !important;
+  color: #ffffff !important;
 }
 
 /* Teal */
 
 .ui.teal.segment:not(.inverted) {
-  border-top: 2px solid #00B5AD !important;
+  border-top: 2px solid #00b5ad !important;
 }
 
 .ui.inverted.teal.segment {
-  background-color: #00B5AD !important;
-  color: #FFFFFF !important;
+  background-color: #00b5ad !important;
+  color: #ffffff !important;
 }
 
 /* Blue */
 
 .ui.blue.segment:not(.inverted) {
-  border-top: 2px solid #2185D0 !important;
+  border-top: 2px solid #2185d0 !important;
 }
 
 .ui.inverted.blue.segment {
-  background-color: #2185D0 !important;
-  color: #FFFFFF !important;
+  background-color: #2185d0 !important;
+  color: #ffffff !important;
 }
 
 /* Violet */
 
 .ui.violet.segment:not(.inverted) {
-  border-top: 2px solid #6435C9 !important;
+  border-top: 2px solid #6435c9 !important;
 }
 
 .ui.inverted.violet.segment {
-  background-color: #6435C9 !important;
-  color: #FFFFFF !important;
+  background-color: #6435c9 !important;
+  color: #ffffff !important;
 }
 
 /* Purple */
 
 .ui.purple.segment:not(.inverted) {
-  border-top: 2px solid #A333C8 !important;
+  border-top: 2px solid #a333c8 !important;
 }
 
 .ui.inverted.purple.segment {
-  background-color: #A333C8 !important;
-  color: #FFFFFF !important;
+  background-color: #a333c8 !important;
+  color: #ffffff !important;
 }
 
 /* Pink */
 
 .ui.pink.segment:not(.inverted) {
-  border-top: 2px solid #E03997 !important;
+  border-top: 2px solid #e03997 !important;
 }
 
 .ui.inverted.pink.segment {
-  background-color: #E03997 !important;
-  color: #FFFFFF !important;
+  background-color: #e03997 !important;
+  color: #ffffff !important;
 }
 
 /* Brown */
 
 .ui.brown.segment:not(.inverted) {
-  border-top: 2px solid #A5673F !important;
+  border-top: 2px solid #a5673f !important;
 }
 
 .ui.inverted.brown.segment {
-  background-color: #A5673F !important;
-  color: #FFFFFF !important;
+  background-color: #a5673f !important;
+  color: #ffffff !important;
 }
 
 /* Grey */
@@ -19098,33 +19190,33 @@ ol.ui.horizontal.list li:before,
 
 .ui.inverted.grey.segment {
   background-color: #767676 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Black */
 
 .ui.black.segment:not(.inverted) {
-  border-top: 2px solid #1B1C1D !important;
+  border-top: 2px solid #1b1c1d !important;
 }
 
 .ui.inverted.black.segment {
-  background-color: #1B1C1D !important;
-  color: #FFFFFF !important;
+  background-color: #1b1c1d !important;
+  color: #ffffff !important;
 }
 
 /*-------------------
        Aligned
 --------------------*/
 
-.ui[class*="left aligned"].segment {
+.ui[class*='left aligned'].segment {
   text-align: left;
 }
 
-.ui[class*="right aligned"].segment {
+.ui[class*='right aligned'].segment {
   text-align: right;
 }
 
-.ui[class*="center aligned"].segment {
+.ui[class*='center aligned'].segment {
   text-align: center;
 }
 
@@ -19133,12 +19225,12 @@ ol.ui.horizontal.list li:before,
 --------------------*/
 
 .ui.floated.segment,
-.ui[class*="left floated"].segment {
+.ui[class*='left floated'].segment {
   float: left;
   margin-right: 1em;
 }
 
-.ui[class*="right floated"].segment {
+.ui[class*='right floated'].segment {
   float: right;
   margin-left: 1em;
 }
@@ -19155,7 +19247,7 @@ ol.ui.horizontal.list li:before,
 
 .ui.inverted.segment,
 .ui.primary.inverted.segment {
-  background: #1B1C1D;
+  background: #1b1c1d;
   color: rgba(255, 255, 255, 0.9);
 }
 
@@ -19182,28 +19274,45 @@ ol.ui.horizontal.list li:before,
 /* Secondary */
 
 .ui.secondary.segment {
-  background: #F3F4F5;
+  background: #f3f4f5;
   color: rgba(0, 0, 0, 0.6);
 }
 
 .ui.secondary.inverted.segment {
   background: #4c4f52 -webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.2)), to(rgba(255, 255, 255, 0.2)));
-  background: #4c4f52 -webkit-linear-gradient(rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.2) 100%);
-  background: #4c4f52 linear-gradient(rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.2) 100%);
+  background: #4c4f52 -webkit-linear-gradient(rgba(255, 255, 255, 0.2) 0%, rgba(
+          255,
+          255,
+          255,
+          0.2
+        )
+        100%);
+  background: #4c4f52
+    linear-gradient(rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.2) 100%);
   color: rgba(255, 255, 255, 0.8);
 }
 
 /* Tertiary */
 
 .ui.tertiary.segment {
-  background: #DCDDDE;
+  background: #dcddde;
   color: rgba(0, 0, 0, 0.6);
 }
 
 .ui.tertiary.inverted.segment {
   background: #717579 -webkit-gradient(linear, left top, left bottom, from(rgba(255, 255, 255, 0.35)), to(rgba(255, 255, 255, 0.35)));
-  background: #717579 -webkit-linear-gradient(rgba(255, 255, 255, 0.35) 0%, rgba(255, 255, 255, 0.35) 100%);
-  background: #717579 linear-gradient(rgba(255, 255, 255, 0.35) 0%, rgba(255, 255, 255, 0.35) 100%);
+  background: #717579 -webkit-linear-gradient(rgba(255, 255, 255, 0.35) 0%, rgba(
+          255,
+          255,
+          255,
+          0.35
+        )
+        100%);
+  background: #717579
+    linear-gradient(
+      rgba(255, 255, 255, 0.35) 0%,
+      rgba(255, 255, 255, 0.35) 100%
+    );
   color: rgba(255, 255, 255, 0.8);
 }
 
@@ -19222,7 +19331,7 @@ ol.ui.horizontal.list li:before,
   max-width: calc(100% - (-1px * 2));
   -webkit-box-shadow: none;
   box-shadow: none;
-  border: 1px solid #D4D4D5;
+  border: 1px solid #d4d4d5;
 }
 
 .ui.attached:not(.message) + .ui.attached.segment:not(.top) {
@@ -19231,7 +19340,7 @@ ol.ui.horizontal.list li:before,
 
 /* Top */
 
-.ui[class*="top attached"].segment {
+.ui[class*='top attached'].segment {
   bottom: 0px;
   margin-bottom: 0em;
   top: 0px;
@@ -19239,13 +19348,13 @@ ol.ui.horizontal.list li:before,
   border-radius: 0.28571429rem 0.28571429rem 0em 0em;
 }
 
-.ui.segment[class*="top attached"]:first-child {
+.ui.segment[class*='top attached']:first-child {
   margin-top: 0em;
 }
 
 /* Bottom */
 
-.ui.segment[class*="bottom attached"] {
+.ui.segment[class*='bottom attached'] {
   bottom: 0px;
   margin-top: 0em;
   top: 0px;
@@ -19255,7 +19364,7 @@ ol.ui.horizontal.list li:before,
   border-radius: 0em 0em 0.28571429rem 0.28571429rem;
 }
 
-.ui.segment[class*="bottom attached"]:last-child {
+.ui.segment[class*='bottom attached']:last-child {
   margin-bottom: 0em;
 }
 
@@ -19383,17 +19492,21 @@ ol.ui.horizontal.list li:before,
   justify-content: center;
   margin: 0em 0em;
   padding: 1.14285714em 2em;
-  background: #FFFFFF;
+  background: #ffffff;
   color: rgba(0, 0, 0, 0.87);
   -webkit-box-shadow: none;
   box-shadow: none;
   border-radius: 0em;
   border: none;
   border-right: 1px solid rgba(34, 36, 38, 0.15);
-  -webkit-transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease, box-shadow 0.1s ease;
-  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, -webkit-box-shadow 0.1s ease;
+  -webkit-transition: background-color 0.1s ease, opacity 0.1s ease,
+    color 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
+  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease,
+    box-shadow 0.1s ease;
+  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease,
+    box-shadow 0.1s ease, -webkit-box-shadow 0.1s ease;
 }
 
 /* Arrow */
@@ -19406,16 +19519,20 @@ ol.ui.horizontal.list li:before,
   top: 50%;
   right: 0%;
   border: medium none;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   width: 1.14285714em;
   height: 1.14285714em;
   border-style: solid;
   border-color: rgba(34, 36, 38, 0.15);
   border-width: 0px 1px 1px 0px;
-  -webkit-transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease, box-shadow 0.1s ease;
-  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, -webkit-box-shadow 0.1s ease;
+  -webkit-transition: background-color 0.1s ease, opacity 0.1s ease,
+    color 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
+  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease,
+    box-shadow 0.1s ease;
+  transition: background-color 0.1s ease, opacity 0.1s ease, color 0.1s ease,
+    box-shadow 0.1s ease, -webkit-box-shadow 0.1s ease;
   -webkit-transform: translateY(-50%) translateX(50%) rotate(-45deg);
   transform: translateY(-50%) translateX(50%) rotate(-45deg);
 }
@@ -19529,7 +19646,7 @@ ol.ui.horizontal.list li:before,
   display: block;
   position: static;
   text-align: center;
-  content: counters(ordered, ".");
+  content: counters(ordered, '.');
   -ms-flex-item-align: middle;
   align-self: middle;
   margin-right: 1rem;
@@ -19679,7 +19796,7 @@ ol.ui.horizontal.list li:before,
 .ui.steps .link.step:hover,
 .ui.steps a.step:hover::after,
 .ui.steps a.step:hover {
-  background: #F9FAFB;
+  background: #f9fafb;
   color: rgba(0, 0, 0, 0.8);
 }
 
@@ -19689,7 +19806,7 @@ ol.ui.horizontal.list li:before,
 .ui.steps .link.step:active,
 .ui.steps a.step:active::after,
 .ui.steps a.step:active {
-  background: #F3F4F5;
+  background: #f3f4f5;
   color: rgba(0, 0, 0, 0.9);
 }
 
@@ -19697,15 +19814,15 @@ ol.ui.horizontal.list li:before,
 
 .ui.steps .step.active {
   cursor: auto;
-  background: #F3F4F5;
+  background: #f3f4f5;
 }
 
 .ui.steps .step.active:after {
-  background: #F3F4F5;
+  background: #f3f4f5;
 }
 
 .ui.steps .step.active .title {
-  color: #4183C4;
+  color: #4183c4;
 }
 
 .ui.ordered.steps .step.active:before,
@@ -19738,7 +19855,7 @@ ol.ui.horizontal.list li:before,
 .ui.steps a.active.step:hover::after,
 .ui.steps a.active.step:hover {
   cursor: pointer;
-  background: #DCDDDE;
+  background: #dcddde;
   color: rgba(0, 0, 0, 0.87);
 }
 
@@ -19746,14 +19863,14 @@ ol.ui.horizontal.list li:before,
 
 .ui.steps .step.completed > .icon:before,
 .ui.ordered.steps .step.completed:before {
-  color: #21BA45;
+  color: #21ba45;
 }
 
 /* Disabled */
 
 .ui.steps .disabled.step {
   cursor: auto;
-  background: #FFFFFF;
+  background: #ffffff;
   pointer-events: none;
 }
 
@@ -19764,7 +19881,7 @@ ol.ui.horizontal.list li:before,
 }
 
 .ui.steps .disabled.step:after {
-  background: #FFFFFF;
+  background: #ffffff;
 }
 
 /*******************************
@@ -19778,7 +19895,7 @@ ol.ui.horizontal.list li:before,
 /* Tablet Or Below */
 
 @media only screen and (max-width: 991px) {
-  .ui[class*="tablet stackable"].steps {
+  .ui[class*='tablet stackable'].steps {
     display: -webkit-inline-box;
     display: -ms-inline-flexbox;
     display: inline-flex;
@@ -19791,7 +19908,7 @@ ol.ui.horizontal.list li:before,
 
   /* Steps */
 
-  .ui[class*="tablet stackable"].steps .step {
+  .ui[class*='tablet stackable'].steps .step {
     -webkit-box-orient: vertical;
     -webkit-box-direction: normal;
     -ms-flex-direction: column;
@@ -19800,31 +19917,31 @@ ol.ui.horizontal.list li:before,
     padding: 1.14285714em 2em;
   }
 
-  .ui[class*="tablet stackable"].steps .step:first-child {
+  .ui[class*='tablet stackable'].steps .step:first-child {
     padding: 1.14285714em 2em;
     border-radius: 0.28571429rem 0.28571429rem 0em 0em;
   }
 
-  .ui[class*="tablet stackable"].steps .step:last-child {
+  .ui[class*='tablet stackable'].steps .step:last-child {
     border-radius: 0em 0em 0.28571429rem 0.28571429rem;
   }
 
   /* Arrow */
 
-  .ui[class*="tablet stackable"].steps .step:after {
+  .ui[class*='tablet stackable'].steps .step:after {
     display: none !important;
   }
 
   /* Content */
 
-  .ui[class*="tablet stackable"].steps .step .content {
+  .ui[class*='tablet stackable'].steps .step .content {
     text-align: center;
   }
 
   /* Icon */
 
-  .ui[class*="tablet stackable"].steps .step > .icon,
-  .ui[class*="tablet stackable"].ordered.steps .step:before {
+  .ui[class*='tablet stackable'].steps .step > .icon,
+  .ui[class*='tablet stackable'].ordered.steps .step:before {
     margin: 0em 0em 1rem 0em;
   }
 }
@@ -19987,7 +20104,10 @@ ol.ui.horizontal.list li:before,
 
 @font-face {
   font-family: 'Step';
-  src: url(data:application/x-font-ttf;charset=utf-8;;base64,AAEAAAAOAIAAAwBgT1MvMj3hSQEAAADsAAAAVmNtYXDQEhm3AAABRAAAAUpjdnQgBkn/lAAABuwAAAAcZnBnbYoKeDsAAAcIAAAJkWdhc3AAAAAQAAAG5AAAAAhnbHlm32cEdgAAApAAAAC2aGVhZAErPHsAAANIAAAANmhoZWEHUwNNAAADgAAAACRobXR4CykAAAAAA6QAAAAMbG9jYQA4AFsAAAOwAAAACG1heHAApgm8AAADuAAAACBuYW1lzJ0aHAAAA9gAAALNcG9zdK69QJgAAAaoAAAAO3ByZXCSoZr/AAAQnAAAAFYAAQO4AZAABQAIAnoCvAAAAIwCegK8AAAB4AAxAQIAAAIABQMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUGZFZABA6ADoAQNS/2oAWgMLAE8AAAABAAAAAAAAAAAAAwAAAAMAAAAcAAEAAAAAAEQAAwABAAAAHAAEACgAAAAGAAQAAQACAADoAf//AAAAAOgA//8AABgBAAEAAAAAAAAAAAEGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAADpAKYABUAHEAZDwEAAQFCAAIBAmoAAQABagAAAGEUFxQDEisBFAcBBiInASY0PwE2Mh8BATYyHwEWA6QP/iAQLBD+6g8PTBAsEKQBbhAsEEwPAhYWEP4gDw8BFhAsEEwQEKUBbxAQTBAAAAH//f+xA18DCwAMABJADwABAQpDAAAACwBEFRMCESsBFA4BIi4CPgEyHgEDWXLG6MhuBnq89Lp+AV51xHR0xOrEdHTEAAAAAAEAAAABAADDeRpdXw889QALA+gAAAAAzzWYjQAAAADPNWBN//3/sQOkAwsAAAAIAAIAAAAAAAAAAQAAA1L/agBaA+gAAP/3A6QAAQAAAAAAAAAAAAAAAAAAAAMD6AAAA+gAAANZAAAAAAAAADgAWwABAAAAAwAWAAEAAAAAAAIABgATAG4AAAAtCZEAAAAAAAAAEgDeAAEAAAAAAAAANQAAAAEAAAAAAAEACAA1AAEAAAAAAAIABwA9AAEAAAAAAAMACABEAAEAAAAAAAQACABMAAEAAAAAAAUACwBUAAEAAAAAAAYACABfAAEAAAAAAAoAKwBnAAEAAAAAAAsAEwCSAAMAAQQJAAAAagClAAMAAQQJAAEAEAEPAAMAAQQJAAIADgEfAAMAAQQJAAMAEAEtAAMAAQQJAAQAEAE9AAMAAQQJAAUAFgFNAAMAAQQJAAYAEAFjAAMAAQQJAAoAVgFzAAMAAQQJAAsAJgHJQ29weXJpZ2h0IChDKSAyMDE0IGJ5IG9yaWdpbmFsIGF1dGhvcnMgQCBmb250ZWxsby5jb21mb250ZWxsb1JlZ3VsYXJmb250ZWxsb2ZvbnRlbGxvVmVyc2lvbiAxLjBmb250ZWxsb0dlbmVyYXRlZCBieSBzdmcydHRmIGZyb20gRm9udGVsbG8gcHJvamVjdC5odHRwOi8vZm9udGVsbG8uY29tAEMAbwBwAHkAcgBpAGcAaAB0ACAAKABDACkAIAAyADAAMQA0ACAAYgB5ACAAbwByAGkAZwBpAG4AYQBsACAAYQB1AHQAaABvAHIAcwAgAEAAIABmAG8AbgB0AGUAbABsAG8ALgBjAG8AbQBmAG8AbgB0AGUAbABsAG8AUgBlAGcAdQBsAGEAcgBmAG8AbgB0AGUAbABsAG8AZgBvAG4AdABlAGwAbABvAFYAZQByAHMAaQBvAG4AIAAxAC4AMABmAG8AbgB0AGUAbABsAG8ARwBlAG4AZQByAGEAdABlAGQAIABiAHkAIABzAHYAZwAyAHQAdABmACAAZgByAG8AbQAgAEYAbwBuAHQAZQBsAGwAbwAgAHAAcgBvAGoAZQBjAHQALgBoAHQAdABwADoALwAvAGYAbwBuAHQAZQBsAGwAbwAuAGMAbwBtAAAAAAIAAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAQIBAwljaGVja21hcmsGY2lyY2xlAAAAAAEAAf//AA8AAAAAAAAAAAAAAAAAAAAAADIAMgML/7EDC/+xsAAssCBgZi2wASwgZCCwwFCwBCZasARFW1ghIyEbilggsFBQWCGwQFkbILA4UFghsDhZWSCwCkVhZLAoUFghsApFILAwUFghsDBZGyCwwFBYIGYgiophILAKUFhgGyCwIFBYIbAKYBsgsDZQWCGwNmAbYFlZWRuwACtZWSOwAFBYZVlZLbACLCBFILAEJWFkILAFQ1BYsAUjQrAGI0IbISFZsAFgLbADLCMhIyEgZLEFYkIgsAYjQrIKAAIqISCwBkMgiiCKsAArsTAFJYpRWGBQG2FSWVgjWSEgsEBTWLAAKxshsEBZI7AAUFhlWS2wBCywB0MrsgACAENgQi2wBSywByNCIyCwACNCYbCAYrABYLAEKi2wBiwgIEUgsAJFY7ABRWJgRLABYC2wBywgIEUgsAArI7ECBCVgIEWKI2EgZCCwIFBYIbAAG7AwUFiwIBuwQFlZI7AAUFhlWbADJSNhRESwAWAtsAgssQUFRbABYUQtsAkssAFgICCwCUNKsABQWCCwCSNCWbAKQ0qwAFJYILAKI0JZLbAKLCC4BABiILgEAGOKI2GwC0NgIIpgILALI0IjLbALLEtUWLEHAURZJLANZSN4LbAMLEtRWEtTWLEHAURZGyFZJLATZSN4LbANLLEADENVWLEMDEOwAWFCsAorWbAAQ7ACJUKxCQIlQrEKAiVCsAEWIyCwAyVQWLEBAENgsAQlQoqKIIojYbAJKiEjsAFhIIojYbAJKiEbsQEAQ2CwAiVCsAIlYbAJKiFZsAlDR7AKQ0dgsIBiILACRWOwAUViYLEAABMjRLABQ7AAPrIBAQFDYEItsA4ssQAFRVRYALAMI0IgYLABYbUNDQEACwBCQopgsQ0FK7BtKxsiWS2wDyyxAA4rLbAQLLEBDistsBEssQIOKy2wEiyxAw4rLbATLLEEDistsBQssQUOKy2wFSyxBg4rLbAWLLEHDistsBcssQgOKy2wGCyxCQ4rLbAZLLAIK7EABUVUWACwDCNCIGCwAWG1DQ0BAAsAQkKKYLENBSuwbSsbIlktsBossQAZKy2wGyyxARkrLbAcLLECGSstsB0ssQMZKy2wHiyxBBkrLbAfLLEFGSstsCAssQYZKy2wISyxBxkrLbAiLLEIGSstsCMssQkZKy2wJCwgPLABYC2wJSwgYLANYCBDI7ABYEOwAiVhsAFgsCQqIS2wJiywJSuwJSotsCcsICBHICCwAkVjsAFFYmAjYTgjIIpVWCBHICCwAkVjsAFFYmAjYTgbIVktsCgssQAFRVRYALABFrAnKrABFTAbIlktsCkssAgrsQAFRVRYALABFrAnKrABFTAbIlktsCosIDWwAWAtsCssALADRWOwAUVisAArsAJFY7ABRWKwACuwABa0AAAAAABEPiM4sSoBFSotsCwsIDwgRyCwAkVjsAFFYmCwAENhOC2wLSwuFzwtsC4sIDwgRyCwAkVjsAFFYmCwAENhsAFDYzgtsC8ssQIAFiUgLiBHsAAjQrACJUmKikcjRyNhIFhiGyFZsAEjQrIuAQEVFCotsDAssAAWsAQlsAQlRyNHI2GwBkUrZYouIyAgPIo4LbAxLLAAFrAEJbAEJSAuRyNHI2EgsAQjQrAGRSsgsGBQWCCwQFFYswIgAyAbswImAxpZQkIjILAIQyCKI0cjRyNhI0ZgsARDsIBiYCCwACsgiophILACQ2BkI7ADQ2FkUFiwAkNhG7ADQ2BZsAMlsIBiYSMgILAEJiNGYTgbI7AIQ0awAiWwCENHI0cjYWAgsARDsIBiYCMgsAArI7AEQ2CwACuwBSVhsAUlsIBisAQmYSCwBCVgZCOwAyVgZFBYIRsjIVkjICCwBCYjRmE4WS2wMiywABYgICCwBSYgLkcjRyNhIzw4LbAzLLAAFiCwCCNCICAgRiNHsAArI2E4LbA0LLAAFrADJbACJUcjRyNhsABUWC4gPCMhG7ACJbACJUcjRyNhILAFJbAEJUcjRyNhsAYlsAUlSbACJWGwAUVjIyBYYhshWWOwAUViYCMuIyAgPIo4IyFZLbA1LLAAFiCwCEMgLkcjRyNhIGCwIGBmsIBiIyAgPIo4LbA2LCMgLkawAiVGUlggPFkusSYBFCstsDcsIyAuRrACJUZQWCA8WS6xJgEUKy2wOCwjIC5GsAIlRlJYIDxZIyAuRrACJUZQWCA8WS6xJgEUKy2wOSywMCsjIC5GsAIlRlJYIDxZLrEmARQrLbA6LLAxK4ogIDywBCNCijgjIC5GsAIlRlJYIDxZLrEmARQrsARDLrAmKy2wOyywABawBCWwBCYgLkcjRyNhsAZFKyMgPCAuIzixJgEUKy2wPCyxCAQlQrAAFrAEJbAEJSAuRyNHI2EgsAQjQrAGRSsgsGBQWCCwQFFYswIgAyAbswImAxpZQkIjIEewBEOwgGJgILAAKyCKimEgsAJDYGQjsANDYWRQWLACQ2EbsANDYFmwAyWwgGJhsAIlRmE4IyA8IzgbISAgRiNHsAArI2E4IVmxJgEUKy2wPSywMCsusSYBFCstsD4ssDErISMgIDywBCNCIzixJgEUK7AEQy6wJistsD8ssAAVIEewACNCsgABARUUEy6wLCotsEAssAAVIEewACNCsgABARUUEy6wLCotsEEssQABFBOwLSotsEIssC8qLbBDLLAAFkUjIC4gRoojYTixJgEUKy2wRCywCCNCsEMrLbBFLLIAADwrLbBGLLIAATwrLbBHLLIBADwrLbBILLIBATwrLbBJLLIAAD0rLbBKLLIAAT0rLbBLLLIBAD0rLbBMLLIBAT0rLbBNLLIAADkrLbBOLLIAATkrLbBPLLIBADkrLbBQLLIBATkrLbBRLLIAADsrLbBSLLIAATsrLbBTLLIBADsrLbBULLIBATsrLbBVLLIAAD4rLbBWLLIAAT4rLbBXLLIBAD4rLbBYLLIBAT4rLbBZLLIAADorLbBaLLIAATorLbBbLLIBADorLbBcLLIBATorLbBdLLAyKy6xJgEUKy2wXiywMiuwNistsF8ssDIrsDcrLbBgLLAAFrAyK7A4Ky2wYSywMysusSYBFCstsGIssDMrsDYrLbBjLLAzK7A3Ky2wZCywMyuwOCstsGUssDQrLrEmARQrLbBmLLA0K7A2Ky2wZyywNCuwNystsGgssDQrsDgrLbBpLLA1Ky6xJgEUKy2waiywNSuwNistsGsssDUrsDcrLbBsLLA1K7A4Ky2wbSwrsAhlsAMkUHiwARUwLQAAAEu4AMhSWLEBAY5ZuQgACABjILABI0SwAyNwsgQoCUVSRLIKAgcqsQYBRLEkAYhRWLBAiFixBgNEsSYBiFFYuAQAiFixBgFEWVlZWbgB/4WwBI2xBQBEAAA=) format('truetype'), url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAAoUAA4AAAAAEPQAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAABRAAAAEQAAABWPeFJAWNtYXAAAAGIAAAAOgAAAUrQEhm3Y3Z0IAAAAcQAAAAUAAAAHAZJ/5RmcGdtAAAB2AAABPkAAAmRigp4O2dhc3AAAAbUAAAACAAAAAgAAAAQZ2x5ZgAABtwAAACuAAAAtt9nBHZoZWFkAAAHjAAAADUAAAA2ASs8e2hoZWEAAAfEAAAAIAAAACQHUwNNaG10eAAAB+QAAAAMAAAADAspAABsb2NhAAAH8AAAAAgAAAAIADgAW21heHAAAAf4AAAAIAAAACAApgm8bmFtZQAACBgAAAF3AAACzcydGhxwb3N0AAAJkAAAACoAAAA7rr1AmHByZXAAAAm8AAAAVgAAAFaSoZr/eJxjYGTewTiBgZWBg6mKaQ8DA0MPhGZ8wGDIyMTAwMTAysyAFQSkuaYwOLxgeMHIHPQ/iyGKmZvBHyjMCJIDAPe9C2B4nGNgYGBmgGAZBkYGEHAB8hjBfBYGDSDNBqQZGZgYGF4w/v8PUvCCAURLMELVAwEjG8OIBwBk5AavAAB4nGNgQANGDEbM3P83gjAAELQD4XicnVXZdtNWFJU8ZHASOmSgoA7X3DhQ68qEKRgwaSrFdiEdHAitBB2kDHTkncc+62uOQrtWH/m07n09JLR0rbYsls++R1tn2DrnRhwjKn0aiGvUoZKXA6msPZZK90lc13Uvj5UMBnFdthJPSZuonSRKat3sUC7xWOsqWSdYJ+PlIFZPVZ5noAziFB5lSUQbRBuplyZJ4onjJ4kWZxAfJUkgJaMQp9LIUEI1GsRS1aFM6dCr1xNx00DKRqMedVhU90PFJ8c1p9SsA0YqVznCFevVRr4bpwMve5DEOsGzrYcxHnisfpQqkIqR6cg/dkpOlIaBVHHUoVbi6DCTX/eRTCrNQKaMYkWl7oG43f102xYxPXQ6vi5KlUaqurnOKJrt0fGogygP2cbppNzQ2fbw5RlTVKtdcbPtQGYNXErJbHSfRAAdJlLj6QFONZwCqRn1R8XZ588BEslclKo8VTKHegOZMzt7cTHtbiersnCknwcyb3Z2452HQ6dXh3/R+hdM4cxHj+Jifj5C+lBqfiJOJKVGWMzyp4YfcVcgQrkxiAsXyuBThDl0RdrZZl3jtTH2hs/5SqlhPQna6KP4fgr9TiQrHGdRo/VInM1j13Wt3GdQS7W7Fzsyr0OVIu7vCwuuM+eEYZ4WC1VfnvneBTT/Bohn/EDeNIVL+5YpSrRvm6JMu2iKCu0SVKVdNsUU7YoppmnPmmKG9h1TzNKeMzLj/8vc55H7HN7xkJv2XeSmfQ+5ad9HbtoPkJtWITdtHblpLyA3rUZu2lWjOnYEGgZpF1IVQdA0svph3Fab9UDWjDR8aWDyLmLI+upER521tcofxX914gsHcmmip7siF5viLq/bFj483e6rj5pG3bDV+MaR8jAeRnocmtBZ+c3hv+1N3S6a7jKqMugBFUwKwABl7UAC0zrbCaT1mqf48gdgXIZ4zkpDtVSfO4am7+V5X/exOfG+x+3GLrdcd3kJWdYNcmP28N9SZKrrH+UtrVQnR6wrJ49VaxhDKrwour6SlHu0tRu/KKmy8l6U1srnk5CbPYMbQlu27mGwI0xpyiUeXlOlKD3UUo6yQyxvKco84JSLC1qGxLgOdQ9qa8TpoXoYGwshhqG0vRBwSCldFd+0ynfxHqtr2Oj4xRXh6XpyEhGf4ir7UfBU10b96A7avGbdMoMpVaqn+4xPsa/b9lFZaaSOsxe3VAfXNOsaORXTT+Rr4HRvOGjdAz1UfDRBI1U1x+jGKGM0ljXl3wR0MVZ+w2jVYvs93E+dpFWsuUuY7JsT9+C0u/0q+7WcW0bW/dcGvW3kip8jMb8tCvw7B2K3ZA3UO5OBGAvIWdAYxhYmdxiug23EbfY/Jqf/34aFRXJXOxq7eerD1ZNRJXfZ8rjLTXZZ16M2R9VOGvsIjS0PN+bY4XIstsRgQbb+wf8x7gF3aVEC4NDIZZiI2nShnurh6h6rsW04VxIBds2x43QAegAuQd8cu9bzCYD13CPnLsB9cgh2yCH4lByCz8i5BfA5OQRfkEMwIIdgl5w7AA/IIXhIDsEeOQSPyNkE+JIcgq/IIYjJIUjIuQ3wmByCJ+QQfE0OwTdGrk5k/pYH2QD6zqKbQKmdGhzaOGRGrk3Y+zxY9oFFZB9aROqRkesT6lMeLPV7i0j9wSJSfzRyY0L9iQdL/dkiUn+xiNRnxpeZIymvDp7zjg7+BJfqrV4AAAAAAQAB//8AD3icY2BkAALmJUwzGEQZZBwk+RkZGBmdGJgYmbIYgMwsoGSiiLgIs5A2owg7I5uSOqOaiT2jmZE8I5gQY17C/09BQEfg3yt+fh8gvYQxD0j68DOJiQn8U+DnZxQDcQUEljLmCwBpBgbG/3//b2SOZ+Zm4GEQcuAH2sblDLSEm8FFVJhJEGgLH6OSHpMdo5EcI3Nk0bEXJ/LYqvZ82VXHGFd6pKTkyCsQwQAAq+QkqAAAeJxjYGRgYADiw5VSsfH8Nl8ZuJlfAEUYzpvO6IXQCb7///7fyLyEmRvI5WBgAokCAFb/DJAAAAB4nGNgZGBgDvqfxRDF/IKB4f935iUMQBEUwAwAi5YFpgPoAAAD6AAAA1kAAAAAAAAAOABbAAEAAAADABYAAQAAAAAAAgAGABMAbgAAAC0JkQAAAAB4nHWQy2rCQBSG//HSi0JbWui2sypKabxgN4IgWHTTbqS4LTHGJBIzMhkFX6Pv0IfpS/RZ+puMpShNmMx3vjlz5mQAXOMbAvnzxJGzwBmjnAs4Rc9ykf7Zcon8YrmMKt4sn9C/W67gAYHlKm7wwQqidM5ogU/LAlfi0nIBF+LOcpH+0XKJ3LNcxq14tXxC71muYCJSy1Xci6+BWm11FIRG1gZ12W62OnK6lYoqStxYumsTKp3KvpyrxPhxrBxPLfc89oN17Op9uJ8nvk4jlciW09yrkZ/42jX+bFc93QRtY+ZyrtVSDm2GXGm18D3jhMasuo3G3/MwgMIKW2hEvKoQBhI12jrnNppooUOaMkMyM8+KkMBFTONizR1htpIy7nPMGSW0PjNisgOP3+WRH5MC7o9ZRR+tHsYT0u6MKPOSfTns7jBrREqyTDezs9/eU2x4WpvWcNeuS511JTE8qCF5H7u1BY1H72S3Ymi7aPD95/9+AN1fhEsAeJxjYGKAAC4G7ICZgYGRiZGZMzkjNTk7N7Eomy05syg5J5WBAQBE1QZBAABLuADIUlixAQGOWbkIAAgAYyCwASNEsAMjcLIEKAlFUkSyCgIHKrEGAUSxJAGIUViwQIhYsQYDRLEmAYhRWLgEAIhYsQYBRFlZWVm4Af+FsASNsQUARAAA) format('woff');
+  src: url(data:application/x-font-ttf;charset=utf-8;;base64,AAEAAAAOAIAAAwBgT1MvMj3hSQEAAADsAAAAVmNtYXDQEhm3AAABRAAAAUpjdnQgBkn/lAAABuwAAAAcZnBnbYoKeDsAAAcIAAAJkWdhc3AAAAAQAAAG5AAAAAhnbHlm32cEdgAAApAAAAC2aGVhZAErPHsAAANIAAAANmhoZWEHUwNNAAADgAAAACRobXR4CykAAAAAA6QAAAAMbG9jYQA4AFsAAAOwAAAACG1heHAApgm8AAADuAAAACBuYW1lzJ0aHAAAA9gAAALNcG9zdK69QJgAAAaoAAAAO3ByZXCSoZr/AAAQnAAAAFYAAQO4AZAABQAIAnoCvAAAAIwCegK8AAAB4AAxAQIAAAIABQMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUGZFZABA6ADoAQNS/2oAWgMLAE8AAAABAAAAAAAAAAAAAwAAAAMAAAAcAAEAAAAAAEQAAwABAAAAHAAEACgAAAAGAAQAAQACAADoAf//AAAAAOgA//8AABgBAAEAAAAAAAAAAAEGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAADpAKYABUAHEAZDwEAAQFCAAIBAmoAAQABagAAAGEUFxQDEisBFAcBBiInASY0PwE2Mh8BATYyHwEWA6QP/iAQLBD+6g8PTBAsEKQBbhAsEEwPAhYWEP4gDw8BFhAsEEwQEKUBbxAQTBAAAAH//f+xA18DCwAMABJADwABAQpDAAAACwBEFRMCESsBFA4BIi4CPgEyHgEDWXLG6MhuBnq89Lp+AV51xHR0xOrEdHTEAAAAAAEAAAABAADDeRpdXw889QALA+gAAAAAzzWYjQAAAADPNWBN//3/sQOkAwsAAAAIAAIAAAAAAAAAAQAAA1L/agBaA+gAAP/3A6QAAQAAAAAAAAAAAAAAAAAAAAMD6AAAA+gAAANZAAAAAAAAADgAWwABAAAAAwAWAAEAAAAAAAIABgATAG4AAAAtCZEAAAAAAAAAEgDeAAEAAAAAAAAANQAAAAEAAAAAAAEACAA1AAEAAAAAAAIABwA9AAEAAAAAAAMACABEAAEAAAAAAAQACABMAAEAAAAAAAUACwBUAAEAAAAAAAYACABfAAEAAAAAAAoAKwBnAAEAAAAAAAsAEwCSAAMAAQQJAAAAagClAAMAAQQJAAEAEAEPAAMAAQQJAAIADgEfAAMAAQQJAAMAEAEtAAMAAQQJAAQAEAE9AAMAAQQJAAUAFgFNAAMAAQQJAAYAEAFjAAMAAQQJAAoAVgFzAAMAAQQJAAsAJgHJQ29weXJpZ2h0IChDKSAyMDE0IGJ5IG9yaWdpbmFsIGF1dGhvcnMgQCBmb250ZWxsby5jb21mb250ZWxsb1JlZ3VsYXJmb250ZWxsb2ZvbnRlbGxvVmVyc2lvbiAxLjBmb250ZWxsb0dlbmVyYXRlZCBieSBzdmcydHRmIGZyb20gRm9udGVsbG8gcHJvamVjdC5odHRwOi8vZm9udGVsbG8uY29tAEMAbwBwAHkAcgBpAGcAaAB0ACAAKABDACkAIAAyADAAMQA0ACAAYgB5ACAAbwByAGkAZwBpAG4AYQBsACAAYQB1AHQAaABvAHIAcwAgAEAAIABmAG8AbgB0AGUAbABsAG8ALgBjAG8AbQBmAG8AbgB0AGUAbABsAG8AUgBlAGcAdQBsAGEAcgBmAG8AbgB0AGUAbABsAG8AZgBvAG4AdABlAGwAbABvAFYAZQByAHMAaQBvAG4AIAAxAC4AMABmAG8AbgB0AGUAbABsAG8ARwBlAG4AZQByAGEAdABlAGQAIABiAHkAIABzAHYAZwAyAHQAdABmACAAZgByAG8AbQAgAEYAbwBuAHQAZQBsAGwAbwAgAHAAcgBvAGoAZQBjAHQALgBoAHQAdABwADoALwAvAGYAbwBuAHQAZQBsAGwAbwAuAGMAbwBtAAAAAAIAAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAQIBAwljaGVja21hcmsGY2lyY2xlAAAAAAEAAf//AA8AAAAAAAAAAAAAAAAAAAAAADIAMgML/7EDC/+xsAAssCBgZi2wASwgZCCwwFCwBCZasARFW1ghIyEbilggsFBQWCGwQFkbILA4UFghsDhZWSCwCkVhZLAoUFghsApFILAwUFghsDBZGyCwwFBYIGYgiophILAKUFhgGyCwIFBYIbAKYBsgsDZQWCGwNmAbYFlZWRuwACtZWSOwAFBYZVlZLbACLCBFILAEJWFkILAFQ1BYsAUjQrAGI0IbISFZsAFgLbADLCMhIyEgZLEFYkIgsAYjQrIKAAIqISCwBkMgiiCKsAArsTAFJYpRWGBQG2FSWVgjWSEgsEBTWLAAKxshsEBZI7AAUFhlWS2wBCywB0MrsgACAENgQi2wBSywByNCIyCwACNCYbCAYrABYLAEKi2wBiwgIEUgsAJFY7ABRWJgRLABYC2wBywgIEUgsAArI7ECBCVgIEWKI2EgZCCwIFBYIbAAG7AwUFiwIBuwQFlZI7AAUFhlWbADJSNhRESwAWAtsAgssQUFRbABYUQtsAkssAFgICCwCUNKsABQWCCwCSNCWbAKQ0qwAFJYILAKI0JZLbAKLCC4BABiILgEAGOKI2GwC0NgIIpgILALI0IjLbALLEtUWLEHAURZJLANZSN4LbAMLEtRWEtTWLEHAURZGyFZJLATZSN4LbANLLEADENVWLEMDEOwAWFCsAorWbAAQ7ACJUKxCQIlQrEKAiVCsAEWIyCwAyVQWLEBAENgsAQlQoqKIIojYbAJKiEjsAFhIIojYbAJKiEbsQEAQ2CwAiVCsAIlYbAJKiFZsAlDR7AKQ0dgsIBiILACRWOwAUViYLEAABMjRLABQ7AAPrIBAQFDYEItsA4ssQAFRVRYALAMI0IgYLABYbUNDQEACwBCQopgsQ0FK7BtKxsiWS2wDyyxAA4rLbAQLLEBDistsBEssQIOKy2wEiyxAw4rLbATLLEEDistsBQssQUOKy2wFSyxBg4rLbAWLLEHDistsBcssQgOKy2wGCyxCQ4rLbAZLLAIK7EABUVUWACwDCNCIGCwAWG1DQ0BAAsAQkKKYLENBSuwbSsbIlktsBossQAZKy2wGyyxARkrLbAcLLECGSstsB0ssQMZKy2wHiyxBBkrLbAfLLEFGSstsCAssQYZKy2wISyxBxkrLbAiLLEIGSstsCMssQkZKy2wJCwgPLABYC2wJSwgYLANYCBDI7ABYEOwAiVhsAFgsCQqIS2wJiywJSuwJSotsCcsICBHICCwAkVjsAFFYmAjYTgjIIpVWCBHICCwAkVjsAFFYmAjYTgbIVktsCgssQAFRVRYALABFrAnKrABFTAbIlktsCkssAgrsQAFRVRYALABFrAnKrABFTAbIlktsCosIDWwAWAtsCssALADRWOwAUVisAArsAJFY7ABRWKwACuwABa0AAAAAABEPiM4sSoBFSotsCwsIDwgRyCwAkVjsAFFYmCwAENhOC2wLSwuFzwtsC4sIDwgRyCwAkVjsAFFYmCwAENhsAFDYzgtsC8ssQIAFiUgLiBHsAAjQrACJUmKikcjRyNhIFhiGyFZsAEjQrIuAQEVFCotsDAssAAWsAQlsAQlRyNHI2GwBkUrZYouIyAgPIo4LbAxLLAAFrAEJbAEJSAuRyNHI2EgsAQjQrAGRSsgsGBQWCCwQFFYswIgAyAbswImAxpZQkIjILAIQyCKI0cjRyNhI0ZgsARDsIBiYCCwACsgiophILACQ2BkI7ADQ2FkUFiwAkNhG7ADQ2BZsAMlsIBiYSMgILAEJiNGYTgbI7AIQ0awAiWwCENHI0cjYWAgsARDsIBiYCMgsAArI7AEQ2CwACuwBSVhsAUlsIBisAQmYSCwBCVgZCOwAyVgZFBYIRsjIVkjICCwBCYjRmE4WS2wMiywABYgICCwBSYgLkcjRyNhIzw4LbAzLLAAFiCwCCNCICAgRiNHsAArI2E4LbA0LLAAFrADJbACJUcjRyNhsABUWC4gPCMhG7ACJbACJUcjRyNhILAFJbAEJUcjRyNhsAYlsAUlSbACJWGwAUVjIyBYYhshWWOwAUViYCMuIyAgPIo4IyFZLbA1LLAAFiCwCEMgLkcjRyNhIGCwIGBmsIBiIyAgPIo4LbA2LCMgLkawAiVGUlggPFkusSYBFCstsDcsIyAuRrACJUZQWCA8WS6xJgEUKy2wOCwjIC5GsAIlRlJYIDxZIyAuRrACJUZQWCA8WS6xJgEUKy2wOSywMCsjIC5GsAIlRlJYIDxZLrEmARQrLbA6LLAxK4ogIDywBCNCijgjIC5GsAIlRlJYIDxZLrEmARQrsARDLrAmKy2wOyywABawBCWwBCYgLkcjRyNhsAZFKyMgPCAuIzixJgEUKy2wPCyxCAQlQrAAFrAEJbAEJSAuRyNHI2EgsAQjQrAGRSsgsGBQWCCwQFFYswIgAyAbswImAxpZQkIjIEewBEOwgGJgILAAKyCKimEgsAJDYGQjsANDYWRQWLACQ2EbsANDYFmwAyWwgGJhsAIlRmE4IyA8IzgbISAgRiNHsAArI2E4IVmxJgEUKy2wPSywMCsusSYBFCstsD4ssDErISMgIDywBCNCIzixJgEUK7AEQy6wJistsD8ssAAVIEewACNCsgABARUUEy6wLCotsEAssAAVIEewACNCsgABARUUEy6wLCotsEEssQABFBOwLSotsEIssC8qLbBDLLAAFkUjIC4gRoojYTixJgEUKy2wRCywCCNCsEMrLbBFLLIAADwrLbBGLLIAATwrLbBHLLIBADwrLbBILLIBATwrLbBJLLIAAD0rLbBKLLIAAT0rLbBLLLIBAD0rLbBMLLIBAT0rLbBNLLIAADkrLbBOLLIAATkrLbBPLLIBADkrLbBQLLIBATkrLbBRLLIAADsrLbBSLLIAATsrLbBTLLIBADsrLbBULLIBATsrLbBVLLIAAD4rLbBWLLIAAT4rLbBXLLIBAD4rLbBYLLIBAT4rLbBZLLIAADorLbBaLLIAATorLbBbLLIBADorLbBcLLIBATorLbBdLLAyKy6xJgEUKy2wXiywMiuwNistsF8ssDIrsDcrLbBgLLAAFrAyK7A4Ky2wYSywMysusSYBFCstsGIssDMrsDYrLbBjLLAzK7A3Ky2wZCywMyuwOCstsGUssDQrLrEmARQrLbBmLLA0K7A2Ky2wZyywNCuwNystsGgssDQrsDgrLbBpLLA1Ky6xJgEUKy2waiywNSuwNistsGsssDUrsDcrLbBsLLA1K7A4Ky2wbSwrsAhlsAMkUHiwARUwLQAAAEu4AMhSWLEBAY5ZuQgACABjILABI0SwAyNwsgQoCUVSRLIKAgcqsQYBRLEkAYhRWLBAiFixBgNEsSYBiFFYuAQAiFixBgFEWVlZWbgB/4WwBI2xBQBEAAA=)
+      format('truetype'),
+    url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAAoUAA4AAAAAEPQAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABPUy8yAAABRAAAAEQAAABWPeFJAWNtYXAAAAGIAAAAOgAAAUrQEhm3Y3Z0IAAAAcQAAAAUAAAAHAZJ/5RmcGdtAAAB2AAABPkAAAmRigp4O2dhc3AAAAbUAAAACAAAAAgAAAAQZ2x5ZgAABtwAAACuAAAAtt9nBHZoZWFkAAAHjAAAADUAAAA2ASs8e2hoZWEAAAfEAAAAIAAAACQHUwNNaG10eAAAB+QAAAAMAAAADAspAABsb2NhAAAH8AAAAAgAAAAIADgAW21heHAAAAf4AAAAIAAAACAApgm8bmFtZQAACBgAAAF3AAACzcydGhxwb3N0AAAJkAAAACoAAAA7rr1AmHByZXAAAAm8AAAAVgAAAFaSoZr/eJxjYGTewTiBgZWBg6mKaQ8DA0MPhGZ8wGDIyMTAwMTAysyAFQSkuaYwOLxgeMHIHPQ/iyGKmZvBHyjMCJIDAPe9C2B4nGNgYGBmgGAZBkYGEHAB8hjBfBYGDSDNBqQZGZgYGF4w/v8PUvCCAURLMELVAwEjG8OIBwBk5AavAAB4nGNgQANGDEbM3P83gjAAELQD4XicnVXZdtNWFJU8ZHASOmSgoA7X3DhQ68qEKRgwaSrFdiEdHAitBB2kDHTkncc+62uOQrtWH/m07n09JLR0rbYsls++R1tn2DrnRhwjKn0aiGvUoZKXA6msPZZK90lc13Uvj5UMBnFdthJPSZuonSRKat3sUC7xWOsqWSdYJ+PlIFZPVZ5noAziFB5lSUQbRBuplyZJ4onjJ4kWZxAfJUkgJaMQp9LIUEI1GsRS1aFM6dCr1xNx00DKRqMedVhU90PFJ8c1p9SsA0YqVznCFevVRr4bpwMve5DEOsGzrYcxHnisfpQqkIqR6cg/dkpOlIaBVHHUoVbi6DCTX/eRTCrNQKaMYkWl7oG43f102xYxPXQ6vi5KlUaqurnOKJrt0fGogygP2cbppNzQ2fbw5RlTVKtdcbPtQGYNXErJbHSfRAAdJlLj6QFONZwCqRn1R8XZ588BEslclKo8VTKHegOZMzt7cTHtbiersnCknwcyb3Z2452HQ6dXh3/R+hdM4cxHj+Jifj5C+lBqfiJOJKVGWMzyp4YfcVcgQrkxiAsXyuBThDl0RdrZZl3jtTH2hs/5SqlhPQna6KP4fgr9TiQrHGdRo/VInM1j13Wt3GdQS7W7Fzsyr0OVIu7vCwuuM+eEYZ4WC1VfnvneBTT/Bohn/EDeNIVL+5YpSrRvm6JMu2iKCu0SVKVdNsUU7YoppmnPmmKG9h1TzNKeMzLj/8vc55H7HN7xkJv2XeSmfQ+5ad9HbtoPkJtWITdtHblpLyA3rUZu2lWjOnYEGgZpF1IVQdA0svph3Fab9UDWjDR8aWDyLmLI+upER521tcofxX914gsHcmmip7siF5viLq/bFj483e6rj5pG3bDV+MaR8jAeRnocmtBZ+c3hv+1N3S6a7jKqMugBFUwKwABl7UAC0zrbCaT1mqf48gdgXIZ4zkpDtVSfO4am7+V5X/exOfG+x+3GLrdcd3kJWdYNcmP28N9SZKrrH+UtrVQnR6wrJ49VaxhDKrwour6SlHu0tRu/KKmy8l6U1srnk5CbPYMbQlu27mGwI0xpyiUeXlOlKD3UUo6yQyxvKco84JSLC1qGxLgOdQ9qa8TpoXoYGwshhqG0vRBwSCldFd+0ynfxHqtr2Oj4xRXh6XpyEhGf4ir7UfBU10b96A7avGbdMoMpVaqn+4xPsa/b9lFZaaSOsxe3VAfXNOsaORXTT+Rr4HRvOGjdAz1UfDRBI1U1x+jGKGM0ljXl3wR0MVZ+w2jVYvs93E+dpFWsuUuY7JsT9+C0u/0q+7WcW0bW/dcGvW3kip8jMb8tCvw7B2K3ZA3UO5OBGAvIWdAYxhYmdxiug23EbfY/Jqf/34aFRXJXOxq7eerD1ZNRJXfZ8rjLTXZZ16M2R9VOGvsIjS0PN+bY4XIstsRgQbb+wf8x7gF3aVEC4NDIZZiI2nShnurh6h6rsW04VxIBds2x43QAegAuQd8cu9bzCYD13CPnLsB9cgh2yCH4lByCz8i5BfA5OQRfkEMwIIdgl5w7AA/IIXhIDsEeOQSPyNkE+JIcgq/IIYjJIUjIuQ3wmByCJ+QQfE0OwTdGrk5k/pYH2QD6zqKbQKmdGhzaOGRGrk3Y+zxY9oFFZB9aROqRkesT6lMeLPV7i0j9wSJSfzRyY0L9iQdL/dkiUn+xiNRnxpeZIymvDp7zjg7+BJfqrV4AAAAAAQAB//8AD3icY2BkAALmJUwzGEQZZBwk+RkZGBmdGJgYmbIYgMwsoGSiiLgIs5A2owg7I5uSOqOaiT2jmZE8I5gQY17C/09BQEfg3yt+fh8gvYQxD0j68DOJiQn8U+DnZxQDcQUEljLmCwBpBgbG/3//b2SOZ+Zm4GEQcuAH2sblDLSEm8FFVJhJEGgLH6OSHpMdo5EcI3Nk0bEXJ/LYqvZ82VXHGFd6pKTkyCsQwQAAq+QkqAAAeJxjYGRgYADiw5VSsfH8Nl8ZuJlfAEUYzpvO6IXQCb7///7fyLyEmRvI5WBgAokCAFb/DJAAAAB4nGNgZGBgDvqfxRDF/IKB4f935iUMQBEUwAwAi5YFpgPoAAAD6AAAA1kAAAAAAAAAOABbAAEAAAADABYAAQAAAAAAAgAGABMAbgAAAC0JkQAAAAB4nHWQy2rCQBSG//HSi0JbWui2sypKabxgN4IgWHTTbqS4LTHGJBIzMhkFX6Pv0IfpS/RZ+puMpShNmMx3vjlz5mQAXOMbAvnzxJGzwBmjnAs4Rc9ykf7Zcon8YrmMKt4sn9C/W67gAYHlKm7wwQqidM5ogU/LAlfi0nIBF+LOcpH+0XKJ3LNcxq14tXxC71muYCJSy1Xci6+BWm11FIRG1gZ12W62OnK6lYoqStxYumsTKp3KvpyrxPhxrBxPLfc89oN17Op9uJ8nvk4jlciW09yrkZ/42jX+bFc93QRtY+ZyrtVSDm2GXGm18D3jhMasuo3G3/MwgMIKW2hEvKoQBhI12jrnNppooUOaMkMyM8+KkMBFTONizR1htpIy7nPMGSW0PjNisgOP3+WRH5MC7o9ZRR+tHsYT0u6MKPOSfTns7jBrREqyTDezs9/eU2x4WpvWcNeuS511JTE8qCF5H7u1BY1H72S3Ymi7aPD95/9+AN1fhEsAeJxjYGKAAC4G7ICZgYGRiZGZMzkjNTk7N7Eomy05syg5J5WBAQBE1QZBAABLuADIUlixAQGOWbkIAAgAYyCwASNEsAMjcLIEKAlFUkSyCgIHKrEGAUSxJAGIUViwQIhYsQYDRLEmAYhRWLgEAIhYsQYBRFlZWVm4Af+FsASNsQUARAAA)
+      format('woff');
 }
 
 .ui.steps .step.completed > .icon:before,
@@ -20047,7 +20167,7 @@ ol.ui.horizontal.list li:before,
 /* Link */
 
 .ui.breadcrumb a {
-  color: #4183C4;
+  color: #4183c4;
 }
 
 .ui.breadcrumb a:hover {
@@ -20200,17 +20320,17 @@ ol.ui.horizontal.list li:before,
 
 .ui.form textarea,
 .ui.form input:not([type]),
-.ui.form input[type="date"],
-.ui.form input[type="datetime-local"],
-.ui.form input[type="email"],
-.ui.form input[type="number"],
-.ui.form input[type="password"],
-.ui.form input[type="search"],
-.ui.form input[type="tel"],
-.ui.form input[type="time"],
-.ui.form input[type="text"],
-.ui.form input[type="file"],
-.ui.form input[type="url"] {
+.ui.form input[type='date'],
+.ui.form input[type='datetime-local'],
+.ui.form input[type='email'],
+.ui.form input[type='number'],
+.ui.form input[type='password'],
+.ui.form input[type='search'],
+.ui.form input[type='tel'],
+.ui.form input[type='time'],
+.ui.form input[type='text'],
+.ui.form input[type='file'],
+.ui.form input[type='url'] {
   width: 100%;
   vertical-align: top;
 }
@@ -20223,17 +20343,17 @@ ol.ui.horizontal.list li:before,
 }
 
 .ui.form input:not([type]),
-.ui.form input[type="date"],
-.ui.form input[type="datetime-local"],
-.ui.form input[type="email"],
-.ui.form input[type="number"],
-.ui.form input[type="password"],
-.ui.form input[type="search"],
-.ui.form input[type="tel"],
-.ui.form input[type="time"],
-.ui.form input[type="text"],
-.ui.form input[type="file"],
-.ui.form input[type="url"] {
+.ui.form input[type='date'],
+.ui.form input[type='datetime-local'],
+.ui.form input[type='email'],
+.ui.form input[type='number'],
+.ui.form input[type='password'],
+.ui.form input[type='search'],
+.ui.form input[type='tel'],
+.ui.form input[type='time'],
+.ui.form input[type='text'],
+.ui.form input[type='file'],
+.ui.form input[type='url'] {
   font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
   margin: 0em;
   outline: none;
@@ -20242,7 +20362,7 @@ ol.ui.horizontal.list li:before,
   line-height: 1.21428571em;
   padding: 0.67857143em 1em;
   font-size: 1em;
-  background: #FFFFFF;
+  background: #ffffff;
   border: 1px solid rgba(34, 36, 38, 0.15);
   color: rgba(0, 0, 0, 0.87);
   border-radius: 0.28571429rem;
@@ -20259,7 +20379,7 @@ ol.ui.horizontal.list li:before,
   -webkit-appearance: none;
   tap-highlight-color: rgba(255, 255, 255, 0);
   padding: 0.78571429em 1em;
-  background: #FFFFFF;
+  background: #ffffff;
   border: 1px solid rgba(34, 36, 38, 0.15);
   outline: none;
   color: rgba(0, 0, 0, 0.87);
@@ -20280,7 +20400,7 @@ ol.ui.horizontal.list li:before,
 }
 
 .ui.form textarea,
-.ui.form input[type="checkbox"] {
+.ui.form input[type='checkbox'] {
   vertical-align: top;
 }
 
@@ -20300,7 +20420,7 @@ ol.ui.horizontal.list li:before,
   display: block;
   height: auto;
   width: 100%;
-  background: #FFFFFF;
+  background: #ffffff;
   border: 1px solid rgba(34, 36, 38, 0.15);
   border-radius: 0.28571429rem;
   -webkit-box-shadow: 0em 0em 0em 0em transparent inset;
@@ -20404,9 +20524,9 @@ ol.ui.horizontal.list li:before,
 
 .ui.form .field .prompt.label {
   white-space: normal;
-  background: #FFFFFF !important;
-  border: 1px solid #E0B4B4 !important;
-  color: #9F3A38 !important;
+  background: #ffffff !important;
+  border: 1px solid #e0b4b4 !important;
+  color: #9f3a38 !important;
 }
 
 .ui.form .inline.fields .field .prompt,
@@ -20433,25 +20553,25 @@ ol.ui.horizontal.list li:before,
 ---------------------*/
 
 .ui.form .field.field input:-webkit-autofill {
-  -webkit-box-shadow: 0px 0px 0px 100px #FFFFF0 inset !important;
-  box-shadow: 0px 0px 0px 100px #FFFFF0 inset !important;
-  border-color: #E5DFA1 !important;
+  -webkit-box-shadow: 0px 0px 0px 100px #fffff0 inset !important;
+  box-shadow: 0px 0px 0px 100px #fffff0 inset !important;
+  border-color: #e5dfa1 !important;
 }
 
 /* Focus */
 
 .ui.form .field.field input:-webkit-autofill:focus {
-  -webkit-box-shadow: 0px 0px 0px 100px #FFFFF0 inset !important;
-  box-shadow: 0px 0px 0px 100px #FFFFF0 inset !important;
-  border-color: #D5C315 !important;
+  -webkit-box-shadow: 0px 0px 0px 100px #fffff0 inset !important;
+  box-shadow: 0px 0px 0px 100px #fffff0 inset !important;
+  border-color: #d5c315 !important;
 }
 
 /* Error */
 
 .ui.form .error.error input:-webkit-autofill {
-  -webkit-box-shadow: 0px 0px 0px 100px #FFFAF0 inset !important;
-  box-shadow: 0px 0px 0px 100px #FFFAF0 inset !important;
-  border-color: #E0B4B4 !important;
+  -webkit-box-shadow: 0px 0px 0px 100px #fffaf0 inset !important;
+  box-shadow: 0px 0px 0px 100px #fffaf0 inset !important;
+  border-color: #e0b4b4 !important;
 }
 
 /*--------------------
@@ -20515,30 +20635,30 @@ ol.ui.horizontal.list li:before,
 ---------------------*/
 
 .ui.form input:not([type]):focus,
-.ui.form input[type="date"]:focus,
-.ui.form input[type="datetime-local"]:focus,
-.ui.form input[type="email"]:focus,
-.ui.form input[type="number"]:focus,
-.ui.form input[type="password"]:focus,
-.ui.form input[type="search"]:focus,
-.ui.form input[type="tel"]:focus,
-.ui.form input[type="time"]:focus,
-.ui.form input[type="text"]:focus,
-.ui.form input[type="file"]:focus,
-.ui.form input[type="url"]:focus {
+.ui.form input[type='date']:focus,
+.ui.form input[type='datetime-local']:focus,
+.ui.form input[type='email']:focus,
+.ui.form input[type='number']:focus,
+.ui.form input[type='password']:focus,
+.ui.form input[type='search']:focus,
+.ui.form input[type='tel']:focus,
+.ui.form input[type='time']:focus,
+.ui.form input[type='text']:focus,
+.ui.form input[type='file']:focus,
+.ui.form input[type='url']:focus {
   color: rgba(0, 0, 0, 0.95);
-  border-color: #85B7D9;
+  border-color: #85b7d9;
   border-radius: 0.28571429rem;
-  background: #FFFFFF;
+  background: #ffffff;
   -webkit-box-shadow: 0px 0em 0em 0em rgba(34, 36, 38, 0.35) inset;
   box-shadow: 0px 0em 0em 0em rgba(34, 36, 38, 0.35) inset;
 }
 
 .ui.form textarea:focus {
   color: rgba(0, 0, 0, 0.95);
-  border-color: #85B7D9;
+  border-color: #85b7d9;
   border-radius: 0.28571429rem;
-  background: #FFFFFF;
+  background: #ffffff;
   -webkit-box-shadow: 0px 0em 0em 0em rgba(34, 36, 38, 0.35) inset;
   box-shadow: 0px 0em 0em 0em rgba(34, 36, 38, 0.35) inset;
   -webkit-appearance: none;
@@ -20610,46 +20730,46 @@ ol.ui.horizontal.list li:before,
 .ui.form .field.error label,
 .ui.form .fields.error .field .input,
 .ui.form .field.error .input {
-  color: #9F3A38;
+  color: #9f3a38;
 }
 
 .ui.form .fields.error .field .corner.label,
 .ui.form .field.error .corner.label {
-  border-color: #9F3A38;
-  color: #FFFFFF;
+  border-color: #9f3a38;
+  color: #ffffff;
 }
 
 .ui.form .fields.error .field textarea,
 .ui.form .fields.error .field select,
 .ui.form .fields.error .field input:not([type]),
-.ui.form .fields.error .field input[type="date"],
-.ui.form .fields.error .field input[type="datetime-local"],
-.ui.form .fields.error .field input[type="email"],
-.ui.form .fields.error .field input[type="number"],
-.ui.form .fields.error .field input[type="password"],
-.ui.form .fields.error .field input[type="search"],
-.ui.form .fields.error .field input[type="tel"],
-.ui.form .fields.error .field input[type="time"],
-.ui.form .fields.error .field input[type="text"],
-.ui.form .fields.error .field input[type="file"],
-.ui.form .fields.error .field input[type="url"],
+.ui.form .fields.error .field input[type='date'],
+.ui.form .fields.error .field input[type='datetime-local'],
+.ui.form .fields.error .field input[type='email'],
+.ui.form .fields.error .field input[type='number'],
+.ui.form .fields.error .field input[type='password'],
+.ui.form .fields.error .field input[type='search'],
+.ui.form .fields.error .field input[type='tel'],
+.ui.form .fields.error .field input[type='time'],
+.ui.form .fields.error .field input[type='text'],
+.ui.form .fields.error .field input[type='file'],
+.ui.form .fields.error .field input[type='url'],
 .ui.form .field.error textarea,
 .ui.form .field.error select,
 .ui.form .field.error input:not([type]),
-.ui.form .field.error input[type="date"],
-.ui.form .field.error input[type="datetime-local"],
-.ui.form .field.error input[type="email"],
-.ui.form .field.error input[type="number"],
-.ui.form .field.error input[type="password"],
-.ui.form .field.error input[type="search"],
-.ui.form .field.error input[type="tel"],
-.ui.form .field.error input[type="time"],
-.ui.form .field.error input[type="text"],
-.ui.form .field.error input[type="file"],
-.ui.form .field.error input[type="url"] {
-  background: #FFF6F6;
-  border-color: #E0B4B4;
-  color: #9F3A38;
+.ui.form .field.error input[type='date'],
+.ui.form .field.error input[type='datetime-local'],
+.ui.form .field.error input[type='email'],
+.ui.form .field.error input[type='number'],
+.ui.form .field.error input[type='password'],
+.ui.form .field.error input[type='search'],
+.ui.form .field.error input[type='tel'],
+.ui.form .field.error input[type='time'],
+.ui.form .field.error input[type='text'],
+.ui.form .field.error input[type='file'],
+.ui.form .field.error input[type='url'] {
+  background: #fff6f6;
+  border-color: #e0b4b4;
+  color: #9f3a38;
   border-radius: '';
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -20658,20 +20778,20 @@ ol.ui.horizontal.list li:before,
 .ui.form .field.error textarea:focus,
 .ui.form .field.error select:focus,
 .ui.form .field.error input:not([type]):focus,
-.ui.form .field.error input[type="date"]:focus,
-.ui.form .field.error input[type="datetime-local"]:focus,
-.ui.form .field.error input[type="email"]:focus,
-.ui.form .field.error input[type="number"]:focus,
-.ui.form .field.error input[type="password"]:focus,
-.ui.form .field.error input[type="search"]:focus,
-.ui.form .field.error input[type="tel"]:focus,
-.ui.form .field.error input[type="time"]:focus,
-.ui.form .field.error input[type="text"]:focus,
-.ui.form .field.error input[type="file"]:focus,
-.ui.form .field.error input[type="url"]:focus {
-  background: #FFF6F6;
-  border-color: #E0B4B4;
-  color: #9F3A38;
+.ui.form .field.error input[type='date']:focus,
+.ui.form .field.error input[type='datetime-local']:focus,
+.ui.form .field.error input[type='email']:focus,
+.ui.form .field.error input[type='number']:focus,
+.ui.form .field.error input[type='password']:focus,
+.ui.form .field.error input[type='search']:focus,
+.ui.form .field.error input[type='tel']:focus,
+.ui.form .field.error input[type='time']:focus,
+.ui.form .field.error input[type='text']:focus,
+.ui.form .field.error input[type='file']:focus,
+.ui.form .field.error input[type='url']:focus {
+  background: #fff6f6;
+  border-color: #e0b4b4;
+  color: #9f3a38;
   -webkit-appearance: none;
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -20692,50 +20812,50 @@ ol.ui.horizontal.list li:before,
 .ui.form .field.error .ui.dropdown,
 .ui.form .field.error .ui.dropdown .text,
 .ui.form .field.error .ui.dropdown .item {
-  background: #FFF6F6;
-  color: #9F3A38;
+  background: #fff6f6;
+  color: #9f3a38;
 }
 
 .ui.form .fields.error .field .ui.dropdown,
 .ui.form .field.error .ui.dropdown {
-  border-color: #E0B4B4 !important;
+  border-color: #e0b4b4 !important;
 }
 
 .ui.form .fields.error .field .ui.dropdown:hover,
 .ui.form .field.error .ui.dropdown:hover {
-  border-color: #E0B4B4 !important;
+  border-color: #e0b4b4 !important;
 }
 
 .ui.form .fields.error .field .ui.dropdown:hover .menu,
 .ui.form .field.error .ui.dropdown:hover .menu {
-  border-color: #E0B4B4;
+  border-color: #e0b4b4;
 }
 
 .ui.form .fields.error .field .ui.multiple.selection.dropdown > .label,
 .ui.form .field.error .ui.multiple.selection.dropdown > .label {
-  background-color: #EACBCB;
-  color: #9F3A38;
+  background-color: #eacbcb;
+  color: #9f3a38;
 }
 
 /* Hover */
 
 .ui.form .fields.error .field .ui.dropdown .menu .item:hover,
 .ui.form .field.error .ui.dropdown .menu .item:hover {
-  background-color: #FBE7E7;
+  background-color: #fbe7e7;
 }
 
 /* Selected */
 
 .ui.form .fields.error .field .ui.dropdown .menu .selected.item,
 .ui.form .field.error .ui.dropdown .menu .selected.item {
-  background-color: #FBE7E7;
+  background-color: #fbe7e7;
 }
 
 /* Active */
 
 .ui.form .fields.error .field .ui.dropdown .menu .active.item,
 .ui.form .field.error .ui.dropdown .menu .active.item {
-  background-color: #FDCFCF !important;
+  background-color: #fdcfcf !important;
 }
 
 /*--------------------
@@ -20746,22 +20866,22 @@ ol.ui.horizontal.list li:before,
 .ui.form .field.error .checkbox:not(.toggle):not(.slider) label,
 .ui.form .fields.error .field .checkbox:not(.toggle):not(.slider) .box,
 .ui.form .field.error .checkbox:not(.toggle):not(.slider) .box {
-  color: #9F3A38;
+  color: #9f3a38;
 }
 
 .ui.form .fields.error .field .checkbox:not(.toggle):not(.slider) label:before,
 .ui.form .field.error .checkbox:not(.toggle):not(.slider) label:before,
 .ui.form .fields.error .field .checkbox:not(.toggle):not(.slider) .box:before,
 .ui.form .field.error .checkbox:not(.toggle):not(.slider) .box:before {
-  background: #FFF6F6;
-  border-color: #E0B4B4;
+  background: #fff6f6;
+  border-color: #e0b4b4;
 }
 
 .ui.form .fields.error .field .checkbox label:after,
 .ui.form .field.error .checkbox label:after,
 .ui.form .fields.error .field .checkbox .box:after,
 .ui.form .field.error .checkbox .box:after {
-  color: #9F3A38;
+  color: #9f3a38;
 }
 
 /*--------------------
@@ -20866,7 +20986,7 @@ ol.ui.horizontal.list li:before,
 .ui.form .required.field > .checkbox:after {
   margin: -0.2em 0em 0em 0.2em;
   content: '*';
-  color: #DB2828;
+  color: #db2828;
 }
 
 .ui.form .required.fields:not(.grouped) > .field > label:after,
@@ -20908,18 +21028,18 @@ ol.ui.horizontal.list li:before,
 /* Inverted Field */
 
 .ui.inverted.form input:not([type]),
-.ui.inverted.form input[type="date"],
-.ui.inverted.form input[type="datetime-local"],
-.ui.inverted.form input[type="email"],
-.ui.inverted.form input[type="number"],
-.ui.inverted.form input[type="password"],
-.ui.inverted.form input[type="search"],
-.ui.inverted.form input[type="tel"],
-.ui.inverted.form input[type="time"],
-.ui.inverted.form input[type="text"],
-.ui.inverted.form input[type="file"],
-.ui.inverted.form input[type="url"] {
-  background: #FFFFFF;
+.ui.inverted.form input[type='date'],
+.ui.inverted.form input[type='datetime-local'],
+.ui.inverted.form input[type='email'],
+.ui.inverted.form input[type='number'],
+.ui.inverted.form input[type='password'],
+.ui.inverted.form input[type='search'],
+.ui.inverted.form input[type='tel'],
+.ui.inverted.form input[type='time'],
+.ui.inverted.form input[type='text'],
+.ui.inverted.form input[type='file'],
+.ui.inverted.form input[type='url'] {
+  background: #ffffff;
   border-color: rgba(255, 255, 255, 0.1);
   color: rgba(0, 0, 0, 0.87);
   -webkit-box-shadow: none;
@@ -21042,8 +21162,10 @@ ol.ui.horizontal.list li:before,
     flex-wrap: wrap;
   }
 
-  .ui[class*="equal width"].form:not(.unstackable) .fields > .field,
-  .ui.form:not(.unstackable) [class*="equal width"].fields:not(.unstackable) > .field,
+  .ui[class*='equal width'].form:not(.unstackable) .fields > .field,
+  .ui.form:not(.unstackable)
+    [class*='equal width'].fields:not(.unstackable)
+    > .field,
   .ui.form:not(.unstackable) .two.fields:not(.unstackable) > .fields,
   .ui.form:not(.unstackable) .two.fields:not(.unstackable) > .field,
   .ui.form:not(.unstackable) .three.fields:not(.unstackable) > .fields,
@@ -21177,8 +21299,8 @@ ol.ui.horizontal.list li:before,
      Equal Width
 ---------------------*/
 
-.ui[class*="equal width"].form .fields > .field,
-.ui.form [class*="equal width"].fields > .field {
+.ui[class*='equal width'].form .fields > .field,
+.ui.form [class*='equal width'].fields > .field {
   width: 100%;
   -webkit-box-flex: 1;
   -ms-flex: 1 1 auto;
@@ -21356,7 +21478,7 @@ ol.ui.horizontal.list li:before,
   margin-right: -1.5rem;
 }
 
-.ui[class*="very relaxed"].grid {
+.ui[class*='very relaxed'].grid {
   margin-left: -2.5rem;
   margin-right: -2.5rem;
 }
@@ -21553,149 +21675,149 @@ ol.ui.horizontal.list li:before,
 
 /* Grid Based */
 
-.ui[class*="one column"].grid > .row > .column,
-.ui[class*="one column"].grid > .column:not(.row) {
+.ui[class*='one column'].grid > .row > .column,
+.ui[class*='one column'].grid > .column:not(.row) {
   width: 100%;
 }
 
-.ui[class*="two column"].grid > .row > .column,
-.ui[class*="two column"].grid > .column:not(.row) {
+.ui[class*='two column'].grid > .row > .column,
+.ui[class*='two column'].grid > .column:not(.row) {
   width: 50%;
 }
 
-.ui[class*="three column"].grid > .row > .column,
-.ui[class*="three column"].grid > .column:not(.row) {
+.ui[class*='three column'].grid > .row > .column,
+.ui[class*='three column'].grid > .column:not(.row) {
   width: 33.33333333%;
 }
 
-.ui[class*="four column"].grid > .row > .column,
-.ui[class*="four column"].grid > .column:not(.row) {
+.ui[class*='four column'].grid > .row > .column,
+.ui[class*='four column'].grid > .column:not(.row) {
   width: 25%;
 }
 
-.ui[class*="five column"].grid > .row > .column,
-.ui[class*="five column"].grid > .column:not(.row) {
+.ui[class*='five column'].grid > .row > .column,
+.ui[class*='five column'].grid > .column:not(.row) {
   width: 20%;
 }
 
-.ui[class*="six column"].grid > .row > .column,
-.ui[class*="six column"].grid > .column:not(.row) {
+.ui[class*='six column'].grid > .row > .column,
+.ui[class*='six column'].grid > .column:not(.row) {
   width: 16.66666667%;
 }
 
-.ui[class*="seven column"].grid > .row > .column,
-.ui[class*="seven column"].grid > .column:not(.row) {
+.ui[class*='seven column'].grid > .row > .column,
+.ui[class*='seven column'].grid > .column:not(.row) {
   width: 14.28571429%;
 }
 
-.ui[class*="eight column"].grid > .row > .column,
-.ui[class*="eight column"].grid > .column:not(.row) {
+.ui[class*='eight column'].grid > .row > .column,
+.ui[class*='eight column'].grid > .column:not(.row) {
   width: 12.5%;
 }
 
-.ui[class*="nine column"].grid > .row > .column,
-.ui[class*="nine column"].grid > .column:not(.row) {
+.ui[class*='nine column'].grid > .row > .column,
+.ui[class*='nine column'].grid > .column:not(.row) {
   width: 11.11111111%;
 }
 
-.ui[class*="ten column"].grid > .row > .column,
-.ui[class*="ten column"].grid > .column:not(.row) {
+.ui[class*='ten column'].grid > .row > .column,
+.ui[class*='ten column'].grid > .column:not(.row) {
   width: 10%;
 }
 
-.ui[class*="eleven column"].grid > .row > .column,
-.ui[class*="eleven column"].grid > .column:not(.row) {
+.ui[class*='eleven column'].grid > .row > .column,
+.ui[class*='eleven column'].grid > .column:not(.row) {
   width: 9.09090909%;
 }
 
-.ui[class*="twelve column"].grid > .row > .column,
-.ui[class*="twelve column"].grid > .column:not(.row) {
+.ui[class*='twelve column'].grid > .row > .column,
+.ui[class*='twelve column'].grid > .column:not(.row) {
   width: 8.33333333%;
 }
 
-.ui[class*="thirteen column"].grid > .row > .column,
-.ui[class*="thirteen column"].grid > .column:not(.row) {
+.ui[class*='thirteen column'].grid > .row > .column,
+.ui[class*='thirteen column'].grid > .column:not(.row) {
   width: 7.69230769%;
 }
 
-.ui[class*="fourteen column"].grid > .row > .column,
-.ui[class*="fourteen column"].grid > .column:not(.row) {
+.ui[class*='fourteen column'].grid > .row > .column,
+.ui[class*='fourteen column'].grid > .column:not(.row) {
   width: 7.14285714%;
 }
 
-.ui[class*="fifteen column"].grid > .row > .column,
-.ui[class*="fifteen column"].grid > .column:not(.row) {
+.ui[class*='fifteen column'].grid > .row > .column,
+.ui[class*='fifteen column'].grid > .column:not(.row) {
   width: 6.66666667%;
 }
 
-.ui[class*="sixteen column"].grid > .row > .column,
-.ui[class*="sixteen column"].grid > .column:not(.row) {
+.ui[class*='sixteen column'].grid > .row > .column,
+.ui[class*='sixteen column'].grid > .column:not(.row) {
   width: 6.25%;
 }
 
 /* Row Based Overrides */
 
-.ui.grid > [class*="one column"].row > .column {
+.ui.grid > [class*='one column'].row > .column {
   width: 100% !important;
 }
 
-.ui.grid > [class*="two column"].row > .column {
+.ui.grid > [class*='two column'].row > .column {
   width: 50% !important;
 }
 
-.ui.grid > [class*="three column"].row > .column {
+.ui.grid > [class*='three column'].row > .column {
   width: 33.33333333% !important;
 }
 
-.ui.grid > [class*="four column"].row > .column {
+.ui.grid > [class*='four column'].row > .column {
   width: 25% !important;
 }
 
-.ui.grid > [class*="five column"].row > .column {
+.ui.grid > [class*='five column'].row > .column {
   width: 20% !important;
 }
 
-.ui.grid > [class*="six column"].row > .column {
+.ui.grid > [class*='six column'].row > .column {
   width: 16.66666667% !important;
 }
 
-.ui.grid > [class*="seven column"].row > .column {
+.ui.grid > [class*='seven column'].row > .column {
   width: 14.28571429% !important;
 }
 
-.ui.grid > [class*="eight column"].row > .column {
+.ui.grid > [class*='eight column'].row > .column {
   width: 12.5% !important;
 }
 
-.ui.grid > [class*="nine column"].row > .column {
+.ui.grid > [class*='nine column'].row > .column {
   width: 11.11111111% !important;
 }
 
-.ui.grid > [class*="ten column"].row > .column {
+.ui.grid > [class*='ten column'].row > .column {
   width: 10% !important;
 }
 
-.ui.grid > [class*="eleven column"].row > .column {
+.ui.grid > [class*='eleven column'].row > .column {
   width: 9.09090909% !important;
 }
 
-.ui.grid > [class*="twelve column"].row > .column {
+.ui.grid > [class*='twelve column'].row > .column {
   width: 8.33333333% !important;
 }
 
-.ui.grid > [class*="thirteen column"].row > .column {
+.ui.grid > [class*='thirteen column'].row > .column {
   width: 7.69230769% !important;
 }
 
-.ui.grid > [class*="fourteen column"].row > .column {
+.ui.grid > [class*='fourteen column'].row > .column {
   width: 7.14285714% !important;
 }
 
-.ui.grid > [class*="fifteen column"].row > .column {
+.ui.grid > [class*='fifteen column'].row > .column {
   width: 6.66666667% !important;
 }
 
-.ui.grid > [class*="sixteen column"].row > .column {
+.ui.grid > [class*='sixteen column'].row > .column {
   width: 6.25% !important;
 }
 
@@ -21712,115 +21834,115 @@ ol.ui.horizontal.list li:before,
 
 /* Sizing Combinations */
 
-.ui.grid > .row > [class*="one wide"].column,
-.ui.grid > .column.row > [class*="one wide"].column,
-.ui.grid > [class*="one wide"].column,
-.ui.column.grid > [class*="one wide"].column {
+.ui.grid > .row > [class*='one wide'].column,
+.ui.grid > .column.row > [class*='one wide'].column,
+.ui.grid > [class*='one wide'].column,
+.ui.column.grid > [class*='one wide'].column {
   width: 6.25% !important;
 }
 
-.ui.grid > .row > [class*="two wide"].column,
-.ui.grid > .column.row > [class*="two wide"].column,
-.ui.grid > [class*="two wide"].column,
-.ui.column.grid > [class*="two wide"].column {
+.ui.grid > .row > [class*='two wide'].column,
+.ui.grid > .column.row > [class*='two wide'].column,
+.ui.grid > [class*='two wide'].column,
+.ui.column.grid > [class*='two wide'].column {
   width: 12.5% !important;
 }
 
-.ui.grid > .row > [class*="three wide"].column,
-.ui.grid > .column.row > [class*="three wide"].column,
-.ui.grid > [class*="three wide"].column,
-.ui.column.grid > [class*="three wide"].column {
+.ui.grid > .row > [class*='three wide'].column,
+.ui.grid > .column.row > [class*='three wide'].column,
+.ui.grid > [class*='three wide'].column,
+.ui.column.grid > [class*='three wide'].column {
   width: 18.75% !important;
 }
 
-.ui.grid > .row > [class*="four wide"].column,
-.ui.grid > .column.row > [class*="four wide"].column,
-.ui.grid > [class*="four wide"].column,
-.ui.column.grid > [class*="four wide"].column {
+.ui.grid > .row > [class*='four wide'].column,
+.ui.grid > .column.row > [class*='four wide'].column,
+.ui.grid > [class*='four wide'].column,
+.ui.column.grid > [class*='four wide'].column {
   width: 25% !important;
 }
 
-.ui.grid > .row > [class*="five wide"].column,
-.ui.grid > .column.row > [class*="five wide"].column,
-.ui.grid > [class*="five wide"].column,
-.ui.column.grid > [class*="five wide"].column {
+.ui.grid > .row > [class*='five wide'].column,
+.ui.grid > .column.row > [class*='five wide'].column,
+.ui.grid > [class*='five wide'].column,
+.ui.column.grid > [class*='five wide'].column {
   width: 31.25% !important;
 }
 
-.ui.grid > .row > [class*="six wide"].column,
-.ui.grid > .column.row > [class*="six wide"].column,
-.ui.grid > [class*="six wide"].column,
-.ui.column.grid > [class*="six wide"].column {
+.ui.grid > .row > [class*='six wide'].column,
+.ui.grid > .column.row > [class*='six wide'].column,
+.ui.grid > [class*='six wide'].column,
+.ui.column.grid > [class*='six wide'].column {
   width: 37.5% !important;
 }
 
-.ui.grid > .row > [class*="seven wide"].column,
-.ui.grid > .column.row > [class*="seven wide"].column,
-.ui.grid > [class*="seven wide"].column,
-.ui.column.grid > [class*="seven wide"].column {
+.ui.grid > .row > [class*='seven wide'].column,
+.ui.grid > .column.row > [class*='seven wide'].column,
+.ui.grid > [class*='seven wide'].column,
+.ui.column.grid > [class*='seven wide'].column {
   width: 43.75% !important;
 }
 
-.ui.grid > .row > [class*="eight wide"].column,
-.ui.grid > .column.row > [class*="eight wide"].column,
-.ui.grid > [class*="eight wide"].column,
-.ui.column.grid > [class*="eight wide"].column {
+.ui.grid > .row > [class*='eight wide'].column,
+.ui.grid > .column.row > [class*='eight wide'].column,
+.ui.grid > [class*='eight wide'].column,
+.ui.column.grid > [class*='eight wide'].column {
   width: 50% !important;
 }
 
-.ui.grid > .row > [class*="nine wide"].column,
-.ui.grid > .column.row > [class*="nine wide"].column,
-.ui.grid > [class*="nine wide"].column,
-.ui.column.grid > [class*="nine wide"].column {
+.ui.grid > .row > [class*='nine wide'].column,
+.ui.grid > .column.row > [class*='nine wide'].column,
+.ui.grid > [class*='nine wide'].column,
+.ui.column.grid > [class*='nine wide'].column {
   width: 56.25% !important;
 }
 
-.ui.grid > .row > [class*="ten wide"].column,
-.ui.grid > .column.row > [class*="ten wide"].column,
-.ui.grid > [class*="ten wide"].column,
-.ui.column.grid > [class*="ten wide"].column {
+.ui.grid > .row > [class*='ten wide'].column,
+.ui.grid > .column.row > [class*='ten wide'].column,
+.ui.grid > [class*='ten wide'].column,
+.ui.column.grid > [class*='ten wide'].column {
   width: 62.5% !important;
 }
 
-.ui.grid > .row > [class*="eleven wide"].column,
-.ui.grid > .column.row > [class*="eleven wide"].column,
-.ui.grid > [class*="eleven wide"].column,
-.ui.column.grid > [class*="eleven wide"].column {
+.ui.grid > .row > [class*='eleven wide'].column,
+.ui.grid > .column.row > [class*='eleven wide'].column,
+.ui.grid > [class*='eleven wide'].column,
+.ui.column.grid > [class*='eleven wide'].column {
   width: 68.75% !important;
 }
 
-.ui.grid > .row > [class*="twelve wide"].column,
-.ui.grid > .column.row > [class*="twelve wide"].column,
-.ui.grid > [class*="twelve wide"].column,
-.ui.column.grid > [class*="twelve wide"].column {
+.ui.grid > .row > [class*='twelve wide'].column,
+.ui.grid > .column.row > [class*='twelve wide'].column,
+.ui.grid > [class*='twelve wide'].column,
+.ui.column.grid > [class*='twelve wide'].column {
   width: 75% !important;
 }
 
-.ui.grid > .row > [class*="thirteen wide"].column,
-.ui.grid > .column.row > [class*="thirteen wide"].column,
-.ui.grid > [class*="thirteen wide"].column,
-.ui.column.grid > [class*="thirteen wide"].column {
+.ui.grid > .row > [class*='thirteen wide'].column,
+.ui.grid > .column.row > [class*='thirteen wide'].column,
+.ui.grid > [class*='thirteen wide'].column,
+.ui.column.grid > [class*='thirteen wide'].column {
   width: 81.25% !important;
 }
 
-.ui.grid > .row > [class*="fourteen wide"].column,
-.ui.grid > .column.row > [class*="fourteen wide"].column,
-.ui.grid > [class*="fourteen wide"].column,
-.ui.column.grid > [class*="fourteen wide"].column {
+.ui.grid > .row > [class*='fourteen wide'].column,
+.ui.grid > .column.row > [class*='fourteen wide'].column,
+.ui.grid > [class*='fourteen wide'].column,
+.ui.column.grid > [class*='fourteen wide'].column {
   width: 87.5% !important;
 }
 
-.ui.grid > .row > [class*="fifteen wide"].column,
-.ui.grid > .column.row > [class*="fifteen wide"].column,
-.ui.grid > [class*="fifteen wide"].column,
-.ui.column.grid > [class*="fifteen wide"].column {
+.ui.grid > .row > [class*='fifteen wide'].column,
+.ui.grid > .column.row > [class*='fifteen wide'].column,
+.ui.grid > [class*='fifteen wide'].column,
+.ui.column.grid > [class*='fifteen wide'].column {
   width: 93.75% !important;
 }
 
-.ui.grid > .row > [class*="sixteen wide"].column,
-.ui.grid > .column.row > [class*="sixteen wide"].column,
-.ui.grid > [class*="sixteen wide"].column,
-.ui.column.grid > [class*="sixteen wide"].column {
+.ui.grid > .row > [class*='sixteen wide'].column,
+.ui.grid > .column.row > [class*='sixteen wide'].column,
+.ui.grid > [class*='sixteen wide'].column,
+.ui.column.grid > [class*='sixteen wide'].column {
   width: 100% !important;
 }
 
@@ -21831,115 +21953,115 @@ ol.ui.horizontal.list li:before,
 /* Mobile Sizing Combinations */
 
 @media only screen and (min-width: 320px) and (max-width: 767px) {
-  .ui.grid > .row > [class*="one wide mobile"].column,
-  .ui.grid > .column.row > [class*="one wide mobile"].column,
-  .ui.grid > [class*="one wide mobile"].column,
-  .ui.column.grid > [class*="one wide mobile"].column {
+  .ui.grid > .row > [class*='one wide mobile'].column,
+  .ui.grid > .column.row > [class*='one wide mobile'].column,
+  .ui.grid > [class*='one wide mobile'].column,
+  .ui.column.grid > [class*='one wide mobile'].column {
     width: 6.25% !important;
   }
 
-  .ui.grid > .row > [class*="two wide mobile"].column,
-  .ui.grid > .column.row > [class*="two wide mobile"].column,
-  .ui.grid > [class*="two wide mobile"].column,
-  .ui.column.grid > [class*="two wide mobile"].column {
+  .ui.grid > .row > [class*='two wide mobile'].column,
+  .ui.grid > .column.row > [class*='two wide mobile'].column,
+  .ui.grid > [class*='two wide mobile'].column,
+  .ui.column.grid > [class*='two wide mobile'].column {
     width: 12.5% !important;
   }
 
-  .ui.grid > .row > [class*="three wide mobile"].column,
-  .ui.grid > .column.row > [class*="three wide mobile"].column,
-  .ui.grid > [class*="three wide mobile"].column,
-  .ui.column.grid > [class*="three wide mobile"].column {
+  .ui.grid > .row > [class*='three wide mobile'].column,
+  .ui.grid > .column.row > [class*='three wide mobile'].column,
+  .ui.grid > [class*='three wide mobile'].column,
+  .ui.column.grid > [class*='three wide mobile'].column {
     width: 18.75% !important;
   }
 
-  .ui.grid > .row > [class*="four wide mobile"].column,
-  .ui.grid > .column.row > [class*="four wide mobile"].column,
-  .ui.grid > [class*="four wide mobile"].column,
-  .ui.column.grid > [class*="four wide mobile"].column {
+  .ui.grid > .row > [class*='four wide mobile'].column,
+  .ui.grid > .column.row > [class*='four wide mobile'].column,
+  .ui.grid > [class*='four wide mobile'].column,
+  .ui.column.grid > [class*='four wide mobile'].column {
     width: 25% !important;
   }
 
-  .ui.grid > .row > [class*="five wide mobile"].column,
-  .ui.grid > .column.row > [class*="five wide mobile"].column,
-  .ui.grid > [class*="five wide mobile"].column,
-  .ui.column.grid > [class*="five wide mobile"].column {
+  .ui.grid > .row > [class*='five wide mobile'].column,
+  .ui.grid > .column.row > [class*='five wide mobile'].column,
+  .ui.grid > [class*='five wide mobile'].column,
+  .ui.column.grid > [class*='five wide mobile'].column {
     width: 31.25% !important;
   }
 
-  .ui.grid > .row > [class*="six wide mobile"].column,
-  .ui.grid > .column.row > [class*="six wide mobile"].column,
-  .ui.grid > [class*="six wide mobile"].column,
-  .ui.column.grid > [class*="six wide mobile"].column {
+  .ui.grid > .row > [class*='six wide mobile'].column,
+  .ui.grid > .column.row > [class*='six wide mobile'].column,
+  .ui.grid > [class*='six wide mobile'].column,
+  .ui.column.grid > [class*='six wide mobile'].column {
     width: 37.5% !important;
   }
 
-  .ui.grid > .row > [class*="seven wide mobile"].column,
-  .ui.grid > .column.row > [class*="seven wide mobile"].column,
-  .ui.grid > [class*="seven wide mobile"].column,
-  .ui.column.grid > [class*="seven wide mobile"].column {
+  .ui.grid > .row > [class*='seven wide mobile'].column,
+  .ui.grid > .column.row > [class*='seven wide mobile'].column,
+  .ui.grid > [class*='seven wide mobile'].column,
+  .ui.column.grid > [class*='seven wide mobile'].column {
     width: 43.75% !important;
   }
 
-  .ui.grid > .row > [class*="eight wide mobile"].column,
-  .ui.grid > .column.row > [class*="eight wide mobile"].column,
-  .ui.grid > [class*="eight wide mobile"].column,
-  .ui.column.grid > [class*="eight wide mobile"].column {
+  .ui.grid > .row > [class*='eight wide mobile'].column,
+  .ui.grid > .column.row > [class*='eight wide mobile'].column,
+  .ui.grid > [class*='eight wide mobile'].column,
+  .ui.column.grid > [class*='eight wide mobile'].column {
     width: 50% !important;
   }
 
-  .ui.grid > .row > [class*="nine wide mobile"].column,
-  .ui.grid > .column.row > [class*="nine wide mobile"].column,
-  .ui.grid > [class*="nine wide mobile"].column,
-  .ui.column.grid > [class*="nine wide mobile"].column {
+  .ui.grid > .row > [class*='nine wide mobile'].column,
+  .ui.grid > .column.row > [class*='nine wide mobile'].column,
+  .ui.grid > [class*='nine wide mobile'].column,
+  .ui.column.grid > [class*='nine wide mobile'].column {
     width: 56.25% !important;
   }
 
-  .ui.grid > .row > [class*="ten wide mobile"].column,
-  .ui.grid > .column.row > [class*="ten wide mobile"].column,
-  .ui.grid > [class*="ten wide mobile"].column,
-  .ui.column.grid > [class*="ten wide mobile"].column {
+  .ui.grid > .row > [class*='ten wide mobile'].column,
+  .ui.grid > .column.row > [class*='ten wide mobile'].column,
+  .ui.grid > [class*='ten wide mobile'].column,
+  .ui.column.grid > [class*='ten wide mobile'].column {
     width: 62.5% !important;
   }
 
-  .ui.grid > .row > [class*="eleven wide mobile"].column,
-  .ui.grid > .column.row > [class*="eleven wide mobile"].column,
-  .ui.grid > [class*="eleven wide mobile"].column,
-  .ui.column.grid > [class*="eleven wide mobile"].column {
+  .ui.grid > .row > [class*='eleven wide mobile'].column,
+  .ui.grid > .column.row > [class*='eleven wide mobile'].column,
+  .ui.grid > [class*='eleven wide mobile'].column,
+  .ui.column.grid > [class*='eleven wide mobile'].column {
     width: 68.75% !important;
   }
 
-  .ui.grid > .row > [class*="twelve wide mobile"].column,
-  .ui.grid > .column.row > [class*="twelve wide mobile"].column,
-  .ui.grid > [class*="twelve wide mobile"].column,
-  .ui.column.grid > [class*="twelve wide mobile"].column {
+  .ui.grid > .row > [class*='twelve wide mobile'].column,
+  .ui.grid > .column.row > [class*='twelve wide mobile'].column,
+  .ui.grid > [class*='twelve wide mobile'].column,
+  .ui.column.grid > [class*='twelve wide mobile'].column {
     width: 75% !important;
   }
 
-  .ui.grid > .row > [class*="thirteen wide mobile"].column,
-  .ui.grid > .column.row > [class*="thirteen wide mobile"].column,
-  .ui.grid > [class*="thirteen wide mobile"].column,
-  .ui.column.grid > [class*="thirteen wide mobile"].column {
+  .ui.grid > .row > [class*='thirteen wide mobile'].column,
+  .ui.grid > .column.row > [class*='thirteen wide mobile'].column,
+  .ui.grid > [class*='thirteen wide mobile'].column,
+  .ui.column.grid > [class*='thirteen wide mobile'].column {
     width: 81.25% !important;
   }
 
-  .ui.grid > .row > [class*="fourteen wide mobile"].column,
-  .ui.grid > .column.row > [class*="fourteen wide mobile"].column,
-  .ui.grid > [class*="fourteen wide mobile"].column,
-  .ui.column.grid > [class*="fourteen wide mobile"].column {
+  .ui.grid > .row > [class*='fourteen wide mobile'].column,
+  .ui.grid > .column.row > [class*='fourteen wide mobile'].column,
+  .ui.grid > [class*='fourteen wide mobile'].column,
+  .ui.column.grid > [class*='fourteen wide mobile'].column {
     width: 87.5% !important;
   }
 
-  .ui.grid > .row > [class*="fifteen wide mobile"].column,
-  .ui.grid > .column.row > [class*="fifteen wide mobile"].column,
-  .ui.grid > [class*="fifteen wide mobile"].column,
-  .ui.column.grid > [class*="fifteen wide mobile"].column {
+  .ui.grid > .row > [class*='fifteen wide mobile'].column,
+  .ui.grid > .column.row > [class*='fifteen wide mobile'].column,
+  .ui.grid > [class*='fifteen wide mobile'].column,
+  .ui.column.grid > [class*='fifteen wide mobile'].column {
     width: 93.75% !important;
   }
 
-  .ui.grid > .row > [class*="sixteen wide mobile"].column,
-  .ui.grid > .column.row > [class*="sixteen wide mobile"].column,
-  .ui.grid > [class*="sixteen wide mobile"].column,
-  .ui.column.grid > [class*="sixteen wide mobile"].column {
+  .ui.grid > .row > [class*='sixteen wide mobile'].column,
+  .ui.grid > .column.row > [class*='sixteen wide mobile'].column,
+  .ui.grid > [class*='sixteen wide mobile'].column,
+  .ui.column.grid > [class*='sixteen wide mobile'].column {
     width: 100% !important;
   }
 }
@@ -21947,115 +22069,115 @@ ol.ui.horizontal.list li:before,
 /* Tablet Sizing Combinations */
 
 @media only screen and (min-width: 768px) and (max-width: 991px) {
-  .ui.grid > .row > [class*="one wide tablet"].column,
-  .ui.grid > .column.row > [class*="one wide tablet"].column,
-  .ui.grid > [class*="one wide tablet"].column,
-  .ui.column.grid > [class*="one wide tablet"].column {
+  .ui.grid > .row > [class*='one wide tablet'].column,
+  .ui.grid > .column.row > [class*='one wide tablet'].column,
+  .ui.grid > [class*='one wide tablet'].column,
+  .ui.column.grid > [class*='one wide tablet'].column {
     width: 6.25% !important;
   }
 
-  .ui.grid > .row > [class*="two wide tablet"].column,
-  .ui.grid > .column.row > [class*="two wide tablet"].column,
-  .ui.grid > [class*="two wide tablet"].column,
-  .ui.column.grid > [class*="two wide tablet"].column {
+  .ui.grid > .row > [class*='two wide tablet'].column,
+  .ui.grid > .column.row > [class*='two wide tablet'].column,
+  .ui.grid > [class*='two wide tablet'].column,
+  .ui.column.grid > [class*='two wide tablet'].column {
     width: 12.5% !important;
   }
 
-  .ui.grid > .row > [class*="three wide tablet"].column,
-  .ui.grid > .column.row > [class*="three wide tablet"].column,
-  .ui.grid > [class*="three wide tablet"].column,
-  .ui.column.grid > [class*="three wide tablet"].column {
+  .ui.grid > .row > [class*='three wide tablet'].column,
+  .ui.grid > .column.row > [class*='three wide tablet'].column,
+  .ui.grid > [class*='three wide tablet'].column,
+  .ui.column.grid > [class*='three wide tablet'].column {
     width: 18.75% !important;
   }
 
-  .ui.grid > .row > [class*="four wide tablet"].column,
-  .ui.grid > .column.row > [class*="four wide tablet"].column,
-  .ui.grid > [class*="four wide tablet"].column,
-  .ui.column.grid > [class*="four wide tablet"].column {
+  .ui.grid > .row > [class*='four wide tablet'].column,
+  .ui.grid > .column.row > [class*='four wide tablet'].column,
+  .ui.grid > [class*='four wide tablet'].column,
+  .ui.column.grid > [class*='four wide tablet'].column {
     width: 25% !important;
   }
 
-  .ui.grid > .row > [class*="five wide tablet"].column,
-  .ui.grid > .column.row > [class*="five wide tablet"].column,
-  .ui.grid > [class*="five wide tablet"].column,
-  .ui.column.grid > [class*="five wide tablet"].column {
+  .ui.grid > .row > [class*='five wide tablet'].column,
+  .ui.grid > .column.row > [class*='five wide tablet'].column,
+  .ui.grid > [class*='five wide tablet'].column,
+  .ui.column.grid > [class*='five wide tablet'].column {
     width: 31.25% !important;
   }
 
-  .ui.grid > .row > [class*="six wide tablet"].column,
-  .ui.grid > .column.row > [class*="six wide tablet"].column,
-  .ui.grid > [class*="six wide tablet"].column,
-  .ui.column.grid > [class*="six wide tablet"].column {
+  .ui.grid > .row > [class*='six wide tablet'].column,
+  .ui.grid > .column.row > [class*='six wide tablet'].column,
+  .ui.grid > [class*='six wide tablet'].column,
+  .ui.column.grid > [class*='six wide tablet'].column {
     width: 37.5% !important;
   }
 
-  .ui.grid > .row > [class*="seven wide tablet"].column,
-  .ui.grid > .column.row > [class*="seven wide tablet"].column,
-  .ui.grid > [class*="seven wide tablet"].column,
-  .ui.column.grid > [class*="seven wide tablet"].column {
+  .ui.grid > .row > [class*='seven wide tablet'].column,
+  .ui.grid > .column.row > [class*='seven wide tablet'].column,
+  .ui.grid > [class*='seven wide tablet'].column,
+  .ui.column.grid > [class*='seven wide tablet'].column {
     width: 43.75% !important;
   }
 
-  .ui.grid > .row > [class*="eight wide tablet"].column,
-  .ui.grid > .column.row > [class*="eight wide tablet"].column,
-  .ui.grid > [class*="eight wide tablet"].column,
-  .ui.column.grid > [class*="eight wide tablet"].column {
+  .ui.grid > .row > [class*='eight wide tablet'].column,
+  .ui.grid > .column.row > [class*='eight wide tablet'].column,
+  .ui.grid > [class*='eight wide tablet'].column,
+  .ui.column.grid > [class*='eight wide tablet'].column {
     width: 50% !important;
   }
 
-  .ui.grid > .row > [class*="nine wide tablet"].column,
-  .ui.grid > .column.row > [class*="nine wide tablet"].column,
-  .ui.grid > [class*="nine wide tablet"].column,
-  .ui.column.grid > [class*="nine wide tablet"].column {
+  .ui.grid > .row > [class*='nine wide tablet'].column,
+  .ui.grid > .column.row > [class*='nine wide tablet'].column,
+  .ui.grid > [class*='nine wide tablet'].column,
+  .ui.column.grid > [class*='nine wide tablet'].column {
     width: 56.25% !important;
   }
 
-  .ui.grid > .row > [class*="ten wide tablet"].column,
-  .ui.grid > .column.row > [class*="ten wide tablet"].column,
-  .ui.grid > [class*="ten wide tablet"].column,
-  .ui.column.grid > [class*="ten wide tablet"].column {
+  .ui.grid > .row > [class*='ten wide tablet'].column,
+  .ui.grid > .column.row > [class*='ten wide tablet'].column,
+  .ui.grid > [class*='ten wide tablet'].column,
+  .ui.column.grid > [class*='ten wide tablet'].column {
     width: 62.5% !important;
   }
 
-  .ui.grid > .row > [class*="eleven wide tablet"].column,
-  .ui.grid > .column.row > [class*="eleven wide tablet"].column,
-  .ui.grid > [class*="eleven wide tablet"].column,
-  .ui.column.grid > [class*="eleven wide tablet"].column {
+  .ui.grid > .row > [class*='eleven wide tablet'].column,
+  .ui.grid > .column.row > [class*='eleven wide tablet'].column,
+  .ui.grid > [class*='eleven wide tablet'].column,
+  .ui.column.grid > [class*='eleven wide tablet'].column {
     width: 68.75% !important;
   }
 
-  .ui.grid > .row > [class*="twelve wide tablet"].column,
-  .ui.grid > .column.row > [class*="twelve wide tablet"].column,
-  .ui.grid > [class*="twelve wide tablet"].column,
-  .ui.column.grid > [class*="twelve wide tablet"].column {
+  .ui.grid > .row > [class*='twelve wide tablet'].column,
+  .ui.grid > .column.row > [class*='twelve wide tablet'].column,
+  .ui.grid > [class*='twelve wide tablet'].column,
+  .ui.column.grid > [class*='twelve wide tablet'].column {
     width: 75% !important;
   }
 
-  .ui.grid > .row > [class*="thirteen wide tablet"].column,
-  .ui.grid > .column.row > [class*="thirteen wide tablet"].column,
-  .ui.grid > [class*="thirteen wide tablet"].column,
-  .ui.column.grid > [class*="thirteen wide tablet"].column {
+  .ui.grid > .row > [class*='thirteen wide tablet'].column,
+  .ui.grid > .column.row > [class*='thirteen wide tablet'].column,
+  .ui.grid > [class*='thirteen wide tablet'].column,
+  .ui.column.grid > [class*='thirteen wide tablet'].column {
     width: 81.25% !important;
   }
 
-  .ui.grid > .row > [class*="fourteen wide tablet"].column,
-  .ui.grid > .column.row > [class*="fourteen wide tablet"].column,
-  .ui.grid > [class*="fourteen wide tablet"].column,
-  .ui.column.grid > [class*="fourteen wide tablet"].column {
+  .ui.grid > .row > [class*='fourteen wide tablet'].column,
+  .ui.grid > .column.row > [class*='fourteen wide tablet'].column,
+  .ui.grid > [class*='fourteen wide tablet'].column,
+  .ui.column.grid > [class*='fourteen wide tablet'].column {
     width: 87.5% !important;
   }
 
-  .ui.grid > .row > [class*="fifteen wide tablet"].column,
-  .ui.grid > .column.row > [class*="fifteen wide tablet"].column,
-  .ui.grid > [class*="fifteen wide tablet"].column,
-  .ui.column.grid > [class*="fifteen wide tablet"].column {
+  .ui.grid > .row > [class*='fifteen wide tablet'].column,
+  .ui.grid > .column.row > [class*='fifteen wide tablet'].column,
+  .ui.grid > [class*='fifteen wide tablet'].column,
+  .ui.column.grid > [class*='fifteen wide tablet'].column {
     width: 93.75% !important;
   }
 
-  .ui.grid > .row > [class*="sixteen wide tablet"].column,
-  .ui.grid > .column.row > [class*="sixteen wide tablet"].column,
-  .ui.grid > [class*="sixteen wide tablet"].column,
-  .ui.column.grid > [class*="sixteen wide tablet"].column {
+  .ui.grid > .row > [class*='sixteen wide tablet'].column,
+  .ui.grid > .column.row > [class*='sixteen wide tablet'].column,
+  .ui.grid > [class*='sixteen wide tablet'].column,
+  .ui.column.grid > [class*='sixteen wide tablet'].column {
     width: 100% !important;
   }
 }
@@ -22063,115 +22185,115 @@ ol.ui.horizontal.list li:before,
 /* Computer/Desktop Sizing Combinations */
 
 @media only screen and (min-width: 992px) {
-  .ui.grid > .row > [class*="one wide computer"].column,
-  .ui.grid > .column.row > [class*="one wide computer"].column,
-  .ui.grid > [class*="one wide computer"].column,
-  .ui.column.grid > [class*="one wide computer"].column {
+  .ui.grid > .row > [class*='one wide computer'].column,
+  .ui.grid > .column.row > [class*='one wide computer'].column,
+  .ui.grid > [class*='one wide computer'].column,
+  .ui.column.grid > [class*='one wide computer'].column {
     width: 6.25% !important;
   }
 
-  .ui.grid > .row > [class*="two wide computer"].column,
-  .ui.grid > .column.row > [class*="two wide computer"].column,
-  .ui.grid > [class*="two wide computer"].column,
-  .ui.column.grid > [class*="two wide computer"].column {
+  .ui.grid > .row > [class*='two wide computer'].column,
+  .ui.grid > .column.row > [class*='two wide computer'].column,
+  .ui.grid > [class*='two wide computer'].column,
+  .ui.column.grid > [class*='two wide computer'].column {
     width: 12.5% !important;
   }
 
-  .ui.grid > .row > [class*="three wide computer"].column,
-  .ui.grid > .column.row > [class*="three wide computer"].column,
-  .ui.grid > [class*="three wide computer"].column,
-  .ui.column.grid > [class*="three wide computer"].column {
+  .ui.grid > .row > [class*='three wide computer'].column,
+  .ui.grid > .column.row > [class*='three wide computer'].column,
+  .ui.grid > [class*='three wide computer'].column,
+  .ui.column.grid > [class*='three wide computer'].column {
     width: 18.75% !important;
   }
 
-  .ui.grid > .row > [class*="four wide computer"].column,
-  .ui.grid > .column.row > [class*="four wide computer"].column,
-  .ui.grid > [class*="four wide computer"].column,
-  .ui.column.grid > [class*="four wide computer"].column {
+  .ui.grid > .row > [class*='four wide computer'].column,
+  .ui.grid > .column.row > [class*='four wide computer'].column,
+  .ui.grid > [class*='four wide computer'].column,
+  .ui.column.grid > [class*='four wide computer'].column {
     width: 25% !important;
   }
 
-  .ui.grid > .row > [class*="five wide computer"].column,
-  .ui.grid > .column.row > [class*="five wide computer"].column,
-  .ui.grid > [class*="five wide computer"].column,
-  .ui.column.grid > [class*="five wide computer"].column {
+  .ui.grid > .row > [class*='five wide computer'].column,
+  .ui.grid > .column.row > [class*='five wide computer'].column,
+  .ui.grid > [class*='five wide computer'].column,
+  .ui.column.grid > [class*='five wide computer'].column {
     width: 31.25% !important;
   }
 
-  .ui.grid > .row > [class*="six wide computer"].column,
-  .ui.grid > .column.row > [class*="six wide computer"].column,
-  .ui.grid > [class*="six wide computer"].column,
-  .ui.column.grid > [class*="six wide computer"].column {
+  .ui.grid > .row > [class*='six wide computer'].column,
+  .ui.grid > .column.row > [class*='six wide computer'].column,
+  .ui.grid > [class*='six wide computer'].column,
+  .ui.column.grid > [class*='six wide computer'].column {
     width: 37.5% !important;
   }
 
-  .ui.grid > .row > [class*="seven wide computer"].column,
-  .ui.grid > .column.row > [class*="seven wide computer"].column,
-  .ui.grid > [class*="seven wide computer"].column,
-  .ui.column.grid > [class*="seven wide computer"].column {
+  .ui.grid > .row > [class*='seven wide computer'].column,
+  .ui.grid > .column.row > [class*='seven wide computer'].column,
+  .ui.grid > [class*='seven wide computer'].column,
+  .ui.column.grid > [class*='seven wide computer'].column {
     width: 43.75% !important;
   }
 
-  .ui.grid > .row > [class*="eight wide computer"].column,
-  .ui.grid > .column.row > [class*="eight wide computer"].column,
-  .ui.grid > [class*="eight wide computer"].column,
-  .ui.column.grid > [class*="eight wide computer"].column {
+  .ui.grid > .row > [class*='eight wide computer'].column,
+  .ui.grid > .column.row > [class*='eight wide computer'].column,
+  .ui.grid > [class*='eight wide computer'].column,
+  .ui.column.grid > [class*='eight wide computer'].column {
     width: 50% !important;
   }
 
-  .ui.grid > .row > [class*="nine wide computer"].column,
-  .ui.grid > .column.row > [class*="nine wide computer"].column,
-  .ui.grid > [class*="nine wide computer"].column,
-  .ui.column.grid > [class*="nine wide computer"].column {
+  .ui.grid > .row > [class*='nine wide computer'].column,
+  .ui.grid > .column.row > [class*='nine wide computer'].column,
+  .ui.grid > [class*='nine wide computer'].column,
+  .ui.column.grid > [class*='nine wide computer'].column {
     width: 56.25% !important;
   }
 
-  .ui.grid > .row > [class*="ten wide computer"].column,
-  .ui.grid > .column.row > [class*="ten wide computer"].column,
-  .ui.grid > [class*="ten wide computer"].column,
-  .ui.column.grid > [class*="ten wide computer"].column {
+  .ui.grid > .row > [class*='ten wide computer'].column,
+  .ui.grid > .column.row > [class*='ten wide computer'].column,
+  .ui.grid > [class*='ten wide computer'].column,
+  .ui.column.grid > [class*='ten wide computer'].column {
     width: 62.5% !important;
   }
 
-  .ui.grid > .row > [class*="eleven wide computer"].column,
-  .ui.grid > .column.row > [class*="eleven wide computer"].column,
-  .ui.grid > [class*="eleven wide computer"].column,
-  .ui.column.grid > [class*="eleven wide computer"].column {
+  .ui.grid > .row > [class*='eleven wide computer'].column,
+  .ui.grid > .column.row > [class*='eleven wide computer'].column,
+  .ui.grid > [class*='eleven wide computer'].column,
+  .ui.column.grid > [class*='eleven wide computer'].column {
     width: 68.75% !important;
   }
 
-  .ui.grid > .row > [class*="twelve wide computer"].column,
-  .ui.grid > .column.row > [class*="twelve wide computer"].column,
-  .ui.grid > [class*="twelve wide computer"].column,
-  .ui.column.grid > [class*="twelve wide computer"].column {
+  .ui.grid > .row > [class*='twelve wide computer'].column,
+  .ui.grid > .column.row > [class*='twelve wide computer'].column,
+  .ui.grid > [class*='twelve wide computer'].column,
+  .ui.column.grid > [class*='twelve wide computer'].column {
     width: 75% !important;
   }
 
-  .ui.grid > .row > [class*="thirteen wide computer"].column,
-  .ui.grid > .column.row > [class*="thirteen wide computer"].column,
-  .ui.grid > [class*="thirteen wide computer"].column,
-  .ui.column.grid > [class*="thirteen wide computer"].column {
+  .ui.grid > .row > [class*='thirteen wide computer'].column,
+  .ui.grid > .column.row > [class*='thirteen wide computer'].column,
+  .ui.grid > [class*='thirteen wide computer'].column,
+  .ui.column.grid > [class*='thirteen wide computer'].column {
     width: 81.25% !important;
   }
 
-  .ui.grid > .row > [class*="fourteen wide computer"].column,
-  .ui.grid > .column.row > [class*="fourteen wide computer"].column,
-  .ui.grid > [class*="fourteen wide computer"].column,
-  .ui.column.grid > [class*="fourteen wide computer"].column {
+  .ui.grid > .row > [class*='fourteen wide computer'].column,
+  .ui.grid > .column.row > [class*='fourteen wide computer'].column,
+  .ui.grid > [class*='fourteen wide computer'].column,
+  .ui.column.grid > [class*='fourteen wide computer'].column {
     width: 87.5% !important;
   }
 
-  .ui.grid > .row > [class*="fifteen wide computer"].column,
-  .ui.grid > .column.row > [class*="fifteen wide computer"].column,
-  .ui.grid > [class*="fifteen wide computer"].column,
-  .ui.column.grid > [class*="fifteen wide computer"].column {
+  .ui.grid > .row > [class*='fifteen wide computer'].column,
+  .ui.grid > .column.row > [class*='fifteen wide computer'].column,
+  .ui.grid > [class*='fifteen wide computer'].column,
+  .ui.column.grid > [class*='fifteen wide computer'].column {
     width: 93.75% !important;
   }
 
-  .ui.grid > .row > [class*="sixteen wide computer"].column,
-  .ui.grid > .column.row > [class*="sixteen wide computer"].column,
-  .ui.grid > [class*="sixteen wide computer"].column,
-  .ui.column.grid > [class*="sixteen wide computer"].column {
+  .ui.grid > .row > [class*='sixteen wide computer'].column,
+  .ui.grid > .column.row > [class*='sixteen wide computer'].column,
+  .ui.grid > [class*='sixteen wide computer'].column,
+  .ui.column.grid > [class*='sixteen wide computer'].column {
     width: 100% !important;
   }
 }
@@ -22179,115 +22301,115 @@ ol.ui.horizontal.list li:before,
 /* Large Monitor Sizing Combinations */
 
 @media only screen and (min-width: 1200px) and (max-width: 1919px) {
-  .ui.grid > .row > [class*="one wide large screen"].column,
-  .ui.grid > .column.row > [class*="one wide large screen"].column,
-  .ui.grid > [class*="one wide large screen"].column,
-  .ui.column.grid > [class*="one wide large screen"].column {
+  .ui.grid > .row > [class*='one wide large screen'].column,
+  .ui.grid > .column.row > [class*='one wide large screen'].column,
+  .ui.grid > [class*='one wide large screen'].column,
+  .ui.column.grid > [class*='one wide large screen'].column {
     width: 6.25% !important;
   }
 
-  .ui.grid > .row > [class*="two wide large screen"].column,
-  .ui.grid > .column.row > [class*="two wide large screen"].column,
-  .ui.grid > [class*="two wide large screen"].column,
-  .ui.column.grid > [class*="two wide large screen"].column {
+  .ui.grid > .row > [class*='two wide large screen'].column,
+  .ui.grid > .column.row > [class*='two wide large screen'].column,
+  .ui.grid > [class*='two wide large screen'].column,
+  .ui.column.grid > [class*='two wide large screen'].column {
     width: 12.5% !important;
   }
 
-  .ui.grid > .row > [class*="three wide large screen"].column,
-  .ui.grid > .column.row > [class*="three wide large screen"].column,
-  .ui.grid > [class*="three wide large screen"].column,
-  .ui.column.grid > [class*="three wide large screen"].column {
+  .ui.grid > .row > [class*='three wide large screen'].column,
+  .ui.grid > .column.row > [class*='three wide large screen'].column,
+  .ui.grid > [class*='three wide large screen'].column,
+  .ui.column.grid > [class*='three wide large screen'].column {
     width: 18.75% !important;
   }
 
-  .ui.grid > .row > [class*="four wide large screen"].column,
-  .ui.grid > .column.row > [class*="four wide large screen"].column,
-  .ui.grid > [class*="four wide large screen"].column,
-  .ui.column.grid > [class*="four wide large screen"].column {
+  .ui.grid > .row > [class*='four wide large screen'].column,
+  .ui.grid > .column.row > [class*='four wide large screen'].column,
+  .ui.grid > [class*='four wide large screen'].column,
+  .ui.column.grid > [class*='four wide large screen'].column {
     width: 25% !important;
   }
 
-  .ui.grid > .row > [class*="five wide large screen"].column,
-  .ui.grid > .column.row > [class*="five wide large screen"].column,
-  .ui.grid > [class*="five wide large screen"].column,
-  .ui.column.grid > [class*="five wide large screen"].column {
+  .ui.grid > .row > [class*='five wide large screen'].column,
+  .ui.grid > .column.row > [class*='five wide large screen'].column,
+  .ui.grid > [class*='five wide large screen'].column,
+  .ui.column.grid > [class*='five wide large screen'].column {
     width: 31.25% !important;
   }
 
-  .ui.grid > .row > [class*="six wide large screen"].column,
-  .ui.grid > .column.row > [class*="six wide large screen"].column,
-  .ui.grid > [class*="six wide large screen"].column,
-  .ui.column.grid > [class*="six wide large screen"].column {
+  .ui.grid > .row > [class*='six wide large screen'].column,
+  .ui.grid > .column.row > [class*='six wide large screen'].column,
+  .ui.grid > [class*='six wide large screen'].column,
+  .ui.column.grid > [class*='six wide large screen'].column {
     width: 37.5% !important;
   }
 
-  .ui.grid > .row > [class*="seven wide large screen"].column,
-  .ui.grid > .column.row > [class*="seven wide large screen"].column,
-  .ui.grid > [class*="seven wide large screen"].column,
-  .ui.column.grid > [class*="seven wide large screen"].column {
+  .ui.grid > .row > [class*='seven wide large screen'].column,
+  .ui.grid > .column.row > [class*='seven wide large screen'].column,
+  .ui.grid > [class*='seven wide large screen'].column,
+  .ui.column.grid > [class*='seven wide large screen'].column {
     width: 43.75% !important;
   }
 
-  .ui.grid > .row > [class*="eight wide large screen"].column,
-  .ui.grid > .column.row > [class*="eight wide large screen"].column,
-  .ui.grid > [class*="eight wide large screen"].column,
-  .ui.column.grid > [class*="eight wide large screen"].column {
+  .ui.grid > .row > [class*='eight wide large screen'].column,
+  .ui.grid > .column.row > [class*='eight wide large screen'].column,
+  .ui.grid > [class*='eight wide large screen'].column,
+  .ui.column.grid > [class*='eight wide large screen'].column {
     width: 50% !important;
   }
 
-  .ui.grid > .row > [class*="nine wide large screen"].column,
-  .ui.grid > .column.row > [class*="nine wide large screen"].column,
-  .ui.grid > [class*="nine wide large screen"].column,
-  .ui.column.grid > [class*="nine wide large screen"].column {
+  .ui.grid > .row > [class*='nine wide large screen'].column,
+  .ui.grid > .column.row > [class*='nine wide large screen'].column,
+  .ui.grid > [class*='nine wide large screen'].column,
+  .ui.column.grid > [class*='nine wide large screen'].column {
     width: 56.25% !important;
   }
 
-  .ui.grid > .row > [class*="ten wide large screen"].column,
-  .ui.grid > .column.row > [class*="ten wide large screen"].column,
-  .ui.grid > [class*="ten wide large screen"].column,
-  .ui.column.grid > [class*="ten wide large screen"].column {
+  .ui.grid > .row > [class*='ten wide large screen'].column,
+  .ui.grid > .column.row > [class*='ten wide large screen'].column,
+  .ui.grid > [class*='ten wide large screen'].column,
+  .ui.column.grid > [class*='ten wide large screen'].column {
     width: 62.5% !important;
   }
 
-  .ui.grid > .row > [class*="eleven wide large screen"].column,
-  .ui.grid > .column.row > [class*="eleven wide large screen"].column,
-  .ui.grid > [class*="eleven wide large screen"].column,
-  .ui.column.grid > [class*="eleven wide large screen"].column {
+  .ui.grid > .row > [class*='eleven wide large screen'].column,
+  .ui.grid > .column.row > [class*='eleven wide large screen'].column,
+  .ui.grid > [class*='eleven wide large screen'].column,
+  .ui.column.grid > [class*='eleven wide large screen'].column {
     width: 68.75% !important;
   }
 
-  .ui.grid > .row > [class*="twelve wide large screen"].column,
-  .ui.grid > .column.row > [class*="twelve wide large screen"].column,
-  .ui.grid > [class*="twelve wide large screen"].column,
-  .ui.column.grid > [class*="twelve wide large screen"].column {
+  .ui.grid > .row > [class*='twelve wide large screen'].column,
+  .ui.grid > .column.row > [class*='twelve wide large screen'].column,
+  .ui.grid > [class*='twelve wide large screen'].column,
+  .ui.column.grid > [class*='twelve wide large screen'].column {
     width: 75% !important;
   }
 
-  .ui.grid > .row > [class*="thirteen wide large screen"].column,
-  .ui.grid > .column.row > [class*="thirteen wide large screen"].column,
-  .ui.grid > [class*="thirteen wide large screen"].column,
-  .ui.column.grid > [class*="thirteen wide large screen"].column {
+  .ui.grid > .row > [class*='thirteen wide large screen'].column,
+  .ui.grid > .column.row > [class*='thirteen wide large screen'].column,
+  .ui.grid > [class*='thirteen wide large screen'].column,
+  .ui.column.grid > [class*='thirteen wide large screen'].column {
     width: 81.25% !important;
   }
 
-  .ui.grid > .row > [class*="fourteen wide large screen"].column,
-  .ui.grid > .column.row > [class*="fourteen wide large screen"].column,
-  .ui.grid > [class*="fourteen wide large screen"].column,
-  .ui.column.grid > [class*="fourteen wide large screen"].column {
+  .ui.grid > .row > [class*='fourteen wide large screen'].column,
+  .ui.grid > .column.row > [class*='fourteen wide large screen'].column,
+  .ui.grid > [class*='fourteen wide large screen'].column,
+  .ui.column.grid > [class*='fourteen wide large screen'].column {
     width: 87.5% !important;
   }
 
-  .ui.grid > .row > [class*="fifteen wide large screen"].column,
-  .ui.grid > .column.row > [class*="fifteen wide large screen"].column,
-  .ui.grid > [class*="fifteen wide large screen"].column,
-  .ui.column.grid > [class*="fifteen wide large screen"].column {
+  .ui.grid > .row > [class*='fifteen wide large screen'].column,
+  .ui.grid > .column.row > [class*='fifteen wide large screen'].column,
+  .ui.grid > [class*='fifteen wide large screen'].column,
+  .ui.column.grid > [class*='fifteen wide large screen'].column {
     width: 93.75% !important;
   }
 
-  .ui.grid > .row > [class*="sixteen wide large screen"].column,
-  .ui.grid > .column.row > [class*="sixteen wide large screen"].column,
-  .ui.grid > [class*="sixteen wide large screen"].column,
-  .ui.column.grid > [class*="sixteen wide large screen"].column {
+  .ui.grid > .row > [class*='sixteen wide large screen'].column,
+  .ui.grid > .column.row > [class*='sixteen wide large screen'].column,
+  .ui.grid > [class*='sixteen wide large screen'].column,
+  .ui.column.grid > [class*='sixteen wide large screen'].column {
     width: 100% !important;
   }
 }
@@ -22295,115 +22417,115 @@ ol.ui.horizontal.list li:before,
 /* Widescreen Sizing Combinations */
 
 @media only screen and (min-width: 1920px) {
-  .ui.grid > .row > [class*="one wide widescreen"].column,
-  .ui.grid > .column.row > [class*="one wide widescreen"].column,
-  .ui.grid > [class*="one wide widescreen"].column,
-  .ui.column.grid > [class*="one wide widescreen"].column {
+  .ui.grid > .row > [class*='one wide widescreen'].column,
+  .ui.grid > .column.row > [class*='one wide widescreen'].column,
+  .ui.grid > [class*='one wide widescreen'].column,
+  .ui.column.grid > [class*='one wide widescreen'].column {
     width: 6.25% !important;
   }
 
-  .ui.grid > .row > [class*="two wide widescreen"].column,
-  .ui.grid > .column.row > [class*="two wide widescreen"].column,
-  .ui.grid > [class*="two wide widescreen"].column,
-  .ui.column.grid > [class*="two wide widescreen"].column {
+  .ui.grid > .row > [class*='two wide widescreen'].column,
+  .ui.grid > .column.row > [class*='two wide widescreen'].column,
+  .ui.grid > [class*='two wide widescreen'].column,
+  .ui.column.grid > [class*='two wide widescreen'].column {
     width: 12.5% !important;
   }
 
-  .ui.grid > .row > [class*="three wide widescreen"].column,
-  .ui.grid > .column.row > [class*="three wide widescreen"].column,
-  .ui.grid > [class*="three wide widescreen"].column,
-  .ui.column.grid > [class*="three wide widescreen"].column {
+  .ui.grid > .row > [class*='three wide widescreen'].column,
+  .ui.grid > .column.row > [class*='three wide widescreen'].column,
+  .ui.grid > [class*='three wide widescreen'].column,
+  .ui.column.grid > [class*='three wide widescreen'].column {
     width: 18.75% !important;
   }
 
-  .ui.grid > .row > [class*="four wide widescreen"].column,
-  .ui.grid > .column.row > [class*="four wide widescreen"].column,
-  .ui.grid > [class*="four wide widescreen"].column,
-  .ui.column.grid > [class*="four wide widescreen"].column {
+  .ui.grid > .row > [class*='four wide widescreen'].column,
+  .ui.grid > .column.row > [class*='four wide widescreen'].column,
+  .ui.grid > [class*='four wide widescreen'].column,
+  .ui.column.grid > [class*='four wide widescreen'].column {
     width: 25% !important;
   }
 
-  .ui.grid > .row > [class*="five wide widescreen"].column,
-  .ui.grid > .column.row > [class*="five wide widescreen"].column,
-  .ui.grid > [class*="five wide widescreen"].column,
-  .ui.column.grid > [class*="five wide widescreen"].column {
+  .ui.grid > .row > [class*='five wide widescreen'].column,
+  .ui.grid > .column.row > [class*='five wide widescreen'].column,
+  .ui.grid > [class*='five wide widescreen'].column,
+  .ui.column.grid > [class*='five wide widescreen'].column {
     width: 31.25% !important;
   }
 
-  .ui.grid > .row > [class*="six wide widescreen"].column,
-  .ui.grid > .column.row > [class*="six wide widescreen"].column,
-  .ui.grid > [class*="six wide widescreen"].column,
-  .ui.column.grid > [class*="six wide widescreen"].column {
+  .ui.grid > .row > [class*='six wide widescreen'].column,
+  .ui.grid > .column.row > [class*='six wide widescreen'].column,
+  .ui.grid > [class*='six wide widescreen'].column,
+  .ui.column.grid > [class*='six wide widescreen'].column {
     width: 37.5% !important;
   }
 
-  .ui.grid > .row > [class*="seven wide widescreen"].column,
-  .ui.grid > .column.row > [class*="seven wide widescreen"].column,
-  .ui.grid > [class*="seven wide widescreen"].column,
-  .ui.column.grid > [class*="seven wide widescreen"].column {
+  .ui.grid > .row > [class*='seven wide widescreen'].column,
+  .ui.grid > .column.row > [class*='seven wide widescreen'].column,
+  .ui.grid > [class*='seven wide widescreen'].column,
+  .ui.column.grid > [class*='seven wide widescreen'].column {
     width: 43.75% !important;
   }
 
-  .ui.grid > .row > [class*="eight wide widescreen"].column,
-  .ui.grid > .column.row > [class*="eight wide widescreen"].column,
-  .ui.grid > [class*="eight wide widescreen"].column,
-  .ui.column.grid > [class*="eight wide widescreen"].column {
+  .ui.grid > .row > [class*='eight wide widescreen'].column,
+  .ui.grid > .column.row > [class*='eight wide widescreen'].column,
+  .ui.grid > [class*='eight wide widescreen'].column,
+  .ui.column.grid > [class*='eight wide widescreen'].column {
     width: 50% !important;
   }
 
-  .ui.grid > .row > [class*="nine wide widescreen"].column,
-  .ui.grid > .column.row > [class*="nine wide widescreen"].column,
-  .ui.grid > [class*="nine wide widescreen"].column,
-  .ui.column.grid > [class*="nine wide widescreen"].column {
+  .ui.grid > .row > [class*='nine wide widescreen'].column,
+  .ui.grid > .column.row > [class*='nine wide widescreen'].column,
+  .ui.grid > [class*='nine wide widescreen'].column,
+  .ui.column.grid > [class*='nine wide widescreen'].column {
     width: 56.25% !important;
   }
 
-  .ui.grid > .row > [class*="ten wide widescreen"].column,
-  .ui.grid > .column.row > [class*="ten wide widescreen"].column,
-  .ui.grid > [class*="ten wide widescreen"].column,
-  .ui.column.grid > [class*="ten wide widescreen"].column {
+  .ui.grid > .row > [class*='ten wide widescreen'].column,
+  .ui.grid > .column.row > [class*='ten wide widescreen'].column,
+  .ui.grid > [class*='ten wide widescreen'].column,
+  .ui.column.grid > [class*='ten wide widescreen'].column {
     width: 62.5% !important;
   }
 
-  .ui.grid > .row > [class*="eleven wide widescreen"].column,
-  .ui.grid > .column.row > [class*="eleven wide widescreen"].column,
-  .ui.grid > [class*="eleven wide widescreen"].column,
-  .ui.column.grid > [class*="eleven wide widescreen"].column {
+  .ui.grid > .row > [class*='eleven wide widescreen'].column,
+  .ui.grid > .column.row > [class*='eleven wide widescreen'].column,
+  .ui.grid > [class*='eleven wide widescreen'].column,
+  .ui.column.grid > [class*='eleven wide widescreen'].column {
     width: 68.75% !important;
   }
 
-  .ui.grid > .row > [class*="twelve wide widescreen"].column,
-  .ui.grid > .column.row > [class*="twelve wide widescreen"].column,
-  .ui.grid > [class*="twelve wide widescreen"].column,
-  .ui.column.grid > [class*="twelve wide widescreen"].column {
+  .ui.grid > .row > [class*='twelve wide widescreen'].column,
+  .ui.grid > .column.row > [class*='twelve wide widescreen'].column,
+  .ui.grid > [class*='twelve wide widescreen'].column,
+  .ui.column.grid > [class*='twelve wide widescreen'].column {
     width: 75% !important;
   }
 
-  .ui.grid > .row > [class*="thirteen wide widescreen"].column,
-  .ui.grid > .column.row > [class*="thirteen wide widescreen"].column,
-  .ui.grid > [class*="thirteen wide widescreen"].column,
-  .ui.column.grid > [class*="thirteen wide widescreen"].column {
+  .ui.grid > .row > [class*='thirteen wide widescreen'].column,
+  .ui.grid > .column.row > [class*='thirteen wide widescreen'].column,
+  .ui.grid > [class*='thirteen wide widescreen'].column,
+  .ui.column.grid > [class*='thirteen wide widescreen'].column {
     width: 81.25% !important;
   }
 
-  .ui.grid > .row > [class*="fourteen wide widescreen"].column,
-  .ui.grid > .column.row > [class*="fourteen wide widescreen"].column,
-  .ui.grid > [class*="fourteen wide widescreen"].column,
-  .ui.column.grid > [class*="fourteen wide widescreen"].column {
+  .ui.grid > .row > [class*='fourteen wide widescreen'].column,
+  .ui.grid > .column.row > [class*='fourteen wide widescreen'].column,
+  .ui.grid > [class*='fourteen wide widescreen'].column,
+  .ui.column.grid > [class*='fourteen wide widescreen'].column {
     width: 87.5% !important;
   }
 
-  .ui.grid > .row > [class*="fifteen wide widescreen"].column,
-  .ui.grid > .column.row > [class*="fifteen wide widescreen"].column,
-  .ui.grid > [class*="fifteen wide widescreen"].column,
-  .ui.column.grid > [class*="fifteen wide widescreen"].column {
+  .ui.grid > .row > [class*='fifteen wide widescreen'].column,
+  .ui.grid > .column.row > [class*='fifteen wide widescreen'].column,
+  .ui.grid > [class*='fifteen wide widescreen'].column,
+  .ui.column.grid > [class*='fifteen wide widescreen'].column {
     width: 93.75% !important;
   }
 
-  .ui.grid > .row > [class*="sixteen wide widescreen"].column,
-  .ui.grid > .column.row > [class*="sixteen wide widescreen"].column,
-  .ui.grid > [class*="sixteen wide widescreen"].column,
-  .ui.column.grid > [class*="sixteen wide widescreen"].column {
+  .ui.grid > .row > [class*='sixteen wide widescreen'].column,
+  .ui.grid > .column.row > [class*='sixteen wide widescreen'].column,
+  .ui.grid > [class*='sixteen wide widescreen'].column,
+  .ui.column.grid > [class*='sixteen wide widescreen'].column {
     width: 100% !important;
   }
 }
@@ -22445,9 +22567,9 @@ ol.ui.horizontal.list li:before,
   padding-right: 1.5rem;
 }
 
-.ui[class*="very relaxed"].grid > .column:not(.row),
-.ui[class*="very relaxed"].grid > .row > .column,
-.ui.grid > [class*="very relaxed"].row > .column {
+.ui[class*='very relaxed'].grid > .column:not(.row),
+.ui[class*='very relaxed'].grid > .row > .column,
+.ui.grid > [class*='very relaxed'].row > .column {
   padding-left: 2.5rem;
   padding-right: 2.5rem;
 }
@@ -22460,8 +22582,8 @@ ol.ui.horizontal.list li:before,
   margin-right: 1.5rem;
 }
 
-.ui[class*="very relaxed"].grid .row + .ui.divider,
-.ui.grid [class*="very relaxed"].row + .ui.divider {
+.ui[class*='very relaxed'].grid .row + .ui.divider,
+.ui.grid [class*='very relaxed'].row + .ui.divider {
   margin-left: 2.5rem;
   margin-right: 2.5rem;
 }
@@ -22474,12 +22596,12 @@ ol.ui.horizontal.list li:before,
   margin: 0em !important;
 }
 
-[class*="horizontally padded"].ui.grid {
+[class*='horizontally padded'].ui.grid {
   margin-left: 0em !important;
   margin-right: 0em !important;
 }
 
-[class*="vertically padded"].ui.grid {
+[class*='vertically padded'].ui.grid {
   margin-top: 0em !important;
   margin-bottom: 0em !important;
 }
@@ -22488,11 +22610,11 @@ ol.ui.horizontal.list li:before,
        "Floated"
 -----------------------*/
 
-.ui.grid [class*="left floated"].column {
+.ui.grid [class*='left floated'].column {
   margin-right: auto;
 }
 
-.ui.grid [class*="right floated"].column {
+.ui.grid [class*='right floated'].column {
   margin-left: auto;
 }
 
@@ -22500,38 +22622,40 @@ ol.ui.horizontal.list li:before,
         Divided
 -----------------------*/
 
-.ui.divided.grid:not([class*="vertically divided"]) > .column:not(.row),
-.ui.divided.grid:not([class*="vertically divided"]) > .row > .column {
+.ui.divided.grid:not([class*='vertically divided']) > .column:not(.row),
+.ui.divided.grid:not([class*='vertically divided']) > .row > .column {
   -webkit-box-shadow: -1px 0px 0px 0px rgba(34, 36, 38, 0.15);
   box-shadow: -1px 0px 0px 0px rgba(34, 36, 38, 0.15);
 }
 
 /* Swap from padding to margin on columns to have dividers align */
 
-.ui[class*="vertically divided"].grid > .column:not(.row),
-.ui[class*="vertically divided"].grid > .row > .column {
+.ui[class*='vertically divided'].grid > .column:not(.row),
+.ui[class*='vertically divided'].grid > .row > .column {
   margin-top: 1rem;
   margin-bottom: 1rem;
   padding-top: 0rem;
   padding-bottom: 0rem;
 }
 
-.ui[class*="vertically divided"].grid > .row {
+.ui[class*='vertically divided'].grid > .row {
   margin-top: 0em;
   margin-bottom: 0em;
 }
 
 /* No divider on first column on row */
 
-.ui.divided.grid:not([class*="vertically divided"]) > .column:first-child,
-.ui.divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
+.ui.divided.grid:not([class*='vertically divided']) > .column:first-child,
+.ui.divided.grid:not([class*='vertically divided'])
+  > .row
+  > .column:first-child {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
 
 /* No space on top of first row */
 
-.ui[class*="vertically divided"].grid > .row:first-child > .column {
+.ui[class*='vertically divided'].grid > .row:first-child > .column {
   margin-top: 0em;
 }
 
@@ -22549,13 +22673,13 @@ ol.ui.horizontal.list li:before,
 
 /* Vertically Divided */
 
-.ui[class*="vertically divided"].grid > .row {
+.ui[class*='vertically divided'].grid > .row {
   position: relative;
 }
 
-.ui[class*="vertically divided"].grid > .row:before {
+.ui[class*='vertically divided'].grid > .row:before {
   position: absolute;
-  content: "";
+  content: '';
   top: 0em;
   left: 0px;
   width: calc(100% - 2rem);
@@ -22567,46 +22691,50 @@ ol.ui.horizontal.list li:before,
 
 /* Padded Horizontally Divided */
 
-[class*="horizontally padded"].ui.divided.grid,
+[class*='horizontally padded'].ui.divided.grid,
 .ui.padded.divided.grid:not(.vertically):not(.horizontally) {
   width: 100%;
 }
 
 /* First Row Vertically Divided */
 
-.ui[class*="vertically divided"].grid > .row:first-child:before {
+.ui[class*='vertically divided'].grid > .row:first-child:before {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
 
 /* Inverted Divided */
 
-.ui.inverted.divided.grid:not([class*="vertically divided"]) > .column:not(.row),
-.ui.inverted.divided.grid:not([class*="vertically divided"]) > .row > .column {
+.ui.inverted.divided.grid:not([class*='vertically divided'])
+  > .column:not(.row),
+.ui.inverted.divided.grid:not([class*='vertically divided']) > .row > .column {
   -webkit-box-shadow: -1px 0px 0px 0px rgba(255, 255, 255, 0.1);
   box-shadow: -1px 0px 0px 0px rgba(255, 255, 255, 0.1);
 }
 
-.ui.inverted.divided.grid:not([class*="vertically divided"]) > .column:not(.row):first-child,
-.ui.inverted.divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
+.ui.inverted.divided.grid:not([class*='vertically divided'])
+  > .column:not(.row):first-child,
+.ui.inverted.divided.grid:not([class*='vertically divided'])
+  > .row
+  > .column:first-child {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
 
-.ui.inverted[class*="vertically divided"].grid > .row:before {
+.ui.inverted[class*='vertically divided'].grid > .row:before {
   -webkit-box-shadow: 0px -1px 0px 0px rgba(255, 255, 255, 0.1);
   box-shadow: 0px -1px 0px 0px rgba(255, 255, 255, 0.1);
 }
 
 /* Relaxed */
 
-.ui.relaxed[class*="vertically divided"].grid > .row:before {
+.ui.relaxed[class*='vertically divided'].grid > .row:before {
   margin-left: 1.5rem;
   margin-right: 1.5rem;
   width: calc(100% - 3rem);
 }
 
-.ui[class*="very relaxed"][class*="vertically divided"].grid > .row:before {
+.ui[class*='very relaxed'][class*='vertically divided'].grid > .row:before {
   margin-left: 2.5rem;
   margin-right: 2.5rem;
   width: calc(100% - 5rem);
@@ -22619,22 +22747,22 @@ ol.ui.horizontal.list li:before,
 .ui.celled.grid {
   width: 100%;
   margin: 1em 0em;
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5;
 }
 
 .ui.celled.grid > .row {
   width: 100% !important;
   margin: 0em;
   padding: 0em;
-  -webkit-box-shadow: 0px -1px 0px 0px #D4D4D5;
-  box-shadow: 0px -1px 0px 0px #D4D4D5;
+  -webkit-box-shadow: 0px -1px 0px 0px #d4d4d5;
+  box-shadow: 0px -1px 0px 0px #d4d4d5;
 }
 
 .ui.celled.grid > .column:not(.row),
 .ui.celled.grid > .row > .column {
-  -webkit-box-shadow: -1px 0px 0px 0px #D4D4D5;
-  box-shadow: -1px 0px 0px 0px #D4D4D5;
+  -webkit-box-shadow: -1px 0px 0px 0px #d4d4d5;
+  box-shadow: -1px 0px 0px 0px #d4d4d5;
 }
 
 .ui.celled.grid > .column:first-child,
@@ -22653,25 +22781,25 @@ ol.ui.horizontal.list li:before,
   padding: 1.5em;
 }
 
-.ui[class*="very relaxed"].celled.grid > .column:not(.row),
-.ui[class*="very relaxed"].celled.grid > .row > .column {
+.ui[class*='very relaxed'].celled.grid > .column:not(.row),
+.ui[class*='very relaxed'].celled.grid > .row > .column {
   padding: 2em;
 }
 
 /* Internally Celled */
 
-.ui[class*="internally celled"].grid {
+.ui[class*='internally celled'].grid {
   -webkit-box-shadow: none;
   box-shadow: none;
   margin: 0em;
 }
 
-.ui[class*="internally celled"].grid > .row:first-child {
+.ui[class*='internally celled'].grid > .row:first-child {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
 
-.ui[class*="internally celled"].grid > .row > .column:first-child {
+.ui[class*='internally celled'].grid > .row > .column:first-child {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
@@ -22682,11 +22810,11 @@ ol.ui.horizontal.list li:before,
 
 /* Top Aligned */
 
-.ui[class*="top aligned"].grid > .column:not(.row),
-.ui[class*="top aligned"].grid > .row > .column,
-.ui.grid > [class*="top aligned"].row > .column,
-.ui.grid > [class*="top aligned"].column:not(.row),
-.ui.grid > .row > [class*="top aligned"].column {
+.ui[class*='top aligned'].grid > .column:not(.row),
+.ui[class*='top aligned'].grid > .row > .column,
+.ui.grid > [class*='top aligned'].row > .column,
+.ui.grid > [class*='top aligned'].column:not(.row),
+.ui.grid > .row > [class*='top aligned'].column {
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
   -ms-flex-direction: column;
@@ -22698,11 +22826,11 @@ ol.ui.horizontal.list li:before,
 
 /* Middle Aligned */
 
-.ui[class*="middle aligned"].grid > .column:not(.row),
-.ui[class*="middle aligned"].grid > .row > .column,
-.ui.grid > [class*="middle aligned"].row > .column,
-.ui.grid > [class*="middle aligned"].column:not(.row),
-.ui.grid > .row > [class*="middle aligned"].column {
+.ui[class*='middle aligned'].grid > .column:not(.row),
+.ui[class*='middle aligned'].grid > .row > .column,
+.ui.grid > [class*='middle aligned'].row > .column,
+.ui.grid > [class*='middle aligned'].column:not(.row),
+.ui.grid > .row > [class*='middle aligned'].column {
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
   -ms-flex-direction: column;
@@ -22714,11 +22842,11 @@ ol.ui.horizontal.list li:before,
 
 /* Bottom Aligned */
 
-.ui[class*="bottom aligned"].grid > .column:not(.row),
-.ui[class*="bottom aligned"].grid > .row > .column,
-.ui.grid > [class*="bottom aligned"].row > .column,
-.ui.grid > [class*="bottom aligned"].column:not(.row),
-.ui.grid > .row > [class*="bottom aligned"].column {
+.ui[class*='bottom aligned'].grid > .column:not(.row),
+.ui[class*='bottom aligned'].grid > .row > .column,
+.ui.grid > [class*='bottom aligned'].row > .column,
+.ui.grid > [class*='bottom aligned'].column:not(.row),
+.ui.grid > .row > [class*='bottom aligned'].column {
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
   -ms-flex-direction: column;
@@ -22762,11 +22890,11 @@ ol.ui.horizontal.list li:before,
 
 /* Left Aligned */
 
-.ui[class*="left aligned"].grid > .column,
-.ui[class*="left aligned"].grid > .row > .column,
-.ui.grid > [class*="left aligned"].row > .column,
-.ui.grid > [class*="left aligned"].column.column,
-.ui.grid > .row > [class*="left aligned"].column.column {
+.ui[class*='left aligned'].grid > .column,
+.ui[class*='left aligned'].grid > .row > .column,
+.ui.grid > [class*='left aligned'].row > .column,
+.ui.grid > [class*='left aligned'].column.column,
+.ui.grid > .row > [class*='left aligned'].column.column {
   text-align: left;
   -ms-flex-item-align: inherit;
   align-self: inherit;
@@ -22774,17 +22902,17 @@ ol.ui.horizontal.list li:before,
 
 /* Center Aligned */
 
-.ui[class*="center aligned"].grid > .column,
-.ui[class*="center aligned"].grid > .row > .column,
-.ui.grid > [class*="center aligned"].row > .column,
-.ui.grid > [class*="center aligned"].column.column,
-.ui.grid > .row > [class*="center aligned"].column.column {
+.ui[class*='center aligned'].grid > .column,
+.ui[class*='center aligned'].grid > .row > .column,
+.ui.grid > [class*='center aligned'].row > .column,
+.ui.grid > [class*='center aligned'].column.column,
+.ui.grid > .row > [class*='center aligned'].column.column {
   text-align: center;
   -ms-flex-item-align: inherit;
   align-self: inherit;
 }
 
-.ui[class*="center aligned"].grid {
+.ui[class*='center aligned'].grid {
   -webkit-box-pack: center;
   -ms-flex-pack: center;
   justify-content: center;
@@ -22792,11 +22920,11 @@ ol.ui.horizontal.list li:before,
 
 /* Right Aligned */
 
-.ui[class*="right aligned"].grid > .column,
-.ui[class*="right aligned"].grid > .row > .column,
-.ui.grid > [class*="right aligned"].row > .column,
-.ui.grid > [class*="right aligned"].column.column,
-.ui.grid > .row > [class*="right aligned"].column.column {
+.ui[class*='right aligned'].grid > .column,
+.ui[class*='right aligned'].grid > .row > .column,
+.ui.grid > [class*='right aligned'].row > .column,
+.ui.grid > [class*='right aligned'].column.column,
+.ui.grid > .row > [class*='right aligned'].column.column {
   text-align: right;
   -ms-flex-item-align: inherit;
   align-self: inherit;
@@ -22843,8 +22971,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .red.row,
 .ui.grid > .red.column,
 .ui.grid > .row > .red.column {
-  background-color: #DB2828 !important;
-  color: #FFFFFF;
+  background-color: #db2828 !important;
+  color: #ffffff;
 }
 
 /* Orange */
@@ -22852,8 +22980,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .orange.row,
 .ui.grid > .orange.column,
 .ui.grid > .row > .orange.column {
-  background-color: #F2711C !important;
-  color: #FFFFFF;
+  background-color: #f2711c !important;
+  color: #ffffff;
 }
 
 /* Yellow */
@@ -22861,8 +22989,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .yellow.row,
 .ui.grid > .yellow.column,
 .ui.grid > .row > .yellow.column {
-  background-color: #FBBD08 !important;
-  color: #FFFFFF;
+  background-color: #fbbd08 !important;
+  color: #ffffff;
 }
 
 /* Olive */
@@ -22870,8 +22998,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .olive.row,
 .ui.grid > .olive.column,
 .ui.grid > .row > .olive.column {
-  background-color: #B5CC18 !important;
-  color: #FFFFFF;
+  background-color: #b5cc18 !important;
+  color: #ffffff;
 }
 
 /* Green */
@@ -22879,8 +23007,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .green.row,
 .ui.grid > .green.column,
 .ui.grid > .row > .green.column {
-  background-color: #21BA45 !important;
-  color: #FFFFFF;
+  background-color: #21ba45 !important;
+  color: #ffffff;
 }
 
 /* Teal */
@@ -22888,8 +23016,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .teal.row,
 .ui.grid > .teal.column,
 .ui.grid > .row > .teal.column {
-  background-color: #00B5AD !important;
-  color: #FFFFFF;
+  background-color: #00b5ad !important;
+  color: #ffffff;
 }
 
 /* Blue */
@@ -22897,8 +23025,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .blue.row,
 .ui.grid > .blue.column,
 .ui.grid > .row > .blue.column {
-  background-color: #2185D0 !important;
-  color: #FFFFFF;
+  background-color: #2185d0 !important;
+  color: #ffffff;
 }
 
 /* Violet */
@@ -22906,8 +23034,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .violet.row,
 .ui.grid > .violet.column,
 .ui.grid > .row > .violet.column {
-  background-color: #6435C9 !important;
-  color: #FFFFFF;
+  background-color: #6435c9 !important;
+  color: #ffffff;
 }
 
 /* Purple */
@@ -22915,8 +23043,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .purple.row,
 .ui.grid > .purple.column,
 .ui.grid > .row > .purple.column {
-  background-color: #A333C8 !important;
-  color: #FFFFFF;
+  background-color: #a333c8 !important;
+  color: #ffffff;
 }
 
 /* Pink */
@@ -22924,8 +23052,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .pink.row,
 .ui.grid > .pink.column,
 .ui.grid > .row > .pink.column {
-  background-color: #E03997 !important;
-  color: #FFFFFF;
+  background-color: #e03997 !important;
+  color: #ffffff;
 }
 
 /* Brown */
@@ -22933,8 +23061,8 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .brown.row,
 .ui.grid > .brown.column,
 .ui.grid > .row > .brown.column {
-  background-color: #A5673F !important;
-  color: #FFFFFF;
+  background-color: #a5673f !important;
+  color: #ffffff;
 }
 
 /* Grey */
@@ -22943,7 +23071,7 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .grey.column,
 .ui.grid > .row > .grey.column {
   background-color: #767676 !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 /* Black */
@@ -22951,26 +23079,26 @@ ol.ui.horizontal.list li:before,
 .ui.grid > .black.row,
 .ui.grid > .black.column,
 .ui.grid > .row > .black.column {
-  background-color: #1B1C1D !important;
-  color: #FFFFFF;
+  background-color: #1b1c1d !important;
+  color: #ffffff;
 }
 
 /*----------------------
       Equal Width
 -----------------------*/
 
-.ui[class*="equal width"].grid > .column:not(.row),
-.ui[class*="equal width"].grid > .row > .column,
-.ui.grid > [class*="equal width"].row > .column {
+.ui[class*='equal width'].grid > .column:not(.row),
+.ui[class*='equal width'].grid > .row > .column,
+.ui.grid > [class*='equal width'].row > .column {
   display: inline-block;
   -webkit-box-flex: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
 }
 
-.ui[class*="equal width"].grid > .wide.column,
-.ui[class*="equal width"].grid > .row > .wide.column,
-.ui.grid > [class*="equal width"].row > .wide.column {
+.ui[class*='equal width'].grid > .wide.column,
+.ui[class*='equal width'].grid > .row > .wide.column,
+.ui.grid > [class*='equal width'].row > .wide.column {
   -webkit-box-flex: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
@@ -22983,17 +23111,17 @@ ol.ui.horizontal.list li:before,
 /* Mobile */
 
 @media only screen and (max-width: 767px) {
-  .ui[class*="mobile reversed"].grid,
-  .ui[class*="mobile reversed"].grid > .row,
-  .ui.grid > [class*="mobile reversed"].row {
+  .ui[class*='mobile reversed'].grid,
+  .ui[class*='mobile reversed'].grid > .row,
+  .ui.grid > [class*='mobile reversed'].row {
     -webkit-box-orient: horizontal;
     -webkit-box-direction: reverse;
     -ms-flex-direction: row-reverse;
     flex-direction: row-reverse;
   }
 
-  .ui[class*="mobile vertically reversed"].grid,
-  .ui.stackable[class*="mobile reversed"] {
+  .ui[class*='mobile vertically reversed'].grid,
+  .ui.stackable[class*='mobile reversed'] {
     -webkit-box-orient: vertical;
     -webkit-box-direction: reverse;
     -ms-flex-direction: column-reverse;
@@ -23002,38 +23130,46 @@ ol.ui.horizontal.list li:before,
 
   /* Divided Reversed */
 
-  .ui[class*="mobile reversed"].divided.grid:not([class*="vertically divided"]) > .column:first-child,
-  .ui[class*="mobile reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
+  .ui[class*='mobile reversed'].divided.grid:not([class*='vertically divided'])
+    > .column:first-child,
+  .ui[class*='mobile reversed'].divided.grid:not([class*='vertically divided'])
+    > .row
+    > .column:first-child {
     -webkit-box-shadow: -1px 0px 0px 0px rgba(34, 36, 38, 0.15);
     box-shadow: -1px 0px 0px 0px rgba(34, 36, 38, 0.15);
   }
 
-  .ui[class*="mobile reversed"].divided.grid:not([class*="vertically divided"]) > .column:last-child,
-  .ui[class*="mobile reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:last-child {
+  .ui[class*='mobile reversed'].divided.grid:not([class*='vertically divided'])
+    > .column:last-child,
+  .ui[class*='mobile reversed'].divided.grid:not([class*='vertically divided'])
+    > .row
+    > .column:last-child {
     -webkit-box-shadow: none;
     box-shadow: none;
   }
 
   /* Vertically Divided Reversed */
 
-  .ui.grid[class*="vertically divided"][class*="mobile vertically reversed"] > .row:first-child:before {
+  .ui.grid[class*='vertically divided'][class*='mobile vertically reversed']
+    > .row:first-child:before {
     -webkit-box-shadow: 0px -1px 0px 0px rgba(34, 36, 38, 0.15);
     box-shadow: 0px -1px 0px 0px rgba(34, 36, 38, 0.15);
   }
 
-  .ui.grid[class*="vertically divided"][class*="mobile vertically reversed"] > .row:last-child:before {
+  .ui.grid[class*='vertically divided'][class*='mobile vertically reversed']
+    > .row:last-child:before {
     -webkit-box-shadow: none;
     box-shadow: none;
   }
 
   /* Celled Reversed */
 
-  .ui[class*="mobile reversed"].celled.grid > .row > .column:first-child {
-    -webkit-box-shadow: -1px 0px 0px 0px #D4D4D5;
-    box-shadow: -1px 0px 0px 0px #D4D4D5;
+  .ui[class*='mobile reversed'].celled.grid > .row > .column:first-child {
+    -webkit-box-shadow: -1px 0px 0px 0px #d4d4d5;
+    box-shadow: -1px 0px 0px 0px #d4d4d5;
   }
 
-  .ui[class*="mobile reversed"].celled.grid > .row > .column:last-child {
+  .ui[class*='mobile reversed'].celled.grid > .row > .column:last-child {
     -webkit-box-shadow: none;
     box-shadow: none;
   }
@@ -23042,16 +23178,16 @@ ol.ui.horizontal.list li:before,
 /* Tablet */
 
 @media only screen and (min-width: 768px) and (max-width: 991px) {
-  .ui[class*="tablet reversed"].grid,
-  .ui[class*="tablet reversed"].grid > .row,
-  .ui.grid > [class*="tablet reversed"].row {
+  .ui[class*='tablet reversed'].grid,
+  .ui[class*='tablet reversed'].grid > .row,
+  .ui.grid > [class*='tablet reversed'].row {
     -webkit-box-orient: horizontal;
     -webkit-box-direction: reverse;
     -ms-flex-direction: row-reverse;
     flex-direction: row-reverse;
   }
 
-  .ui[class*="tablet vertically reversed"].grid {
+  .ui[class*='tablet vertically reversed'].grid {
     -webkit-box-orient: vertical;
     -webkit-box-direction: reverse;
     -ms-flex-direction: column-reverse;
@@ -23060,38 +23196,46 @@ ol.ui.horizontal.list li:before,
 
   /* Divided Reversed */
 
-  .ui[class*="tablet reversed"].divided.grid:not([class*="vertically divided"]) > .column:first-child,
-  .ui[class*="tablet reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
+  .ui[class*='tablet reversed'].divided.grid:not([class*='vertically divided'])
+    > .column:first-child,
+  .ui[class*='tablet reversed'].divided.grid:not([class*='vertically divided'])
+    > .row
+    > .column:first-child {
     -webkit-box-shadow: -1px 0px 0px 0px rgba(34, 36, 38, 0.15);
     box-shadow: -1px 0px 0px 0px rgba(34, 36, 38, 0.15);
   }
 
-  .ui[class*="tablet reversed"].divided.grid:not([class*="vertically divided"]) > .column:last-child,
-  .ui[class*="tablet reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:last-child {
+  .ui[class*='tablet reversed'].divided.grid:not([class*='vertically divided'])
+    > .column:last-child,
+  .ui[class*='tablet reversed'].divided.grid:not([class*='vertically divided'])
+    > .row
+    > .column:last-child {
     -webkit-box-shadow: none;
     box-shadow: none;
   }
 
   /* Vertically Divided Reversed */
 
-  .ui.grid[class*="vertically divided"][class*="tablet vertically reversed"] > .row:first-child:before {
+  .ui.grid[class*='vertically divided'][class*='tablet vertically reversed']
+    > .row:first-child:before {
     -webkit-box-shadow: 0px -1px 0px 0px rgba(34, 36, 38, 0.15);
     box-shadow: 0px -1px 0px 0px rgba(34, 36, 38, 0.15);
   }
 
-  .ui.grid[class*="vertically divided"][class*="tablet vertically reversed"] > .row:last-child:before {
+  .ui.grid[class*='vertically divided'][class*='tablet vertically reversed']
+    > .row:last-child:before {
     -webkit-box-shadow: none;
     box-shadow: none;
   }
 
   /* Celled Reversed */
 
-  .ui[class*="tablet reversed"].celled.grid > .row > .column:first-child {
-    -webkit-box-shadow: -1px 0px 0px 0px #D4D4D5;
-    box-shadow: -1px 0px 0px 0px #D4D4D5;
+  .ui[class*='tablet reversed'].celled.grid > .row > .column:first-child {
+    -webkit-box-shadow: -1px 0px 0px 0px #d4d4d5;
+    box-shadow: -1px 0px 0px 0px #d4d4d5;
   }
 
-  .ui[class*="tablet reversed"].celled.grid > .row > .column:last-child {
+  .ui[class*='tablet reversed'].celled.grid > .row > .column:last-child {
     -webkit-box-shadow: none;
     box-shadow: none;
   }
@@ -23100,16 +23244,16 @@ ol.ui.horizontal.list li:before,
 /* Computer */
 
 @media only screen and (min-width: 992px) {
-  .ui[class*="computer reversed"].grid,
-  .ui[class*="computer reversed"].grid > .row,
-  .ui.grid > [class*="computer reversed"].row {
+  .ui[class*='computer reversed'].grid,
+  .ui[class*='computer reversed'].grid > .row,
+  .ui.grid > [class*='computer reversed'].row {
     -webkit-box-orient: horizontal;
     -webkit-box-direction: reverse;
     -ms-flex-direction: row-reverse;
     flex-direction: row-reverse;
   }
 
-  .ui[class*="computer vertically reversed"].grid {
+  .ui[class*='computer vertically reversed'].grid {
     -webkit-box-orient: vertical;
     -webkit-box-direction: reverse;
     -ms-flex-direction: column-reverse;
@@ -23118,38 +23262,46 @@ ol.ui.horizontal.list li:before,
 
   /* Divided Reversed */
 
-  .ui[class*="computer reversed"].divided.grid:not([class*="vertically divided"]) > .column:first-child,
-  .ui[class*="computer reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:first-child {
+  .ui[class*='computer reversed'].divided.grid:not([class*='vertically divided'])
+    > .column:first-child,
+  .ui[class*='computer reversed'].divided.grid:not([class*='vertically divided'])
+    > .row
+    > .column:first-child {
     -webkit-box-shadow: -1px 0px 0px 0px rgba(34, 36, 38, 0.15);
     box-shadow: -1px 0px 0px 0px rgba(34, 36, 38, 0.15);
   }
 
-  .ui[class*="computer reversed"].divided.grid:not([class*="vertically divided"]) > .column:last-child,
-  .ui[class*="computer reversed"].divided.grid:not([class*="vertically divided"]) > .row > .column:last-child {
+  .ui[class*='computer reversed'].divided.grid:not([class*='vertically divided'])
+    > .column:last-child,
+  .ui[class*='computer reversed'].divided.grid:not([class*='vertically divided'])
+    > .row
+    > .column:last-child {
     -webkit-box-shadow: none;
     box-shadow: none;
   }
 
   /* Vertically Divided Reversed */
 
-  .ui.grid[class*="vertically divided"][class*="computer vertically reversed"] > .row:first-child:before {
+  .ui.grid[class*='vertically divided'][class*='computer vertically reversed']
+    > .row:first-child:before {
     -webkit-box-shadow: 0px -1px 0px 0px rgba(34, 36, 38, 0.15);
     box-shadow: 0px -1px 0px 0px rgba(34, 36, 38, 0.15);
   }
 
-  .ui.grid[class*="vertically divided"][class*="computer vertically reversed"] > .row:last-child:before {
+  .ui.grid[class*='vertically divided'][class*='computer vertically reversed']
+    > .row:last-child:before {
     -webkit-box-shadow: none;
     box-shadow: none;
   }
 
   /* Celled Reversed */
 
-  .ui[class*="computer reversed"].celled.grid > .row > .column:first-child {
-    -webkit-box-shadow: -1px 0px 0px 0px #D4D4D5;
-    box-shadow: -1px 0px 0px 0px #D4D4D5;
+  .ui[class*='computer reversed'].celled.grid > .row > .column:first-child {
+    -webkit-box-shadow: -1px 0px 0px 0px #d4d4d5;
+    box-shadow: -1px 0px 0px 0px #d4d4d5;
   }
 
-  .ui[class*="computer reversed"].celled.grid > .row > .column:last-child {
+  .ui[class*='computer reversed'].celled.grid > .row > .column:last-child {
     -webkit-box-shadow: none;
     box-shadow: none;
   }
@@ -23182,93 +23334,93 @@ ol.ui.horizontal.list li:before,
     margin: 0em;
   }
 
-  .ui[class*="two column"].doubling.grid > .row > .column,
-  .ui[class*="two column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="two column"].doubling.row.row > .column {
+  .ui[class*='two column'].doubling.grid > .row > .column,
+  .ui[class*='two column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='two column'].doubling.row.row > .column {
     width: 100% !important;
   }
 
-  .ui[class*="three column"].doubling.grid > .row > .column,
-  .ui[class*="three column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="three column"].doubling.row.row > .column {
+  .ui[class*='three column'].doubling.grid > .row > .column,
+  .ui[class*='three column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='three column'].doubling.row.row > .column {
     width: 50% !important;
   }
 
-  .ui[class*="four column"].doubling.grid > .row > .column,
-  .ui[class*="four column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="four column"].doubling.row.row > .column {
+  .ui[class*='four column'].doubling.grid > .row > .column,
+  .ui[class*='four column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='four column'].doubling.row.row > .column {
     width: 50% !important;
   }
 
-  .ui[class*="five column"].doubling.grid > .row > .column,
-  .ui[class*="five column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="five column"].doubling.row.row > .column {
+  .ui[class*='five column'].doubling.grid > .row > .column,
+  .ui[class*='five column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='five column'].doubling.row.row > .column {
     width: 33.33333333% !important;
   }
 
-  .ui[class*="six column"].doubling.grid > .row > .column,
-  .ui[class*="six column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="six column"].doubling.row.row > .column {
+  .ui[class*='six column'].doubling.grid > .row > .column,
+  .ui[class*='six column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='six column'].doubling.row.row > .column {
     width: 33.33333333% !important;
   }
 
-  .ui[class*="seven column"].doubling.grid > .row > .column,
-  .ui[class*="seven column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="seven column"].doubling.row.row > .column {
+  .ui[class*='seven column'].doubling.grid > .row > .column,
+  .ui[class*='seven column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='seven column'].doubling.row.row > .column {
     width: 33.33333333% !important;
   }
 
-  .ui[class*="eight column"].doubling.grid > .row > .column,
-  .ui[class*="eight column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="eight column"].doubling.row.row > .column {
+  .ui[class*='eight column'].doubling.grid > .row > .column,
+  .ui[class*='eight column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='eight column'].doubling.row.row > .column {
     width: 25% !important;
   }
 
-  .ui[class*="nine column"].doubling.grid > .row > .column,
-  .ui[class*="nine column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="nine column"].doubling.row.row > .column {
+  .ui[class*='nine column'].doubling.grid > .row > .column,
+  .ui[class*='nine column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='nine column'].doubling.row.row > .column {
     width: 25% !important;
   }
 
-  .ui[class*="ten column"].doubling.grid > .row > .column,
-  .ui[class*="ten column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="ten column"].doubling.row.row > .column {
+  .ui[class*='ten column'].doubling.grid > .row > .column,
+  .ui[class*='ten column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='ten column'].doubling.row.row > .column {
     width: 20% !important;
   }
 
-  .ui[class*="eleven column"].doubling.grid > .row > .column,
-  .ui[class*="eleven column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="eleven column"].doubling.row.row > .column {
+  .ui[class*='eleven column'].doubling.grid > .row > .column,
+  .ui[class*='eleven column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='eleven column'].doubling.row.row > .column {
     width: 20% !important;
   }
 
-  .ui[class*="twelve column"].doubling.grid > .row > .column,
-  .ui[class*="twelve column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="twelve column"].doubling.row.row > .column {
+  .ui[class*='twelve column'].doubling.grid > .row > .column,
+  .ui[class*='twelve column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='twelve column'].doubling.row.row > .column {
     width: 16.66666667% !important;
   }
 
-  .ui[class*="thirteen column"].doubling.grid > .row > .column,
-  .ui[class*="thirteen column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="thirteen column"].doubling.row.row > .column {
+  .ui[class*='thirteen column'].doubling.grid > .row > .column,
+  .ui[class*='thirteen column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='thirteen column'].doubling.row.row > .column {
     width: 16.66666667% !important;
   }
 
-  .ui[class*="fourteen column"].doubling.grid > .row > .column,
-  .ui[class*="fourteen column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="fourteen column"].doubling.row.row > .column {
+  .ui[class*='fourteen column'].doubling.grid > .row > .column,
+  .ui[class*='fourteen column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='fourteen column'].doubling.row.row > .column {
     width: 14.28571429% !important;
   }
 
-  .ui[class*="fifteen column"].doubling.grid > .row > .column,
-  .ui[class*="fifteen column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="fifteen column"].doubling.row.row > .column {
+  .ui[class*='fifteen column'].doubling.grid > .row > .column,
+  .ui[class*='fifteen column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='fifteen column'].doubling.row.row > .column {
     width: 14.28571429% !important;
   }
 
-  .ui[class*="sixteen column"].doubling.grid > .row > .column,
-  .ui[class*="sixteen column"].doubling.grid > .column:not(.row),
-  .ui.grid > [class*="sixteen column"].doubling.row.row > .column {
+  .ui[class*='sixteen column'].doubling.grid > .row > .column,
+  .ui[class*='sixteen column'].doubling.grid > .column:not(.row),
+  .ui.grid > [class*='sixteen column'].doubling.row.row > .column {
     width: 12.5% !important;
   }
 }
@@ -23291,93 +23443,115 @@ ol.ui.horizontal.list li:before,
     box-shadow: none !important;
   }
 
-  .ui[class*="two column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="two column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="two column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='two column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='two column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid > [class*='two column'].doubling:not(.stackable).row.row > .column {
     width: 100% !important;
   }
 
-  .ui[class*="three column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="three column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="three column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='three column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='three column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid
+    > [class*='three column'].doubling:not(.stackable).row.row
+    > .column {
     width: 50% !important;
   }
 
-  .ui[class*="four column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="four column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="four column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='four column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='four column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid > [class*='four column'].doubling:not(.stackable).row.row > .column {
     width: 50% !important;
   }
 
-  .ui[class*="five column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="five column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="five column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='five column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='five column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid > [class*='five column'].doubling:not(.stackable).row.row > .column {
     width: 50% !important;
   }
 
-  .ui[class*="six column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="six column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="six column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='six column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='six column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid > [class*='six column'].doubling:not(.stackable).row.row > .column {
     width: 50% !important;
   }
 
-  .ui[class*="seven column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="seven column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="seven column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='seven column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='seven column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid
+    > [class*='seven column'].doubling:not(.stackable).row.row
+    > .column {
     width: 50% !important;
   }
 
-  .ui[class*="eight column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="eight column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="eight column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='eight column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='eight column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid
+    > [class*='eight column'].doubling:not(.stackable).row.row
+    > .column {
     width: 50% !important;
   }
 
-  .ui[class*="nine column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="nine column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="nine column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='nine column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='nine column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid > [class*='nine column'].doubling:not(.stackable).row.row > .column {
     width: 33.33333333% !important;
   }
 
-  .ui[class*="ten column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="ten column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="ten column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='ten column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='ten column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid > [class*='ten column'].doubling:not(.stackable).row.row > .column {
     width: 33.33333333% !important;
   }
 
-  .ui[class*="eleven column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="eleven column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="eleven column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='eleven column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='eleven column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid
+    > [class*='eleven column'].doubling:not(.stackable).row.row
+    > .column {
     width: 33.33333333% !important;
   }
 
-  .ui[class*="twelve column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="twelve column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="twelve column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='twelve column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='twelve column'].doubling:not(.stackable).grid > .column:not(.row),
+  .ui.grid
+    > [class*='twelve column'].doubling:not(.stackable).row.row
+    > .column {
     width: 33.33333333% !important;
   }
 
-  .ui[class*="thirteen column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="thirteen column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="thirteen column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='thirteen column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='thirteen column'].doubling:not(.stackable).grid
+    > .column:not(.row),
+  .ui.grid
+    > [class*='thirteen column'].doubling:not(.stackable).row.row
+    > .column {
     width: 33.33333333% !important;
   }
 
-  .ui[class*="fourteen column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="fourteen column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="fourteen column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='fourteen column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='fourteen column'].doubling:not(.stackable).grid
+    > .column:not(.row),
+  .ui.grid
+    > [class*='fourteen column'].doubling:not(.stackable).row.row
+    > .column {
     width: 25% !important;
   }
 
-  .ui[class*="fifteen column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="fifteen column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="fifteen column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='fifteen column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='fifteen column'].doubling:not(.stackable).grid
+    > .column:not(.row),
+  .ui.grid
+    > [class*='fifteen column'].doubling:not(.stackable).row.row
+    > .column {
     width: 25% !important;
   }
 
-  .ui[class*="sixteen column"].doubling:not(.stackable).grid > .row > .column,
-  .ui[class*="sixteen column"].doubling:not(.stackable).grid > .column:not(.row),
-  .ui.grid > [class*="sixteen column"].doubling:not(.stackable).row.row > .column {
+  .ui[class*='sixteen column'].doubling:not(.stackable).grid > .row > .column,
+  .ui[class*='sixteen column'].doubling:not(.stackable).grid
+    > .column:not(.row),
+  .ui.grid
+    > [class*='sixteen column'].doubling:not(.stackable).row.row
+    > .column {
     width: 25% !important;
   }
 }
@@ -23476,31 +23650,31 @@ ol.ui.horizontal.list li:before,
 /* Mobile Only Hide */
 
 @media only screen and (max-width: 767px) {
-  .ui[class*="tablet only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="tablet only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="tablet only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="tablet only"].column:not(.mobile) {
+  .ui[class*='tablet only'].grid.grid.grid:not(.mobile),
+  .ui.grid.grid.grid > [class*='tablet only'].row:not(.mobile),
+  .ui.grid.grid.grid > [class*='tablet only'].column:not(.mobile),
+  .ui.grid.grid.grid > .row > [class*='tablet only'].column:not(.mobile) {
     display: none !important;
   }
 
-  .ui[class*="computer only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="computer only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="computer only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="computer only"].column:not(.mobile) {
+  .ui[class*='computer only'].grid.grid.grid:not(.mobile),
+  .ui.grid.grid.grid > [class*='computer only'].row:not(.mobile),
+  .ui.grid.grid.grid > [class*='computer only'].column:not(.mobile),
+  .ui.grid.grid.grid > .row > [class*='computer only'].column:not(.mobile) {
     display: none !important;
   }
 
-  .ui[class*="large screen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="large screen only"].column:not(.mobile) {
+  .ui[class*='large screen only'].grid.grid.grid:not(.mobile),
+  .ui.grid.grid.grid > [class*='large screen only'].row:not(.mobile),
+  .ui.grid.grid.grid > [class*='large screen only'].column:not(.mobile),
+  .ui.grid.grid.grid > .row > [class*='large screen only'].column:not(.mobile) {
     display: none !important;
   }
 
-  .ui[class*="widescreen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+  .ui[class*='widescreen only'].grid.grid.grid:not(.mobile),
+  .ui.grid.grid.grid > [class*='widescreen only'].row:not(.mobile),
+  .ui.grid.grid.grid > [class*='widescreen only'].column:not(.mobile),
+  .ui.grid.grid.grid > .row > [class*='widescreen only'].column:not(.mobile) {
     display: none !important;
   }
 }
@@ -23508,31 +23682,31 @@ ol.ui.horizontal.list li:before,
 /* Tablet Only Hide */
 
 @media only screen and (min-width: 768px) and (max-width: 991px) {
-  .ui[class*="mobile only"].grid.grid.grid:not(.tablet),
-  .ui.grid.grid.grid > [class*="mobile only"].row:not(.tablet),
-  .ui.grid.grid.grid > [class*="mobile only"].column:not(.tablet),
-  .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.tablet) {
+  .ui[class*='mobile only'].grid.grid.grid:not(.tablet),
+  .ui.grid.grid.grid > [class*='mobile only'].row:not(.tablet),
+  .ui.grid.grid.grid > [class*='mobile only'].column:not(.tablet),
+  .ui.grid.grid.grid > .row > [class*='mobile only'].column:not(.tablet) {
     display: none !important;
   }
 
-  .ui[class*="computer only"].grid.grid.grid:not(.tablet),
-  .ui.grid.grid.grid > [class*="computer only"].row:not(.tablet),
-  .ui.grid.grid.grid > [class*="computer only"].column:not(.tablet),
-  .ui.grid.grid.grid > .row > [class*="computer only"].column:not(.tablet) {
+  .ui[class*='computer only'].grid.grid.grid:not(.tablet),
+  .ui.grid.grid.grid > [class*='computer only'].row:not(.tablet),
+  .ui.grid.grid.grid > [class*='computer only'].column:not(.tablet),
+  .ui.grid.grid.grid > .row > [class*='computer only'].column:not(.tablet) {
     display: none !important;
   }
 
-  .ui[class*="large screen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="large screen only"].column:not(.mobile) {
+  .ui[class*='large screen only'].grid.grid.grid:not(.mobile),
+  .ui.grid.grid.grid > [class*='large screen only'].row:not(.mobile),
+  .ui.grid.grid.grid > [class*='large screen only'].column:not(.mobile),
+  .ui.grid.grid.grid > .row > [class*='large screen only'].column:not(.mobile) {
     display: none !important;
   }
 
-  .ui[class*="widescreen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+  .ui[class*='widescreen only'].grid.grid.grid:not(.mobile),
+  .ui.grid.grid.grid > [class*='widescreen only'].row:not(.mobile),
+  .ui.grid.grid.grid > [class*='widescreen only'].column:not(.mobile),
+  .ui.grid.grid.grid > .row > [class*='widescreen only'].column:not(.mobile) {
     display: none !important;
   }
 }
@@ -23540,31 +23714,31 @@ ol.ui.horizontal.list li:before,
 /* Computer Only Hide */
 
 @media only screen and (min-width: 992px) and (max-width: 1199px) {
-  .ui[class*="mobile only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.computer) {
+  .ui[class*='mobile only'].grid.grid.grid:not(.computer),
+  .ui.grid.grid.grid > [class*='mobile only'].row:not(.computer),
+  .ui.grid.grid.grid > [class*='mobile only'].column:not(.computer),
+  .ui.grid.grid.grid > .row > [class*='mobile only'].column:not(.computer) {
     display: none !important;
   }
 
-  .ui[class*="tablet only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="tablet only"].column:not(.computer) {
+  .ui[class*='tablet only'].grid.grid.grid:not(.computer),
+  .ui.grid.grid.grid > [class*='tablet only'].row:not(.computer),
+  .ui.grid.grid.grid > [class*='tablet only'].column:not(.computer),
+  .ui.grid.grid.grid > .row > [class*='tablet only'].column:not(.computer) {
     display: none !important;
   }
 
-  .ui[class*="large screen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="large screen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="large screen only"].column:not(.mobile) {
+  .ui[class*='large screen only'].grid.grid.grid:not(.mobile),
+  .ui.grid.grid.grid > [class*='large screen only'].row:not(.mobile),
+  .ui.grid.grid.grid > [class*='large screen only'].column:not(.mobile),
+  .ui.grid.grid.grid > .row > [class*='large screen only'].column:not(.mobile) {
     display: none !important;
   }
 
-  .ui[class*="widescreen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+  .ui[class*='widescreen only'].grid.grid.grid:not(.mobile),
+  .ui.grid.grid.grid > [class*='widescreen only'].row:not(.mobile),
+  .ui.grid.grid.grid > [class*='widescreen only'].column:not(.mobile),
+  .ui.grid.grid.grid > .row > [class*='widescreen only'].column:not(.mobile) {
     display: none !important;
   }
 }
@@ -23572,24 +23746,24 @@ ol.ui.horizontal.list li:before,
 /* Large Screen Only Hide */
 
 @media only screen and (min-width: 1200px) and (max-width: 1919px) {
-  .ui[class*="mobile only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.computer) {
+  .ui[class*='mobile only'].grid.grid.grid:not(.computer),
+  .ui.grid.grid.grid > [class*='mobile only'].row:not(.computer),
+  .ui.grid.grid.grid > [class*='mobile only'].column:not(.computer),
+  .ui.grid.grid.grid > .row > [class*='mobile only'].column:not(.computer) {
     display: none !important;
   }
 
-  .ui[class*="tablet only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="tablet only"].column:not(.computer) {
+  .ui[class*='tablet only'].grid.grid.grid:not(.computer),
+  .ui.grid.grid.grid > [class*='tablet only'].row:not(.computer),
+  .ui.grid.grid.grid > [class*='tablet only'].column:not(.computer),
+  .ui.grid.grid.grid > .row > [class*='tablet only'].column:not(.computer) {
     display: none !important;
   }
 
-  .ui[class*="widescreen only"].grid.grid.grid:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].row:not(.mobile),
-  .ui.grid.grid.grid > [class*="widescreen only"].column:not(.mobile),
-  .ui.grid.grid.grid > .row > [class*="widescreen only"].column:not(.mobile) {
+  .ui[class*='widescreen only'].grid.grid.grid:not(.mobile),
+  .ui.grid.grid.grid > [class*='widescreen only'].row:not(.mobile),
+  .ui.grid.grid.grid > [class*='widescreen only'].column:not(.mobile),
+  .ui.grid.grid.grid > .row > [class*='widescreen only'].column:not(.mobile) {
     display: none !important;
   }
 }
@@ -23597,17 +23771,17 @@ ol.ui.horizontal.list li:before,
 /* Widescreen Only Hide */
 
 @media only screen and (min-width: 1920px) {
-  .ui[class*="mobile only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="mobile only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="mobile only"].column:not(.computer) {
+  .ui[class*='mobile only'].grid.grid.grid:not(.computer),
+  .ui.grid.grid.grid > [class*='mobile only'].row:not(.computer),
+  .ui.grid.grid.grid > [class*='mobile only'].column:not(.computer),
+  .ui.grid.grid.grid > .row > [class*='mobile only'].column:not(.computer) {
     display: none !important;
   }
 
-  .ui[class*="tablet only"].grid.grid.grid:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].row:not(.computer),
-  .ui.grid.grid.grid > [class*="tablet only"].column:not(.computer),
-  .ui.grid.grid.grid > .row > [class*="tablet only"].column:not(.computer) {
+  .ui[class*='tablet only'].grid.grid.grid:not(.computer),
+  .ui.grid.grid.grid > [class*='tablet only'].row:not(.computer),
+  .ui.grid.grid.grid > [class*='tablet only'].column:not(.computer),
+  .ui.grid.grid.grid > .row > [class*='tablet only'].column:not(.computer) {
     display: none !important;
   }
 }
@@ -23644,7 +23818,7 @@ ol.ui.horizontal.list li:before,
   display: flex;
   margin: 1rem 0em;
   font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-  background: #FFFFFF;
+  background: #ffffff;
   font-weight: normal;
   border: 1px solid rgba(34, 36, 38, 0.15);
   -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
@@ -23714,10 +23888,13 @@ ol.ui.horizontal.list li:before,
   text-transform: none;
   color: rgba(0, 0, 0, 0.87);
   font-weight: normal;
-  -webkit-transition: background 0.1s ease, color 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: background 0.1s ease, color 0.1s ease, -webkit-box-shadow 0.1s ease;
+  -webkit-transition: background 0.1s ease, color 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
+  transition: background 0.1s ease, color 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
   transition: background 0.1s ease, box-shadow 0.1s ease, color 0.1s ease;
-  transition: background 0.1s ease, box-shadow 0.1s ease, color 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: background 0.1s ease, box-shadow 0.1s ease, color 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
 }
 
 .ui.menu > .item:first-child {
@@ -23854,7 +24031,7 @@ ol.ui.horizontal.list li:before,
 .ui.menu .dropdown.item .menu {
   min-width: calc(100% - 1px);
   border-radius: 0em 0em 0.28571429rem 0.28571429rem;
-  background: #FFFFFF;
+  background: #ffffff;
   margin: 0em 0px 0px;
   -webkit-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.08);
   box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.08);
@@ -23933,7 +24110,7 @@ ol.ui.horizontal.list li:before,
 
 .ui.vertical.menu .dropdown.item > .icon {
   float: right;
-  content: "\f0da";
+  content: '\f0da';
   margin-left: 1em;
 }
 
@@ -23976,14 +24153,14 @@ ol.ui.horizontal.list li:before,
 
 .ui.menu .item > .label {
   background: #999999;
-  color: #FFFFFF;
+  color: #ffffff;
   margin-left: 1em;
   padding: 0.3em 0.78571429em;
 }
 
 .ui.vertical.menu .item > .label {
   background: #999999;
-  color: #FFFFFF;
+  color: #ffffff;
   margin-top: -0.15em;
   margin-bottom: -0.15em;
   padding: 0.3em 0.78571429em;
@@ -24052,7 +24229,9 @@ ol.ui.horizontal.list li:before,
 }
 
 @media only screen and (min-width: 768px) {
-  .ui.menu:not(.secondary):not(.text):not(.tabular):not(.borderless) > .container > .item:not(.right):not(.borderless):first-child {
+  .ui.menu:not(.secondary):not(.text):not(.tabular):not(.borderless)
+    > .container
+    > .item:not(.right):not(.borderless):first-child {
     border-left: 1px solid rgba(34, 36, 38, 0.1);
   }
 }
@@ -24168,7 +24347,7 @@ Floated Menu / Item
   -webkit-box-direction: normal;
   -ms-flex-direction: column;
   flex-direction: column;
-  background: #FFFFFF;
+  background: #ffffff;
   -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
   box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
 }
@@ -24289,7 +24468,7 @@ Floated Menu / Item
   box-shadow: none !important;
   border: none;
   background: none transparent;
-  border-bottom: 1px solid #D4D4D5;
+  border-bottom: 1px solid #d4d4d5;
 }
 
 .ui.tabular.fluid.menu {
@@ -24320,10 +24499,10 @@ Floated Menu / Item
 /* Active */
 
 .ui.tabular.menu .active.item {
-  background: none #FFFFFF;
+  background: none #ffffff;
   color: rgba(0, 0, 0, 0.95);
   border-top-width: 1px;
-  border-color: #D4D4D5;
+  border-color: #d4d4d5;
   font-weight: bold;
   margin-bottom: -1px;
   -webkit-box-shadow: none;
@@ -24356,7 +24535,7 @@ Floated Menu / Item
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
   border-bottom: none;
-  border-top: 1px solid #D4D4D5;
+  border-top: 1px solid #d4d4d5;
 }
 
 .ui.bottom.tabular.menu .item {
@@ -24368,9 +24547,9 @@ Floated Menu / Item
 }
 
 .ui.bottom.tabular.menu .active.item {
-  background: none #FFFFFF;
+  background: none #ffffff;
   color: rgba(0, 0, 0, 0.95);
-  border-color: #D4D4D5;
+  border-color: #d4d4d5;
   margin: -1px 0px 0px 0px;
   border-radius: 0px 0px 0.28571429rem 0.28571429rem !important;
 }
@@ -24383,7 +24562,7 @@ Floated Menu / Item
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
   border-bottom: none;
-  border-right: 1px solid #D4D4D5;
+  border-right: 1px solid #d4d4d5;
 }
 
 .ui.vertical.tabular.menu .item {
@@ -24395,9 +24574,9 @@ Floated Menu / Item
 }
 
 .ui.vertical.tabular.menu .active.item {
-  background: none #FFFFFF;
+  background: none #ffffff;
   color: rgba(0, 0, 0, 0.95);
-  border-color: #D4D4D5;
+  border-color: #d4d4d5;
   margin: 0px -1px 0px 0px;
   border-radius: 0.28571429rem 0px 0px 0.28571429rem !important;
 }
@@ -24411,7 +24590,7 @@ Floated Menu / Item
   box-shadow: none !important;
   border-bottom: none;
   border-right: none;
-  border-left: 1px solid #D4D4D5;
+  border-left: 1px solid #d4d4d5;
 }
 
 .ui.vertical.right.tabular.menu .item {
@@ -24423,9 +24602,9 @@ Floated Menu / Item
 }
 
 .ui.vertical.right.tabular.menu .active.item {
-  background: none #FFFFFF;
+  background: none #ffffff;
   color: rgba(0, 0, 0, 0.95);
-  border-color: #D4D4D5;
+  border-color: #d4d4d5;
   margin: 0px 0px 0px -1px;
   border-radius: 0px 0.28571429rem 0.28571429rem 0px !important;
 }
@@ -24696,7 +24875,7 @@ Floated Menu / Item
   background-color: transparent;
   -webkit-box-shadow: none;
   box-shadow: none;
-  border-color: #1B1C1D;
+  border-color: #1b1c1d;
   font-weight: bold;
   color: rgba(0, 0, 0, 0.95);
 }
@@ -24704,7 +24883,7 @@ Floated Menu / Item
 /* Active Hover */
 
 .ui.secondary.pointing.menu .active.item:hover {
-  border-color: #1B1C1D;
+  border-color: #1b1c1d;
   color: rgba(0, 0, 0, 0.95);
 }
 
@@ -24735,7 +24914,7 @@ Floated Menu / Item
 /* Vertical Active */
 
 .ui.secondary.vertical.pointing.menu .active.item {
-  border-color: #1B1C1D;
+  border-color: #1b1c1d;
 }
 
 /* Inverted */
@@ -24754,7 +24933,7 @@ Floated Menu / Item
 }
 
 .ui.secondary.inverted.pointing.menu .header.item {
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Hover */
@@ -24767,7 +24946,7 @@ Floated Menu / Item
 /* Active */
 
 .ui.secondary.inverted.pointing.menu .active.item {
-  border-color: #FFFFFF;
+  border-color: #ffffff;
   color: #ffffff;
 }
 
@@ -24936,7 +25115,7 @@ Floated Menu / Item
 .ui.icon.menu .item {
   height: auto;
   text-align: center;
-  color: #1B1C1D;
+  color: #1b1c1d;
 }
 
 /* Icon */
@@ -24971,7 +25150,7 @@ Floated Menu / Item
 /* Inverted */
 
 .ui.inverted.icon.menu .item {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 /*--------------
@@ -25067,68 +25246,68 @@ Floated Menu / Item
 
 .ui.menu .red.active.item,
 .ui.red.menu .active.item {
-  border-color: #DB2828 !important;
-  color: #DB2828 !important;
+  border-color: #db2828 !important;
+  color: #db2828 !important;
 }
 
 .ui.menu .orange.active.item,
 .ui.orange.menu .active.item {
-  border-color: #F2711C !important;
-  color: #F2711C !important;
+  border-color: #f2711c !important;
+  color: #f2711c !important;
 }
 
 .ui.menu .yellow.active.item,
 .ui.yellow.menu .active.item {
-  border-color: #FBBD08 !important;
-  color: #FBBD08 !important;
+  border-color: #fbbd08 !important;
+  color: #fbbd08 !important;
 }
 
 .ui.menu .olive.active.item,
 .ui.olive.menu .active.item {
-  border-color: #B5CC18 !important;
-  color: #B5CC18 !important;
+  border-color: #b5cc18 !important;
+  color: #b5cc18 !important;
 }
 
 .ui.menu .green.active.item,
 .ui.green.menu .active.item {
-  border-color: #21BA45 !important;
-  color: #21BA45 !important;
+  border-color: #21ba45 !important;
+  color: #21ba45 !important;
 }
 
 .ui.menu .teal.active.item,
 .ui.teal.menu .active.item {
-  border-color: #00B5AD !important;
-  color: #00B5AD !important;
+  border-color: #00b5ad !important;
+  color: #00b5ad !important;
 }
 
 .ui.menu .blue.active.item,
 .ui.blue.menu .active.item {
-  border-color: #2185D0 !important;
-  color: #2185D0 !important;
+  border-color: #2185d0 !important;
+  color: #2185d0 !important;
 }
 
 .ui.menu .violet.active.item,
 .ui.violet.menu .active.item {
-  border-color: #6435C9 !important;
-  color: #6435C9 !important;
+  border-color: #6435c9 !important;
+  color: #6435c9 !important;
 }
 
 .ui.menu .purple.active.item,
 .ui.purple.menu .active.item {
-  border-color: #A333C8 !important;
-  color: #A333C8 !important;
+  border-color: #a333c8 !important;
+  color: #a333c8 !important;
 }
 
 .ui.menu .pink.active.item,
 .ui.pink.menu .active.item {
-  border-color: #E03997 !important;
-  color: #E03997 !important;
+  border-color: #e03997 !important;
+  color: #e03997 !important;
 }
 
 .ui.menu .brown.active.item,
 .ui.brown.menu .active.item {
-  border-color: #A5673F !important;
-  color: #A5673F !important;
+  border-color: #a5673f !important;
+  color: #a5673f !important;
 }
 
 .ui.menu .grey.active.item,
@@ -25143,7 +25322,7 @@ Floated Menu / Item
 
 .ui.inverted.menu {
   border: 0px solid transparent;
-  background: #1B1C1D;
+  background: #1b1c1d;
   -webkit-box-shadow: none;
   box-shadow: none;
 }
@@ -25226,11 +25405,11 @@ Floated Menu / Item
 
 .ui.inverted.vertical.menu .item .menu .active.item {
   background: transparent;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.pointing.menu .active.item:after {
-  background: #3D3E3F !important;
+  background: #3d3e3f !important;
   margin: 0em !important;
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
@@ -25241,11 +25420,11 @@ Floated Menu / Item
 
 .ui.inverted.menu .active.item:hover {
   background: rgba(255, 255, 255, 0.15);
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 .ui.inverted.pointing.menu .active.item:hover:after {
-  background: #3D3E3F !important;
+  background: #3d3e3f !important;
 }
 
 /*--------------
@@ -25274,7 +25453,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .red.active.item,
 .ui.inverted.red.menu {
-  background-color: #DB2828;
+  background-color: #db2828;
 }
 
 .ui.inverted.red.menu .item:before {
@@ -25289,7 +25468,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .orange.active.item,
 .ui.inverted.orange.menu {
-  background-color: #F2711C;
+  background-color: #f2711c;
 }
 
 .ui.inverted.orange.menu .item:before {
@@ -25304,7 +25483,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .yellow.active.item,
 .ui.inverted.yellow.menu {
-  background-color: #FBBD08;
+  background-color: #fbbd08;
 }
 
 .ui.inverted.yellow.menu .item:before {
@@ -25319,7 +25498,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .olive.active.item,
 .ui.inverted.olive.menu {
-  background-color: #B5CC18;
+  background-color: #b5cc18;
 }
 
 .ui.inverted.olive.menu .item:before {
@@ -25334,7 +25513,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .green.active.item,
 .ui.inverted.green.menu {
-  background-color: #21BA45;
+  background-color: #21ba45;
 }
 
 .ui.inverted.green.menu .item:before {
@@ -25349,7 +25528,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .teal.active.item,
 .ui.inverted.teal.menu {
-  background-color: #00B5AD;
+  background-color: #00b5ad;
 }
 
 .ui.inverted.teal.menu .item:before {
@@ -25364,7 +25543,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .blue.active.item,
 .ui.inverted.blue.menu {
-  background-color: #2185D0;
+  background-color: #2185d0;
 }
 
 .ui.inverted.blue.menu .item:before {
@@ -25379,7 +25558,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .violet.active.item,
 .ui.inverted.violet.menu {
-  background-color: #6435C9;
+  background-color: #6435c9;
 }
 
 .ui.inverted.violet.menu .item:before {
@@ -25394,7 +25573,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .purple.active.item,
 .ui.inverted.purple.menu {
-  background-color: #A333C8;
+  background-color: #a333c8;
 }
 
 .ui.inverted.purple.menu .item:before {
@@ -25409,7 +25588,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .pink.active.item,
 .ui.inverted.pink.menu {
-  background-color: #E03997;
+  background-color: #e03997;
 }
 
 .ui.inverted.pink.menu .item:before {
@@ -25424,7 +25603,7 @@ Floated Menu / Item
 
 .ui.inverted.menu .brown.active.item,
 .ui.inverted.brown.menu {
-  background-color: #A5673F;
+  background-color: #a5673f;
 }
 
 .ui.inverted.brown.menu .item:before {
@@ -25612,20 +25791,20 @@ Floated Menu / Item
 }
 
 .ui.fixed.menu,
-.ui[class*="top fixed"].menu {
+.ui[class*='top fixed'].menu {
   top: 0px;
   left: 0px;
   right: auto;
   bottom: auto;
 }
 
-.ui[class*="top fixed"].menu {
+.ui[class*='top fixed'].menu {
   border-top: none;
   border-left: none;
   border-right: none;
 }
 
-.ui[class*="right fixed"].menu {
+.ui[class*='right fixed'].menu {
   border-top: none;
   border-bottom: none;
   border-right: none;
@@ -25637,7 +25816,7 @@ Floated Menu / Item
   height: 100%;
 }
 
-.ui[class*="bottom fixed"].menu {
+.ui[class*='bottom fixed'].menu {
   border-bottom: none;
   border-left: none;
   border-right: none;
@@ -25647,7 +25826,7 @@ Floated Menu / Item
   right: auto;
 }
 
-.ui[class*="left fixed"].menu {
+.ui[class*='left fixed'].menu {
   border-top: none;
   border-bottom: none;
   border-left: none;
@@ -25682,8 +25861,8 @@ Floated Menu / Item
   width: 0.57142857em;
   height: 0.57142857em;
   border: none;
-  border-bottom: 1px solid #D4D4D5;
-  border-right: 1px solid #D4D4D5;
+  border-bottom: 1px solid #d4d4d5;
+  border-right: 1px solid #d4d4d5;
   z-index: 2;
   -webkit-transition: background 0.1s ease;
   transition: background 0.1s ease;
@@ -25699,8 +25878,8 @@ Floated Menu / Item
   transform: translateX(50%) translateY(-50%) rotate(45deg);
   margin: 0em -0.5px 0em 0em;
   border: none;
-  border-top: 1px solid #D4D4D5;
-  border-right: 1px solid #D4D4D5;
+  border-top: 1px solid #d4d4d5;
+  border-right: 1px solid #d4d4d5;
 }
 
 /* Active */
@@ -25723,27 +25902,27 @@ Floated Menu / Item
 /* Colors */
 
 .ui.pointing.menu .active.item:hover:after {
-  background-color: #F2F2F2;
+  background-color: #f2f2f2;
 }
 
 .ui.pointing.menu .active.item:after {
-  background-color: #F2F2F2;
+  background-color: #f2f2f2;
 }
 
 .ui.pointing.menu .active.item:hover:after {
-  background-color: #F2F2F2;
+  background-color: #f2f2f2;
 }
 
 .ui.vertical.pointing.menu .active.item:hover:after {
-  background-color: #F2F2F2;
+  background-color: #f2f2f2;
 }
 
 .ui.vertical.pointing.menu .active.item:after {
-  background-color: #F2F2F2;
+  background-color: #f2f2f2;
 }
 
 .ui.vertical.pointing.menu .menu .active.item:after {
-  background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
 /*--------------
@@ -25769,7 +25948,7 @@ Floated Menu / Item
 
 /* Top */
 
-.ui[class*="top attached"].menu {
+.ui[class*='top attached'].menu {
   bottom: 0px;
   margin-bottom: 0em;
   top: 0px;
@@ -25777,13 +25956,13 @@ Floated Menu / Item
   border-radius: 0.28571429rem 0.28571429rem 0em 0em;
 }
 
-.ui.menu[class*="top attached"]:first-child {
+.ui.menu[class*='top attached']:first-child {
   margin-top: 0em;
 }
 
 /* Bottom */
 
-.ui[class*="bottom attached"].menu {
+.ui[class*='bottom attached'].menu {
   bottom: 0px;
   margin-top: 0em;
   top: 0px;
@@ -25793,7 +25972,7 @@ Floated Menu / Item
   border-radius: 0em 0em 0.28571429rem 0.28571429rem;
 }
 
-.ui[class*="bottom attached"].menu:last-child {
+.ui[class*='bottom attached'].menu:last-child {
   margin-bottom: 0em;
 }
 
@@ -25810,7 +25989,7 @@ Floated Menu / Item
 /* Tabular Attached */
 
 .ui.attached.menu:not(.tabular) {
-  border: 1px solid #D4D4D5;
+  border: 1px solid #d4d4d5;
 }
 
 .ui.attached.inverted.menu {
@@ -25932,17 +26111,23 @@ Floated Menu / Item
   position: relative;
   min-height: 1em;
   margin: 1em 0em;
-  background: #F8F8F9;
+  background: #f8f8f9;
   padding: 1em 1.5em;
   line-height: 1.4285em;
   color: rgba(0, 0, 0, 0.87);
-  -webkit-transition: opacity 0.1s ease, color 0.1s ease, background 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: opacity 0.1s ease, color 0.1s ease, background 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: opacity 0.1s ease, color 0.1s ease, background 0.1s ease, box-shadow 0.1s ease;
-  transition: opacity 0.1s ease, color 0.1s ease, background 0.1s ease, box-shadow 0.1s ease, -webkit-box-shadow 0.1s ease;
+  -webkit-transition: opacity 0.1s ease, color 0.1s ease, background 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
+  transition: opacity 0.1s ease, color 0.1s ease, background 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
+  transition: opacity 0.1s ease, color 0.1s ease, background 0.1s ease,
+    box-shadow 0.1s ease;
+  transition: opacity 0.1s ease, color 0.1s ease, background 0.1s ease,
+    box-shadow 0.1s ease, -webkit-box-shadow 0.1s ease;
   border-radius: 0.28571429rem;
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.22) inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.22) inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.22) inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.22) inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.message:first-child {
@@ -26134,8 +26319,10 @@ Floated Menu / Item
 .ui.bottom.attached.message {
   margin-top: -1px;
   border-radius: 0em 0em 0.28571429rem 0.28571429rem;
-  -webkit-box-shadow: 0em 0em 0em 1px rgba(34, 36, 38, 0.15) inset, 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
-  box-shadow: 0em 0em 0em 1px rgba(34, 36, 38, 0.15) inset, 0px 1px 2px 0 rgba(34, 36, 38, 0.15);
+  -webkit-box-shadow: 0em 0em 0em 1px rgba(34, 36, 38, 0.15) inset,
+    0px 1px 2px 0 rgba(34, 36, 38, 0.15);
+  box-shadow: 0em 0em 0em 1px rgba(34, 36, 38, 0.15) inset,
+    0px 1px 2px 0 rgba(34, 36, 38, 0.15);
 }
 
 .ui.bottom.attached.message:not(:last-child) {
@@ -26193,8 +26380,12 @@ Floated Menu / Item
 ---------------*/
 
 .ui.floating.message {
-  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.22) inset, 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.22) inset, 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  -webkit-box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.22) inset,
+    0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 0px 0px 1px rgba(34, 36, 38, 0.22) inset,
+    0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
 }
 
 /*--------------
@@ -26202,7 +26393,7 @@ Floated Menu / Item
 ---------------*/
 
 .ui.black.message {
-  background-color: #1B1C1D;
+  background-color: #1b1c1d;
   color: rgba(255, 255, 255, 0.9);
 }
 
@@ -26213,118 +26404,125 @@ Floated Menu / Item
 /* Positive */
 
 .ui.positive.message {
-  background-color: #FCFFF5;
-  color: #2C662D;
+  background-color: #fcfff5;
+  color: #2c662d;
 }
 
 .ui.positive.message,
 .ui.attached.positive.message {
-  -webkit-box-shadow: 0px 0px 0px 1px #A3C293 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #A3C293 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  -webkit-box-shadow: 0px 0px 0px 1px #a3c293 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #a3c293 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.positive.message .header {
-  color: #1A531B;
+  color: #1a531b;
 }
 
 /* Negative */
 
 .ui.negative.message {
-  background-color: #FFF6F6;
-  color: #9F3A38;
+  background-color: #fff6f6;
+  color: #9f3a38;
 }
 
 .ui.negative.message,
 .ui.attached.negative.message {
-  -webkit-box-shadow: 0px 0px 0px 1px #E0B4B4 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #E0B4B4 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  -webkit-box-shadow: 0px 0px 0px 1px #e0b4b4 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #e0b4b4 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.negative.message .header {
-  color: #912D2B;
+  color: #912d2b;
 }
 
 /* Info */
 
 .ui.info.message {
-  background-color: #F8FFFF;
-  color: #276F86;
+  background-color: #f8ffff;
+  color: #276f86;
 }
 
 .ui.info.message,
 .ui.attached.info.message {
-  -webkit-box-shadow: 0px 0px 0px 1px #A9D5DE inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #A9D5DE inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  -webkit-box-shadow: 0px 0px 0px 1px #a9d5de inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #a9d5de inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.info.message .header {
-  color: #0E566C;
+  color: #0e566c;
 }
 
 /* Warning */
 
 .ui.warning.message {
-  background-color: #FFFAF3;
-  color: #573A08;
+  background-color: #fffaf3;
+  color: #573a08;
 }
 
 .ui.warning.message,
 .ui.attached.warning.message {
-  -webkit-box-shadow: 0px 0px 0px 1px #C9BA9B inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #C9BA9B inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  -webkit-box-shadow: 0px 0px 0px 1px #c9ba9b inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #c9ba9b inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.warning.message .header {
-  color: #794B02;
+  color: #794b02;
 }
 
 /* Error */
 
 .ui.error.message {
-  background-color: #FFF6F6;
-  color: #9F3A38;
+  background-color: #fff6f6;
+  color: #9f3a38;
 }
 
 .ui.error.message,
 .ui.attached.error.message {
-  -webkit-box-shadow: 0px 0px 0px 1px #E0B4B4 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #E0B4B4 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  -webkit-box-shadow: 0px 0px 0px 1px #e0b4b4 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #e0b4b4 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.error.message .header {
-  color: #912D2B;
+  color: #912d2b;
 }
 
 /* Success */
 
 .ui.success.message {
-  background-color: #FCFFF5;
-  color: #2C662D;
+  background-color: #fcfff5;
+  color: #2c662d;
 }
 
 .ui.success.message,
 .ui.attached.success.message {
-  -webkit-box-shadow: 0px 0px 0px 1px #A3C293 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #A3C293 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  -webkit-box-shadow: 0px 0px 0px 1px #a3c293 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #a3c293 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.success.message .header {
-  color: #1A531B;
+  color: #1a531b;
 }
 
 /* Colors */
 
 .ui.inverted.message,
 .ui.black.message {
-  background-color: #1B1C1D;
+  background-color: #1b1c1d;
   color: rgba(255, 255, 255, 0.9);
 }
 
 .ui.red.message {
-  background-color: #FFE8E6;
-  color: #DB2828;
-  -webkit-box-shadow: 0px 0px 0px 1px #DB2828 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #DB2828 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #ffe8e6;
+  color: #db2828;
+  -webkit-box-shadow: 0px 0px 0px 1px #db2828 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #db2828 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.red.message .header {
@@ -26332,10 +26530,11 @@ Floated Menu / Item
 }
 
 .ui.orange.message {
-  background-color: #FFEDDE;
-  color: #F2711C;
-  -webkit-box-shadow: 0px 0px 0px 1px #F2711C inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #F2711C inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #ffedde;
+  color: #f2711c;
+  -webkit-box-shadow: 0px 0px 0px 1px #f2711c inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #f2711c inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.orange.message .header {
@@ -26343,10 +26542,11 @@ Floated Menu / Item
 }
 
 .ui.yellow.message {
-  background-color: #FFF8DB;
-  color: #B58105;
-  -webkit-box-shadow: 0px 0px 0px 1px #B58105 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #B58105 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #fff8db;
+  color: #b58105;
+  -webkit-box-shadow: 0px 0px 0px 1px #b58105 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #b58105 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.yellow.message .header {
@@ -26354,10 +26554,11 @@ Floated Menu / Item
 }
 
 .ui.olive.message {
-  background-color: #FBFDEF;
-  color: #8ABC1E;
-  -webkit-box-shadow: 0px 0px 0px 1px #8ABC1E inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #8ABC1E inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #fbfdef;
+  color: #8abc1e;
+  -webkit-box-shadow: 0px 0px 0px 1px #8abc1e inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #8abc1e inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.olive.message .header {
@@ -26365,10 +26566,11 @@ Floated Menu / Item
 }
 
 .ui.green.message {
-  background-color: #E5F9E7;
-  color: #1EBC30;
-  -webkit-box-shadow: 0px 0px 0px 1px #1EBC30 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #1EBC30 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #e5f9e7;
+  color: #1ebc30;
+  -webkit-box-shadow: 0px 0px 0px 1px #1ebc30 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #1ebc30 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.green.message .header {
@@ -26376,10 +26578,11 @@ Floated Menu / Item
 }
 
 .ui.teal.message {
-  background-color: #E1F7F7;
-  color: #10A3A3;
-  -webkit-box-shadow: 0px 0px 0px 1px #10A3A3 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #10A3A3 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #e1f7f7;
+  color: #10a3a3;
+  -webkit-box-shadow: 0px 0px 0px 1px #10a3a3 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #10a3a3 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.teal.message .header {
@@ -26387,10 +26590,11 @@ Floated Menu / Item
 }
 
 .ui.blue.message {
-  background-color: #DFF0FF;
-  color: #2185D0;
-  -webkit-box-shadow: 0px 0px 0px 1px #2185D0 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #2185D0 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #dff0ff;
+  color: #2185d0;
+  -webkit-box-shadow: 0px 0px 0px 1px #2185d0 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #2185d0 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.blue.message .header {
@@ -26398,10 +26602,11 @@ Floated Menu / Item
 }
 
 .ui.violet.message {
-  background-color: #EAE7FF;
-  color: #6435C9;
-  -webkit-box-shadow: 0px 0px 0px 1px #6435C9 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #6435C9 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #eae7ff;
+  color: #6435c9;
+  -webkit-box-shadow: 0px 0px 0px 1px #6435c9 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #6435c9 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.violet.message .header {
@@ -26409,10 +26614,11 @@ Floated Menu / Item
 }
 
 .ui.purple.message {
-  background-color: #F6E7FF;
-  color: #A333C8;
-  -webkit-box-shadow: 0px 0px 0px 1px #A333C8 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #A333C8 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #f6e7ff;
+  color: #a333c8;
+  -webkit-box-shadow: 0px 0px 0px 1px #a333c8 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #a333c8 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.purple.message .header {
@@ -26420,10 +26626,11 @@ Floated Menu / Item
 }
 
 .ui.pink.message {
-  background-color: #FFE3FB;
-  color: #E03997;
-  -webkit-box-shadow: 0px 0px 0px 1px #E03997 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #E03997 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #ffe3fb;
+  color: #e03997;
+  -webkit-box-shadow: 0px 0px 0px 1px #e03997 inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #e03997 inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.pink.message .header {
@@ -26431,10 +26638,11 @@ Floated Menu / Item
 }
 
 .ui.brown.message {
-  background-color: #F1E2D3;
-  color: #A5673F;
-  -webkit-box-shadow: 0px 0px 0px 1px #A5673F inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
-  box-shadow: 0px 0px 0px 1px #A5673F inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
+  background-color: #f1e2d3;
+  color: #a5673f;
+  -webkit-box-shadow: 0px 0px 0px 1px #a5673f inset,
+    0px 0px 0px 0px rgba(0, 0, 0, 0);
+  box-shadow: 0px 0px 0px 1px #a5673f inset, 0px 0px 0px 0px rgba(0, 0, 0, 0);
 }
 
 .ui.brown.message .header {
@@ -26502,7 +26710,7 @@ Floated Menu / Item
 
 .ui.table {
   width: 100%;
-  background: #FFFFFF;
+  background: #ffffff;
   margin: 1em 0em;
   border: 1px solid rgba(34, 36, 38, 0.15);
   -webkit-box-shadow: none;
@@ -26543,7 +26751,7 @@ Floated Menu / Item
 
 .ui.table thead th {
   cursor: auto;
-  background: #F9FAFB;
+  background: #f9fafb;
   text-align: inherit;
   color: rgba(0, 0, 0, 0.87);
   padding: 0.92857143em 0.78571429em;
@@ -26581,7 +26789,7 @@ Floated Menu / Item
 .ui.table tfoot th {
   cursor: auto;
   border-top: 1px solid rgba(34, 36, 38, 0.15);
-  background: #F9FAFB;
+  background: #f9fafb;
   text-align: inherit;
   color: rgba(0, 0, 0, 0.87);
   padding: 0.78571429em 0.78571429em;
@@ -26765,8 +26973,8 @@ Floated Menu / Item
   background: transparent;
   font-weight: normal;
   color: rgba(0, 0, 0, 0.4);
-  -webkit-box-shadow: -1px -1px 0px 1px #FFFFFF;
-  box-shadow: -1px -1px 0px 1px #FFFFFF;
+  -webkit-box-shadow: -1px -1px 0px 1px #ffffff;
+  box-shadow: -1px -1px 0px 1px #ffffff;
 }
 
 .ui.definition.table tfoot:not(.full-width) th:first-child {
@@ -26774,20 +26982,20 @@ Floated Menu / Item
   background: transparent;
   font-weight: rgba(0, 0, 0, 0.4);
   color: normal;
-  -webkit-box-shadow: 1px 1px 0px 1px #FFFFFF;
-  box-shadow: 1px 1px 0px 1px #FFFFFF;
+  -webkit-box-shadow: 1px 1px 0px 1px #ffffff;
+  box-shadow: 1px 1px 0px 1px #ffffff;
 }
 
 /* Remove Border */
 
 .ui.celled.definition.table thead:not(.full-width) th:first-child {
-  -webkit-box-shadow: 0px -1px 0px 1px #FFFFFF;
-  box-shadow: 0px -1px 0px 1px #FFFFFF;
+  -webkit-box-shadow: 0px -1px 0px 1px #ffffff;
+  box-shadow: 0px -1px 0px 1px #ffffff;
 }
 
 .ui.celled.definition.table tfoot:not(.full-width) th:first-child {
-  -webkit-box-shadow: 0px 1px 0px 1px #FFFFFF;
-  box-shadow: 0px 1px 0px 1px #FFFFFF;
+  -webkit-box-shadow: 0px 1px 0px 1px #ffffff;
+  box-shadow: 0px 1px 0px 1px #ffffff;
 }
 
 /* Highlight Defining Column */
@@ -26830,14 +27038,14 @@ Floated Menu / Item
 
 .ui.table tr.positive,
 .ui.table td.positive {
-  -webkit-box-shadow: 0px 0px 0px #A3C293 inset;
-  box-shadow: 0px 0px 0px #A3C293 inset;
+  -webkit-box-shadow: 0px 0px 0px #a3c293 inset;
+  box-shadow: 0px 0px 0px #a3c293 inset;
 }
 
 .ui.table tr.positive,
 .ui.table td.positive {
-  background: #FCFFF5 !important;
-  color: #2C662D !important;
+  background: #fcfff5 !important;
+  color: #2c662d !important;
 }
 
 /*--------------
@@ -26846,14 +27054,14 @@ Floated Menu / Item
 
 .ui.table tr.negative,
 .ui.table td.negative {
-  -webkit-box-shadow: 0px 0px 0px #E0B4B4 inset;
-  box-shadow: 0px 0px 0px #E0B4B4 inset;
+  -webkit-box-shadow: 0px 0px 0px #e0b4b4 inset;
+  box-shadow: 0px 0px 0px #e0b4b4 inset;
 }
 
 .ui.table tr.negative,
 .ui.table td.negative {
-  background: #FFF6F6 !important;
-  color: #9F3A38 !important;
+  background: #fff6f6 !important;
+  color: #9f3a38 !important;
 }
 
 /*--------------
@@ -26862,14 +27070,14 @@ Floated Menu / Item
 
 .ui.table tr.error,
 .ui.table td.error {
-  -webkit-box-shadow: 0px 0px 0px #E0B4B4 inset;
-  box-shadow: 0px 0px 0px #E0B4B4 inset;
+  -webkit-box-shadow: 0px 0px 0px #e0b4b4 inset;
+  box-shadow: 0px 0px 0px #e0b4b4 inset;
 }
 
 .ui.table tr.error,
 .ui.table td.error {
-  background: #FFF6F6 !important;
-  color: #9F3A38 !important;
+  background: #fff6f6 !important;
+  color: #9f3a38 !important;
 }
 
 /*--------------
@@ -26878,14 +27086,14 @@ Floated Menu / Item
 
 .ui.table tr.warning,
 .ui.table td.warning {
-  -webkit-box-shadow: 0px 0px 0px #C9BA9B inset;
-  box-shadow: 0px 0px 0px #C9BA9B inset;
+  -webkit-box-shadow: 0px 0px 0px #c9ba9b inset;
+  box-shadow: 0px 0px 0px #c9ba9b inset;
 }
 
 .ui.table tr.warning,
 .ui.table td.warning {
-  background: #FFFAF3 !important;
-  color: #573A08 !important;
+  background: #fffaf3 !important;
+  color: #573a08 !important;
 }
 
 /*--------------
@@ -26900,7 +27108,7 @@ Floated Menu / Item
 
 .ui.table tr.active,
 .ui.table td.active {
-  background: #E0E0E0 !important;
+  background: #e0e0e0 !important;
   color: rgba(0, 0, 0, 0.87) !important;
 }
 
@@ -26925,36 +27133,36 @@ Floated Menu / Item
 ---------------*/
 
 @media only screen and (max-width: 991px) {
-  .ui[class*="tablet stackable"].table,
-  .ui[class*="tablet stackable"].table tbody,
-  .ui[class*="tablet stackable"].table tr,
-  .ui[class*="tablet stackable"].table tr > th,
-  .ui[class*="tablet stackable"].table tr > td {
+  .ui[class*='tablet stackable'].table,
+  .ui[class*='tablet stackable'].table tbody,
+  .ui[class*='tablet stackable'].table tr,
+  .ui[class*='tablet stackable'].table tr > th,
+  .ui[class*='tablet stackable'].table tr > td {
     width: 100% !important;
     display: block !important;
   }
 
-  .ui[class*="tablet stackable"].table {
+  .ui[class*='tablet stackable'].table {
     padding: 0em;
   }
 
-  .ui[class*="tablet stackable"].table thead {
+  .ui[class*='tablet stackable'].table thead {
     display: block;
   }
 
-  .ui[class*="tablet stackable"].table tfoot {
+  .ui[class*='tablet stackable'].table tfoot {
     display: block;
   }
 
-  .ui[class*="tablet stackable"].table tr {
+  .ui[class*='tablet stackable'].table tr {
     padding-top: 1em;
     padding-bottom: 1em;
     -webkit-box-shadow: 0px -1px 0px 0px rgba(0, 0, 0, 0.1) inset !important;
     box-shadow: 0px -1px 0px 0px rgba(0, 0, 0, 0.1) inset !important;
   }
 
-  .ui[class*="tablet stackable"].table tr > th,
-  .ui[class*="tablet stackable"].table tr > td {
+  .ui[class*='tablet stackable'].table tr > th,
+  .ui[class*='tablet stackable'].table tr > td {
     background: none;
     border: none !important;
     padding: 0.25em 0.75em;
@@ -26964,7 +27172,7 @@ Floated Menu / Item
 
   /* Definition Table */
 
-  .ui.definition[class*="tablet stackable"].table thead th:first-child {
+  .ui.definition[class*='tablet stackable'].table thead th:first-child {
     -webkit-box-shadow: none !important;
     box-shadow: none !important;
   }
@@ -26974,18 +27182,18 @@ Floated Menu / Item
  Text Alignment
 ---------------*/
 
-.ui.table[class*="left aligned"],
-.ui.table [class*="left aligned"] {
+.ui.table[class*='left aligned'],
+.ui.table [class*='left aligned'] {
   text-align: left;
 }
 
-.ui.table[class*="center aligned"],
-.ui.table [class*="center aligned"] {
+.ui.table[class*='center aligned'],
+.ui.table [class*='center aligned'] {
   text-align: center;
 }
 
-.ui.table[class*="right aligned"],
-.ui.table [class*="right aligned"] {
+.ui.table[class*='right aligned'],
+.ui.table [class*='right aligned'] {
   text-align: right;
 }
 
@@ -26993,18 +27201,18 @@ Floated Menu / Item
  Vertical Alignment
 ------------------*/
 
-.ui.table[class*="top aligned"],
-.ui.table [class*="top aligned"] {
+.ui.table[class*='top aligned'],
+.ui.table [class*='top aligned'] {
   vertical-align: top;
 }
 
-.ui.table[class*="middle aligned"],
-.ui.table [class*="middle aligned"] {
+.ui.table[class*='middle aligned'],
+.ui.table [class*='middle aligned'] {
   vertical-align: middle;
 }
 
-.ui.table[class*="bottom aligned"],
-.ui.table [class*="bottom aligned"] {
+.ui.table[class*='bottom aligned'],
+.ui.table [class*='bottom aligned'] {
   vertical-align: bottom;
 }
 
@@ -27079,7 +27287,7 @@ Floated Menu / Item
 .ui.selectable.table tr.active:hover,
 .ui.table tr td.selectable.active:hover,
 .ui.selectable.table tr:hover td.active {
-  background: #E0E0E0 !important;
+  background: #e0e0e0 !important;
   color: rgba(0, 0, 0, 0.87) !important;
 }
 
@@ -27112,7 +27320,7 @@ Floated Menu / Item
   max-width: calc(100% - (-1px * 2));
   -webkit-box-shadow: none;
   box-shadow: none;
-  border: 1px solid #D4D4D5;
+  border: 1px solid #d4d4d5;
 }
 
 .ui.attached + .ui.attached.table:not(.top) {
@@ -27121,7 +27329,7 @@ Floated Menu / Item
 
 /* Top */
 
-.ui[class*="top attached"].table {
+.ui[class*='top attached'].table {
   bottom: 0px;
   margin-bottom: 0em;
   top: 0px;
@@ -27129,13 +27337,13 @@ Floated Menu / Item
   border-radius: 0.28571429rem 0.28571429rem 0em 0em;
 }
 
-.ui.table[class*="top attached"]:first-child {
+.ui.table[class*='top attached']:first-child {
   margin-top: 0em;
 }
 
 /* Bottom */
 
-.ui[class*="bottom attached"].table {
+.ui[class*='bottom attached'].table {
   bottom: 0px;
   margin-top: 0em;
   top: 0px;
@@ -27145,7 +27353,7 @@ Floated Menu / Item
   border-radius: 0em 0em 0.28571429rem 0.28571429rem;
 }
 
-.ui[class*="bottom attached"].table:last-child {
+.ui[class*='bottom attached'].table:last-child {
   margin-bottom: 0em;
 }
 
@@ -27170,7 +27378,7 @@ Floated Menu / Item
 /* Allow striped active hover */
 
 .ui.striped.selectable.selectable.selectable.table tbody tr.active:hover {
-  background: #EFEFEF !important;
+  background: #efefef !important;
   color: rgba(0, 0, 0, 0.95) !important;
 }
 
@@ -27178,13 +27386,13 @@ Floated Menu / Item
    Single Line
 ---------------*/
 
-.ui.table[class*="single line"],
-.ui.table [class*="single line"] {
+.ui.table[class*='single line'],
+.ui.table [class*='single line'] {
   white-space: nowrap;
 }
 
-.ui.table[class*="single line"],
-.ui.table [class*="single line"] {
+.ui.table[class*='single line'],
+.ui.table [class*='single line'] {
   white-space: nowrap;
 }
 
@@ -27195,122 +27403,122 @@ Floated Menu / Item
 /* Red */
 
 .ui.red.table {
-  border-top: 0.2em solid #DB2828;
+  border-top: 0.2em solid #db2828;
 }
 
 .ui.inverted.red.table {
-  background-color: #DB2828 !important;
-  color: #FFFFFF !important;
+  background-color: #db2828 !important;
+  color: #ffffff !important;
 }
 
 /* Orange */
 
 .ui.orange.table {
-  border-top: 0.2em solid #F2711C;
+  border-top: 0.2em solid #f2711c;
 }
 
 .ui.inverted.orange.table {
-  background-color: #F2711C !important;
-  color: #FFFFFF !important;
+  background-color: #f2711c !important;
+  color: #ffffff !important;
 }
 
 /* Yellow */
 
 .ui.yellow.table {
-  border-top: 0.2em solid #FBBD08;
+  border-top: 0.2em solid #fbbd08;
 }
 
 .ui.inverted.yellow.table {
-  background-color: #FBBD08 !important;
-  color: #FFFFFF !important;
+  background-color: #fbbd08 !important;
+  color: #ffffff !important;
 }
 
 /* Olive */
 
 .ui.olive.table {
-  border-top: 0.2em solid #B5CC18;
+  border-top: 0.2em solid #b5cc18;
 }
 
 .ui.inverted.olive.table {
-  background-color: #B5CC18 !important;
-  color: #FFFFFF !important;
+  background-color: #b5cc18 !important;
+  color: #ffffff !important;
 }
 
 /* Green */
 
 .ui.green.table {
-  border-top: 0.2em solid #21BA45;
+  border-top: 0.2em solid #21ba45;
 }
 
 .ui.inverted.green.table {
-  background-color: #21BA45 !important;
-  color: #FFFFFF !important;
+  background-color: #21ba45 !important;
+  color: #ffffff !important;
 }
 
 /* Teal */
 
 .ui.teal.table {
-  border-top: 0.2em solid #00B5AD;
+  border-top: 0.2em solid #00b5ad;
 }
 
 .ui.inverted.teal.table {
-  background-color: #00B5AD !important;
-  color: #FFFFFF !important;
+  background-color: #00b5ad !important;
+  color: #ffffff !important;
 }
 
 /* Blue */
 
 .ui.blue.table {
-  border-top: 0.2em solid #2185D0;
+  border-top: 0.2em solid #2185d0;
 }
 
 .ui.inverted.blue.table {
-  background-color: #2185D0 !important;
-  color: #FFFFFF !important;
+  background-color: #2185d0 !important;
+  color: #ffffff !important;
 }
 
 /* Violet */
 
 .ui.violet.table {
-  border-top: 0.2em solid #6435C9;
+  border-top: 0.2em solid #6435c9;
 }
 
 .ui.inverted.violet.table {
-  background-color: #6435C9 !important;
-  color: #FFFFFF !important;
+  background-color: #6435c9 !important;
+  color: #ffffff !important;
 }
 
 /* Purple */
 
 .ui.purple.table {
-  border-top: 0.2em solid #A333C8;
+  border-top: 0.2em solid #a333c8;
 }
 
 .ui.inverted.purple.table {
-  background-color: #A333C8 !important;
-  color: #FFFFFF !important;
+  background-color: #a333c8 !important;
+  color: #ffffff !important;
 }
 
 /* Pink */
 
 .ui.pink.table {
-  border-top: 0.2em solid #E03997;
+  border-top: 0.2em solid #e03997;
 }
 
 .ui.inverted.pink.table {
-  background-color: #E03997 !important;
-  color: #FFFFFF !important;
+  background-color: #e03997 !important;
+  color: #ffffff !important;
 }
 
 /* Brown */
 
 .ui.brown.table {
-  border-top: 0.2em solid #A5673F;
+  border-top: 0.2em solid #a5673f;
 }
 
 .ui.inverted.brown.table {
-  background-color: #A5673F !important;
-  color: #FFFFFF !important;
+  background-color: #a5673f !important;
+  color: #ffffff !important;
 }
 
 /* Grey */
@@ -27321,18 +27529,18 @@ Floated Menu / Item
 
 .ui.inverted.grey.table {
   background-color: #767676 !important;
-  color: #FFFFFF !important;
+  color: #ffffff !important;
 }
 
 /* Black */
 
 .ui.black.table {
-  border-top: 0.2em solid #1B1C1D;
+  border-top: 0.2em solid #1b1c1d;
 }
 
 .ui.inverted.black.table {
-  background-color: #1B1C1D !important;
-  color: #FFFFFF !important;
+  background-color: #1b1c1d !important;
+  color: #ffffff !important;
 }
 
 /*--------------
@@ -27564,16 +27772,20 @@ Floated Menu / Item
 /* Inverted */
 
 .ui.inverted.sortable.table thead th.sorted {
-  background: rgba(255, 255, 255, 0.15) -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(0, 0, 0, 0.05)));
+  background: rgba(255, 255, 255, 0.15) -webkit-gradient(linear, left top, left
+        bottom, from(transparent), to(rgba(0, 0, 0, 0.05)));
   background: rgba(255, 255, 255, 0.15) -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05));
-  background: rgba(255, 255, 255, 0.15) linear-gradient(transparent, rgba(0, 0, 0, 0.05));
+  background: rgba(255, 255, 255, 0.15)
+    linear-gradient(transparent, rgba(0, 0, 0, 0.05));
   color: #ffffff;
 }
 
 .ui.inverted.sortable.table thead th:hover {
-  background: rgba(255, 255, 255, 0.08) -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(0, 0, 0, 0.05)));
+  background: rgba(255, 255, 255, 0.08) -webkit-gradient(linear, left top, left
+        bottom, from(transparent), to(rgba(0, 0, 0, 0.05)));
   background: rgba(255, 255, 255, 0.08) -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05));
-  background: rgba(255, 255, 255, 0.08) linear-gradient(transparent, rgba(0, 0, 0, 0.05));
+  background: rgba(255, 255, 255, 0.08)
+    linear-gradient(transparent, rgba(0, 0, 0, 0.05));
   color: #ffffff;
 }
 
@@ -27616,7 +27828,7 @@ Floated Menu / Item
 
 .ui.inverted.definition.table tfoot:not(.full-width) th:first-child,
 .ui.inverted.definition.table thead:not(.full-width) th:first-child {
-  background: #FFFFFF;
+  background: #ffffff;
 }
 
 .ui.inverted.definition.table tr td:first-child {
@@ -27668,26 +27880,29 @@ Floated Menu / Item
 
 /* Very Basic */
 
-.ui[class*="very basic"].table {
+.ui[class*='very basic'].table {
   border: none;
 }
 
-.ui[class*="very basic"].table:not(.sortable):not(.striped) th,
-.ui[class*="very basic"].table:not(.sortable):not(.striped) td {
+.ui[class*='very basic'].table:not(.sortable):not(.striped) th,
+.ui[class*='very basic'].table:not(.sortable):not(.striped) td {
   padding: '';
 }
 
-.ui[class*="very basic"].table:not(.sortable):not(.striped) th:first-child,
-.ui[class*="very basic"].table:not(.sortable):not(.striped) td:first-child {
+.ui[class*='very basic'].table:not(.sortable):not(.striped) th:first-child,
+.ui[class*='very basic'].table:not(.sortable):not(.striped) td:first-child {
   padding-left: 0em;
 }
 
-.ui[class*="very basic"].table:not(.sortable):not(.striped) th:last-child,
-.ui[class*="very basic"].table:not(.sortable):not(.striped) td:last-child {
+.ui[class*='very basic'].table:not(.sortable):not(.striped) th:last-child,
+.ui[class*='very basic'].table:not(.sortable):not(.striped) td:last-child {
   padding-right: 0em;
 }
 
-.ui[class*="very basic"].table:not(.sortable):not(.striped) thead tr:first-child th {
+.ui[class*='very basic'].table:not(.sortable):not(.striped)
+  thead
+  tr:first-child
+  th {
   padding-top: 0em;
 }
 
@@ -27721,12 +27936,12 @@ Floated Menu / Item
 
 /* Very */
 
-.ui[class*="very padded"].table th {
+.ui[class*='very padded'].table th {
   padding-left: 1.5em;
   padding-right: 1.5em;
 }
 
-.ui[class*="very padded"].table td {
+.ui[class*='very padded'].table td {
   padding: 1.5em 1.5em;
 }
 
@@ -27745,12 +27960,12 @@ Floated Menu / Item
 
 /* Very */
 
-.ui[class*="very compact"].table th {
+.ui[class*='very compact'].table th {
   padding-left: 0.6em;
   padding-right: 0.6em;
 }
 
-.ui[class*="very compact"].table td {
+.ui[class*='very compact'].table td {
   padding: 0.4em 0.6em;
 }
 
@@ -27828,21 +28043,21 @@ Floated Menu / Item
 
 /* Medium Rectangle */
 
-.ui[class*="medium rectangle"].ad {
+.ui[class*='medium rectangle'].ad {
   width: 300px;
   height: 250px;
 }
 
 /* Large Rectangle */
 
-.ui[class*="large rectangle"].ad {
+.ui[class*='large rectangle'].ad {
   width: 336px;
   height: 280px;
 }
 
 /* Half Page */
 
-.ui[class*="half page"].ad {
+.ui[class*='half page'].ad {
   width: 300px;
   height: 600px;
 }
@@ -27860,7 +28075,7 @@ Floated Menu / Item
 
 /* Small Square */
 
-.ui[class*="small square"].ad {
+.ui[class*='small square'].ad {
   width: 200px;
   height: 200px;
 }
@@ -27871,14 +28086,14 @@ Floated Menu / Item
 
 /* Small Rectangle */
 
-.ui[class*="small rectangle"].ad {
+.ui[class*='small rectangle'].ad {
   width: 180px;
   height: 150px;
 }
 
 /* Vertical Rectangle */
 
-.ui[class*="vertical rectangle"].ad {
+.ui[class*='vertical rectangle'].ad {
   width: 240px;
   height: 400px;
 }
@@ -27892,12 +28107,12 @@ Floated Menu / Item
   height: 90px;
 }
 
-.ui[class*="square button"].ad {
+.ui[class*='square button'].ad {
   width: 125px;
   height: 125px;
 }
 
-.ui[class*="small button"].ad {
+.ui[class*='small button'].ad {
   width: 120px;
   height: 60px;
 }
@@ -27915,7 +28130,7 @@ Floated Menu / Item
 
 /* Wide Skyscraper */
 
-.ui[class*="wide skyscraper"].ad {
+.ui[class*='wide skyscraper'].ad {
   width: 160px;
 }
 
@@ -27932,21 +28147,21 @@ Floated Menu / Item
 
 /* Vertical Banner */
 
-.ui[class*="vertical banner"].ad {
+.ui[class*='vertical banner'].ad {
   width: 120px;
   height: 240px;
 }
 
 /* Top Banner */
 
-.ui[class*="top banner"].ad {
+.ui[class*='top banner'].ad {
   width: 930px;
   height: 180px;
 }
 
 /* Half Banner */
 
-.ui[class*="half banner"].ad {
+.ui[class*='half banner'].ad {
   width: 234px;
   height: 60px;
 }
@@ -27957,7 +28172,7 @@ Floated Menu / Item
 
 /* Leaderboard */
 
-.ui[class*="large leaderboard"].ad {
+.ui[class*='large leaderboard'].ad {
   width: 970px;
   height: 90px;
 }
@@ -27997,14 +28212,14 @@ Floated Menu / Item
 
 /* Large Mobile Banner */
 
-.ui[class*="large mobile banner"].ad {
+.ui[class*='large mobile banner'].ad {
   width: 320px;
   height: 100px;
 }
 
 /* Mobile Leaderboard */
 
-.ui[class*="mobile leaderboard"].ad {
+.ui[class*='mobile leaderboard'].ad {
   width: 320px;
   height: 50px;
 }
@@ -28048,7 +28263,7 @@ Floated Menu / Item
   -webkit-transform: translateX(-50%) translateY(-50%);
   transform: translateX(-50%) translateY(-50%);
   content: 'Ad';
-  color: #FFFFFF;
+  color: #ffffff;
   font-size: 1em;
   font-weight: bold;
 }
@@ -28099,16 +28314,17 @@ Floated Menu / Item
   flex-direction: column;
   width: 290px;
   min-height: 0px;
-  background: #FFFFFF;
+  background: #ffffff;
   padding: 0em;
   border: none;
   border-radius: 0.28571429rem;
-  -webkit-box-shadow: 0px 1px 3px 0px #D4D4D5, 0px 0px 0px 1px #D4D4D5;
-  box-shadow: 0px 1px 3px 0px #D4D4D5, 0px 0px 0px 1px #D4D4D5;
+  -webkit-box-shadow: 0px 1px 3px 0px #d4d4d5, 0px 0px 0px 1px #d4d4d5;
+  box-shadow: 0px 1px 3px 0px #d4d4d5, 0px 0px 0px 1px #d4d4d5;
   -webkit-transition: -webkit-box-shadow 0.1s ease, -webkit-transform 0.1s ease;
   transition: -webkit-box-shadow 0.1s ease, -webkit-transform 0.1s ease;
   transition: box-shadow 0.1s ease, transform 0.1s ease;
-  transition: box-shadow 0.1s ease, transform 0.1s ease, -webkit-box-shadow 0.1s ease, -webkit-transform 0.1s ease;
+  transition: box-shadow 0.1s ease, transform 0.1s ease,
+    -webkit-box-shadow 0.1s ease, -webkit-transform 0.1s ease;
   z-index: '';
 }
 
@@ -28275,13 +28491,13 @@ Floated Menu / Item
  Floated Content
 -----------------*/
 
-.ui.cards > .card [class*="left floated"],
-.ui.card [class*="left floated"] {
+.ui.cards > .card [class*='left floated'],
+.ui.card [class*='left floated'] {
   float: left;
 }
 
-.ui.cards > .card [class*="right floated"],
-.ui.card [class*="right floated"] {
+.ui.cards > .card [class*='right floated'],
+.ui.card [class*='right floated'] {
   float: right;
 }
 
@@ -28289,18 +28505,18 @@ Floated Menu / Item
      Aligned
 ---------------*/
 
-.ui.cards > .card [class*="left aligned"],
-.ui.card [class*="left aligned"] {
+.ui.cards > .card [class*='left aligned'],
+.ui.card [class*='left aligned'] {
   text-align: left;
 }
 
-.ui.cards > .card [class*="center aligned"],
-.ui.card [class*="center aligned"] {
+.ui.cards > .card [class*='center aligned'],
+.ui.card [class*='center aligned'] {
   text-align: center;
 }
 
-.ui.cards > .card [class*="right aligned"],
-.ui.card [class*="right aligned"] {
+.ui.cards > .card [class*='right aligned'],
+.ui.card [class*='right aligned'] {
   text-align: right;
 }
 
@@ -28368,8 +28584,8 @@ Floated Menu / Item
   margin-right: 0em;
 }
 
-.ui.cards > .card .meta [class*="right floated"],
-.ui.card .meta [class*="right floated"] {
+.ui.cards > .card .meta [class*='right floated'],
+.ui.card .meta [class*='right floated'] {
   margin-right: 0em;
   margin-left: 0.3em;
 }
@@ -28425,7 +28641,7 @@ Floated Menu / Item
 .ui.cards > .card > .button,
 .ui.card > .button {
   margin: 0px -1px;
-  width: calc(100% +  2px );
+  width: calc(100% + 2px);
 }
 
 /*--------------
@@ -28457,12 +28673,12 @@ Floated Menu / Item
 .ui.cards > .card > .content .star.icon:hover,
 .ui.card > .content .star.icon:hover {
   opacity: 1;
-  color: #FFB70A;
+  color: #ffb70a;
 }
 
 .ui.cards > .card > .content .active.star.icon,
 .ui.card > .content .active.star.icon {
-  color: #FFE623;
+  color: #ffe623;
 }
 
 /*-----Like----- */
@@ -28480,12 +28696,12 @@ Floated Menu / Item
 .ui.cards > .card > .content .like.icon:hover,
 .ui.card > .content .like.icon:hover {
   opacity: 1;
-  color: #FF2733;
+  color: #ff2733;
 }
 
 .ui.cards > .card > .content .active.like.icon,
 .ui.card > .content .active.like.icon {
-  color: #FF2733;
+  color: #ff2733;
 }
 
 /*----------------
@@ -28534,22 +28750,31 @@ Floated Menu / Item
 
 .ui.raised.cards > .card,
 .ui.raised.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5,
+    0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
 }
 
 .ui.raised.cards a.card:hover,
 .ui.link.cards .raised.card:hover,
 a.ui.raised.card:hover,
 .ui.link.raised.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 4px 0px rgba(34, 36, 38, 0.15), 0px 2px 10px 0px rgba(34, 36, 38, 0.25);
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 4px 0px rgba(34, 36, 38, 0.15), 0px 2px 10px 0px rgba(34, 36, 38, 0.25);
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5,
+    0px 2px 4px 0px rgba(34, 36, 38, 0.15),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.25);
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 4px 0px rgba(34, 36, 38, 0.15),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.25);
 }
 
 .ui.raised.cards > .card,
 .ui.raised.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5,
+    0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
 }
 
 /*-------------------
@@ -28594,10 +28819,10 @@ a.ui.card:hover,
 .ui.link.card:hover {
   cursor: pointer;
   z-index: 5;
-  background: #FFFFFF;
+  background: #ffffff;
   border: none;
-  -webkit-box-shadow: 0px 1px 3px 0px #BCBDBD, 0px 0px 0px 1px #D4D4D5;
-  box-shadow: 0px 1px 3px 0px #BCBDBD, 0px 0px 0px 1px #D4D4D5;
+  -webkit-box-shadow: 0px 1px 3px 0px #bcbdbd, 0px 0px 0px 1px #d4d4d5;
+  box-shadow: 0px 1px 3px 0px #bcbdbd, 0px 0px 0px 1px #d4d4d5;
   -webkit-transform: translateY(-3px);
   transform: translateY(-3px);
 }
@@ -28611,15 +28836,19 @@ a.ui.card:hover,
 .ui.red.cards > .card,
 .ui.cards > .red.card,
 .ui.red.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #DB2828, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #DB2828, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #db2828,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #db2828,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.red.cards > .card:hover,
 .ui.cards > .red.card:hover,
 .ui.red.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #d01919, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #d01919, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #d01919,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #d01919,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Orange */
@@ -28627,15 +28856,19 @@ a.ui.card:hover,
 .ui.orange.cards > .card,
 .ui.cards > .orange.card,
 .ui.orange.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #F2711C, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #F2711C, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #f2711c,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #f2711c,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.orange.cards > .card:hover,
 .ui.cards > .orange.card:hover,
 .ui.orange.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #f26202, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #f26202, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #f26202,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #f26202,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Yellow */
@@ -28643,15 +28876,19 @@ a.ui.card:hover,
 .ui.yellow.cards > .card,
 .ui.cards > .yellow.card,
 .ui.yellow.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #FBBD08, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #FBBD08, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #fbbd08,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #fbbd08,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.yellow.cards > .card:hover,
 .ui.cards > .yellow.card:hover,
 .ui.yellow.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #eaae00, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #eaae00, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #eaae00,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #eaae00,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Olive */
@@ -28659,15 +28896,19 @@ a.ui.card:hover,
 .ui.olive.cards > .card,
 .ui.cards > .olive.card,
 .ui.olive.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #B5CC18, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #B5CC18, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #b5cc18,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #b5cc18,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.olive.cards > .card:hover,
 .ui.cards > .olive.card:hover,
 .ui.olive.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #a7bd0d, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #a7bd0d, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #a7bd0d,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #a7bd0d,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Green */
@@ -28675,15 +28916,19 @@ a.ui.card:hover,
 .ui.green.cards > .card,
 .ui.cards > .green.card,
 .ui.green.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #21BA45, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #21BA45, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #21ba45,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #21ba45,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.green.cards > .card:hover,
 .ui.cards > .green.card:hover,
 .ui.green.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #16ab39, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #16ab39, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #16ab39,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #16ab39,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Teal */
@@ -28691,15 +28936,19 @@ a.ui.card:hover,
 .ui.teal.cards > .card,
 .ui.cards > .teal.card,
 .ui.teal.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #00B5AD, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #00B5AD, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #00b5ad,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #00b5ad,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.teal.cards > .card:hover,
 .ui.cards > .teal.card:hover,
 .ui.teal.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #009c95, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #009c95, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #009c95,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #009c95,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Blue */
@@ -28707,15 +28956,19 @@ a.ui.card:hover,
 .ui.blue.cards > .card,
 .ui.cards > .blue.card,
 .ui.blue.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #2185D0, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #2185D0, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #2185d0,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #2185d0,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.blue.cards > .card:hover,
 .ui.cards > .blue.card:hover,
 .ui.blue.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #1678c2, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #1678c2, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #1678c2,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #1678c2,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Violet */
@@ -28723,15 +28976,19 @@ a.ui.card:hover,
 .ui.violet.cards > .card,
 .ui.cards > .violet.card,
 .ui.violet.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #6435C9, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #6435C9, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #6435c9,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #6435c9,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.violet.cards > .card:hover,
 .ui.cards > .violet.card:hover,
 .ui.violet.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #5829bb, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #5829bb, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #5829bb,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #5829bb,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Purple */
@@ -28739,15 +28996,19 @@ a.ui.card:hover,
 .ui.purple.cards > .card,
 .ui.cards > .purple.card,
 .ui.purple.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #A333C8, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #A333C8, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #a333c8,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #a333c8,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.purple.cards > .card:hover,
 .ui.cards > .purple.card:hover,
 .ui.purple.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #9627ba, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #9627ba, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #9627ba,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #9627ba,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Pink */
@@ -28755,15 +29016,19 @@ a.ui.card:hover,
 .ui.pink.cards > .card,
 .ui.cards > .pink.card,
 .ui.pink.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #E03997, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #E03997, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #e03997,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #e03997,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.pink.cards > .card:hover,
 .ui.cards > .pink.card:hover,
 .ui.pink.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #e61a8d, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #e61a8d, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #e61a8d,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #e61a8d,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Brown */
@@ -28771,15 +29036,19 @@ a.ui.card:hover,
 .ui.brown.cards > .card,
 .ui.cards > .brown.card,
 .ui.brown.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #A5673F, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #A5673F, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #a5673f,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #a5673f,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.brown.cards > .card:hover,
 .ui.cards > .brown.card:hover,
 .ui.brown.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #975b33, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #975b33, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #975b33,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #975b33,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Grey */
@@ -28787,15 +29056,19 @@ a.ui.card:hover,
 .ui.grey.cards > .card,
 .ui.cards > .grey.card,
 .ui.grey.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #767676, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #767676, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #767676,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #767676,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.grey.cards > .card:hover,
 .ui.cards > .grey.card:hover,
 .ui.grey.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #838383, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #838383, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #838383,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #838383,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /* Black */
@@ -28803,15 +29076,19 @@ a.ui.card:hover,
 .ui.black.cards > .card,
 .ui.cards > .black.card,
 .ui.black.card {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #1B1C1D, 0px 1px 3px 0px #D4D4D5;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #1B1C1D, 0px 1px 3px 0px #D4D4D5;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #1b1c1d,
+    0px 1px 3px 0px #d4d4d5;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #1b1c1d,
+    0px 1px 3px 0px #d4d4d5;
 }
 
 .ui.black.cards > .card:hover,
 .ui.cards > .black.card:hover,
 .ui.black.card:hover {
-  -webkit-box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #27292a, 0px 1px 3px 0px #BCBDBD;
-  box-shadow: 0px 0px 0px 1px #D4D4D5, 0px 2px 0px 0px #27292a, 0px 1px 3px 0px #BCBDBD;
+  -webkit-box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #27292a,
+    0px 1px 3px 0px #bcbdbd;
+  box-shadow: 0px 0px 0px 1px #d4d4d5, 0px 2px 0px 0px #27292a,
+    0px 1px 3px 0px #bcbdbd;
 }
 
 /*--------------
@@ -28833,7 +29110,7 @@ a.ui.card:hover,
 }
 
 .ui.two.cards > .card {
-  width: calc( 50%  -  2em );
+  width: calc(50% - 2em);
   margin-left: 1em;
   margin-right: 1em;
 }
@@ -28844,7 +29121,7 @@ a.ui.card:hover,
 }
 
 .ui.three.cards > .card {
-  width: calc( 33.33333333%  -  2em );
+  width: calc(33.33333333% - 2em);
   margin-left: 1em;
   margin-right: 1em;
 }
@@ -28855,7 +29132,7 @@ a.ui.card:hover,
 }
 
 .ui.four.cards > .card {
-  width: calc( 25%  -  1.5em );
+  width: calc(25% - 1.5em);
   margin-left: 0.75em;
   margin-right: 0.75em;
 }
@@ -28866,7 +29143,7 @@ a.ui.card:hover,
 }
 
 .ui.five.cards > .card {
-  width: calc( 20%  -  1.5em );
+  width: calc(20% - 1.5em);
   margin-left: 0.75em;
   margin-right: 0.75em;
 }
@@ -28877,7 +29154,7 @@ a.ui.card:hover,
 }
 
 .ui.six.cards > .card {
-  width: calc( 16.66666667%  -  1.5em );
+  width: calc(16.66666667% - 1.5em);
   margin-left: 0.75em;
   margin-right: 0.75em;
 }
@@ -28888,7 +29165,7 @@ a.ui.card:hover,
 }
 
 .ui.seven.cards > .card {
-  width: calc( 14.28571429%  -  1em );
+  width: calc(14.28571429% - 1em);
   margin-left: 0.5em;
   margin-right: 0.5em;
 }
@@ -28899,7 +29176,7 @@ a.ui.card:hover,
 }
 
 .ui.eight.cards > .card {
-  width: calc( 12.5%  -  1em );
+  width: calc(12.5% - 1em);
   margin-left: 0.5em;
   margin-right: 0.5em;
   font-size: 11px;
@@ -28911,7 +29188,7 @@ a.ui.card:hover,
 }
 
 .ui.nine.cards > .card {
-  width: calc( 11.11111111%  -  1em );
+  width: calc(11.11111111% - 1em);
   margin-left: 0.5em;
   margin-right: 0.5em;
   font-size: 10px;
@@ -28923,7 +29200,7 @@ a.ui.card:hover,
 }
 
 .ui.ten.cards > .card {
-  width: calc( 10%  -  1em );
+  width: calc(10% - 1em);
   margin-left: 0.5em;
   margin-right: 0.5em;
 }
@@ -28952,7 +29229,7 @@ a.ui.card:hover,
   }
 
   .ui.three.doubling.cards > .card {
-    width: calc( 50%  -  2em );
+    width: calc(50% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -28963,7 +29240,7 @@ a.ui.card:hover,
   }
 
   .ui.four.doubling.cards > .card {
-    width: calc( 50%  -  2em );
+    width: calc(50% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -28974,7 +29251,7 @@ a.ui.card:hover,
   }
 
   .ui.five.doubling.cards > .card {
-    width: calc( 50%  -  2em );
+    width: calc(50% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -28985,7 +29262,7 @@ a.ui.card:hover,
   }
 
   .ui.six.doubling.cards > .card {
-    width: calc( 50%  -  2em );
+    width: calc(50% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -28996,7 +29273,7 @@ a.ui.card:hover,
   }
 
   .ui.seven.doubling.cards > .card {
-    width: calc( 33.33333333%  -  2em );
+    width: calc(33.33333333% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -29007,7 +29284,7 @@ a.ui.card:hover,
   }
 
   .ui.eight.doubling.cards > .card {
-    width: calc( 33.33333333%  -  2em );
+    width: calc(33.33333333% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -29018,7 +29295,7 @@ a.ui.card:hover,
   }
 
   .ui.nine.doubling.cards > .card {
-    width: calc( 33.33333333%  -  2em );
+    width: calc(33.33333333% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -29029,7 +29306,7 @@ a.ui.card:hover,
   }
 
   .ui.ten.doubling.cards > .card {
-    width: calc( 33.33333333%  -  2em );
+    width: calc(33.33333333% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -29055,7 +29332,7 @@ a.ui.card:hover,
   }
 
   .ui.three.doubling.cards > .card {
-    width: calc( 50%  -  2em );
+    width: calc(50% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -29066,7 +29343,7 @@ a.ui.card:hover,
   }
 
   .ui.four.doubling.cards > .card {
-    width: calc( 50%  -  2em );
+    width: calc(50% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -29077,7 +29354,7 @@ a.ui.card:hover,
   }
 
   .ui.five.doubling.cards > .card {
-    width: calc( 33.33333333%  -  2em );
+    width: calc(33.33333333% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -29088,7 +29365,7 @@ a.ui.card:hover,
   }
 
   .ui.six.doubling.cards > .card {
-    width: calc( 33.33333333%  -  2em );
+    width: calc(33.33333333% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -29099,7 +29376,7 @@ a.ui.card:hover,
   }
 
   .ui.eight.doubling.cards > .card {
-    width: calc( 33.33333333%  -  2em );
+    width: calc(33.33333333% - 2em);
     margin-left: 1em;
     margin-right: 1em;
   }
@@ -29110,7 +29387,7 @@ a.ui.card:hover,
   }
 
   .ui.eight.doubling.cards > .card {
-    width: calc( 25%  -  1.5em );
+    width: calc(25% - 1.5em);
     margin-left: 0.75em;
     margin-right: 0.75em;
   }
@@ -29121,7 +29398,7 @@ a.ui.card:hover,
   }
 
   .ui.nine.doubling.cards > .card {
-    width: calc( 25%  -  1.5em );
+    width: calc(25% - 1.5em);
     margin-left: 0.75em;
     margin-right: 0.75em;
   }
@@ -29132,7 +29409,7 @@ a.ui.card:hover,
   }
 
   .ui.ten.doubling.cards > .card {
-    width: calc( 20%  -  1.5em );
+    width: calc(20% - 1.5em);
     margin-left: 0.75em;
     margin-right: 0.75em;
   }
@@ -29156,7 +29433,7 @@ a.ui.card:hover,
     height: auto !important;
     margin: 1em 1em;
     padding: 0 !important;
-    width: calc( 100%  -  2em ) !important;
+    width: calc(100% - 2em) !important;
   }
 }
 
@@ -29717,11 +29994,11 @@ a.ui.card:hover,
 }
 
 .ui.feed > .event > .content .meta .like:hover .icon {
-  color: #FF2733;
+  color: #ff2733;
 }
 
 .ui.feed > .event > .content .meta .active.like .icon {
-  color: #EF404A;
+  color: #ef404a;
 }
 
 /* First element */
@@ -29939,11 +30216,11 @@ a.ui.card:hover,
      Floated
 ---------------*/
 
-.ui.items > .item [class*="left floated"] {
+.ui.items > .item [class*='left floated'] {
   float: left;
 }
 
-.ui.items > .item [class*="right floated"] {
+.ui.items > .item [class*='right floated'] {
   float: right;
 }
 
@@ -30007,7 +30284,7 @@ a.ui.card:hover,
   margin-right: 0em;
 }
 
-.ui.items > .item .meta [class*="right floated"] {
+.ui.items > .item .meta [class*='right floated'] {
   margin-right: 0em;
   margin-left: 0.3em;
 }
@@ -30065,11 +30342,11 @@ a.ui.card:hover,
 
 .ui.items > .item > .content .favorite.icon:hover {
   opacity: 1;
-  color: #FFB70A;
+  color: #ffb70a;
 }
 
 .ui.items > .item > .content .active.favorite.icon {
-  color: #FFE623;
+  color: #ffe623;
 }
 
 /*-----Like----- */
@@ -30085,11 +30362,11 @@ a.ui.card:hover,
 
 .ui.items > .item > .content .like.icon:hover {
   opacity: 1;
-  color: #FF2733;
+  color: #ff2733;
 }
 
 .ui.items > .item > .content .active.like.icon {
-  color: #FF2733;
+  color: #ff2733;
 }
 
 /*----------------
@@ -30117,7 +30394,7 @@ a.ui.card:hover,
   margin: 0.25rem 0.5rem 0.25rem 0em;
 }
 
-.ui.items > .item .extra > [class*="right floated"] {
+.ui.items > .item .extra > [class*='right floated'] {
   margin: 0.25rem 0em 0.25rem 0.5rem;
 }
 
@@ -30195,17 +30472,17 @@ a.ui.card:hover,
        Aligned
 --------------------*/
 
-.ui.items > .item > .image + [class*="top aligned"].content {
+.ui.items > .item > .image + [class*='top aligned'].content {
   -ms-flex-item-align: start;
   align-self: flex-start;
 }
 
-.ui.items > .item > .image + [class*="middle aligned"].content {
+.ui.items > .item > .image + [class*='middle aligned'].content {
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.ui.items > .item > .image + [class*="bottom aligned"].content {
+.ui.items > .item > .image + [class*='bottom aligned'].content {
   -ms-flex-item-align: end;
   align-self: flex-end;
 }
@@ -30218,7 +30495,7 @@ a.ui.card:hover,
   margin: 1.5em 0em;
 }
 
-.ui[class*="very relaxed"].items > .item {
+.ui[class*='very relaxed'].items > .item {
   margin: 2em 0em;
 }
 
@@ -30250,7 +30527,7 @@ a.ui.card:hover,
   padding: 1.5em 0em;
 }
 
-.ui[class*="very relaxed"].divided.items > .item {
+.ui[class*='very relaxed'].divided.items > .item {
   margin: 0em;
   padding: 2em 0em;
 }
@@ -30403,7 +30680,7 @@ a.ui.card:hover,
   font-size: 4rem;
   font-weight: normal;
   line-height: 1em;
-  color: #1B1C1D;
+  color: #1b1c1d;
   text-transform: uppercase;
   text-align: center;
 }
@@ -30641,67 +30918,67 @@ a.ui.card:hover,
 .ui.red.statistics .statistic > .value,
 .ui.statistics .red.statistic > .value,
 .ui.red.statistic > .value {
-  color: #DB2828;
+  color: #db2828;
 }
 
 .ui.orange.statistics .statistic > .value,
 .ui.statistics .orange.statistic > .value,
 .ui.orange.statistic > .value {
-  color: #F2711C;
+  color: #f2711c;
 }
 
 .ui.yellow.statistics .statistic > .value,
 .ui.statistics .yellow.statistic > .value,
 .ui.yellow.statistic > .value {
-  color: #FBBD08;
+  color: #fbbd08;
 }
 
 .ui.olive.statistics .statistic > .value,
 .ui.statistics .olive.statistic > .value,
 .ui.olive.statistic > .value {
-  color: #B5CC18;
+  color: #b5cc18;
 }
 
 .ui.green.statistics .statistic > .value,
 .ui.statistics .green.statistic > .value,
 .ui.green.statistic > .value {
-  color: #21BA45;
+  color: #21ba45;
 }
 
 .ui.teal.statistics .statistic > .value,
 .ui.statistics .teal.statistic > .value,
 .ui.teal.statistic > .value {
-  color: #00B5AD;
+  color: #00b5ad;
 }
 
 .ui.blue.statistics .statistic > .value,
 .ui.statistics .blue.statistic > .value,
 .ui.blue.statistic > .value {
-  color: #2185D0;
+  color: #2185d0;
 }
 
 .ui.violet.statistics .statistic > .value,
 .ui.statistics .violet.statistic > .value,
 .ui.violet.statistic > .value {
-  color: #6435C9;
+  color: #6435c9;
 }
 
 .ui.purple.statistics .statistic > .value,
 .ui.statistics .purple.statistic > .value,
 .ui.purple.statistic > .value {
-  color: #A333C8;
+  color: #a333c8;
 }
 
 .ui.pink.statistics .statistic > .value,
 .ui.statistics .pink.statistic > .value,
 .ui.pink.statistic > .value {
-  color: #E03997;
+  color: #e03997;
 }
 
 .ui.brown.statistics .statistic > .value,
 .ui.statistics .brown.statistic > .value,
 .ui.brown.statistic > .value {
-  color: #A5673F;
+  color: #a5673f;
 }
 
 .ui.grey.statistics .statistic > .value,
@@ -30716,7 +30993,7 @@ a.ui.card:hover,
 
 .ui.inverted.statistics .statistic > .value,
 .ui.inverted.statistic .value {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.statistics .statistic > .label,
@@ -30727,85 +31004,85 @@ a.ui.card:hover,
 .ui.inverted.red.statistics .statistic > .value,
 .ui.statistics .inverted.red.statistic > .value,
 .ui.inverted.red.statistic > .value {
-  color: #FF695E;
+  color: #ff695e;
 }
 
 .ui.inverted.orange.statistics .statistic > .value,
 .ui.statistics .inverted.orange.statistic > .value,
 .ui.inverted.orange.statistic > .value {
-  color: #FF851B;
+  color: #ff851b;
 }
 
 .ui.inverted.yellow.statistics .statistic > .value,
 .ui.statistics .inverted.yellow.statistic > .value,
 .ui.inverted.yellow.statistic > .value {
-  color: #FFE21F;
+  color: #ffe21f;
 }
 
 .ui.inverted.olive.statistics .statistic > .value,
 .ui.statistics .inverted.olive.statistic > .value,
 .ui.inverted.olive.statistic > .value {
-  color: #D9E778;
+  color: #d9e778;
 }
 
 .ui.inverted.green.statistics .statistic > .value,
 .ui.statistics .inverted.green.statistic > .value,
 .ui.inverted.green.statistic > .value {
-  color: #2ECC40;
+  color: #2ecc40;
 }
 
 .ui.inverted.teal.statistics .statistic > .value,
 .ui.statistics .inverted.teal.statistic > .value,
 .ui.inverted.teal.statistic > .value {
-  color: #6DFFFF;
+  color: #6dffff;
 }
 
 .ui.inverted.blue.statistics .statistic > .value,
 .ui.statistics .inverted.blue.statistic > .value,
 .ui.inverted.blue.statistic > .value {
-  color: #54C8FF;
+  color: #54c8ff;
 }
 
 .ui.inverted.violet.statistics .statistic > .value,
 .ui.statistics .inverted.violet.statistic > .value,
 .ui.inverted.violet.statistic > .value {
-  color: #A291FB;
+  color: #a291fb;
 }
 
 .ui.inverted.purple.statistics .statistic > .value,
 .ui.statistics .inverted.purple.statistic > .value,
 .ui.inverted.purple.statistic > .value {
-  color: #DC73FF;
+  color: #dc73ff;
 }
 
 .ui.inverted.pink.statistics .statistic > .value,
 .ui.statistics .inverted.pink.statistic > .value,
 .ui.inverted.pink.statistic > .value {
-  color: #FF8EDF;
+  color: #ff8edf;
 }
 
 .ui.inverted.brown.statistics .statistic > .value,
 .ui.statistics .inverted.brown.statistic > .value,
 .ui.inverted.brown.statistic > .value {
-  color: #D67C1C;
+  color: #d67c1c;
 }
 
 .ui.inverted.grey.statistics .statistic > .value,
 .ui.statistics .inverted.grey.statistic > .value,
 .ui.inverted.grey.statistic > .value {
-  color: #DCDDDE;
+  color: #dcddde;
 }
 
 /*--------------
     Floated
 ---------------*/
 
-.ui[class*="left floated"].statistic {
+.ui[class*='left floated'].statistic {
   float: left;
   margin: 0em 2em 1em 0em;
 }
 
-.ui[class*="right floated"].statistic {
+.ui[class*='right floated'].statistic {
   float: right;
   margin: 0em 0em 1em 2em;
 }
@@ -31001,7 +31278,8 @@ a.ui.card:hover,
   -webkit-transition: opacity 0.1s ease, -webkit-transform 0.1s ease;
   transition: opacity 0.1s ease, -webkit-transform 0.1s ease;
   transition: transform 0.1s ease, opacity 0.1s ease;
-  transition: transform 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease;
+  transition: transform 0.1s ease, opacity 0.1s ease,
+    -webkit-transform 0.1s ease;
   vertical-align: baseline;
   -webkit-transform: none;
   transform: none;
@@ -31062,9 +31340,11 @@ a.ui.card:hover,
 .ui.styled.accordion,
 .ui.styled.accordion .accordion {
   border-radius: 0.28571429rem;
-  background: #FFFFFF;
-  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15);
-  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15);
+  background: #ffffff;
+  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15);
 }
 
 .ui.styled.accordion .title,
@@ -31164,7 +31444,10 @@ a.ui.card:hover,
 
 @font-face {
   font-family: 'Accordion';
-  src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMggjB5AAAAC8AAAAYGNtYXAPfOIKAAABHAAAAExnYXNwAAAAEAAAAWgAAAAIZ2x5Zryj6HgAAAFwAAAAyGhlYWT/0IhHAAACOAAAADZoaGVhApkB5wAAAnAAAAAkaG10eAJuABIAAAKUAAAAGGxvY2EAjABWAAACrAAAAA5tYXhwAAgAFgAAArwAAAAgbmFtZfC1n04AAALcAAABPHBvc3QAAwAAAAAEGAAAACAAAwIAAZAABQAAAUwBZgAAAEcBTAFmAAAA9QAZAIQAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADw2gHg/+D/4AHgACAAAAABAAAAAAAAAAAAAAAgAAAAAAACAAAAAwAAABQAAwABAAAAFAAEADgAAAAKAAgAAgACAAEAIPDa//3//wAAAAAAIPDZ//3//wAB/+MPKwADAAEAAAAAAAAAAAAAAAEAAf//AA8AAQAAAAAAAAAAAAIAADc5AQAAAAABAAAAAAAAAAAAAgAANzkBAAAAAAEAAAAAAAAAAAACAAA3OQEAAAAAAQASAEkAtwFuABMAADc0PwE2FzYXFh0BFAcGJwYvASY1EgaABQgHBQYGBQcIBYAG2wcGfwcBAQcECf8IBAcBAQd/BgYAAAAAAQAAAEkApQFuABMAADcRNDc2MzIfARYVFA8BBiMiJyY1AAUGBwgFgAYGgAUIBwYFWwEACAUGBoAFCAcFgAYGBQcAAAABAAAAAQAAqWYls18PPPUACwIAAAAAAM/9o+4AAAAAz/2j7gAAAAAAtwFuAAAACAACAAAAAAAAAAEAAAHg/+AAAAIAAAAAAAC3AAEAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAQAAAAC3ABIAtwAAAAAAAAAKABQAHgBCAGQAAAABAAAABgAUAAEAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAADgCuAAEAAAAAAAEADAAAAAEAAAAAAAIADgBAAAEAAAAAAAMADAAiAAEAAAAAAAQADABOAAEAAAAAAAUAFgAMAAEAAAAAAAYABgAuAAEAAAAAAAoANABaAAMAAQQJAAEADAAAAAMAAQQJAAIADgBAAAMAAQQJAAMADAAiAAMAAQQJAAQADABOAAMAAQQJAAUAFgAMAAMAAQQJAAYADAA0AAMAAQQJAAoANABaAHIAYQB0AGkAbgBnAFYAZQByAHMAaQBvAG4AIAAxAC4AMAByAGEAdABpAG4AZ3JhdGluZwByAGEAdABpAG4AZwBSAGUAZwB1AGwAYQByAHIAYQB0AGkAbgBnAEYAbwBuAHQAIABnAGUAbgBlAHIAYQB0AGUAZAAgAGIAeQAgAEkAYwBvAE0AbwBvAG4ALgADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) format('truetype'), url(data:application/font-woff;charset=utf-8;base64,d09GRk9UVE8AAASwAAoAAAAABGgAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABDRkYgAAAA9AAAAS0AAAEtFpovuE9TLzIAAAIkAAAAYAAAAGAIIweQY21hcAAAAoQAAABMAAAATA984gpnYXNwAAAC0AAAAAgAAAAIAAAAEGhlYWQAAALYAAAANgAAADb/0IhHaGhlYQAAAxAAAAAkAAAAJAKZAedobXR4AAADNAAAABgAAAAYAm4AEm1heHAAAANMAAAABgAAAAYABlAAbmFtZQAAA1QAAAE8AAABPPC1n05wb3N0AAAEkAAAACAAAAAgAAMAAAEABAQAAQEBB3JhdGluZwABAgABADr4HAL4GwP4GAQeCgAZU/+Lix4KABlT/4uLDAeLa/iU+HQFHQAAAHkPHQAAAH4RHQAAAAkdAAABJBIABwEBBw0PERQZHnJhdGluZ3JhdGluZ3UwdTF1MjB1RjBEOXVGMERBAAACAYkABAAGAQEEBwoNVp38lA78lA78lA77lA773Z33bxWLkI2Qj44I9xT3FAWOj5CNkIuQi4+JjoePiI2Gi4YIi/uUBYuGiYeHiIiHh4mGi4aLho2Ijwj7FPcUBYeOiY+LkAgO+92L5hWL95QFi5CNkI6Oj4+PjZCLkIuQiY6HCPcU+xQFj4iNhouGi4aJh4eICPsU+xQFiIeGiYaLhouHjYePiI6Jj4uQCA74lBT4lBWLDAoAAAAAAwIAAZAABQAAAUwBZgAAAEcBTAFmAAAA9QAZAIQAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADw2gHg/+D/4AHgACAAAAABAAAAAAAAAAAAAAAgAAAAAAACAAAAAwAAABQAAwABAAAAFAAEADgAAAAKAAgAAgACAAEAIPDa//3//wAAAAAAIPDZ//3//wAB/+MPKwADAAEAAAAAAAAAAAAAAAEAAf//AA8AAQAAAAEAADfYOJZfDzz1AAsCAAAAAADP/aPuAAAAAM/9o+4AAAAAALcBbgAAAAgAAgAAAAAAAAABAAAB4P/gAAACAAAAAAAAtwABAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAEAAAAAtwASALcAAAAAUAAABgAAAAAADgCuAAEAAAAAAAEADAAAAAEAAAAAAAIADgBAAAEAAAAAAAMADAAiAAEAAAAAAAQADABOAAEAAAAAAAUAFgAMAAEAAAAAAAYABgAuAAEAAAAAAAoANABaAAMAAQQJAAEADAAAAAMAAQQJAAIADgBAAAMAAQQJAAMADAAiAAMAAQQJAAQADABOAAMAAQQJAAUAFgAMAAMAAQQJAAYADAA0AAMAAQQJAAoANABaAHIAYQB0AGkAbgBnAFYAZQByAHMAaQBvAG4AIAAxAC4AMAByAGEAdABpAG4AZ3JhdGluZwByAGEAdABpAG4AZwBSAGUAZwB1AGwAYQByAHIAYQB0AGkAbgBnAEYAbwBuAHQAIABnAGUAbgBlAHIAYQB0AGUAZAAgAGIAeQAgAEkAYwBvAE0AbwBvAG4ALgADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) format('woff');
+  src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMggjB5AAAAC8AAAAYGNtYXAPfOIKAAABHAAAAExnYXNwAAAAEAAAAWgAAAAIZ2x5Zryj6HgAAAFwAAAAyGhlYWT/0IhHAAACOAAAADZoaGVhApkB5wAAAnAAAAAkaG10eAJuABIAAAKUAAAAGGxvY2EAjABWAAACrAAAAA5tYXhwAAgAFgAAArwAAAAgbmFtZfC1n04AAALcAAABPHBvc3QAAwAAAAAEGAAAACAAAwIAAZAABQAAAUwBZgAAAEcBTAFmAAAA9QAZAIQAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADw2gHg/+D/4AHgACAAAAABAAAAAAAAAAAAAAAgAAAAAAACAAAAAwAAABQAAwABAAAAFAAEADgAAAAKAAgAAgACAAEAIPDa//3//wAAAAAAIPDZ//3//wAB/+MPKwADAAEAAAAAAAAAAAAAAAEAAf//AA8AAQAAAAAAAAAAAAIAADc5AQAAAAABAAAAAAAAAAAAAgAANzkBAAAAAAEAAAAAAAAAAAACAAA3OQEAAAAAAQASAEkAtwFuABMAADc0PwE2FzYXFh0BFAcGJwYvASY1EgaABQgHBQYGBQcIBYAG2wcGfwcBAQcECf8IBAcBAQd/BgYAAAAAAQAAAEkApQFuABMAADcRNDc2MzIfARYVFA8BBiMiJyY1AAUGBwgFgAYGgAUIBwYFWwEACAUGBoAFCAcFgAYGBQcAAAABAAAAAQAAqWYls18PPPUACwIAAAAAAM/9o+4AAAAAz/2j7gAAAAAAtwFuAAAACAACAAAAAAAAAAEAAAHg/+AAAAIAAAAAAAC3AAEAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAQAAAAC3ABIAtwAAAAAAAAAKABQAHgBCAGQAAAABAAAABgAUAAEAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAADgCuAAEAAAAAAAEADAAAAAEAAAAAAAIADgBAAAEAAAAAAAMADAAiAAEAAAAAAAQADABOAAEAAAAAAAUAFgAMAAEAAAAAAAYABgAuAAEAAAAAAAoANABaAAMAAQQJAAEADAAAAAMAAQQJAAIADgBAAAMAAQQJAAMADAAiAAMAAQQJAAQADABOAAMAAQQJAAUAFgAMAAMAAQQJAAYADAA0AAMAAQQJAAoANABaAHIAYQB0AGkAbgBnAFYAZQByAHMAaQBvAG4AIAAxAC4AMAByAGEAdABpAG4AZ3JhdGluZwByAGEAdABpAG4AZwBSAGUAZwB1AGwAYQByAHIAYQB0AGkAbgBnAEYAbwBuAHQAIABnAGUAbgBlAHIAYQB0AGUAZAAgAGIAeQAgAEkAYwBvAE0AbwBvAG4ALgADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)
+      format('truetype'),
+    url(data:application/font-woff;charset=utf-8;base64,d09GRk9UVE8AAASwAAoAAAAABGgAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABDRkYgAAAA9AAAAS0AAAEtFpovuE9TLzIAAAIkAAAAYAAAAGAIIweQY21hcAAAAoQAAABMAAAATA984gpnYXNwAAAC0AAAAAgAAAAIAAAAEGhlYWQAAALYAAAANgAAADb/0IhHaGhlYQAAAxAAAAAkAAAAJAKZAedobXR4AAADNAAAABgAAAAYAm4AEm1heHAAAANMAAAABgAAAAYABlAAbmFtZQAAA1QAAAE8AAABPPC1n05wb3N0AAAEkAAAACAAAAAgAAMAAAEABAQAAQEBB3JhdGluZwABAgABADr4HAL4GwP4GAQeCgAZU/+Lix4KABlT/4uLDAeLa/iU+HQFHQAAAHkPHQAAAH4RHQAAAAkdAAABJBIABwEBBw0PERQZHnJhdGluZ3JhdGluZ3UwdTF1MjB1RjBEOXVGMERBAAACAYkABAAGAQEEBwoNVp38lA78lA78lA77lA773Z33bxWLkI2Qj44I9xT3FAWOj5CNkIuQi4+JjoePiI2Gi4YIi/uUBYuGiYeHiIiHh4mGi4aLho2Ijwj7FPcUBYeOiY+LkAgO+92L5hWL95QFi5CNkI6Oj4+PjZCLkIuQiY6HCPcU+xQFj4iNhouGi4aJh4eICPsU+xQFiIeGiYaLhouHjYePiI6Jj4uQCA74lBT4lBWLDAoAAAAAAwIAAZAABQAAAUwBZgAAAEcBTAFmAAAA9QAZAIQAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADw2gHg/+D/4AHgACAAAAABAAAAAAAAAAAAAAAgAAAAAAACAAAAAwAAABQAAwABAAAAFAAEADgAAAAKAAgAAgACAAEAIPDa//3//wAAAAAAIPDZ//3//wAB/+MPKwADAAEAAAAAAAAAAAAAAAEAAf//AA8AAQAAAAEAADfYOJZfDzz1AAsCAAAAAADP/aPuAAAAAM/9o+4AAAAAALcBbgAAAAgAAgAAAAAAAAABAAAB4P/gAAACAAAAAAAAtwABAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAEAAAAAtwASALcAAAAAUAAABgAAAAAADgCuAAEAAAAAAAEADAAAAAEAAAAAAAIADgBAAAEAAAAAAAMADAAiAAEAAAAAAAQADABOAAEAAAAAAAUAFgAMAAEAAAAAAAYABgAuAAEAAAAAAAoANABaAAMAAQQJAAEADAAAAAMAAQQJAAIADgBAAAMAAQQJAAMADAAiAAMAAQQJAAQADABOAAMAAQQJAAUAFgAMAAMAAQQJAAYADAA0AAMAAQQJAAoANABaAHIAYQB0AGkAbgBnAFYAZQByAHMAaQBvAG4AIAAxAC4AMAByAGEAdABpAG4AZ3JhdGluZwByAGEAdABpAG4AZwBSAGUAZwB1AGwAYQByAHIAYQB0AGkAbgBnAEYAbwBuAHQAIABnAGUAbgBlAHIAYQB0AGUAZAAgAGIAeQAgAEkAYwBvAE0AbwBvAG4ALgADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)
+      format('woff');
   font-weight: normal;
   font-style: normal;
 }
@@ -31184,7 +31467,7 @@ a.ui.card:hover,
 
 .ui.accordion .title .dropdown.icon:before,
 .ui.accordion .accordion .title .dropdown.icon:before {
-  content: '\f0da' ;
+  content: '\f0da';
 }
 
 /*******************************
@@ -31224,8 +31507,8 @@ a.ui.card:hover,
 
 /* HTML Checkbox */
 
-.ui.checkbox input[type="checkbox"],
-.ui.checkbox input[type="radio"] {
+.ui.checkbox input[type='checkbox'],
+.ui.checkbox input[type='radio'] {
   cursor: pointer;
   position: absolute;
   top: 0px;
@@ -31259,13 +31542,18 @@ a.ui.card:hover,
   width: 17px;
   height: 17px;
   content: '';
-  background: #FFFFFF;
+  background: #ffffff;
   border-radius: 0.21428571rem;
-  -webkit-transition: border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease;
-  transition: border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;
-  border: 1px solid #D4D4D5;
+  -webkit-transition: border 0.1s ease, opacity 0.1s ease,
+    -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
+  transition: border 0.1s ease, opacity 0.1s ease, transform 0.1s ease,
+    box-shadow 0.1s ease;
+  transition: border 0.1s ease, opacity 0.1s ease, transform 0.1s ease,
+    box-shadow 0.1s ease, -webkit-transform 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
+  border: 1px solid #d4d4d5;
 }
 
 /*--------------
@@ -31283,10 +31571,15 @@ a.ui.card:hover,
   text-align: center;
   opacity: 0;
   color: rgba(0, 0, 0, 0.87);
-  -webkit-transition: border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease;
-  transition: border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;
+  -webkit-transition: border 0.1s ease, opacity 0.1s ease,
+    -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
+  transition: border 0.1s ease, opacity 0.1s ease, transform 0.1s ease,
+    box-shadow 0.1s ease;
+  transition: border 0.1s ease, opacity 0.1s ease, transform 0.1s ease,
+    box-shadow 0.1s ease, -webkit-transform 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
 }
 
 /*--------------
@@ -31318,7 +31611,7 @@ a.ui.card:hover,
 
 .ui.checkbox .box:hover::before,
 .ui.checkbox label:hover::before {
-  background: #FFFFFF;
+  background: #ffffff;
   border-color: rgba(34, 36, 38, 0.35);
 }
 
@@ -31333,7 +31626,7 @@ a.ui.card:hover,
 
 .ui.checkbox .box:active::before,
 .ui.checkbox label:active::before {
-  background: #F9FAFB;
+  background: #f9fafb;
   border-color: rgba(34, 36, 38, 0.35);
 }
 
@@ -31352,8 +31645,8 @@ a.ui.card:hover,
 
 .ui.checkbox input:focus ~ .box:before,
 .ui.checkbox input:focus ~ label:before {
-  background: #FFFFFF;
-  border-color: #96C8DA;
+  background: #ffffff;
+  border-color: #96c8da;
 }
 
 .ui.checkbox input:focus ~ .box:after,
@@ -31371,7 +31664,7 @@ a.ui.card:hover,
 
 .ui.checkbox input:checked ~ .box:before,
 .ui.checkbox input:checked ~ label:before {
-  background: #FFFFFF;
+  background: #ffffff;
   border-color: rgba(34, 36, 38, 0.35);
 }
 
@@ -31385,14 +31678,14 @@ a.ui.card:hover,
   Indeterminate
 ---------------*/
 
-.ui.checkbox input:not([type=radio]):indeterminate ~ .box:before,
-.ui.checkbox input:not([type=radio]):indeterminate ~ label:before {
-  background: #FFFFFF;
+.ui.checkbox input:not([type='radio']):indeterminate ~ .box:before,
+.ui.checkbox input:not([type='radio']):indeterminate ~ label:before {
+  background: #ffffff;
   border-color: rgba(34, 36, 38, 0.35);
 }
 
-.ui.checkbox input:not([type=radio]):indeterminate ~ .box:after,
-.ui.checkbox input:not([type=radio]):indeterminate ~ label:after {
+.ui.checkbox input:not([type='radio']):indeterminate ~ .box:after,
+.ui.checkbox input:not([type='radio']):indeterminate ~ label:after {
   opacity: 1;
   color: rgba(0, 0, 0, 0.95);
 }
@@ -31401,16 +31694,16 @@ a.ui.card:hover,
   Active Focus
 ---------------*/
 
-.ui.checkbox input:not([type=radio]):indeterminate:focus ~ .box:before,
-.ui.checkbox input:not([type=radio]):indeterminate:focus ~ label:before,
+.ui.checkbox input:not([type='radio']):indeterminate:focus ~ .box:before,
+.ui.checkbox input:not([type='radio']):indeterminate:focus ~ label:before,
 .ui.checkbox input:checked:focus ~ .box:before,
 .ui.checkbox input:checked:focus ~ label:before {
-  background: #FFFFFF;
-  border-color: #96C8DA;
+  background: #ffffff;
+  border-color: #96c8da;
 }
 
-.ui.checkbox input:not([type=radio]):indeterminate:focus ~ .box:after,
-.ui.checkbox input:not([type=radio]):indeterminate:focus ~ label:after,
+.ui.checkbox input:not([type='radio']):indeterminate:focus ~ .box:after,
+.ui.checkbox input:not([type='radio']):indeterminate:focus ~ label:after,
 .ui.checkbox input:checked:focus ~ .box:after,
 .ui.checkbox input:checked:focus ~ label:after {
   color: rgba(0, 0, 0, 0.95);
@@ -31519,7 +31812,7 @@ a.ui.card:hover,
 
 .ui.radio.checkbox input:focus ~ .box:before,
 .ui.radio.checkbox input:focus ~ label:before {
-  background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
 .ui.radio.checkbox input:focus ~ .box:after,
@@ -31538,7 +31831,7 @@ a.ui.card:hover,
 
 .ui.radio.checkbox input:checked ~ .box:before,
 .ui.radio.checkbox input:checked ~ label:before {
-  background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
 .ui.radio.checkbox input:checked ~ .box:after,
@@ -31550,7 +31843,7 @@ a.ui.card:hover,
 
 .ui.radio.checkbox input:focus:checked ~ .box:before,
 .ui.radio.checkbox input:focus:checked ~ label:before {
-  background-color: #FFFFFF;
+  background-color: #ffffff;
 }
 
 .ui.radio.checkbox input:focus:checked ~ .box:after,
@@ -31607,16 +31900,18 @@ a.ui.card:hover,
 
 .ui.slider.checkbox .box:after,
 .ui.slider.checkbox label:after {
-  background: #FFFFFF -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(0, 0, 0, 0.05)));
-  background: #FFFFFF -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05));
-  background: #FFFFFF linear-gradient(transparent, rgba(0, 0, 0, 0.05));
+  background: #ffffff -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(0, 0, 0, 0.05)));
+  background: #ffffff -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05));
+  background: #ffffff linear-gradient(transparent, rgba(0, 0, 0, 0.05));
   position: absolute;
   content: '' !important;
   opacity: 1;
   z-index: 2;
   border: none;
-  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
   width: 1.5rem;
   height: 1.5rem;
   top: -0.25rem;
@@ -31729,16 +32024,18 @@ a.ui.card:hover,
 
 .ui.toggle.checkbox .box:after,
 .ui.toggle.checkbox label:after {
-  background: #FFFFFF -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(0, 0, 0, 0.05)));
-  background: #FFFFFF -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05));
-  background: #FFFFFF linear-gradient(transparent, rgba(0, 0, 0, 0.05));
+  background: #ffffff -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(0, 0, 0, 0.05)));
+  background: #ffffff -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05));
+  background: #ffffff linear-gradient(transparent, rgba(0, 0, 0, 0.05));
   position: absolute;
   content: '' !important;
   opacity: 1;
   z-index: 2;
   border: none;
-  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
   width: 1.5rem;
   height: 1.5rem;
   top: 0rem;
@@ -31751,8 +32048,10 @@ a.ui.card:hover,
 .ui.toggle.checkbox input ~ .box:after,
 .ui.toggle.checkbox input ~ label:after {
   left: -0.05rem;
-  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
 }
 
 /* Focus */
@@ -31780,14 +32079,16 @@ a.ui.card:hover,
 
 .ui.toggle.checkbox input:checked ~ .box:before,
 .ui.toggle.checkbox input:checked ~ label:before {
-  background-color: #2185D0 !important;
+  background-color: #2185d0 !important;
 }
 
 .ui.toggle.checkbox input:checked ~ .box:after,
 .ui.toggle.checkbox input:checked ~ label:after {
   left: 2.15rem;
-  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
-  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15), 0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
+  -webkit-box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
+  box-shadow: 0px 1px 2px 0 rgba(34, 36, 38, 0.15),
+    0px 0px 0px 1px rgba(34, 36, 38, 0.15) inset;
 }
 
 /* Active Focus */
@@ -31831,7 +32132,8 @@ a.ui.card:hover,
 
 @font-face {
   font-family: 'Checkbox';
-  src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMg8SBD8AAAC8AAAAYGNtYXAYVtCJAAABHAAAAFRnYXNwAAAAEAAAAXAAAAAIZ2x5Zn4huwUAAAF4AAABYGhlYWQGPe1ZAAAC2AAAADZoaGVhB30DyAAAAxAAAAAkaG10eBBKAEUAAAM0AAAAHGxvY2EAmgESAAADUAAAABBtYXhwAAkALwAAA2AAAAAgbmFtZSC8IugAAAOAAAABknBvc3QAAwAAAAAFFAAAACAAAwMTAZAABQAAApkCzAAAAI8CmQLMAAAB6wAzAQkAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADoAgPA/8AAQAPAAEAAAAABAAAAAAAAAAAAAAAgAAAAAAADAAAAAwAAABwAAQADAAAAHAADAAEAAAAcAAQAOAAAAAoACAACAAIAAQAg6AL//f//AAAAAAAg6AD//f//AAH/4xgEAAMAAQAAAAAAAAAAAAAAAQAB//8ADwABAAAAAAAAAAAAAgAANzkBAAAAAAEAAAAAAAAAAAACAAA3OQEAAAAAAQAAAAAAAAAAAAIAADc5AQAAAAABAEUAUQO7AvgAGgAAARQHAQYjIicBJjU0PwE2MzIfAQE2MzIfARYVA7sQ/hQQFhcQ/uMQEE4QFxcQqAF2EBcXEE4QAnMWEP4UEBABHRAXFhBOEBCoAXcQEE4QFwAAAAABAAABbgMlAkkAFAAAARUUBwYjISInJj0BNDc2MyEyFxYVAyUQEBf9SRcQEBAQFwK3FxAQAhJtFxAQEBAXbRcQEBAQFwAAAAABAAAASQMlA24ALAAAARUUBwYrARUUBwYrASInJj0BIyInJj0BNDc2OwE1NDc2OwEyFxYdATMyFxYVAyUQEBfuEBAXbhYQEO4XEBAQEBfuEBAWbhcQEO4XEBACEm0XEBDuFxAQEBAX7hAQF20XEBDuFxAQEBAX7hAQFwAAAQAAAAIAAHRSzT9fDzz1AAsEAAAAAADRsdR3AAAAANGx1HcAAAAAA7sDbgAAAAgAAgAAAAAAAAABAAADwP/AAAAEAAAAAAADuwABAAAAAAAAAAAAAAAAAAAABwQAAAAAAAAAAAAAAAIAAAAEAABFAyUAAAMlAAAAAAAAAAoAFAAeAE4AcgCwAAEAAAAHAC0AAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAOAK4AAQAAAAAAAQAIAAAAAQAAAAAAAgAHAGkAAQAAAAAAAwAIADkAAQAAAAAABAAIAH4AAQAAAAAABQALABgAAQAAAAAABgAIAFEAAQAAAAAACgAaAJYAAwABBAkAAQAQAAgAAwABBAkAAgAOAHAAAwABBAkAAwAQAEEAAwABBAkABAAQAIYAAwABBAkABQAWACMAAwABBAkABgAQAFkAAwABBAkACgA0ALBDaGVja2JveABDAGgAZQBjAGsAYgBvAHhWZXJzaW9uIDIuMABWAGUAcgBzAGkAbwBuACAAMgAuADBDaGVja2JveABDAGgAZQBjAGsAYgBvAHhDaGVja2JveABDAGgAZQBjAGsAYgBvAHhSZWd1bGFyAFIAZQBnAHUAbABhAHJDaGVja2JveABDAGgAZQBjAGsAYgBvAHhGb250IGdlbmVyYXRlZCBieSBJY29Nb29uLgBGAG8AbgB0ACAAZwBlAG4AZQByAGEAdABlAGQAIABiAHkAIABJAGMAbwBNAG8AbwBuAC4AAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA) format('truetype');
+  src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMg8SBD8AAAC8AAAAYGNtYXAYVtCJAAABHAAAAFRnYXNwAAAAEAAAAXAAAAAIZ2x5Zn4huwUAAAF4AAABYGhlYWQGPe1ZAAAC2AAAADZoaGVhB30DyAAAAxAAAAAkaG10eBBKAEUAAAM0AAAAHGxvY2EAmgESAAADUAAAABBtYXhwAAkALwAAA2AAAAAgbmFtZSC8IugAAAOAAAABknBvc3QAAwAAAAAFFAAAACAAAwMTAZAABQAAApkCzAAAAI8CmQLMAAAB6wAzAQkAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADoAgPA/8AAQAPAAEAAAAABAAAAAAAAAAAAAAAgAAAAAAADAAAAAwAAABwAAQADAAAAHAADAAEAAAAcAAQAOAAAAAoACAACAAIAAQAg6AL//f//AAAAAAAg6AD//f//AAH/4xgEAAMAAQAAAAAAAAAAAAAAAQAB//8ADwABAAAAAAAAAAAAAgAANzkBAAAAAAEAAAAAAAAAAAACAAA3OQEAAAAAAQAAAAAAAAAAAAIAADc5AQAAAAABAEUAUQO7AvgAGgAAARQHAQYjIicBJjU0PwE2MzIfAQE2MzIfARYVA7sQ/hQQFhcQ/uMQEE4QFxcQqAF2EBcXEE4QAnMWEP4UEBABHRAXFhBOEBCoAXcQEE4QFwAAAAABAAABbgMlAkkAFAAAARUUBwYjISInJj0BNDc2MyEyFxYVAyUQEBf9SRcQEBAQFwK3FxAQAhJtFxAQEBAXbRcQEBAQFwAAAAABAAAASQMlA24ALAAAARUUBwYrARUUBwYrASInJj0BIyInJj0BNDc2OwE1NDc2OwEyFxYdATMyFxYVAyUQEBfuEBAXbhYQEO4XEBAQEBfuEBAWbhcQEO4XEBACEm0XEBDuFxAQEBAX7hAQF20XEBDuFxAQEBAX7hAQFwAAAQAAAAIAAHRSzT9fDzz1AAsEAAAAAADRsdR3AAAAANGx1HcAAAAAA7sDbgAAAAgAAgAAAAAAAAABAAADwP/AAAAEAAAAAAADuwABAAAAAAAAAAAAAAAAAAAABwQAAAAAAAAAAAAAAAIAAAAEAABFAyUAAAMlAAAAAAAAAAoAFAAeAE4AcgCwAAEAAAAHAC0AAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAOAK4AAQAAAAAAAQAIAAAAAQAAAAAAAgAHAGkAAQAAAAAAAwAIADkAAQAAAAAABAAIAH4AAQAAAAAABQALABgAAQAAAAAABgAIAFEAAQAAAAAACgAaAJYAAwABBAkAAQAQAAgAAwABBAkAAgAOAHAAAwABBAkAAwAQAEEAAwABBAkABAAQAIYAAwABBAkABQAWACMAAwABBAkABgAQAFkAAwABBAkACgA0ALBDaGVja2JveABDAGgAZQBjAGsAYgBvAHhWZXJzaW9uIDIuMABWAGUAcgBzAGkAbwBuACAAMgAuADBDaGVja2JveABDAGgAZQBjAGsAYgBvAHhDaGVja2JveABDAGgAZQBjAGsAYgBvAHhSZWd1bGFyAFIAZQBnAHUAbABhAHJDaGVja2JveABDAGgAZQBjAGsAYgBvAHhGb250IGdlbmVyYXRlZCBieSBJY29Nb29uLgBGAG8AbgB0ACAAZwBlAG4AZQByAGEAdABlAGQAIABiAHkAIABJAGMAbwBNAG8AbwBuAC4AAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA)
+    format('truetype');
 }
 
 /* Checkmark */
@@ -31927,7 +32229,7 @@ a.ui.card:hover,
   -moz-user-select: text;
   -ms-user-select: text;
   user-select: text;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 /* Loose Coupling */
@@ -32003,13 +32305,13 @@ a.ui.card:hover,
     Alignment
 ---------------*/
 
-.ui[class*="top aligned"].dimmer {
+.ui[class*='top aligned'].dimmer {
   -webkit-box-pack: start;
   -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
-.ui[class*="bottom aligned"].dimmer {
+.ui[class*='bottom aligned'].dimmer {
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   justify-content: flex-end;
@@ -32087,7 +32389,7 @@ body.dimmable > .dimmer {
 }
 
 .ui.inverted.dimmer > .content > * {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 /*--------------
@@ -32153,7 +32455,8 @@ body.dimmable > .dimmer {
   -webkit-transition: width 0.1s ease, -webkit-box-shadow 0.1s ease;
   transition: width 0.1s ease, -webkit-box-shadow 0.1s ease;
   transition: box-shadow 0.1s ease, width 0.1s ease;
-  transition: box-shadow 0.1s ease, width 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: box-shadow 0.1s ease, width 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 
@@ -32176,7 +32479,7 @@ body.dimmable > .dimmer {
   min-width: max-content;
   margin: 0em;
   padding: 0em 0em;
-  background: #FFFFFF;
+  background: #ffffff;
   font-size: 1em;
   text-shadow: none;
   text-align: left;
@@ -32265,15 +32568,15 @@ body.dimmable > .dimmer {
   Floated Content
 ---------------*/
 
-.ui.dropdown > .text > [class*="right floated"],
-.ui.dropdown .menu .item > [class*="right floated"] {
+.ui.dropdown > .text > [class*='right floated'],
+.ui.dropdown .menu .item > [class*='right floated'] {
   float: right !important;
   margin-right: 0em !important;
   margin-left: 1em !important;
 }
 
-.ui.dropdown > .text > [class*="left floated"],
-.ui.dropdown .menu .item > [class*="left floated"] {
+.ui.dropdown > .text > [class*='left floated'],
+.ui.dropdown .menu .item > [class*='left floated'] {
   float: left !important;
   margin-left: 0em !important;
   margin-right: 1em !important;
@@ -32499,7 +32802,7 @@ body.dimmable > .dimmer {
   transform: rotateZ(0deg);
   min-width: 14em;
   min-height: 2.71428571em;
-  background: #FFFFFF;
+  background: #ffffff;
   display: inline-block;
   padding: 0.78571429em 2.1em 0.78571429em 1em;
   color: rgba(0, 0, 0, 0.87);
@@ -32510,7 +32813,8 @@ body.dimmable > .dimmer {
   -webkit-transition: width 0.1s ease, -webkit-box-shadow 0.1s ease;
   transition: width 0.1s ease, -webkit-box-shadow 0.1s ease;
   transition: box-shadow 0.1s ease, width 0.1s ease;
-  transition: box-shadow 0.1s ease, width 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: box-shadow 0.1s ease, width 0.1s ease,
+    -webkit-box-shadow 0.1s ease;
 }
 
 .ui.selection.dropdown.visible,
@@ -32561,8 +32865,8 @@ select.ui.dropdown {
   width: auto;
   outline: none;
   margin: 0px -1px;
-  min-width: calc(100% +  2px );
-  width: calc(100% +  2px );
+  min-width: calc(100% + 2px);
+  width: calc(100% + 2px);
   border-radius: 0em 0em 0.28571429rem 0.28571429rem;
   -webkit-box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
   box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
@@ -32610,7 +32914,7 @@ select.ui.dropdown {
 /* Menu Item */
 
 .ui.selection.dropdown .menu > .item {
-  border-top: 1px solid #FAFAFA;
+  border-top: 1px solid #fafafa;
   padding: 0.78571429rem 1.14285714rem !important;
   white-space: normal;
   word-wrap: normal;
@@ -32633,13 +32937,13 @@ select.ui.dropdown {
 /* Active */
 
 .ui.selection.active.dropdown {
-  border-color: #96C8DA;
+  border-color: #96c8da;
   -webkit-box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
   box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
 }
 
 .ui.selection.active.dropdown .menu {
-  border-color: #96C8DA;
+  border-color: #96c8da;
   -webkit-box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
   box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
 }
@@ -32647,13 +32951,13 @@ select.ui.dropdown {
 /* Focus */
 
 .ui.selection.dropdown:focus {
-  border-color: #96C8DA;
+  border-color: #96c8da;
   -webkit-box-shadow: none;
   box-shadow: none;
 }
 
 .ui.selection.dropdown:focus .menu {
-  border-color: #96C8DA;
+  border-color: #96c8da;
   -webkit-box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
   box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
 }
@@ -32668,13 +32972,13 @@ select.ui.dropdown {
 /* Visible Hover */
 
 .ui.selection.active.dropdown:hover {
-  border-color: #96C8DA;
+  border-color: #96c8da;
   -webkit-box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
   box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
 }
 
 .ui.selection.active.dropdown:hover .menu {
-  border-color: #96C8DA;
+  border-color: #96c8da;
   -webkit-box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
   box-shadow: 0px 2px 3px 0px rgba(34, 36, 38, 0.15);
 }
@@ -33120,41 +33424,41 @@ select.ui.dropdown {
 .ui.dropdown.error,
 .ui.dropdown.error > .text,
 .ui.dropdown.error > .default.text {
-  color: #9F3A38;
+  color: #9f3a38;
 }
 
 .ui.selection.dropdown.error {
-  background: #FFF6F6;
-  border-color: #E0B4B4;
+  background: #fff6f6;
+  border-color: #e0b4b4;
 }
 
 .ui.selection.dropdown.error:hover {
-  border-color: #E0B4B4;
+  border-color: #e0b4b4;
 }
 
 .ui.dropdown.error > .menu,
 .ui.dropdown.error > .menu .menu {
-  border-color: #E0B4B4;
+  border-color: #e0b4b4;
 }
 
 .ui.dropdown.error > .menu > .item {
-  color: #9F3A38;
+  color: #9f3a38;
 }
 
 .ui.multiple.selection.error.dropdown > .label {
-  border-color: #E0B4B4;
+  border-color: #e0b4b4;
 }
 
 /* Item Hover */
 
 .ui.dropdown.error > .menu > .item:hover {
-  background-color: #FFF2F2;
+  background-color: #fff2f2;
 }
 
 /* Item Active */
 
 .ui.dropdown.error > .menu .active.item {
-  background-color: #FDCFCF;
+  background-color: #fdcfcf;
 }
 
 /*--------------------
@@ -33483,8 +33787,10 @@ select.ui.dropdown {
 .ui.floating.dropdown .menu {
   left: 0;
   right: auto;
-  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15) !important;
-  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15) !important;
+  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15) !important;
+  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15) !important;
   border-radius: 0.28571429rem !important;
 }
 
@@ -33515,7 +33821,7 @@ select.ui.dropdown {
   height: 0.5em;
   -webkit-box-shadow: -1px -1px 0px 0px rgba(34, 36, 38, 0.15);
   box-shadow: -1px -1px 0px 0px rgba(34, 36, 38, 0.15);
-  background: #FFFFFF;
+  background: #ffffff;
   z-index: 2;
 }
 
@@ -33731,7 +34037,8 @@ select.ui.dropdown {
 
 @font-face {
   font-family: 'Dropdown';
-  src: url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAAVgAA8AAAAACFAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAABWAAAABwAAAAchGgaq0dERUYAAAF0AAAAHAAAAB4AJwAPT1MvMgAAAZAAAABDAAAAVnW4TJdjbWFwAAAB1AAAAEsAAAFS8CcaqmN2dCAAAAIgAAAABAAAAAQAEQFEZ2FzcAAAAiQAAAAIAAAACP//AANnbHlmAAACLAAAAQoAAAGkrRHP9WhlYWQAAAM4AAAAMAAAADYPK8YyaGhlYQAAA2gAAAAdAAAAJANCAb1obXR4AAADiAAAACIAAAAiCBkAOGxvY2EAAAOsAAAAFAAAABQBnAIybWF4cAAAA8AAAAAfAAAAIAEVAF5uYW1lAAAD4AAAATAAAAKMFGlj5HBvc3QAAAUQAAAARgAAAHJoedjqd2ViZgAABVgAAAAGAAAABrO7W5UAAAABAAAAANXulPUAAAAA1r4hgAAAAADXu2Q1eNpjYGRgYOABYjEgZmJgBEIOIGYB8xgAA/YAN3jaY2BktGOcwMDKwMI4jTGNgYHBHUp/ZZBkaGFgYGJgZWbACgLSXFMYHFT/fLjFeOD/AQY9xjMMbkBhRpAcAN48DQYAeNpjYGBgZoBgGQZGBhDwAfIYwXwWBgMgzQGETAwMqn8+8H649f8/lHX9//9b7Pzf+fWgusCAkY0BzmUE6gHpQwGMDMMeAACbxg7SAAARAUQAAAAB//8AAnjadZBPSsNAGMXfS+yMqYgOhpSuSlKadmUhiVEhEMQzFF22m17BbbvzCh5BXCUn6EG8gjeQ4DepwYo4i+/ffL95j4EDA+CFC7jQuKyIeVHrI3wkleq9F7XrSInKteOeHdda8bOoaeepSc00NWPz/LRec9G8GabyGtEdF7h19z033GAMTK7zbM42xNEZpzYof0RtQ5CUHAQJ73OtVyutc+3b7Ou//b8XNlsPx3jgjUifABdhEohKJJL5iM5p39uqc7X1+sRQSqmGrUVhlsJ4lpmEUVwyT8SUYtg0P9DyNzPADDs+tjrGV6KRCRfsui3eHcL4/p8ZXvfMlcnEU+CLv7hDykOP+AKTPTxbAAB42mNgZGBgAGKuf5KP4vltvjLIMzGAwLV9ig0g+vruFFMQzdjACOJzMIClARh0CTJ42mNgZGBgPPD/AJD8wgAEjA0MjAyogAMAbOQEAQAAAAC7ABEAAAAAAKoAAAH0AAABgAAAAUAACAFAAAgAwAAXAAAAAAAAACoAKgAqADIAbACGAKAAugDSeNpjYGRgYOBkUGFgYgABEMkFhAwM/xn0QAIADdUBdAB42qWQvUoDQRSFv3GjaISUQaymSmGxJoGAsRC0iPYLsU50Y6IxrvlRtPCJJKUPIBb+PIHv4EN4djKuKAqCDHfmu+feOdwZoMCUAJNbAlYUMzaUlM14jjxbngOq7HnOia89z1Pk1vMCa9x7ztPkzfMyJbPj+ZGi6Xp+omxuPD+zaD7meaFg7mb8GrBqHmhwxoAxlm0uiRkpP9X5m26pKRoMxTGR1D49Dv/Yb/91o6l8qL6eu5n2hZQzn68utR9m3FU2cB4t9cdSLG2utI+44Eh/P9bqKO+oJ/WxmXssj77YkrjasZQD6SFddythk3Wtzrf+UF2p076Udla1VNzsERP3kkjVRKel7mp1udXYcHtZSlV7RfmJe1GiFWveluaeKD5/MuJcSk8Tpm/vvwPIbmJleNpjYGKAAFYG7ICTgYGRiZGZkYWRlZGNkZ2Rg5GTLT2nsiDDEEIZsZfmZRqZujmDaDcDAxcI7WIOpS2gtCWUdgQAZkcSmQAAAAFblbO6AAA=) format('woff');
+  src: url(data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAAVgAA8AAAAACFAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAABWAAAABwAAAAchGgaq0dERUYAAAF0AAAAHAAAAB4AJwAPT1MvMgAAAZAAAABDAAAAVnW4TJdjbWFwAAAB1AAAAEsAAAFS8CcaqmN2dCAAAAIgAAAABAAAAAQAEQFEZ2FzcAAAAiQAAAAIAAAACP//AANnbHlmAAACLAAAAQoAAAGkrRHP9WhlYWQAAAM4AAAAMAAAADYPK8YyaGhlYQAAA2gAAAAdAAAAJANCAb1obXR4AAADiAAAACIAAAAiCBkAOGxvY2EAAAOsAAAAFAAAABQBnAIybWF4cAAAA8AAAAAfAAAAIAEVAF5uYW1lAAAD4AAAATAAAAKMFGlj5HBvc3QAAAUQAAAARgAAAHJoedjqd2ViZgAABVgAAAAGAAAABrO7W5UAAAABAAAAANXulPUAAAAA1r4hgAAAAADXu2Q1eNpjYGRgYOABYjEgZmJgBEIOIGYB8xgAA/YAN3jaY2BktGOcwMDKwMI4jTGNgYHBHUp/ZZBkaGFgYGJgZWbACgLSXFMYHFT/fLjFeOD/AQY9xjMMbkBhRpAcAN48DQYAeNpjYGBgZoBgGQZGBhDwAfIYwXwWBgMgzQGETAwMqn8+8H649f8/lHX9//9b7Pzf+fWgusCAkY0BzmUE6gHpQwGMDMMeAACbxg7SAAARAUQAAAAB//8AAnjadZBPSsNAGMXfS+yMqYgOhpSuSlKadmUhiVEhEMQzFF22m17BbbvzCh5BXCUn6EG8gjeQ4DepwYo4i+/ffL95j4EDA+CFC7jQuKyIeVHrI3wkleq9F7XrSInKteOeHdda8bOoaeepSc00NWPz/LRec9G8GabyGtEdF7h19z033GAMTK7zbM42xNEZpzYof0RtQ5CUHAQJ73OtVyutc+3b7Ou//b8XNlsPx3jgjUifABdhEohKJJL5iM5p39uqc7X1+sRQSqmGrUVhlsJ4lpmEUVwyT8SUYtg0P9DyNzPADDs+tjrGV6KRCRfsui3eHcL4/p8ZXvfMlcnEU+CLv7hDykOP+AKTPTxbAAB42mNgZGBgAGKuf5KP4vltvjLIMzGAwLV9ig0g+vruFFMQzdjACOJzMIClARh0CTJ42mNgZGBgPPD/AJD8wgAEjA0MjAyogAMAbOQEAQAAAAC7ABEAAAAAAKoAAAH0AAABgAAAAUAACAFAAAgAwAAXAAAAAAAAACoAKgAqADIAbACGAKAAugDSeNpjYGRgYOBkUGFgYgABEMkFhAwM/xn0QAIADdUBdAB42qWQvUoDQRSFv3GjaISUQaymSmGxJoGAsRC0iPYLsU50Y6IxrvlRtPCJJKUPIBb+PIHv4EN4djKuKAqCDHfmu+feOdwZoMCUAJNbAlYUMzaUlM14jjxbngOq7HnOia89z1Pk1vMCa9x7ztPkzfMyJbPj+ZGi6Xp+omxuPD+zaD7meaFg7mb8GrBqHmhwxoAxlm0uiRkpP9X5m26pKRoMxTGR1D49Dv/Yb/91o6l8qL6eu5n2hZQzn68utR9m3FU2cB4t9cdSLG2utI+44Eh/P9bqKO+oJ/WxmXssj77YkrjasZQD6SFddythk3Wtzrf+UF2p076Udla1VNzsERP3kkjVRKel7mp1udXYcHtZSlV7RfmJe1GiFWveluaeKD5/MuJcSk8Tpm/vvwPIbmJleNpjYGKAAFYG7ICTgYGRiZGZkYWRlZGNkZ2Rg5GTLT2nsiDDEEIZsZfmZRqZujmDaDcDAxcI7WIOpS2gtCWUdgQAZkcSmQAAAAFblbO6AAA=)
+    format('woff');
   font-weight: normal;
   font-style: normal;
 }
@@ -33759,22 +34066,22 @@ select.ui.dropdown {
 /* Sub Menu */
 
 .ui.dropdown .menu .item .dropdown.icon:before {
-  content: '\f0da' ;
+  content: '\f0da';
 }
 
 .ui.dropdown .item .left.dropdown.icon:before,
 .ui.dropdown .left.menu .item .dropdown.icon:before {
-  content: "\f0d9" ;
+  content: '\f0d9';
 }
 
 /* Vertical Menu Dropdown */
 
 .ui.vertical.menu .dropdown.item > .dropdown.icon:before {
-  content: "\f0da" ;
+  content: '\f0da';
 }
 
 .ui.dropdown > .clear.icon:before {
-  content: "\f00d";
+  content: '\f00d';
 }
 
 /* Icons for Reference (Subsetted in 2.4.0)
@@ -33807,7 +34114,7 @@ select.ui.dropdown {
   max-width: 100%;
   height: 0px;
   overflow: hidden;
-  background: #DCDDDE;
+  background: #dcddde;
   padding-bottom: 56.25%;
 }
 
@@ -33887,7 +34194,7 @@ select.ui.dropdown {
   z-index: 4;
   -webkit-transform: translateX(-50%) translateY(-50%);
   transform: translateX(-50%) translateY(-50%);
-  color: #FFFFFF;
+  color: #ffffff;
   font-size: 6rem;
   text-shadow: 0px 2px 10px rgba(34, 36, 38, 0.2);
   -webkit-transition: opacity 0.5s ease, color 0.5s ease;
@@ -33910,7 +34217,7 @@ select.ui.dropdown {
 }
 
 .ui.embed .icon:hover:before {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 /*--------------
@@ -33942,15 +34249,15 @@ select.ui.dropdown {
   padding-bottom: 100%;
 }
 
-.ui[class*="4:3"].embed {
+.ui[class*='4:3'].embed {
   padding-bottom: 75%;
 }
 
-.ui[class*="16:9"].embed {
+.ui[class*='16:9'].embed {
   padding-bottom: 56.25%;
 }
 
-.ui[class*="21:9"].embed {
+.ui[class*='21:9'].embed {
   padding-bottom: 42.85714286%;
 }
 /*!
@@ -33972,10 +34279,12 @@ select.ui.dropdown {
   display: none;
   z-index: 1001;
   text-align: left;
-  background: #FFFFFF;
+  background: #ffffff;
   border: none;
-  -webkit-box-shadow: 1px 3px 3px 0px rgba(0, 0, 0, 0.2), 1px 3px 15px 2px rgba(0, 0, 0, 0.2);
-  box-shadow: 1px 3px 3px 0px rgba(0, 0, 0, 0.2), 1px 3px 15px 2px rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: 1px 3px 3px 0px rgba(0, 0, 0, 0.2),
+    1px 3px 15px 2px rgba(0, 0, 0, 0.2);
+  box-shadow: 1px 3px 3px 0px rgba(0, 0, 0, 0.2),
+    1px 3px 15px 2px rgba(0, 0, 0, 0.2);
   -webkit-transform-origin: 50% 25%;
   transform-origin: 50% 25%;
   -webkit-box-flex: 0;
@@ -34016,7 +34325,7 @@ select.ui.dropdown {
   z-index: 1;
   opacity: 0.8;
   font-size: 1.25em;
-  color: #FFFFFF;
+  color: #ffffff;
   width: 2.25rem;
   height: 2.25rem;
   padding: 0.625rem 0rem 0rem 0rem;
@@ -34033,7 +34342,7 @@ select.ui.dropdown {
 .ui.modal > .header {
   display: block;
   font-family: 'Lato', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-  background: #FFFFFF;
+  background: #ffffff;
   margin: 0em;
   padding: 1.25rem 1.5rem;
   -webkit-box-shadow: none;
@@ -34058,7 +34367,7 @@ select.ui.dropdown {
   font-size: 1em;
   line-height: 1.4;
   padding: 1.5rem;
-  background: #FFFFFF;
+  background: #ffffff;
 }
 
 .ui.modal > .image.content {
@@ -34083,17 +34392,17 @@ select.ui.dropdown {
   align-self: top;
 }
 
-.ui.modal > [class*="top aligned"] {
+.ui.modal > [class*='top aligned'] {
   -ms-flex-item-align: top;
   align-self: top;
 }
 
-.ui.modal > [class*="middle aligned"] {
+.ui.modal > [class*='middle aligned'] {
   -ms-flex-item-align: middle;
   align-self: middle;
 }
 
-.ui.modal > [class*="stretched"] {
+.ui.modal > [class*='stretched'] {
   -ms-flex-item-align: stretch;
   align-self: stretch;
 }
@@ -34135,7 +34444,7 @@ select.ui.dropdown {
 ---------------*/
 
 .ui.modal > .actions {
-  background: #F9FAFB;
+  background: #f9fafb;
   padding: 1rem 1rem;
   border-top: 1px solid rgba(34, 36, 38, 0.15);
   text-align: right;
@@ -34282,7 +34591,7 @@ select.ui.dropdown {
   border-radius: 0em;
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.basic.modal > .header,
@@ -34292,7 +34601,7 @@ select.ui.dropdown {
 }
 
 .ui.basic.modal > .header {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.basic.modal > .close {
@@ -34327,7 +34636,7 @@ select.ui.dropdown {
 
 @media only screen and (max-width: 991px) {
   .ui.basic.modal > .close {
-    color: #FFFFFF;
+    color: #ffffff;
   }
 }
 
@@ -34355,24 +34664,24 @@ select.ui.dropdown {
 
 /* Top Aligned Modal */
 
-.modals.dimmer[class*="top aligned"] .modal {
+.modals.dimmer[class*='top aligned'] .modal {
   margin: 5vh auto;
 }
 
 @media only screen and (max-width: 767px) {
-  .modals.dimmer[class*="top aligned"] .modal {
+  .modals.dimmer[class*='top aligned'] .modal {
     margin: 1rem auto;
   }
 }
 
 /* Legacy Top Aligned */
 
-.legacy.modals.dimmer[class*="top aligned"] {
+.legacy.modals.dimmer[class*='top aligned'] {
   padding-top: 5vh;
 }
 
 @media only screen and (max-width: 767px) {
-  .legacy.modals.dimmer[class*="top aligned"] {
+  .legacy.modals.dimmer[class*='top aligned'] {
     padding-top: 1rem;
   }
 }
@@ -34677,7 +34986,7 @@ a.ui.nag {
 .ui.nag > .title {
   display: inline-block;
   margin: 0em 0.5em;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.nag > .close.icon {
@@ -34688,7 +34997,7 @@ a.ui.nag {
   right: 1em;
   font-size: 1em;
   margin: -0.5em 0em 0em;
-  color: #FFFFFF;
+  color: #ffffff;
   -webkit-transition: opacity 0.2s ease;
   transition: opacity 0.2s ease;
 }
@@ -34746,7 +35055,7 @@ a.ui.nag {
 
 .ui.inverted.nags .nag,
 .ui.inverted.nag {
-  background-color: #F3F4F5;
+  background-color: #f3f4f5;
   color: rgba(0, 0, 0, 0.85);
 }
 
@@ -34804,17 +35113,19 @@ a.ui.nag {
   min-width: -moz-min-content;
   min-width: min-content;
   z-index: 1900;
-  border: 1px solid #D4D4D5;
+  border: 1px solid #d4d4d5;
   line-height: 1.4285em;
   max-width: 250px;
-  background: #FFFFFF;
+  background: #ffffff;
   padding: 0.833em 1em;
   font-weight: normal;
   font-style: normal;
   color: rgba(0, 0, 0, 0.87);
   border-radius: 0.28571429rem;
-  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
 }
 
 .ui.popup > .header {
@@ -34834,7 +35145,7 @@ a.ui.nag {
   content: '';
   width: 0.71428571em;
   height: 0.71428571em;
-  background: #FFFFFF;
+  background: #ffffff;
   -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
   z-index: 2;
@@ -34865,7 +35176,7 @@ a.ui.nag {
   font-size: 1rem;
   width: 0.71428571em;
   height: 0.71428571em;
-  background: #FFFFFF;
+  background: #ffffff;
   -webkit-transform: rotate(45deg);
   transform: rotate(45deg);
   z-index: 2;
@@ -34883,17 +35194,19 @@ a.ui.nag {
   text-align: left;
   white-space: nowrap;
   font-size: 1rem;
-  border: 1px solid #D4D4D5;
+  border: 1px solid #d4d4d5;
   line-height: 1.4285em;
   max-width: none;
-  background: #FFFFFF;
+  background: #ffffff;
   padding: 0.833em 1em;
   font-weight: normal;
   font-style: normal;
   color: rgba(0, 0, 0, 0.87);
   border-radius: 0.28571429rem;
-  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
   z-index: 1;
 }
 
@@ -34904,7 +35217,7 @@ a.ui.nag {
   right: auto;
   bottom: 100%;
   left: 50%;
-  background: #FFFFFF;
+  background: #ffffff;
   margin-left: -0.07142857rem;
   margin-bottom: 0.14285714rem;
 }
@@ -34958,42 +35271,42 @@ a.ui.nag {
 /* Animation Position */
 
 [data-tooltip]:after,
-[data-tooltip][data-position="top center"]:after,
-[data-tooltip][data-position="bottom center"]:after {
+[data-tooltip][data-position='top center']:after,
+[data-tooltip][data-position='bottom center']:after {
   -webkit-transform: translateX(-50%) scale(0) !important;
   transform: translateX(-50%) scale(0) !important;
 }
 
 [data-tooltip]:hover:after,
-[data-tooltip][data-position="bottom center"]:hover:after {
+[data-tooltip][data-position='bottom center']:hover:after {
   -webkit-transform: translateX(-50%) scale(1) !important;
   transform: translateX(-50%) scale(1) !important;
 }
 
-[data-tooltip][data-position="left center"]:after,
-[data-tooltip][data-position="right center"]:after {
+[data-tooltip][data-position='left center']:after,
+[data-tooltip][data-position='right center']:after {
   -webkit-transform: translateY(-50%) scale(0) !important;
   transform: translateY(-50%) scale(0) !important;
 }
 
-[data-tooltip][data-position="left center"]:hover:after,
-[data-tooltip][data-position="right center"]:hover:after {
+[data-tooltip][data-position='left center']:hover:after,
+[data-tooltip][data-position='right center']:hover:after {
   -webkit-transform: translateY(-50%) scale(1) !important;
   transform: translateY(-50%) scale(1) !important;
 }
 
-[data-tooltip][data-position="top left"]:after,
-[data-tooltip][data-position="top right"]:after,
-[data-tooltip][data-position="bottom left"]:after,
-[data-tooltip][data-position="bottom right"]:after {
+[data-tooltip][data-position='top left']:after,
+[data-tooltip][data-position='top right']:after,
+[data-tooltip][data-position='bottom left']:after,
+[data-tooltip][data-position='bottom right']:after {
   -webkit-transform: scale(0) !important;
   transform: scale(0) !important;
 }
 
-[data-tooltip][data-position="top left"]:hover:after,
-[data-tooltip][data-position="top right"]:hover:after,
-[data-tooltip][data-position="bottom left"]:hover:after,
-[data-tooltip][data-position="bottom right"]:hover:after {
+[data-tooltip][data-position='top left']:hover:after,
+[data-tooltip][data-position='top right']:hover:after,
+[data-tooltip][data-position='bottom left']:hover:after,
+[data-tooltip][data-position='bottom right']:hover:after {
   -webkit-transform: scale(1) !important;
   transform: scale(1) !important;
 }
@@ -35012,14 +35325,14 @@ a.ui.nag {
 /* Arrow Position */
 
 [data-tooltip][data-inverted]:before {
-  background: #1B1C1D;
+  background: #1b1c1d;
 }
 
 /* Popup  */
 
 [data-tooltip][data-inverted]:after {
-  background: #1B1C1D;
-  color: #FFFFFF;
+  background: #1b1c1d;
+  color: #ffffff;
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -35027,7 +35340,7 @@ a.ui.nag {
 
 [data-tooltip][data-inverted]:after .header {
   background-color: none;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 /*--------------
@@ -35036,7 +35349,7 @@ a.ui.nag {
 
 /* Top Center */
 
-[data-position="top center"][data-tooltip]:after {
+[data-position='top center'][data-tooltip]:after {
   top: auto;
   right: auto;
   left: 50%;
@@ -35046,19 +35359,19 @@ a.ui.nag {
   margin-bottom: 0.5em;
 }
 
-[data-position="top center"][data-tooltip]:before {
+[data-position='top center'][data-tooltip]:before {
   top: auto;
   right: auto;
   bottom: 100%;
   left: 50%;
-  background: #FFFFFF;
+  background: #ffffff;
   margin-left: -0.07142857rem;
   margin-bottom: 0.14285714rem;
 }
 
 /* Top Left */
 
-[data-position="top left"][data-tooltip]:after {
+[data-position='top left'][data-tooltip]:after {
   top: auto;
   right: auto;
   left: 0;
@@ -35066,7 +35379,7 @@ a.ui.nag {
   margin-bottom: 0.5em;
 }
 
-[data-position="top left"][data-tooltip]:before {
+[data-position='top left'][data-tooltip]:before {
   top: auto;
   right: auto;
   bottom: 100%;
@@ -35077,7 +35390,7 @@ a.ui.nag {
 
 /* Top Right */
 
-[data-position="top right"][data-tooltip]:after {
+[data-position='top right'][data-tooltip]:after {
   top: auto;
   left: auto;
   right: 0;
@@ -35085,7 +35398,7 @@ a.ui.nag {
   margin-bottom: 0.5em;
 }
 
-[data-position="top right"][data-tooltip]:before {
+[data-position='top right'][data-tooltip]:before {
   top: auto;
   left: auto;
   bottom: 100%;
@@ -35096,7 +35409,7 @@ a.ui.nag {
 
 /* Bottom Center */
 
-[data-position="bottom center"][data-tooltip]:after {
+[data-position='bottom center'][data-tooltip]:after {
   bottom: auto;
   right: auto;
   left: 50%;
@@ -35106,7 +35419,7 @@ a.ui.nag {
   margin-top: 0.5em;
 }
 
-[data-position="bottom center"][data-tooltip]:before {
+[data-position='bottom center'][data-tooltip]:before {
   bottom: auto;
   right: auto;
   top: 100%;
@@ -35117,13 +35430,13 @@ a.ui.nag {
 
 /* Bottom Left */
 
-[data-position="bottom left"][data-tooltip]:after {
+[data-position='bottom left'][data-tooltip]:after {
   left: 0;
   top: 100%;
   margin-top: 0.5em;
 }
 
-[data-position="bottom left"][data-tooltip]:before {
+[data-position='bottom left'][data-tooltip]:before {
   bottom: auto;
   right: auto;
   top: 100%;
@@ -35134,13 +35447,13 @@ a.ui.nag {
 
 /* Bottom Right */
 
-[data-position="bottom right"][data-tooltip]:after {
+[data-position='bottom right'][data-tooltip]:after {
   right: 0;
   top: 100%;
   margin-top: 0.5em;
 }
 
-[data-position="bottom right"][data-tooltip]:before {
+[data-position='bottom right'][data-tooltip]:before {
   bottom: auto;
   left: auto;
   top: 100%;
@@ -35151,7 +35464,7 @@ a.ui.nag {
 
 /* Left Center */
 
-[data-position="left center"][data-tooltip]:after {
+[data-position='left center'][data-tooltip]:after {
   right: 100%;
   top: 50%;
   margin-right: 0.5em;
@@ -35159,7 +35472,7 @@ a.ui.nag {
   transform: translateY(-50%);
 }
 
-[data-position="left center"][data-tooltip]:before {
+[data-position='left center'][data-tooltip]:before {
   right: 100%;
   top: 50%;
   margin-top: -0.14285714rem;
@@ -35168,7 +35481,7 @@ a.ui.nag {
 
 /* Right Center */
 
-[data-position="right center"][data-tooltip]:after {
+[data-position='right center'][data-tooltip]:after {
   left: 100%;
   top: 50%;
   margin-left: 0.5em;
@@ -35176,7 +35489,7 @@ a.ui.nag {
   transform: translateY(-50%);
 }
 
-[data-position="right center"][data-tooltip]:before {
+[data-position='right center'][data-tooltip]:before {
   left: 100%;
   top: 50%;
   margin-top: -0.07142857rem;
@@ -35185,78 +35498,78 @@ a.ui.nag {
 
 /* Arrow */
 
-[data-position~="bottom"][data-tooltip]:before {
-  background: #FFFFFF;
+[data-position~='bottom'][data-tooltip]:before {
+  background: #ffffff;
   -webkit-box-shadow: -1px -1px 0px 0px #bababc;
   box-shadow: -1px -1px 0px 0px #bababc;
 }
 
-[data-position="left center"][data-tooltip]:before {
-  background: #FFFFFF;
+[data-position='left center'][data-tooltip]:before {
+  background: #ffffff;
   -webkit-box-shadow: 1px -1px 0px 0px #bababc;
   box-shadow: 1px -1px 0px 0px #bababc;
 }
 
-[data-position="right center"][data-tooltip]:before {
-  background: #FFFFFF;
+[data-position='right center'][data-tooltip]:before {
+  background: #ffffff;
   -webkit-box-shadow: -1px 1px 0px 0px #bababc;
   box-shadow: -1px 1px 0px 0px #bababc;
 }
 
-[data-position~="top"][data-tooltip]:before {
-  background: #FFFFFF;
+[data-position~='top'][data-tooltip]:before {
+  background: #ffffff;
 }
 
 /* Inverted Arrow Color */
 
-[data-inverted][data-position~="bottom"][data-tooltip]:before {
-  background: #1B1C1D;
+[data-inverted][data-position~='bottom'][data-tooltip]:before {
+  background: #1b1c1d;
   -webkit-box-shadow: -1px -1px 0px 0px #bababc;
   box-shadow: -1px -1px 0px 0px #bababc;
 }
 
-[data-inverted][data-position="left center"][data-tooltip]:before {
-  background: #1B1C1D;
+[data-inverted][data-position='left center'][data-tooltip]:before {
+  background: #1b1c1d;
   -webkit-box-shadow: 1px -1px 0px 0px #bababc;
   box-shadow: 1px -1px 0px 0px #bababc;
 }
 
-[data-inverted][data-position="right center"][data-tooltip]:before {
-  background: #1B1C1D;
+[data-inverted][data-position='right center'][data-tooltip]:before {
+  background: #1b1c1d;
   -webkit-box-shadow: -1px 1px 0px 0px #bababc;
   box-shadow: -1px 1px 0px 0px #bababc;
 }
 
-[data-inverted][data-position~="top"][data-tooltip]:before {
-  background: #1B1C1D;
+[data-inverted][data-position~='top'][data-tooltip]:before {
+  background: #1b1c1d;
 }
 
-[data-position~="bottom"][data-tooltip]:before {
+[data-position~='bottom'][data-tooltip]:before {
   -webkit-transform-origin: center bottom;
   transform-origin: center bottom;
 }
 
-[data-position~="bottom"][data-tooltip]:after {
+[data-position~='bottom'][data-tooltip]:after {
   -webkit-transform-origin: center top;
   transform-origin: center top;
 }
 
-[data-position="left center"][data-tooltip]:before {
+[data-position='left center'][data-tooltip]:before {
   -webkit-transform-origin: top center;
   transform-origin: top center;
 }
 
-[data-position="left center"][data-tooltip]:after {
+[data-position='left center'][data-tooltip]:after {
   -webkit-transform-origin: right center;
   transform-origin: right center;
 }
 
-[data-position="right center"][data-tooltip]:before {
+[data-position='right center'][data-tooltip]:before {
   -webkit-transform-origin: right center;
   transform-origin: right center;
 }
 
-[data-position="right center"][data-tooltip]:after {
+[data-position='right center'][data-tooltip]:after {
   -webkit-transform-origin: left center;
   transform-origin: left center;
 }
@@ -35442,31 +35755,31 @@ a.ui.nag {
 /* Arrow Color By Location */
 
 .ui.bottom.popup:before {
-  background: #FFFFFF;
+  background: #ffffff;
 }
 
 .ui.right.center.popup:before,
 .ui.left.center.popup:before {
-  background: #FFFFFF;
+  background: #ffffff;
 }
 
 .ui.top.popup:before {
-  background: #FFFFFF;
+  background: #ffffff;
 }
 
 /* Inverted Arrow Color */
 
 .ui.inverted.bottom.popup:before {
-  background: #1B1C1D;
+  background: #1b1c1d;
 }
 
 .ui.inverted.right.center.popup:before,
 .ui.inverted.left.center.popup:before {
-  background: #1B1C1D;
+  background: #1b1c1d;
 }
 
 .ui.inverted.top.popup:before {
-  background: #1B1C1D;
+  background: #1b1c1d;
 }
 
 /*******************************
@@ -35522,13 +35835,13 @@ a.ui.nag {
   max-width: 350px;
 }
 
-.ui[class*="very wide"].popup {
+.ui[class*='very wide'].popup {
   max-width: 550px;
 }
 
 @media only screen and (max-width: 767px) {
   .ui.wide.popup,
-  .ui[class*="very wide"].popup {
+  .ui[class*='very wide'].popup {
     max-width: 250px;
   }
 }
@@ -35549,8 +35862,8 @@ a.ui.nag {
 /* Inverted colors  */
 
 .ui.inverted.popup {
-  background: #1B1C1D;
-  color: #FFFFFF;
+  background: #1b1c1d;
+  color: #ffffff;
   border: none;
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -35558,11 +35871,11 @@ a.ui.nag {
 
 .ui.inverted.popup .header {
   background-color: none;
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.popup:before {
-  background-color: #1B1C1D;
+  background-color: #1b1c1d;
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
 }
@@ -35706,94 +36019,94 @@ a.ui.nag {
 
 /* Indicating */
 
-.ui.indicating.progress[data-percent^="1"] .bar,
-.ui.indicating.progress[data-percent^="2"] .bar {
-  background-color: #D95C5C;
+.ui.indicating.progress[data-percent^='1'] .bar,
+.ui.indicating.progress[data-percent^='2'] .bar {
+  background-color: #d95c5c;
 }
 
-.ui.indicating.progress[data-percent^="3"] .bar {
-  background-color: #EFBC72;
+.ui.indicating.progress[data-percent^='3'] .bar {
+  background-color: #efbc72;
 }
 
-.ui.indicating.progress[data-percent^="4"] .bar,
-.ui.indicating.progress[data-percent^="5"] .bar {
-  background-color: #E6BB48;
+.ui.indicating.progress[data-percent^='4'] .bar,
+.ui.indicating.progress[data-percent^='5'] .bar {
+  background-color: #e6bb48;
 }
 
-.ui.indicating.progress[data-percent^="6"] .bar {
-  background-color: #DDC928;
+.ui.indicating.progress[data-percent^='6'] .bar {
+  background-color: #ddc928;
 }
 
-.ui.indicating.progress[data-percent^="7"] .bar,
-.ui.indicating.progress[data-percent^="8"] .bar {
-  background-color: #B4D95C;
+.ui.indicating.progress[data-percent^='7'] .bar,
+.ui.indicating.progress[data-percent^='8'] .bar {
+  background-color: #b4d95c;
 }
 
-.ui.indicating.progress[data-percent^="9"] .bar,
-.ui.indicating.progress[data-percent^="100"] .bar {
-  background-color: #66DA81;
+.ui.indicating.progress[data-percent^='9'] .bar,
+.ui.indicating.progress[data-percent^='100'] .bar {
+  background-color: #66da81;
 }
 
 /* Indicating Label */
 
-.ui.indicating.progress[data-percent^="1"] .label,
-.ui.indicating.progress[data-percent^="2"] .label {
+.ui.indicating.progress[data-percent^='1'] .label,
+.ui.indicating.progress[data-percent^='2'] .label {
   color: rgba(0, 0, 0, 0.87);
 }
 
-.ui.indicating.progress[data-percent^="3"] .label {
+.ui.indicating.progress[data-percent^='3'] .label {
   color: rgba(0, 0, 0, 0.87);
 }
 
-.ui.indicating.progress[data-percent^="4"] .label,
-.ui.indicating.progress[data-percent^="5"] .label {
+.ui.indicating.progress[data-percent^='4'] .label,
+.ui.indicating.progress[data-percent^='5'] .label {
   color: rgba(0, 0, 0, 0.87);
 }
 
-.ui.indicating.progress[data-percent^="6"] .label {
+.ui.indicating.progress[data-percent^='6'] .label {
   color: rgba(0, 0, 0, 0.87);
 }
 
-.ui.indicating.progress[data-percent^="7"] .label,
-.ui.indicating.progress[data-percent^="8"] .label {
+.ui.indicating.progress[data-percent^='7'] .label,
+.ui.indicating.progress[data-percent^='8'] .label {
   color: rgba(0, 0, 0, 0.87);
 }
 
-.ui.indicating.progress[data-percent^="9"] .label,
-.ui.indicating.progress[data-percent^="100"] .label {
+.ui.indicating.progress[data-percent^='9'] .label,
+.ui.indicating.progress[data-percent^='100'] .label {
   color: rgba(0, 0, 0, 0.87);
 }
 
 /* Single Digits */
 
-.ui.indicating.progress[data-percent="1"] .bar,
-.ui.indicating.progress[data-percent="2"] .bar,
-.ui.indicating.progress[data-percent="3"] .bar,
-.ui.indicating.progress[data-percent="4"] .bar,
-.ui.indicating.progress[data-percent="5"] .bar,
-.ui.indicating.progress[data-percent="6"] .bar,
-.ui.indicating.progress[data-percent="7"] .bar,
-.ui.indicating.progress[data-percent="8"] .bar,
-.ui.indicating.progress[data-percent="9"] .bar {
-  background-color: #D95C5C;
+.ui.indicating.progress[data-percent='1'] .bar,
+.ui.indicating.progress[data-percent='2'] .bar,
+.ui.indicating.progress[data-percent='3'] .bar,
+.ui.indicating.progress[data-percent='4'] .bar,
+.ui.indicating.progress[data-percent='5'] .bar,
+.ui.indicating.progress[data-percent='6'] .bar,
+.ui.indicating.progress[data-percent='7'] .bar,
+.ui.indicating.progress[data-percent='8'] .bar,
+.ui.indicating.progress[data-percent='9'] .bar {
+  background-color: #d95c5c;
 }
 
-.ui.indicating.progress[data-percent="1"] .label,
-.ui.indicating.progress[data-percent="2"] .label,
-.ui.indicating.progress[data-percent="3"] .label,
-.ui.indicating.progress[data-percent="4"] .label,
-.ui.indicating.progress[data-percent="5"] .label,
-.ui.indicating.progress[data-percent="6"] .label,
-.ui.indicating.progress[data-percent="7"] .label,
-.ui.indicating.progress[data-percent="8"] .label,
-.ui.indicating.progress[data-percent="9"] .label {
+.ui.indicating.progress[data-percent='1'] .label,
+.ui.indicating.progress[data-percent='2'] .label,
+.ui.indicating.progress[data-percent='3'] .label,
+.ui.indicating.progress[data-percent='4'] .label,
+.ui.indicating.progress[data-percent='5'] .label,
+.ui.indicating.progress[data-percent='6'] .label,
+.ui.indicating.progress[data-percent='7'] .label,
+.ui.indicating.progress[data-percent='8'] .label,
+.ui.indicating.progress[data-percent='9'] .label {
   color: rgba(0, 0, 0, 0.87);
 }
 
 /* Indicating Success */
 
 .ui.indicating.progress.success .label {
-  color: #1A531B;
+  color: #1a531b;
 }
 
 /*******************************
@@ -35805,7 +36118,7 @@ a.ui.nag {
 ---------------*/
 
 .ui.progress.success .bar {
-  background-color: #21BA45 !important;
+  background-color: #21ba45 !important;
 }
 
 .ui.progress.success .bar,
@@ -35815,7 +36128,7 @@ a.ui.nag {
 }
 
 .ui.progress.success > .label {
-  color: #1A531B;
+  color: #1a531b;
 }
 
 /*--------------
@@ -35823,7 +36136,7 @@ a.ui.nag {
 ---------------*/
 
 .ui.progress.warning .bar {
-  background-color: #F2C037 !important;
+  background-color: #f2c037 !important;
 }
 
 .ui.progress.warning .bar,
@@ -35833,7 +36146,7 @@ a.ui.nag {
 }
 
 .ui.progress.warning > .label {
-  color: #794B02;
+  color: #794b02;
 }
 
 /*--------------
@@ -35841,7 +36154,7 @@ a.ui.nag {
 ---------------*/
 
 .ui.progress.error .bar {
-  background-color: #DB2828 !important;
+  background-color: #db2828 !important;
 }
 
 .ui.progress.error .bar,
@@ -35851,7 +36164,7 @@ a.ui.nag {
 }
 
 .ui.progress.error > .label {
-  color: #912D2B;
+  color: #912d2b;
 }
 
 /*--------------
@@ -35871,7 +36184,7 @@ a.ui.nag {
   left: 0px;
   right: 0px;
   bottom: 0px;
-  background: #FFFFFF;
+  background: #ffffff;
   border-radius: 0.28571429rem;
   -webkit-animation: progress-active 2s ease infinite;
   animation: progress-active 2s ease infinite;
@@ -35933,23 +36246,23 @@ a.ui.nag {
 }
 
 .ui.inverted.progress .bar > .progress {
-  color: #F9FAFB;
+  color: #f9fafb;
 }
 
 .ui.inverted.progress > .label {
-  color: #FFFFFF;
+  color: #ffffff;
 }
 
 .ui.inverted.progress.success > .label {
-  color: #21BA45;
+  color: #21ba45;
 }
 
 .ui.inverted.progress.warning > .label {
-  color: #F2C037;
+  color: #f2c037;
 }
 
 .ui.inverted.progress.error > .label {
-  color: #DB2828;
+  color: #db2828;
 }
 
 /*--------------
@@ -36014,111 +36327,111 @@ a.ui.nag {
 /* Red */
 
 .ui.red.progress .bar {
-  background-color: #DB2828;
+  background-color: #db2828;
 }
 
 .ui.red.inverted.progress .bar {
-  background-color: #FF695E;
+  background-color: #ff695e;
 }
 
 /* Orange */
 
 .ui.orange.progress .bar {
-  background-color: #F2711C;
+  background-color: #f2711c;
 }
 
 .ui.orange.inverted.progress .bar {
-  background-color: #FF851B;
+  background-color: #ff851b;
 }
 
 /* Yellow */
 
 .ui.yellow.progress .bar {
-  background-color: #FBBD08;
+  background-color: #fbbd08;
 }
 
 .ui.yellow.inverted.progress .bar {
-  background-color: #FFE21F;
+  background-color: #ffe21f;
 }
 
 /* Olive */
 
 .ui.olive.progress .bar {
-  background-color: #B5CC18;
+  background-color: #b5cc18;
 }
 
 .ui.olive.inverted.progress .bar {
-  background-color: #D9E778;
+  background-color: #d9e778;
 }
 
 /* Green */
 
 .ui.green.progress .bar {
-  background-color: #21BA45;
+  background-color: #21ba45;
 }
 
 .ui.green.inverted.progress .bar {
-  background-color: #2ECC40;
+  background-color: #2ecc40;
 }
 
 /* Teal */
 
 .ui.teal.progress .bar {
-  background-color: #00B5AD;
+  background-color: #00b5ad;
 }
 
 .ui.teal.inverted.progress .bar {
-  background-color: #6DFFFF;
+  background-color: #6dffff;
 }
 
 /* Blue */
 
 .ui.blue.progress .bar {
-  background-color: #2185D0;
+  background-color: #2185d0;
 }
 
 .ui.blue.inverted.progress .bar {
-  background-color: #54C8FF;
+  background-color: #54c8ff;
 }
 
 /* Violet */
 
 .ui.violet.progress .bar {
-  background-color: #6435C9;
+  background-color: #6435c9;
 }
 
 .ui.violet.inverted.progress .bar {
-  background-color: #A291FB;
+  background-color: #a291fb;
 }
 
 /* Purple */
 
 .ui.purple.progress .bar {
-  background-color: #A333C8;
+  background-color: #a333c8;
 }
 
 .ui.purple.inverted.progress .bar {
-  background-color: #DC73FF;
+  background-color: #dc73ff;
 }
 
 /* Pink */
 
 .ui.pink.progress .bar {
-  background-color: #E03997;
+  background-color: #e03997;
 }
 
 .ui.pink.inverted.progress .bar {
-  background-color: #FF8EDF;
+  background-color: #ff8edf;
 }
 
 /* Brown */
 
 .ui.brown.progress .bar {
-  background-color: #A5673F;
+  background-color: #a5673f;
 }
 
 .ui.brown.inverted.progress .bar {
-  background-color: #D67C1C;
+  background-color: #d67c1c;
 }
 
 /* Grey */
@@ -36128,13 +36441,13 @@ a.ui.nag {
 }
 
 .ui.grey.inverted.progress .bar {
-  background-color: #DCDDDE;
+  background-color: #dcddde;
 }
 
 /* Black */
 
 .ui.black.progress .bar {
-  background-color: #1B1C1D;
+  background-color: #1b1c1d;
 }
 
 .ui.black.inverted.progress .bar {
@@ -36232,8 +36545,10 @@ a.ui.nag {
   cursor: pointer;
   width: 1.25em;
   height: auto;
-  -webkit-transition: opacity 0.1s ease, background 0.1s ease, text-shadow 0.1s ease, color 0.1s ease;
-  transition: opacity 0.1s ease, background 0.1s ease, text-shadow 0.1s ease, color 0.1s ease;
+  -webkit-transition: opacity 0.1s ease, background 0.1s ease,
+    text-shadow 0.1s ease, color 0.1s ease;
+  transition: opacity 0.1s ease, background 0.1s ease, text-shadow 0.1s ease,
+    color 0.1s ease;
 }
 
 /*******************************
@@ -36284,8 +36599,9 @@ a.ui.nag {
 
 .ui.star.rating .active.icon {
   background: transparent !important;
-  color: #FFE623 !important;
-  text-shadow: 0px -1px 0px #DDC507, -1px 0px 0px #DDC507, 0px 1px 0px #DDC507, 1px 0px 0px #DDC507 !important;
+  color: #ffe623 !important;
+  text-shadow: 0px -1px 0px #ddc507, -1px 0px 0px #ddc507, 0px 1px 0px #ddc507,
+    1px 0px 0px #ddc507 !important;
 }
 
 /* Selected Star */
@@ -36293,8 +36609,9 @@ a.ui.nag {
 .ui.star.rating .icon.selected,
 .ui.star.rating .icon.selected.active {
   background: transparent !important;
-  color: #FFCC00 !important;
-  text-shadow: 0px -1px 0px #E6A200, -1px 0px 0px #E6A200, 0px 1px 0px #E6A200, 1px 0px 0px #E6A200 !important;
+  color: #ffcc00 !important;
+  text-shadow: 0px -1px 0px #e6a200, -1px 0px 0px #e6a200, 0px 1px 0px #e6a200,
+    1px 0px 0px #e6a200 !important;
 }
 
 /*-------------------
@@ -36313,8 +36630,9 @@ a.ui.nag {
 
 .ui.heart.rating .active.icon {
   background: transparent !important;
-  color: #FF6D75 !important;
-  text-shadow: 0px -1px 0px #CD0707, -1px 0px 0px #CD0707, 0px 1px 0px #CD0707, 1px 0px 0px #CD0707 !important;
+  color: #ff6d75 !important;
+  text-shadow: 0px -1px 0px #cd0707, -1px 0px 0px #cd0707, 0px 1px 0px #cd0707,
+    1px 0px 0px #cd0707 !important;
 }
 
 /* Selected Heart */
@@ -36322,8 +36640,9 @@ a.ui.nag {
 .ui.heart.rating .icon.selected,
 .ui.heart.rating .icon.selected.active {
   background: transparent !important;
-  color: #FF3000 !important;
-  text-shadow: 0px -1px 0px #AA0101, -1px 0px 0px #AA0101, 0px 1px 0px #AA0101, 1px 0px 0px #AA0101 !important;
+  color: #ff3000 !important;
+  text-shadow: 0px -1px 0px #aa0101, -1px 0px 0px #aa0101, 0px 1px 0px #aa0101,
+    1px 0px 0px #aa0101 !important;
 }
 
 /*******************************
@@ -36393,7 +36712,10 @@ a.ui.nag {
 
 @font-face {
   font-family: 'Rating';
-  src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMggjCBsAAAC8AAAAYGNtYXCj2pm8AAABHAAAAKRnYXNwAAAAEAAAAcAAAAAIZ2x5ZlJbXMYAAAHIAAARnGhlYWQBGAe5AAATZAAAADZoaGVhA+IB/QAAE5wAAAAkaG10eCzgAEMAABPAAAAAcGxvY2EwXCxOAAAUMAAAADptYXhwACIAnAAAFGwAAAAgbmFtZfC1n04AABSMAAABPHBvc3QAAwAAAAAVyAAAACAAAwIAAZAABQAAAUwBZgAAAEcBTAFmAAAA9QAZAIQAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADxZQHg/+D/4AHgACAAAAABAAAAAAAAAAAAAAAgAAAAAAACAAAAAwAAABQAAwABAAAAFAAEAJAAAAAgACAABAAAAAEAIOYF8AbwDfAj8C7wbvBw8Irwl/Cc8SPxZf/9//8AAAAAACDmAPAE8AzwI/Au8G7wcPCH8JfwnPEj8WT//f//AAH/4xoEEAYQAQ/sD+IPow+iD4wPgA98DvYOtgADAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAH//wAPAAEAAAAAAAAAAAACAAA3OQEAAAAAAQAAAAAAAAAAAAIAADc5AQAAAAABAAAAAAAAAAAAAgAANzkBAAAAAAIAAP/tAgAB0wAKABUAAAEvAQ8BFwc3Fyc3BQc3Jz8BHwEHFycCALFPT7GAHp6eHoD/AHAWW304OH1bFnABGRqgoBp8sFNTsHyyOnxYEnFxElh8OgAAAAACAAD/7QIAAdMACgASAAABLwEPARcHNxcnNwUxER8BBxcnAgCxT0+xgB6enh6A/wA4fVsWcAEZGqCgGnywU1OwfLIBHXESWHw6AAAAAQAA/+0CAAHTAAoAAAEvAQ8BFwc3Fyc3AgCxT0+xgB6enh6AARkaoKAafLBTU7B8AAAAAAEAAAAAAgABwAArAAABFA4CBzEHDgMjIi4CLwEuAzU0PgIzMh4CFz4DMzIeAhUCAAcMEgugBgwMDAYGDAwMBqALEgwHFyg2HhAfGxkKChkbHxAeNigXAS0QHxsZCqAGCwkGBQkLBqAKGRsfEB42KBcHDBILCxIMBxcoNh4AAAAAAgAAAAACAAHAACsAWAAAATQuAiMiDgIHLgMjIg4CFRQeAhcxFx4DMzI+Aj8BPgM1DwEiFCIGMTAmIjQjJy4DNTQ+AjMyHgIfATc+AzMyHgIVFA4CBwIAFyg2HhAfGxkKChkbHxAeNigXBwwSC6AGDAwMBgYMDAwGoAsSDAdbogEBAQEBAaIGCgcEDRceEQkREA4GLy8GDhARCREeFw0EBwoGAS0eNigXBwwSCwsSDAcXKDYeEB8bGQqgBgsJBgUJCwagChkbHxA+ogEBAQGiBg4QEQkRHhcNBAcKBjQ0BgoHBA0XHhEJERAOBgABAAAAAAIAAcAAMQAAARQOAgcxBw4DIyIuAi8BLgM1ND4CMzIeAhcHFwc3Jzc+AzMyHgIVAgAHDBILoAYMDAwGBgwMDAagCxIMBxcoNh4KFRMSCC9wQLBwJwUJCgkFHjYoFwEtEB8bGQqgBgsJBgUJCwagChkbHxAeNigXAwUIBUtAoMBAOwECAQEXKDYeAAABAAAAAAIAAbcAKgAAEzQ3NjMyFxYXFhcWFzY3Njc2NzYzMhcWFRQPAQYjIi8BJicmJyYnJicmNQAkJUARExIQEAsMCgoMCxAQEhMRQCUkQbIGBwcGsgMFBQsKCQkGBwExPyMkBgYLCgkKCgoKCQoLBgYkIz8/QawFBawCBgUNDg4OFRQTAAAAAQAAAA0B2wHSACYAABM0PwI2FzYfAhYVFA8BFxQVFAcGByYvAQcGByYnJjU0PwEnJjUAEI9BBQkIBkCPEAdoGQMDBgUGgIEGBQYDAwEYaAcBIwsCFoEMAQEMgRYCCwYIZJABBQUFAwEBAkVFAgEBAwUFAwOQZAkFAAAAAAIAAAANAdsB0gAkAC4AABM0PwI2FzYfAhYVFA8BFxQVFAcmLwEHBgcmJyY1ND8BJyY1HwEHNxcnNy8BBwAQj0EFCQgGQI8QB2gZDAUGgIEGBQYDAwEYaAc/WBVsaxRXeDY2ASMLAhaBDAEBDIEWAgsGCGSQAQUNAQECRUUCAQEDBQUDA5BkCQURVXg4OHhVEW5uAAABACMAKQHdAXwAGgAANzQ/ATYXNh8BNzYXNh8BFhUUDwEGByYvASY1IwgmCAwLCFS8CAsMCCYICPUIDAsIjgjSCwkmCQEBCVS7CQEBCSYJCg0H9gcBAQePBwwAAAEAHwAfAXMBcwAsAAA3ND8BJyY1ND8BNjMyHwE3NjMyHwEWFRQPARcWFRQPAQYjIi8BBwYjIi8BJjUfCFRUCAgnCAwLCFRUCAwLCCcICFRUCAgnCAsMCFRUCAsMCCcIYgsIVFQIDAsIJwgIVFQICCcICwwIVFQICwwIJwgIVFQICCcIDAAAAAACAAAAJQFJAbcAHwArAAA3NTQ3NjsBNTQ3NjMyFxYdATMyFxYdARQHBiMhIicmNTczNTQnJiMiBwYdAQAICAsKJSY1NCYmCQsICAgIC/7tCwgIW5MWFR4fFRZApQsICDc0JiYmJjQ3CAgLpQsICAgIC8A3HhYVFRYeNwAAAQAAAAcBbgG3ACEAADcRNDc2NzYzITIXFhcWFREUBwYHBiMiLwEHBiMiJyYnJjUABgUKBgYBLAYGCgUGBgUKBQcOCn5+Cg4GBgoFBicBcAoICAMDAwMICAr+kAoICAQCCXl5CQIECAgKAAAAAwAAACUCAAFuABgAMQBKAAA3NDc2NzYzMhcWFxYVFAcGBwYjIicmJyY1MxYXFjMyNzY3JicWFRQHBiMiJyY1NDcGBzcUFxYzMjc2NTQ3NjMyNzY1NCcmIyIHBhUABihDREtLREMoBgYoQ0RLS0RDKAYlJjk5Q0M5OSYrQREmJTU1JSYRQSuEBAQGBgQEEREZBgQEBAQGJBkayQoKQSgoKChBCgoKCkEoJycoQQoKOiMjIyM6RCEeIjUmJSUmNSIeIUQlBgQEBAQGGBIRBAQGBgQEGhojAAAABQAAAAkCAAGJACwAOABRAGgAcAAANzQ3Njc2MzIXNzYzMhcWFxYXFhcWFxYVFDEGBwYPAQYjIicmNTQ3JicmJyY1MxYXNyYnJjU0NwYHNxQXFjMyNzY1NDc2MzI3NjU0JyYjIgcGFRc3Njc2NyYnNxYXFhcWFRQHBgcGBwYjPwEWFRQHBgcABitBQU0ZGhADBQEEBAUFBAUEBQEEHjw8Hg4DBQQiBQ0pIyIZBiUvSxYZDg4RQSuEBAQGBgQEEREZBgQEBAQGJBkaVxU9MzQiIDASGxkZEAYGCxQrODk/LlACFxYlyQsJQycnBRwEAgEDAwIDAwIBAwUCNmxsNhkFFAMFBBUTHh8nCQtKISgSHBsfIh4hRCUGBAQEBAYYEhEEBAYGBAQaGiPJJQUiIjYzISASGhkbCgoKChIXMRsbUZANCyghIA8AAAMAAAAAAbcB2wA5AEoAlAAANzU0NzY7ATY3Njc2NzY3Njc2MzIXFhcWFRQHMzIXFhUUBxYVFAcUFRQHFgcGKwEiJyYnJisBIicmNTcUFxYzMjc2NTQnJiMiBwYVFzMyFxYXFhcWFxYXFhcWOwEyNTQnNjc2NTQnNjU0JyYnNjc2NTQnJisBNDc2NTQnJiMGBwYHBgcGBwYHBgcGBwYHBgcGBwYrARUACwoQTgodEQ4GBAMFBgwLDxgTEwoKDjMdFhYOAgoRARkZKCUbGxsjIQZSEAoLJQUFCAcGBQUGBwgFBUkJBAUFBAQHBwMDBwcCPCUjNwIJBQUFDwMDBAkGBgsLDmUODgoJGwgDAwYFDAYQAQUGAwQGBgYFBgUGBgQJSbcPCwsGJhUPCBERExMMCgkJFBQhGxwWFR4ZFQoKFhMGBh0WKBcXBgcMDAoLDxIHBQYGBQcIBQYGBQgSAQEBAQICAQEDAgEULwgIBQoLCgsJDhQHCQkEAQ0NCg8LCxAdHREcDQ4IEBETEw0GFAEHBwUECAgFBQUFAgO3AAADAAD/2wG3AbcAPABNAJkAADc1NDc2OwEyNzY3NjsBMhcWBxUWFRQVFhUUBxYVFAcGKwEWFRQHBgcGIyInJicmJyYnJicmJyYnIyInJjU3FBcWMzI3NjU0JyYjIgcGFRczMhcWFxYXFhcWFxYXFhcWFxYXFhcWFzI3NjU0JyY1MzI3NjU0JyYjNjc2NTQnNjU0JyYnNjU0JyYrASIHIgcGBwYHBgcGIwYrARUACwoQUgYhJRsbHiAoGRkBEQoCDhYWHTMOCgoTExgPCwoFBgIBBAMFDhEdCk4QCgslBQUIBwYFBQYHCAUFSQkEBgYFBgUGBgYEAwYFARAGDAUGAwMIGwkKDg5lDgsLBgYJBAMDDwUFBQkCDg4ZJSU8AgcHAwMHBwQEBQUECbe3DwsKDAwHBhcWJwIWHQYGExYKChUZHhYVHRoiExQJCgsJDg4MDAwNBg4WJQcLCw+kBwUGBgUHCAUGBgUIpAMCBQYFBQcIBAUHBwITBwwTExERBw0OHBEdHRALCw8KDQ0FCQkHFA4JCwoLCgUICBgMCxUDAgEBAgMBAQG3AAAAAQAAAA0A7gHSABQAABM0PwI2FxEHBgcmJyY1ND8BJyY1ABCPQQUJgQYFBgMDARhoBwEjCwIWgQwB/oNFAgEBAwUFAwOQZAkFAAAAAAIAAAAAAgABtwAqAFkAABM0NzYzMhcWFxYXFhc2NzY3Njc2MzIXFhUUDwEGIyIvASYnJicmJyYnJjUzFB8BNzY1NCcmJyYnJicmIyIHBgcGBwYHBiMiJyYnJicmJyYjIgcGBwYHBgcGFQAkJUARExIQEAsMCgoMCxAQEhMRQCUkQbIGBwcGsgMFBQsKCQkGByU1pqY1BgYJCg4NDg0PDhIRDg8KCgcFCQkFBwoKDw4REg4PDQ4NDgoJBgYBMT8jJAYGCwoJCgoKCgkKCwYGJCM/P0GsBQWsAgYFDQ4ODhUUEzA1oJ82MBcSEgoLBgcCAgcHCwsKCQgHBwgJCgsLBwcCAgcGCwoSEhcAAAACAAAABwFuAbcAIQAoAAA3ETQ3Njc2MyEyFxYXFhURFAcGBwYjIi8BBwYjIicmJyY1PwEfAREhEQAGBQoGBgEsBgYKBQYGBQoFBw4Kfn4KDgYGCgUGJZIZef7cJwFwCggIAwMDAwgICv6QCggIBAIJeXkJAgQICAoIjRl0AWP+nQAAAAABAAAAJQHbAbcAMgAANzU0NzY7ATU0NzYzMhcWHQEUBwYrASInJj0BNCcmIyIHBh0BMzIXFh0BFAcGIyEiJyY1AAgIC8AmJjQ1JiUFBQgSCAUFFhUfHhUWHAsICAgIC/7tCwgIQKULCAg3NSUmJiU1SQgFBgYFCEkeFhUVFh43CAgLpQsICAgICwAAAAIAAQANAdsB0gAiAC0AABM2PwI2MzIfAhYXFg8BFxYHBiMiLwEHBiMiJyY/AScmNx8CLwE/AS8CEwEDDJBABggJBUGODgIDCmcYAgQCCAMIf4IFBgYEAgEZaQgC7hBbEgINSnkILgEBJggCFYILC4IVAggICWWPCgUFA0REAwUFCo9lCQipCTBmEw1HEhFc/u0AAAADAAAAAAHJAbcAFAAlAHkAADc1NDc2OwEyFxYdARQHBisBIicmNTcUFxYzMjc2NTQnJiMiBwYVFzU0NzYzNjc2NzY3Njc2NzY3Njc2NzY3NjMyFxYXFhcWFxYXFhUUFRQHBgcGBxQHBgcGBzMyFxYVFAcWFRYHFgcGBxYHBgcjIicmJyYnJiciJyY1AAUGB1MHBQYGBQdTBwYFJQUFCAcGBQUGBwgFBWQFBQgGDw8OFAkFBAQBAQMCAQIEBAYFBw4KCgcHBQQCAwEBAgMDAgYCAgIBAU8XEBAQBQEOBQUECwMREiYlExYXDAwWJAoHBQY3twcGBQUGB7cIBQUFBQgkBwYFBQYHCAUGBgUIJLcHBQYBEBATGQkFCQgGBQwLBgcICQUGAwMFBAcHBgYICQQEBwsLCwYGCgIDBAMCBBEQFhkSDAoVEhAREAsgFBUBBAUEBAcMAQUFCAAAAAADAAD/2wHJAZIAFAAlAHkAADcUFxYXNxY3Nj0BNCcmBycGBwYdATc0NzY3FhcWFRQHBicGJyY1FzU0NzY3Fjc2NzY3NjcXNhcWBxYXFgcWBxQHFhUUBwYHJxYXFhcWFRYXFhcWFRQVFAcGBwYHBgcGBwYnBicmJyYnJicmJyYnJicmJyYnJiciJyY1AAUGB1MHBQYGBQdTBwYFJQUFCAcGBQUGBwgFBWQGBQcKJBYMDBcWEyUmEhEDCwQFBQ4BBRAQEBdPAQECAgIGAgMDAgEBAwIEBQcHCgoOBwUGBAQCAQIDAQEEBAUJFA4PDwYIBQWlBwYFAQEBBwQJtQkEBwEBAQUGB7eTBwYEAQEEBgcJBAYBAQYECZS4BwYEAgENBwUCBgMBAQEXEyEJEhAREBcIDhAaFhEPAQEFAgQCBQELBQcKDAkIBAUHCgUGBwgDBgIEAQEHBQkIBwUMCwcECgcGCRoREQ8CBgQIAAAAAQAAAAEAAJth57dfDzz1AAsCAAAAAADP/GODAAAAAM/8Y4MAAP/bAgAB2wAAAAgAAgAAAAAAAAABAAAB4P/gAAACAAAAAAACAAABAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAEAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAdwAAAHcAAACAAAjAZMAHwFJAAABbgAAAgAAAAIAAAACAAAAAgAAAAEAAAACAAAAAW4AAAHcAAAB3AABAdwAAAHcAAAAAAAAAAoAFAAeAEoAcACKAMoBQAGIAcwCCgJUAoICxgMEAzoDpgRKBRgF7AYSBpgG2gcgB2oIGAjOAAAAAQAAABwAmgAFAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAA4ArgABAAAAAAABAAwAAAABAAAAAAACAA4AQAABAAAAAAADAAwAIgABAAAAAAAEAAwATgABAAAAAAAFABYADAABAAAAAAAGAAYALgABAAAAAAAKADQAWgADAAEECQABAAwAAAADAAEECQACAA4AQAADAAEECQADAAwAIgADAAEECQAEAAwATgADAAEECQAFABYADAADAAEECQAGAAwANAADAAEECQAKADQAWgByAGEAdABpAG4AZwBWAGUAcgBzAGkAbwBuACAAMQAuADAAcgBhAHQAaQBuAGdyYXRpbmcAcgBhAHQAaQBuAGcAUgBlAGcAdQBsAGEAcgByAGEAdABpAG4AZwBGAG8AbgB0ACAAZwBlAG4AZQByAGEAdABlAGQAIABiAHkAIABJAGMAbwBNAG8AbwBuAC4AAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==) format('truetype'), url(data:application/font-woff;charset=utf-8;base64,d09GRk9UVE8AABcUAAoAAAAAFswAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABDRkYgAAAA9AAAEuEAABLho6TvIE9TLzIAABPYAAAAYAAAAGAIIwgbY21hcAAAFDgAAACkAAAApKPambxnYXNwAAAU3AAAAAgAAAAIAAAAEGhlYWQAABTkAAAANgAAADYBGAe5aGhlYQAAFRwAAAAkAAAAJAPiAf1obXR4AAAVQAAAAHAAAABwLOAAQ21heHAAABWwAAAABgAAAAYAHFAAbmFtZQAAFbgAAAE8AAABPPC1n05wb3N0AAAW9AAAACAAAAAgAAMAAAEABAQAAQEBB3JhdGluZwABAgABADr4HAL4GwP4GAQeCgAZU/+Lix4KABlT/4uLDAeLZviU+HQFHQAAAP0PHQAAAQIRHQAAAAkdAAAS2BIAHQEBBw0PERQZHiMoLTI3PEFGS1BVWl9kaW5zeH2Ch4xyYXRpbmdyYXRpbmd1MHUxdTIwdUU2MDB1RTYwMXVFNjAydUU2MDN1RTYwNHVFNjA1dUYwMDR1RjAwNXVGMDA2dUYwMEN1RjAwRHVGMDIzdUYwMkV1RjA2RXVGMDcwdUYwODd1RjA4OHVGMDg5dUYwOEF1RjA5N3VGMDlDdUYxMjN1RjE2NHVGMTY1AAACAYkAGgAcAgABAAQABwAKAA0AVgCWAL0BAgGMAeQCbwLwA4cD5QR0BQMFdgZgB8MJkQtxC7oM2Q1jDggOmRAYEZr8lA78lA78lA77lA74lPetFftFpTz3NDz7NPtFcfcU+xBt+0T3Mt73Mjht90T3FPcQBfuU+0YV+wRRofcQMOP3EZ3D9wXD+wX3EXkwM6H7EPsExQUO+JT3rRX7RaU89zQ8+zT7RXH3FPsQbftE9zLe9zI4bfdE9xT3EAX7lPtGFYuLi/exw/sF9xF5MDOh+xD7BMUFDviU960V+0WlPPc0PPs0+0Vx9xT7EG37RPcy3vcyOG33RPcU9xAFDviU98EVi2B4ZG5wCIuL+zT7NAV7e3t7e4t7i3ube5sI+zT3NAVupniyi7aL3M3N3Iu2i7J4pm6mqLKetovci81JizoIDviU98EVi9xJzTqLYItkeHBucKhknmCLOotJSYs6i2CeZKhwCIuL9zT7NAWbe5t7m4ubi5ubm5sI9zT3NAWopp6yi7YIME0V+zb7NgWKioqKiouKi4qMiowI+zb3NgV6m4Ghi6OLubCwuYuji6GBm3oIule6vwWbnKGVo4u5i7Bmi12Lc4F1ensIDviU98EVi2B4ZG5wCIuL+zT7NAV7e3t7e4t7i3ube5sI+zT3NAVupniyi7aL3M3N3Iuni6WDoX4IXED3BEtL+zT3RPdU+wTLssYFl46YjZiL3IvNSYs6CA6L98UVi7WXrKOio6Otl7aLlouXiZiHl4eWhZaEloSUhZKFk4SShZKEkpKSkZOSkpGUkZaSCJaSlpGXj5iPl42Wi7aLrX+jc6N0l2qLYYthdWBgYAj7RvtABYeIh4mGi4aLh42Hjgj7RvdABYmNiY2Hj4iOhpGDlISUhZWFlIWVhpaHmYaYiZiLmAgOZ4v3txWLkpCPlo0I9yOgzPcWBY6SkI+Ri5CLkIePhAjL+xb3I3YFlomQh4uEi4aJh4aGCCMmpPsjBYuKi4mLiIuHioiJiImIiIqHi4iLh4yHjQj7FM/7FUcFh4mHioiLh4uIjImOiY6KjouPi4yLjYyOCKP3IyPwBYaQiZCLjwgOZ4v3txWLkpCPlo0I9yOgzPcWBY6SkI+Ri5CLkIePhAjL+xb3I3YFlomQh4uEi4aJh4aGCCMmpPsjBYuKi4mLiIuCh4aDi4iLh4yHjQj7FM/7FUcFh4mHioiLh4uIjImOiY6KjouPi4yLjYyOCKP3IyPwBYaQiZCLjwjKeRXjN3b7DfcAxPZSd/cN4t/7DJ1V9wFV+wEFDq73ZhWLk42RkZEIsbIFkZCRjpOLkouSiJCGCN8291D3UAWQkJKOkouTi5GIkYYIsWQFkYaNhIuEi4OJhYWFCPuJ+4kFhYWFiYOLhIuEjYaRCPsi9yIFhZCJkouSCA77AartFYuSjpKQkAjf3zffBYaQiJKLk4uSjpKQkAiysgWRkJGOk4uSi5KIkIYI3zff3wWQkJKOk4uSi5KIkIYIsmQFkIaOhIuEi4OIhIaGCDc33zcFkIaOhIuEi4OIhYaFCGRkBYaGhIiEi4OLhI6GkAg33zc3BYaGhIiEi4OLhY6FkAhksgWGkYiRi5MIDvtLi8sVi/c5BYuSjpKQkJCQko6SiwiVi4vCBYuul6mkpKSkqpiui66LqX6kcqRymG2LaAiLVJSLBZKLkoiQhpCGjoSLhAiL+zkFi4OIhYaGhoWEiYSLCPuniwWEi4SNhpGGkIiRi5MI5vdUFfcni4vCBYufhJx8mn2ZepJ3i3aLeoR9fX18g3qLdwiLVAUO+yaLshWL+AQFi5GNkY+RjpCQj5KNj42PjI+LCPfAiwWPi4+Kj4mRiZCHj4aPhY2Fi4UIi/wEBYuEiYWHhoeGhoeFiIiKhoqHi4GLhI6EkQj7EvcN+xL7DQWEhYOIgouHi4eLh42EjoaPiJCHkImRi5IIDov3XRWLko2Rj5Kltq+vuKW4pbuZvYu9i7t9uHG4ca9npWCPhI2Fi4SLhYmEh4RxYGdoXnAIXnFbflmLWYtbmF6lXqZnrnG2h5KJkouRCLCLFaRkq2yxdLF0tH+4i7iLtJexorGiq6qksm64Z61goZZ3kXaLdItnfm1ycnJybX9oiwhoi22XcqRypH6pi6+LopGglp9gdWdpbl4I9xiwFYuHjIiOiI6IjoqPi4+LjoyOjo2OjY6Lj4ubkJmXl5eWmZGbi4+LjoyOjo2OjY6LjwiLj4mOiY6IjYiNh4tzi3eCenp6eoJ3i3MIDov3XRWLko2Sj5GouK+utqW3pbqYvouci5yJnIgIm6cFjY6NjI+LjIuNi42JjYqOio+JjomOiY6KjomOiY6JjoqNioyKjomMiYuHi4qLiouLCHdnbVVjQ2NDbVV3Zwh9cgWJiIiJiIuJi36SdJiIjYmOi46LjY+UlJlvl3KcdJ90oHeie6WHkYmSi5IIsIsVqlq0Z711CKGzBXqXfpqCnoKdhp6LoIuikaCWn2B1Z2luXgj3GLAVi4eMiI6IjoiOio+Lj4uOjI6OjY6NjouPi5uQmZeXl5aZkZuLj4uOjI6OjY6NjouPCIuPiY6JjoiNiI2Hi3OLd4J6enp6gneLcwji+10VoLAFtI+wmK2hrqKnqKKvdq1wp2uhCJ2rBZ1/nHycepx6mHqWeY+EjYWLhIuEiYWHhIR/gH1+fG9qaXJmeWV5Y4Jhiwi53BXb9yQFjIKMg4uEi3CDc3x1fHV3fHOBCA6L1BWL90sFi5WPlJKSkpKTj5aLCNmLBZKPmJqepJaZlZeVlY+Qj5ONl42WjpeOmI+YkZWTk5OSk46Vi5uLmYiYhZiFlIGSfgiSfo55i3WLeYd5gXgIvosFn4uchJl8mn2Seot3i3qGfIJ9jYSLhYuEi3yIfoR+i4eLh4uHi3eGen99i3CDdnt8CHt8dYNwiwhmiwV5i3mNeY95kHeRc5N1k36Ph4sIOYsFgIuDjoSShJKHlIuVCLCdFYuGjIePiI+Hj4mQi5CLj42Pj46OjY+LkIuQiZCIjoePh42Gi4aLh4mHh4eIioaLhgjUeRWUiwWNi46Lj4qOi4+KjYqOi4+Kj4mQio6KjYqNio+Kj4mQio6KjIqzfquEpIsIrosFr4uemouri5CKkYqQkY6QkI6SjpKNkouSi5KJkoiRlZWQlouYi5CKkImRiZGJj4iOCJGMkI+PlI+UjZKLkouViJODk4SSgo+CiwgmiwWLlpCalJ6UnpCbi5aLnoiYhJSFlH+QeYuGhoeDiYCJf4h/h3+IfoWBg4KHh4SCgH4Ii4qIiYiGh4aIh4mIiIiIh4eGh4aHh4eHiIiHiIeHiIiHiIeKh4mIioiLCIKLi/tLBQ6L90sVi/dLBYuVj5OSk5KSk46WiwjdiwWPi5iPoZOkk6CRnZCdj56Nn4sIq4sFpougg5x8m3yTd4txCIuJBZd8kHuLd4uHi4eLh5J+jn6LfIuEi4SJhZR9kHyLeot3hHp8fH19eoR3iwhYiwWVeI95i3mLdIh6hH6EfoKBfoV+hX2He4uBi4OPg5KFkYaTh5SHlYiTipOKk4qTiJMIiZSIkYiPgZSBl4CaeKR+moSPCD2LBYCLg4+EkoSSh5SLlQiw9zgVi4aMh4+Ij4ePiZCLkIuPjY+Pjo6Nj4uQi5CJkIiOh4+HjYaLhouHiYeHh4iKhouGCNT7OBWUiwWOi46Kj4mPio+IjoiPh4+IjoePiI+Hj4aPho6HjoiNiI6Hj4aOho6Ii4qWfpKDj4YIk4ORgY5+j36OgI1/jYCPg5CGnYuXj5GUkpSOmYuei5aGmoKfgp6GmouWCPCLBZSLlI+SkpOTjpOLlYuSiZKHlIeUho+Fi46PjY+NkY2RjJCLkIuYhpaBlY6RjZKLkgiLkomSiJKIkoaQhY6MkIyRi5CLm4aXgpOBkn6Pe4sIZosFcotrhGN9iouIioaJh4qHiomKiYqIioaKh4mHioiKiYuHioiLh4qIi4mLCIKLi/tLBQ77lIv3txWLkpCPlo0I9yOgzPcWBY6SkI+RiwiL/BL7FUcFh4mHioiLh4uIjImOiY6KjouPi4yLjYyOCKP3IyPwBYaQiZCLjwgOi/fFFYu1l6yjoqOjrZe2i5aLl4mYh5eHloWWhJaElIWShZOEkoWShJKSkpGTkpKRlJGWkgiWkpaRl4+Yj5eNlou2i61/o3OjdJdqi2GLYXVgYGAI+0b7QAWHiIeJhouGi4eNh44I+0b3QAWJjYmNh4+IjoaRg5SElIWVhZSFlYaWh5mGmImYi5gIsIsVi2ucaa9oCPc6+zT3OvczBa+vnK2Lq4ubiZiHl4eXhpSFkoSSg5GCj4KQgo2CjYONgYuBi4KLgIl/hoCGgIWChAiBg4OFhISEhYaFhoaIhoaJhYuFi4aNiJCGkIaRhJGEkoORgZOCkoCRgJB/kICNgosIgYuBi4OJgomCiYKGgoeDhYSEhYSGgod/h3+Jfot7CA77JouyFYv4BAWLkY2Rj5GOkJCPko2PjY+Mj4sI98CLBY+Lj4qPiZGJkIePho+FjYWLhQiL/AQFi4SJhYeGh4aGh4WIiIqGioeLgYuEjoSRCPsS9w37EvsNBYSFg4iCi4eLh4uHjYSOho+IkIeQiZGLkgiwkxX3JvchpHL3DfsIi/f3+7iLi/v3BQ5ni8sVi/c5BYuSjpKQkJCQko6Siwj3VIuLwgWLrpippKSkpKmYrouvi6l+pHKkcpdti2gIi0IFi4aKhoeIh4eHiYaLCHmLBYaLh42Hj4eOipCLkAiL1AWLn4OcfZp9mXqSdot3i3qEfX18fIR6i3cIi1SniwWSi5KIkIaQho6Ei4QIi/s5BYuDiIWGhoaFhImEiwj7p4sFhIuEjYaRhpCIkYuTCA5njPe6FYyQkI6UjQj3I6DM9xYFj5KPj5GLkIuQh4+ECMv7FvcjdgWUiZCIjYaNhoiFhYUIIyak+yMFjIWKhomHiYiIiYaLiIuHjIeNCPsUz/sVRwWHiYeKiIuHi4eNiY6Jj4uQjJEIo/cjI/AFhZGJkY2QCPeB+z0VnILlW3rxiJ6ZmNTS+wydgpxe54v7pwUOZ4vCFYv3SwWLkI2Pjo+Pjo+NkIsI3osFkIuPiY6Ij4eNh4uGCIv7SwWLhomHh4eIh4eKhosIOIsFhouHjIePiI+Jj4uQCLCvFYuGjIePh46IkImQi5CLj42Pjo6PjY+LkIuQiZCIjoePh42Gi4aLhomIh4eIioaLhgjvZxWL90sFi5CNj46Oj4+PjZCLj4ySkJWWlZaVl5SXmJuVl5GRjo6OkI6RjZCNkIyPjI6MkY2TCIySjJGMj4yPjZCOkY6RjpCPjo6Pj42Qi5SLk4qSiZKJkYiPiJCIjoiPho6GjYeMhwiNh4yGjIaMhYuHi4iLiIuHi4eLg4uEiYSJhImFiYeJh4mFh4WLioqJiomJiIqJiokIi4qKiIqJCNqLBZqLmIWWgJaAkH+LfIt6hn2Af46DjYSLhIt9h36Cf4+Bi3+HgImAhYKEhI12hnmAfgh/fXiDcosIZosFfot+jHyOfI5/joOOg41/j32Qc5N8j4SMhouHjYiOh4+Jj4uQCA5ni/c5FYuGjYaOiI+Hj4mQiwjeiwWQi4+Njo+Pjo2Qi5AIi/dKBYuQiZCHjoiPh42Giwg4iwWGi4eJh4eIiImGi4YIi/tKBbD3JhWLkIyPj4+OjpCNkIuQi4+Jj4iOh42Hi4aLhomHiIeHh4eKhouGi4aMiI+Hj4qPi5AI7/snFYv3SwWLkI2Qj46Oj4+NkIuSi5qPo5OZkJePk46TjZeOmo6ajpiMmIsIsIsFpIueg5d9ln6Qeol1koSRgo2Aj4CLgIeAlH+Pfot9i4WJhIiCloCQfIt7i3yFfoGACICAfoZ8iwg8iwWMiIyJi4mMiYyJjYmMiIyKi4mPhI2GjYeNh42GjYOMhIyEi4SLhouHi4iLiYuGioYIioWKhomHioeJh4iGh4eIh4aIh4iFiISJhImDioKLhouHjYiPh4+Ij4iRiJGJkIqPCIqPipGKkomTipGKj4qOiZCJkYiQiJCIjoWSgZZ+nIKXgZaBloGWhJGHi4aLh42HjwiIjomQi48IDviUFPiUFYsMCgAAAAADAgABkAAFAAABTAFmAAAARwFMAWYAAAD1ABkAhAAAAAAAAAAAAAAAAAAAAAEQAAAAAAAAAAAAAAAAAAAAAEAAAPFlAeD/4P/gAeAAIAAAAAEAAAAAAAAAAAAAACAAAAAAAAIAAAADAAAAFAADAAEAAAAUAAQAkAAAACAAIAAEAAAAAQAg5gXwBvAN8CPwLvBu8HDwivCX8JzxI/Fl//3//wAAAAAAIOYA8ATwDPAj8C7wbvBw8Ifwl/Cc8SPxZP/9//8AAf/jGgQQBhABD+wP4g+jD6IPjA+AD3wO9g62AAMAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAf//AA8AAQAAAAEAAJrVlLJfDzz1AAsCAAAAAADP/GODAAAAAM/8Y4MAAP/bAgAB2wAAAAgAAgAAAAAAAAABAAAB4P/gAAACAAAAAAACAAABAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAEAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAdwAAAHcAAACAAAjAZMAHwFJAAABbgAAAgAAAAIAAAACAAAAAgAAAAEAAAACAAAAAW4AAAHcAAAB3AABAdwAAAHcAAAAAFAAABwAAAAAAA4ArgABAAAAAAABAAwAAAABAAAAAAACAA4AQAABAAAAAAADAAwAIgABAAAAAAAEAAwATgABAAAAAAAFABYADAABAAAAAAAGAAYALgABAAAAAAAKADQAWgADAAEECQABAAwAAAADAAEECQACAA4AQAADAAEECQADAAwAIgADAAEECQAEAAwATgADAAEECQAFABYADAADAAEECQAGAAwANAADAAEECQAKADQAWgByAGEAdABpAG4AZwBWAGUAcgBzAGkAbwBuACAAMQAuADAAcgBhAHQAaQBuAGdyYXRpbmcAcgBhAHQAaQBuAGcAUgBlAGcAdQBsAGEAcgByAGEAdABpAG4AZwBGAG8AbgB0ACAAZwBlAG4AZQByAGEAdABlAGQAIABiAHkAIABJAGMAbwBNAG8AbwBuAC4AAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==) format('woff');
+  src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMggjCBsAAAC8AAAAYGNtYXCj2pm8AAABHAAAAKRnYXNwAAAAEAAAAcAAAAAIZ2x5ZlJbXMYAAAHIAAARnGhlYWQBGAe5AAATZAAAADZoaGVhA+IB/QAAE5wAAAAkaG10eCzgAEMAABPAAAAAcGxvY2EwXCxOAAAUMAAAADptYXhwACIAnAAAFGwAAAAgbmFtZfC1n04AABSMAAABPHBvc3QAAwAAAAAVyAAAACAAAwIAAZAABQAAAUwBZgAAAEcBTAFmAAAA9QAZAIQAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADxZQHg/+D/4AHgACAAAAABAAAAAAAAAAAAAAAgAAAAAAACAAAAAwAAABQAAwABAAAAFAAEAJAAAAAgACAABAAAAAEAIOYF8AbwDfAj8C7wbvBw8Irwl/Cc8SPxZf/9//8AAAAAACDmAPAE8AzwI/Au8G7wcPCH8JfwnPEj8WT//f//AAH/4xoEEAYQAQ/sD+IPow+iD4wPgA98DvYOtgADAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAH//wAPAAEAAAAAAAAAAAACAAA3OQEAAAAAAQAAAAAAAAAAAAIAADc5AQAAAAABAAAAAAAAAAAAAgAANzkBAAAAAAIAAP/tAgAB0wAKABUAAAEvAQ8BFwc3Fyc3BQc3Jz8BHwEHFycCALFPT7GAHp6eHoD/AHAWW304OH1bFnABGRqgoBp8sFNTsHyyOnxYEnFxElh8OgAAAAACAAD/7QIAAdMACgASAAABLwEPARcHNxcnNwUxER8BBxcnAgCxT0+xgB6enh6A/wA4fVsWcAEZGqCgGnywU1OwfLIBHXESWHw6AAAAAQAA/+0CAAHTAAoAAAEvAQ8BFwc3Fyc3AgCxT0+xgB6enh6AARkaoKAafLBTU7B8AAAAAAEAAAAAAgABwAArAAABFA4CBzEHDgMjIi4CLwEuAzU0PgIzMh4CFz4DMzIeAhUCAAcMEgugBgwMDAYGDAwMBqALEgwHFyg2HhAfGxkKChkbHxAeNigXAS0QHxsZCqAGCwkGBQkLBqAKGRsfEB42KBcHDBILCxIMBxcoNh4AAAAAAgAAAAACAAHAACsAWAAAATQuAiMiDgIHLgMjIg4CFRQeAhcxFx4DMzI+Aj8BPgM1DwEiFCIGMTAmIjQjJy4DNTQ+AjMyHgIfATc+AzMyHgIVFA4CBwIAFyg2HhAfGxkKChkbHxAeNigXBwwSC6AGDAwMBgYMDAwGoAsSDAdbogEBAQEBAaIGCgcEDRceEQkREA4GLy8GDhARCREeFw0EBwoGAS0eNigXBwwSCwsSDAcXKDYeEB8bGQqgBgsJBgUJCwagChkbHxA+ogEBAQGiBg4QEQkRHhcNBAcKBjQ0BgoHBA0XHhEJERAOBgABAAAAAAIAAcAAMQAAARQOAgcxBw4DIyIuAi8BLgM1ND4CMzIeAhcHFwc3Jzc+AzMyHgIVAgAHDBILoAYMDAwGBgwMDAagCxIMBxcoNh4KFRMSCC9wQLBwJwUJCgkFHjYoFwEtEB8bGQqgBgsJBgUJCwagChkbHxAeNigXAwUIBUtAoMBAOwECAQEXKDYeAAABAAAAAAIAAbcAKgAAEzQ3NjMyFxYXFhcWFzY3Njc2NzYzMhcWFRQPAQYjIi8BJicmJyYnJicmNQAkJUARExIQEAsMCgoMCxAQEhMRQCUkQbIGBwcGsgMFBQsKCQkGBwExPyMkBgYLCgkKCgoKCQoLBgYkIz8/QawFBawCBgUNDg4OFRQTAAAAAQAAAA0B2wHSACYAABM0PwI2FzYfAhYVFA8BFxQVFAcGByYvAQcGByYnJjU0PwEnJjUAEI9BBQkIBkCPEAdoGQMDBgUGgIEGBQYDAwEYaAcBIwsCFoEMAQEMgRYCCwYIZJABBQUFAwEBAkVFAgEBAwUFAwOQZAkFAAAAAAIAAAANAdsB0gAkAC4AABM0PwI2FzYfAhYVFA8BFxQVFAcmLwEHBgcmJyY1ND8BJyY1HwEHNxcnNy8BBwAQj0EFCQgGQI8QB2gZDAUGgIEGBQYDAwEYaAc/WBVsaxRXeDY2ASMLAhaBDAEBDIEWAgsGCGSQAQUNAQECRUUCAQEDBQUDA5BkCQURVXg4OHhVEW5uAAABACMAKQHdAXwAGgAANzQ/ATYXNh8BNzYXNh8BFhUUDwEGByYvASY1IwgmCAwLCFS8CAsMCCYICPUIDAsIjgjSCwkmCQEBCVS7CQEBCSYJCg0H9gcBAQePBwwAAAEAHwAfAXMBcwAsAAA3ND8BJyY1ND8BNjMyHwE3NjMyHwEWFRQPARcWFRQPAQYjIi8BBwYjIi8BJjUfCFRUCAgnCAwLCFRUCAwLCCcICFRUCAgnCAsMCFRUCAsMCCcIYgsIVFQIDAsIJwgIVFQICCcICwwIVFQICwwIJwgIVFQICCcIDAAAAAACAAAAJQFJAbcAHwArAAA3NTQ3NjsBNTQ3NjMyFxYdATMyFxYdARQHBiMhIicmNTczNTQnJiMiBwYdAQAICAsKJSY1NCYmCQsICAgIC/7tCwgIW5MWFR4fFRZApQsICDc0JiYmJjQ3CAgLpQsICAgIC8A3HhYVFRYeNwAAAQAAAAcBbgG3ACEAADcRNDc2NzYzITIXFhcWFREUBwYHBiMiLwEHBiMiJyYnJjUABgUKBgYBLAYGCgUGBgUKBQcOCn5+Cg4GBgoFBicBcAoICAMDAwMICAr+kAoICAQCCXl5CQIECAgKAAAAAwAAACUCAAFuABgAMQBKAAA3NDc2NzYzMhcWFxYVFAcGBwYjIicmJyY1MxYXFjMyNzY3JicWFRQHBiMiJyY1NDcGBzcUFxYzMjc2NTQ3NjMyNzY1NCcmIyIHBhUABihDREtLREMoBgYoQ0RLS0RDKAYlJjk5Q0M5OSYrQREmJTU1JSYRQSuEBAQGBgQEEREZBgQEBAQGJBkayQoKQSgoKChBCgoKCkEoJycoQQoKOiMjIyM6RCEeIjUmJSUmNSIeIUQlBgQEBAQGGBIRBAQGBgQEGhojAAAABQAAAAkCAAGJACwAOABRAGgAcAAANzQ3Njc2MzIXNzYzMhcWFxYXFhcWFxYVFDEGBwYPAQYjIicmNTQ3JicmJyY1MxYXNyYnJjU0NwYHNxQXFjMyNzY1NDc2MzI3NjU0JyYjIgcGFRc3Njc2NyYnNxYXFhcWFRQHBgcGBwYjPwEWFRQHBgcABitBQU0ZGhADBQEEBAUFBAUEBQEEHjw8Hg4DBQQiBQ0pIyIZBiUvSxYZDg4RQSuEBAQGBgQEEREZBgQEBAQGJBkaVxU9MzQiIDASGxkZEAYGCxQrODk/LlACFxYlyQsJQycnBRwEAgEDAwIDAwIBAwUCNmxsNhkFFAMFBBUTHh8nCQtKISgSHBsfIh4hRCUGBAQEBAYYEhEEBAYGBAQaGiPJJQUiIjYzISASGhkbCgoKChIXMRsbUZANCyghIA8AAAMAAAAAAbcB2wA5AEoAlAAANzU0NzY7ATY3Njc2NzY3Njc2MzIXFhcWFRQHMzIXFhUUBxYVFAcUFRQHFgcGKwEiJyYnJisBIicmNTcUFxYzMjc2NTQnJiMiBwYVFzMyFxYXFhcWFxYXFhcWOwEyNTQnNjc2NTQnNjU0JyYnNjc2NTQnJisBNDc2NTQnJiMGBwYHBgcGBwYHBgcGBwYHBgcGBwYrARUACwoQTgodEQ4GBAMFBgwLDxgTEwoKDjMdFhYOAgoRARkZKCUbGxsjIQZSEAoLJQUFCAcGBQUGBwgFBUkJBAUFBAQHBwMDBwcCPCUjNwIJBQUFDwMDBAkGBgsLDmUODgoJGwgDAwYFDAYQAQUGAwQGBgYFBgUGBgQJSbcPCwsGJhUPCBERExMMCgkJFBQhGxwWFR4ZFQoKFhMGBh0WKBcXBgcMDAoLDxIHBQYGBQcIBQYGBQgSAQEBAQICAQEDAgEULwgIBQoLCgsJDhQHCQkEAQ0NCg8LCxAdHREcDQ4IEBETEw0GFAEHBwUECAgFBQUFAgO3AAADAAD/2wG3AbcAPABNAJkAADc1NDc2OwEyNzY3NjsBMhcWBxUWFRQVFhUUBxYVFAcGKwEWFRQHBgcGIyInJicmJyYnJicmJyYnIyInJjU3FBcWMzI3NjU0JyYjIgcGFRczMhcWFxYXFhcWFxYXFhcWFxYXFhcWFzI3NjU0JyY1MzI3NjU0JyYjNjc2NTQnNjU0JyYnNjU0JyYrASIHIgcGBwYHBgcGIwYrARUACwoQUgYhJRsbHiAoGRkBEQoCDhYWHTMOCgoTExgPCwoFBgIBBAMFDhEdCk4QCgslBQUIBwYFBQYHCAUFSQkEBgYFBgUGBgYEAwYFARAGDAUGAwMIGwkKDg5lDgsLBgYJBAMDDwUFBQkCDg4ZJSU8AgcHAwMHBwQEBQUECbe3DwsKDAwHBhcWJwIWHQYGExYKChUZHhYVHRoiExQJCgsJDg4MDAwNBg4WJQcLCw+kBwUGBgUHCAUGBgUIpAMCBQYFBQcIBAUHBwITBwwTExERBw0OHBEdHRALCw8KDQ0FCQkHFA4JCwoLCgUICBgMCxUDAgEBAgMBAQG3AAAAAQAAAA0A7gHSABQAABM0PwI2FxEHBgcmJyY1ND8BJyY1ABCPQQUJgQYFBgMDARhoBwEjCwIWgQwB/oNFAgEBAwUFAwOQZAkFAAAAAAIAAAAAAgABtwAqAFkAABM0NzYzMhcWFxYXFhc2NzY3Njc2MzIXFhUUDwEGIyIvASYnJicmJyYnJjUzFB8BNzY1NCcmJyYnJicmIyIHBgcGBwYHBiMiJyYnJicmJyYjIgcGBwYHBgcGFQAkJUARExIQEAsMCgoMCxAQEhMRQCUkQbIGBwcGsgMFBQsKCQkGByU1pqY1BgYJCg4NDg0PDhIRDg8KCgcFCQkFBwoKDw4REg4PDQ4NDgoJBgYBMT8jJAYGCwoJCgoKCgkKCwYGJCM/P0GsBQWsAgYFDQ4ODhUUEzA1oJ82MBcSEgoLBgcCAgcHCwsKCQgHBwgJCgsLBwcCAgcGCwoSEhcAAAACAAAABwFuAbcAIQAoAAA3ETQ3Njc2MyEyFxYXFhURFAcGBwYjIi8BBwYjIicmJyY1PwEfAREhEQAGBQoGBgEsBgYKBQYGBQoFBw4Kfn4KDgYGCgUGJZIZef7cJwFwCggIAwMDAwgICv6QCggIBAIJeXkJAgQICAoIjRl0AWP+nQAAAAABAAAAJQHbAbcAMgAANzU0NzY7ATU0NzYzMhcWHQEUBwYrASInJj0BNCcmIyIHBh0BMzIXFh0BFAcGIyEiJyY1AAgIC8AmJjQ1JiUFBQgSCAUFFhUfHhUWHAsICAgIC/7tCwgIQKULCAg3NSUmJiU1SQgFBgYFCEkeFhUVFh43CAgLpQsICAgICwAAAAIAAQANAdsB0gAiAC0AABM2PwI2MzIfAhYXFg8BFxYHBiMiLwEHBiMiJyY/AScmNx8CLwE/AS8CEwEDDJBABggJBUGODgIDCmcYAgQCCAMIf4IFBgYEAgEZaQgC7hBbEgINSnkILgEBJggCFYILC4IVAggICWWPCgUFA0REAwUFCo9lCQipCTBmEw1HEhFc/u0AAAADAAAAAAHJAbcAFAAlAHkAADc1NDc2OwEyFxYdARQHBisBIicmNTcUFxYzMjc2NTQnJiMiBwYVFzU0NzYzNjc2NzY3Njc2NzY3Njc2NzY3NjMyFxYXFhcWFxYXFhUUFRQHBgcGBxQHBgcGBzMyFxYVFAcWFRYHFgcGBxYHBgcjIicmJyYnJiciJyY1AAUGB1MHBQYGBQdTBwYFJQUFCAcGBQUGBwgFBWQFBQgGDw8OFAkFBAQBAQMCAQIEBAYFBw4KCgcHBQQCAwEBAgMDAgYCAgIBAU8XEBAQBQEOBQUECwMREiYlExYXDAwWJAoHBQY3twcGBQUGB7cIBQUFBQgkBwYFBQYHCAUGBgUIJLcHBQYBEBATGQkFCQgGBQwLBgcICQUGAwMFBAcHBgYICQQEBwsLCwYGCgIDBAMCBBEQFhkSDAoVEhAREAsgFBUBBAUEBAcMAQUFCAAAAAADAAD/2wHJAZIAFAAlAHkAADcUFxYXNxY3Nj0BNCcmBycGBwYdATc0NzY3FhcWFRQHBicGJyY1FzU0NzY3Fjc2NzY3NjcXNhcWBxYXFgcWBxQHFhUUBwYHJxYXFhcWFRYXFhcWFRQVFAcGBwYHBgcGBwYnBicmJyYnJicmJyYnJicmJyYnJiciJyY1AAUGB1MHBQYGBQdTBwYFJQUFCAcGBQUGBwgFBWQGBQcKJBYMDBcWEyUmEhEDCwQFBQ4BBRAQEBdPAQECAgIGAgMDAgEBAwIEBQcHCgoOBwUGBAQCAQIDAQEEBAUJFA4PDwYIBQWlBwYFAQEBBwQJtQkEBwEBAQUGB7eTBwYEAQEEBgcJBAYBAQYECZS4BwYEAgENBwUCBgMBAQEXEyEJEhAREBcIDhAaFhEPAQEFAgQCBQELBQcKDAkIBAUHCgUGBwgDBgIEAQEHBQkIBwUMCwcECgcGCRoREQ8CBgQIAAAAAQAAAAEAAJth57dfDzz1AAsCAAAAAADP/GODAAAAAM/8Y4MAAP/bAgAB2wAAAAgAAgAAAAAAAAABAAAB4P/gAAACAAAAAAACAAABAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAEAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAdwAAAHcAAACAAAjAZMAHwFJAAABbgAAAgAAAAIAAAACAAAAAgAAAAEAAAACAAAAAW4AAAHcAAAB3AABAdwAAAHcAAAAAAAAAAoAFAAeAEoAcACKAMoBQAGIAcwCCgJUAoICxgMEAzoDpgRKBRgF7AYSBpgG2gcgB2oIGAjOAAAAAQAAABwAmgAFAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAA4ArgABAAAAAAABAAwAAAABAAAAAAACAA4AQAABAAAAAAADAAwAIgABAAAAAAAEAAwATgABAAAAAAAFABYADAABAAAAAAAGAAYALgABAAAAAAAKADQAWgADAAEECQABAAwAAAADAAEECQACAA4AQAADAAEECQADAAwAIgADAAEECQAEAAwATgADAAEECQAFABYADAADAAEECQAGAAwANAADAAEECQAKADQAWgByAGEAdABpAG4AZwBWAGUAcgBzAGkAbwBuACAAMQAuADAAcgBhAHQAaQBuAGdyYXRpbmcAcgBhAHQAaQBuAGcAUgBlAGcAdQBsAGEAcgByAGEAdABpAG4AZwBGAG8AbgB0ACAAZwBlAG4AZQByAGEAdABlAGQAIABiAHkAIABJAGMAbwBNAG8AbwBuAC4AAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==)
+      format('truetype'),
+    url(data:application/font-woff;charset=utf-8;base64,d09GRk9UVE8AABcUAAoAAAAAFswAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABDRkYgAAAA9AAAEuEAABLho6TvIE9TLzIAABPYAAAAYAAAAGAIIwgbY21hcAAAFDgAAACkAAAApKPambxnYXNwAAAU3AAAAAgAAAAIAAAAEGhlYWQAABTkAAAANgAAADYBGAe5aGhlYQAAFRwAAAAkAAAAJAPiAf1obXR4AAAVQAAAAHAAAABwLOAAQ21heHAAABWwAAAABgAAAAYAHFAAbmFtZQAAFbgAAAE8AAABPPC1n05wb3N0AAAW9AAAACAAAAAgAAMAAAEABAQAAQEBB3JhdGluZwABAgABADr4HAL4GwP4GAQeCgAZU/+Lix4KABlT/4uLDAeLZviU+HQFHQAAAP0PHQAAAQIRHQAAAAkdAAAS2BIAHQEBBw0PERQZHiMoLTI3PEFGS1BVWl9kaW5zeH2Ch4xyYXRpbmdyYXRpbmd1MHUxdTIwdUU2MDB1RTYwMXVFNjAydUU2MDN1RTYwNHVFNjA1dUYwMDR1RjAwNXVGMDA2dUYwMEN1RjAwRHVGMDIzdUYwMkV1RjA2RXVGMDcwdUYwODd1RjA4OHVGMDg5dUYwOEF1RjA5N3VGMDlDdUYxMjN1RjE2NHVGMTY1AAACAYkAGgAcAgABAAQABwAKAA0AVgCWAL0BAgGMAeQCbwLwA4cD5QR0BQMFdgZgB8MJkQtxC7oM2Q1jDggOmRAYEZr8lA78lA78lA77lA74lPetFftFpTz3NDz7NPtFcfcU+xBt+0T3Mt73Mjht90T3FPcQBfuU+0YV+wRRofcQMOP3EZ3D9wXD+wX3EXkwM6H7EPsExQUO+JT3rRX7RaU89zQ8+zT7RXH3FPsQbftE9zLe9zI4bfdE9xT3EAX7lPtGFYuLi/exw/sF9xF5MDOh+xD7BMUFDviU960V+0WlPPc0PPs0+0Vx9xT7EG37RPcy3vcyOG33RPcU9xAFDviU98EVi2B4ZG5wCIuL+zT7NAV7e3t7e4t7i3ube5sI+zT3NAVupniyi7aL3M3N3Iu2i7J4pm6mqLKetovci81JizoIDviU98EVi9xJzTqLYItkeHBucKhknmCLOotJSYs6i2CeZKhwCIuL9zT7NAWbe5t7m4ubi5ubm5sI9zT3NAWopp6yi7YIME0V+zb7NgWKioqKiouKi4qMiowI+zb3NgV6m4Ghi6OLubCwuYuji6GBm3oIule6vwWbnKGVo4u5i7Bmi12Lc4F1ensIDviU98EVi2B4ZG5wCIuL+zT7NAV7e3t7e4t7i3ube5sI+zT3NAVupniyi7aL3M3N3Iuni6WDoX4IXED3BEtL+zT3RPdU+wTLssYFl46YjZiL3IvNSYs6CA6L98UVi7WXrKOio6Otl7aLlouXiZiHl4eWhZaEloSUhZKFk4SShZKEkpKSkZOSkpGUkZaSCJaSlpGXj5iPl42Wi7aLrX+jc6N0l2qLYYthdWBgYAj7RvtABYeIh4mGi4aLh42Hjgj7RvdABYmNiY2Hj4iOhpGDlISUhZWFlIWVhpaHmYaYiZiLmAgOZ4v3txWLkpCPlo0I9yOgzPcWBY6SkI+Ri5CLkIePhAjL+xb3I3YFlomQh4uEi4aJh4aGCCMmpPsjBYuKi4mLiIuHioiJiImIiIqHi4iLh4yHjQj7FM/7FUcFh4mHioiLh4uIjImOiY6KjouPi4yLjYyOCKP3IyPwBYaQiZCLjwgOZ4v3txWLkpCPlo0I9yOgzPcWBY6SkI+Ri5CLkIePhAjL+xb3I3YFlomQh4uEi4aJh4aGCCMmpPsjBYuKi4mLiIuCh4aDi4iLh4yHjQj7FM/7FUcFh4mHioiLh4uIjImOiY6KjouPi4yLjYyOCKP3IyPwBYaQiZCLjwjKeRXjN3b7DfcAxPZSd/cN4t/7DJ1V9wFV+wEFDq73ZhWLk42RkZEIsbIFkZCRjpOLkouSiJCGCN8291D3UAWQkJKOkouTi5GIkYYIsWQFkYaNhIuEi4OJhYWFCPuJ+4kFhYWFiYOLhIuEjYaRCPsi9yIFhZCJkouSCA77AartFYuSjpKQkAjf3zffBYaQiJKLk4uSjpKQkAiysgWRkJGOk4uSi5KIkIYI3zff3wWQkJKOk4uSi5KIkIYIsmQFkIaOhIuEi4OIhIaGCDc33zcFkIaOhIuEi4OIhYaFCGRkBYaGhIiEi4OLhI6GkAg33zc3BYaGhIiEi4OLhY6FkAhksgWGkYiRi5MIDvtLi8sVi/c5BYuSjpKQkJCQko6SiwiVi4vCBYuul6mkpKSkqpiui66LqX6kcqRymG2LaAiLVJSLBZKLkoiQhpCGjoSLhAiL+zkFi4OIhYaGhoWEiYSLCPuniwWEi4SNhpGGkIiRi5MI5vdUFfcni4vCBYufhJx8mn2ZepJ3i3aLeoR9fX18g3qLdwiLVAUO+yaLshWL+AQFi5GNkY+RjpCQj5KNj42PjI+LCPfAiwWPi4+Kj4mRiZCHj4aPhY2Fi4UIi/wEBYuEiYWHhoeGhoeFiIiKhoqHi4GLhI6EkQj7EvcN+xL7DQWEhYOIgouHi4eLh42EjoaPiJCHkImRi5IIDov3XRWLko2Rj5Kltq+vuKW4pbuZvYu9i7t9uHG4ca9npWCPhI2Fi4SLhYmEh4RxYGdoXnAIXnFbflmLWYtbmF6lXqZnrnG2h5KJkouRCLCLFaRkq2yxdLF0tH+4i7iLtJexorGiq6qksm64Z61goZZ3kXaLdItnfm1ycnJybX9oiwhoi22XcqRypH6pi6+LopGglp9gdWdpbl4I9xiwFYuHjIiOiI6IjoqPi4+LjoyOjo2OjY6Lj4ubkJmXl5eWmZGbi4+LjoyOjo2OjY6LjwiLj4mOiY6IjYiNh4tzi3eCenp6eoJ3i3MIDov3XRWLko2Sj5GouK+utqW3pbqYvouci5yJnIgIm6cFjY6NjI+LjIuNi42JjYqOio+JjomOiY6KjomOiY6JjoqNioyKjomMiYuHi4qLiouLCHdnbVVjQ2NDbVV3Zwh9cgWJiIiJiIuJi36SdJiIjYmOi46LjY+UlJlvl3KcdJ90oHeie6WHkYmSi5IIsIsVqlq0Z711CKGzBXqXfpqCnoKdhp6LoIuikaCWn2B1Z2luXgj3GLAVi4eMiI6IjoiOio+Lj4uOjI6OjY6NjouPi5uQmZeXl5aZkZuLj4uOjI6OjY6NjouPCIuPiY6JjoiNiI2Hi3OLd4J6enp6gneLcwji+10VoLAFtI+wmK2hrqKnqKKvdq1wp2uhCJ2rBZ1/nHycepx6mHqWeY+EjYWLhIuEiYWHhIR/gH1+fG9qaXJmeWV5Y4Jhiwi53BXb9yQFjIKMg4uEi3CDc3x1fHV3fHOBCA6L1BWL90sFi5WPlJKSkpKTj5aLCNmLBZKPmJqepJaZlZeVlY+Qj5ONl42WjpeOmI+YkZWTk5OSk46Vi5uLmYiYhZiFlIGSfgiSfo55i3WLeYd5gXgIvosFn4uchJl8mn2Seot3i3qGfIJ9jYSLhYuEi3yIfoR+i4eLh4uHi3eGen99i3CDdnt8CHt8dYNwiwhmiwV5i3mNeY95kHeRc5N1k36Ph4sIOYsFgIuDjoSShJKHlIuVCLCdFYuGjIePiI+Hj4mQi5CLj42Pj46OjY+LkIuQiZCIjoePh42Gi4aLh4mHh4eIioaLhgjUeRWUiwWNi46Lj4qOi4+KjYqOi4+Kj4mQio6KjYqNio+Kj4mQio6KjIqzfquEpIsIrosFr4uemouri5CKkYqQkY6QkI6SjpKNkouSi5KJkoiRlZWQlouYi5CKkImRiZGJj4iOCJGMkI+PlI+UjZKLkouViJODk4SSgo+CiwgmiwWLlpCalJ6UnpCbi5aLnoiYhJSFlH+QeYuGhoeDiYCJf4h/h3+IfoWBg4KHh4SCgH4Ii4qIiYiGh4aIh4mIiIiIh4eGh4aHh4eHiIiHiIeHiIiHiIeKh4mIioiLCIKLi/tLBQ6L90sVi/dLBYuVj5OSk5KSk46WiwjdiwWPi5iPoZOkk6CRnZCdj56Nn4sIq4sFpougg5x8m3yTd4txCIuJBZd8kHuLd4uHi4eLh5J+jn6LfIuEi4SJhZR9kHyLeot3hHp8fH19eoR3iwhYiwWVeI95i3mLdIh6hH6EfoKBfoV+hX2He4uBi4OPg5KFkYaTh5SHlYiTipOKk4qTiJMIiZSIkYiPgZSBl4CaeKR+moSPCD2LBYCLg4+EkoSSh5SLlQiw9zgVi4aMh4+Ij4ePiZCLkIuPjY+Pjo6Nj4uQi5CJkIiOh4+HjYaLhouHiYeHh4iKhouGCNT7OBWUiwWOi46Kj4mPio+IjoiPh4+IjoePiI+Hj4aPho6HjoiNiI6Hj4aOho6Ii4qWfpKDj4YIk4ORgY5+j36OgI1/jYCPg5CGnYuXj5GUkpSOmYuei5aGmoKfgp6GmouWCPCLBZSLlI+SkpOTjpOLlYuSiZKHlIeUho+Fi46PjY+NkY2RjJCLkIuYhpaBlY6RjZKLkgiLkomSiJKIkoaQhY6MkIyRi5CLm4aXgpOBkn6Pe4sIZosFcotrhGN9iouIioaJh4qHiomKiYqIioaKh4mHioiKiYuHioiLh4qIi4mLCIKLi/tLBQ77lIv3txWLkpCPlo0I9yOgzPcWBY6SkI+RiwiL/BL7FUcFh4mHioiLh4uIjImOiY6KjouPi4yLjYyOCKP3IyPwBYaQiZCLjwgOi/fFFYu1l6yjoqOjrZe2i5aLl4mYh5eHloWWhJaElIWShZOEkoWShJKSkpGTkpKRlJGWkgiWkpaRl4+Yj5eNlou2i61/o3OjdJdqi2GLYXVgYGAI+0b7QAWHiIeJhouGi4eNh44I+0b3QAWJjYmNh4+IjoaRg5SElIWVhZSFlYaWh5mGmImYi5gIsIsVi2ucaa9oCPc6+zT3OvczBa+vnK2Lq4ubiZiHl4eXhpSFkoSSg5GCj4KQgo2CjYONgYuBi4KLgIl/hoCGgIWChAiBg4OFhISEhYaFhoaIhoaJhYuFi4aNiJCGkIaRhJGEkoORgZOCkoCRgJB/kICNgosIgYuBi4OJgomCiYKGgoeDhYSEhYSGgod/h3+Jfot7CA77JouyFYv4BAWLkY2Rj5GOkJCPko2PjY+Mj4sI98CLBY+Lj4qPiZGJkIePho+FjYWLhQiL/AQFi4SJhYeGh4aGh4WIiIqGioeLgYuEjoSRCPsS9w37EvsNBYSFg4iCi4eLh4uHjYSOho+IkIeQiZGLkgiwkxX3JvchpHL3DfsIi/f3+7iLi/v3BQ5ni8sVi/c5BYuSjpKQkJCQko6Siwj3VIuLwgWLrpippKSkpKmYrouvi6l+pHKkcpdti2gIi0IFi4aKhoeIh4eHiYaLCHmLBYaLh42Hj4eOipCLkAiL1AWLn4OcfZp9mXqSdot3i3qEfX18fIR6i3cIi1SniwWSi5KIkIaQho6Ei4QIi/s5BYuDiIWGhoaFhImEiwj7p4sFhIuEjYaRhpCIkYuTCA5njPe6FYyQkI6UjQj3I6DM9xYFj5KPj5GLkIuQh4+ECMv7FvcjdgWUiZCIjYaNhoiFhYUIIyak+yMFjIWKhomHiYiIiYaLiIuHjIeNCPsUz/sVRwWHiYeKiIuHi4eNiY6Jj4uQjJEIo/cjI/AFhZGJkY2QCPeB+z0VnILlW3rxiJ6ZmNTS+wydgpxe54v7pwUOZ4vCFYv3SwWLkI2Pjo+Pjo+NkIsI3osFkIuPiY6Ij4eNh4uGCIv7SwWLhomHh4eIh4eKhosIOIsFhouHjIePiI+Jj4uQCLCvFYuGjIePh46IkImQi5CLj42Pjo6PjY+LkIuQiZCIjoePh42Gi4aLhomIh4eIioaLhgjvZxWL90sFi5CNj46Oj4+PjZCLj4ySkJWWlZaVl5SXmJuVl5GRjo6OkI6RjZCNkIyPjI6MkY2TCIySjJGMj4yPjZCOkY6RjpCPjo6Pj42Qi5SLk4qSiZKJkYiPiJCIjoiPho6GjYeMhwiNh4yGjIaMhYuHi4iLiIuHi4eLg4uEiYSJhImFiYeJh4mFh4WLioqJiomJiIqJiokIi4qKiIqJCNqLBZqLmIWWgJaAkH+LfIt6hn2Af46DjYSLhIt9h36Cf4+Bi3+HgImAhYKEhI12hnmAfgh/fXiDcosIZosFfot+jHyOfI5/joOOg41/j32Qc5N8j4SMhouHjYiOh4+Jj4uQCA5ni/c5FYuGjYaOiI+Hj4mQiwjeiwWQi4+Njo+Pjo2Qi5AIi/dKBYuQiZCHjoiPh42Giwg4iwWGi4eJh4eIiImGi4YIi/tKBbD3JhWLkIyPj4+OjpCNkIuQi4+Jj4iOh42Hi4aLhomHiIeHh4eKhouGi4aMiI+Hj4qPi5AI7/snFYv3SwWLkI2Qj46Oj4+NkIuSi5qPo5OZkJePk46TjZeOmo6ajpiMmIsIsIsFpIueg5d9ln6Qeol1koSRgo2Aj4CLgIeAlH+Pfot9i4WJhIiCloCQfIt7i3yFfoGACICAfoZ8iwg8iwWMiIyJi4mMiYyJjYmMiIyKi4mPhI2GjYeNh42GjYOMhIyEi4SLhouHi4iLiYuGioYIioWKhomHioeJh4iGh4eIh4aIh4iFiISJhImDioKLhouHjYiPh4+Ij4iRiJGJkIqPCIqPipGKkomTipGKj4qOiZCJkYiQiJCIjoWSgZZ+nIKXgZaBloGWhJGHi4aLh42HjwiIjomQi48IDviUFPiUFYsMCgAAAAADAgABkAAFAAABTAFmAAAARwFMAWYAAAD1ABkAhAAAAAAAAAAAAAAAAAAAAAEQAAAAAAAAAAAAAAAAAAAAAEAAAPFlAeD/4P/gAeAAIAAAAAEAAAAAAAAAAAAAACAAAAAAAAIAAAADAAAAFAADAAEAAAAUAAQAkAAAACAAIAAEAAAAAQAg5gXwBvAN8CPwLvBu8HDwivCX8JzxI/Fl//3//wAAAAAAIOYA8ATwDPAj8C7wbvBw8Ifwl/Cc8SPxZP/9//8AAf/jGgQQBhABD+wP4g+jD6IPjA+AD3wO9g62AAMAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAf//AA8AAQAAAAEAAJrVlLJfDzz1AAsCAAAAAADP/GODAAAAAM/8Y4MAAP/bAgAB2wAAAAgAAgAAAAAAAAABAAAB4P/gAAACAAAAAAACAAABAAAAAAAAAAAAAAAAAAAAHAAAAAAAAAAAAAAAAAEAAAACAAAAAgAAAAIAAAACAAAAAgAAAAIAAAACAAAAAdwAAAHcAAACAAAjAZMAHwFJAAABbgAAAgAAAAIAAAACAAAAAgAAAAEAAAACAAAAAW4AAAHcAAAB3AABAdwAAAHcAAAAAFAAABwAAAAAAA4ArgABAAAAAAABAAwAAAABAAAAAAACAA4AQAABAAAAAAADAAwAIgABAAAAAAAEAAwATgABAAAAAAAFABYADAABAAAAAAAGAAYALgABAAAAAAAKADQAWgADAAEECQABAAwAAAADAAEECQACAA4AQAADAAEECQADAAwAIgADAAEECQAEAAwATgADAAEECQAFABYADAADAAEECQAGAAwANAADAAEECQAKADQAWgByAGEAdABpAG4AZwBWAGUAcgBzAGkAbwBuACAAMQAuADAAcgBhAHQAaQBuAGdyYXRpbmcAcgBhAHQAaQBuAGcAUgBlAGcAdQBsAGEAcgByAGEAdABpAG4AZwBGAG8AbgB0ACAAZwBlAG4AZQByAGEAdABlAGQAIABiAHkAIABJAGMAbwBNAG8AbwBuAC4AAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==)
+      format('woff');
   font-weight: normal;
   font-style: normal;
 }
@@ -36498,15 +36820,19 @@ a.ui.nag {
   line-height: 1.21428571em;
   padding: 0.67857143em 1em;
   font-size: 1em;
-  background: #FFFFFF;
+  background: #ffffff;
   border: 1px solid rgba(34, 36, 38, 0.15);
   color: rgba(0, 0, 0, 0.87);
   -webkit-box-shadow: 0em 0em 0em 0em transparent inset;
   box-shadow: 0em 0em 0em 0em transparent inset;
-  -webkit-transition: background-color 0.1s ease, color 0.1s ease, border-color 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: background-color 0.1s ease, color 0.1s ease, border-color 0.1s ease, -webkit-box-shadow 0.1s ease;
-  transition: background-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, border-color 0.1s ease;
-  transition: background-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease, border-color 0.1s ease, -webkit-box-shadow 0.1s ease;
+  -webkit-transition: background-color 0.1s ease, color 0.1s ease,
+    border-color 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: background-color 0.1s ease, color 0.1s ease,
+    border-color 0.1s ease, -webkit-box-shadow 0.1s ease;
+  transition: background-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease,
+    border-color 0.1s ease;
+  transition: background-color 0.1s ease, color 0.1s ease, box-shadow 0.1s ease,
+    border-color 0.1s ease, -webkit-box-shadow 0.1s ease;
 }
 
 .ui.search .prompt {
@@ -36535,13 +36861,15 @@ a.ui.nag {
   white-space: normal;
   text-align: left;
   text-transform: none;
-  background: #FFFFFF;
+  background: #ffffff;
   margin-top: 0.5em;
   width: 18em;
   border-radius: 0.28571429rem;
-  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12), 0px 2px 10px 0px rgba(34, 36, 38, 0.15);
-  border: 1px solid #D4D4D5;
+  -webkit-box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  box-shadow: 0px 2px 4px 0px rgba(34, 36, 38, 0.12),
+    0px 2px 10px 0px rgba(34, 36, 38, 0.15);
+  border: 1px solid #d4d4d5;
   z-index: 998;
 }
 
@@ -36613,7 +36941,7 @@ a.ui.nag {
 
 .ui.search > .results .result .price {
   float: right;
-  color: #21BA45;
+  color: #21ba45;
 }
 
 /*--------------
@@ -36642,7 +36970,7 @@ a.ui.nag {
 .ui.search > .results > .action {
   display: block;
   border-top: none;
-  background: #F3F4F5;
+  background: #f3f4f5;
   padding: 0.92857143em 1em;
   color: rgba(0, 0, 0, 0.87);
   font-weight: bold;
@@ -36659,7 +36987,7 @@ a.ui.nag {
 
 .ui.search > .prompt:focus {
   border-color: rgba(34, 36, 38, 0.35);
-  background: #FFFFFF;
+  background: #ffffff;
   color: rgba(0, 0, 0, 0.95);
 }
 
@@ -36705,11 +37033,11 @@ a.ui.nag {
 
 .ui.search > .results .result:hover,
 .ui.category.search > .results .category .result:hover {
-  background: #F9FAFB;
+  background: #f9fafb;
 }
 
 .ui.search .action:hover {
-  background: #E0E0E0;
+  background: #e0e0e0;
 }
 
 /*--------------
@@ -36717,7 +37045,7 @@ a.ui.nag {
 ---------------*/
 
 .ui.category.search > .results .category.active {
-  background: #F3F4F5;
+  background: #f3f4f5;
 }
 
 .ui.category.search > .results .category.active > .name {
@@ -36728,7 +37056,7 @@ a.ui.nag {
 .ui.category.search > .results .category .result.active {
   position: relative;
   border-left-color: rgba(34, 36, 38, 0.1);
-  background: #F3F4F5;
+  background: #f3f4f5;
   -webkit-box-shadow: none;
   box-shadow: none;
 }
@@ -36785,13 +37113,16 @@ a.ui.nag {
   pointer-events: auto;
 }
 
-.ui.search.selection > .icon.input:not([class*="left icon"]) > .icon ~ .remove.icon {
+.ui.search.selection
+  > .icon.input:not([class*='left icon'])
+  > .icon
+  ~ .remove.icon {
   right: 1.85714em;
 }
 
 .ui.search.selection > .icon.input > .remove.icon:hover {
   opacity: 1;
-  color: #DB2828;
+  color: #db2828;
 }
 
 /*--------------
@@ -36811,7 +37142,7 @@ a.ui.nag {
 
 .ui.category.search > .results .category {
   display: table-row;
-  background: #F3F4F5;
+  background: #f3f4f5;
   -webkit-box-shadow: none;
   box-shadow: none;
   -webkit-transition: background 0.1s ease, border-color 0.1s ease;
@@ -36854,7 +37185,7 @@ a.ui.nag {
 
 .ui.category.search > .results .category .results {
   display: table-cell;
-  background: #FFFFFF;
+  background: #ffffff;
   border-left: 1px solid rgba(34, 36, 38, 0.15);
   border-bottom: 1px solid rgba(34, 36, 38, 0.1);
 }
@@ -36874,12 +37205,12 @@ a.ui.nag {
      Left / Right
 --------------------*/
 
-.ui[class*="left aligned"].search > .results {
+.ui[class*='left aligned'].search > .results {
   right: auto;
   left: 0%;
 }
 
-.ui[class*="right aligned"].search > .results {
+.ui[class*='right aligned'].search > .results {
   right: 0%;
   left: auto;
 }
@@ -36961,10 +37292,15 @@ a.ui.nag {
   display: inline-block;
   -webkit-perspective: 2000px;
   perspective: 2000px;
-  -webkit-transition: left 0.6s ease-in-out, width 0.6s ease-in-out, height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
-  transition: left 0.6s ease-in-out, width 0.6s ease-in-out, height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
-  transition: transform 0.6s ease-in-out, left 0.6s ease-in-out, width 0.6s ease-in-out, height 0.6s ease-in-out;
-  transition: transform 0.6s ease-in-out, left 0.6s ease-in-out, width 0.6s ease-in-out, height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
+  -webkit-transition: left 0.6s ease-in-out, width 0.6s ease-in-out,
+    height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
+  transition: left 0.6s ease-in-out, width 0.6s ease-in-out,
+    height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
+  transition: transform 0.6s ease-in-out, left 0.6s ease-in-out,
+    width 0.6s ease-in-out, height 0.6s ease-in-out;
+  transition: transform 0.6s ease-in-out, left 0.6s ease-in-out,
+    width 0.6s ease-in-out, height 0.6s ease-in-out,
+    -webkit-transform 0.6s ease-in-out;
 }
 
 .ui.shape .sides {
@@ -36997,7 +37333,7 @@ a.ui.nag {
   min-width: 15em;
   height: 15em;
   padding: 2em;
-  background-color: #E6E6E6;
+  background-color: #e6e6e6;
   color: rgba(0, 0, 0, 0.87);
   -webkit-box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.3);
   box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.3);
@@ -37075,10 +37411,15 @@ a.ui.nag {
 }
 
 .ui.shape.animating .sides {
-  -webkit-transition: left 0.6s ease-in-out, width 0.6s ease-in-out, height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
-  transition: left 0.6s ease-in-out, width 0.6s ease-in-out, height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
-  transition: transform 0.6s ease-in-out, left 0.6s ease-in-out, width 0.6s ease-in-out, height 0.6s ease-in-out;
-  transition: transform 0.6s ease-in-out, left 0.6s ease-in-out, width 0.6s ease-in-out, height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
+  -webkit-transition: left 0.6s ease-in-out, width 0.6s ease-in-out,
+    height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
+  transition: left 0.6s ease-in-out, width 0.6s ease-in-out,
+    height 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;
+  transition: transform 0.6s ease-in-out, left 0.6s ease-in-out,
+    width 0.6s ease-in-out, height 0.6s ease-in-out;
+  transition: transform 0.6s ease-in-out, left 0.6s ease-in-out,
+    width 0.6s ease-in-out, height 0.6s ease-in-out,
+    -webkit-transform 0.6s ease-in-out;
 }
 
 .ui.shape.animating .side {
@@ -37246,7 +37587,7 @@ body.pushable {
 }
 
 body.pushable > .pusher {
-  background: #FFFFFF;
+  background: #ffffff;
 }
 
 /* Pusher should inherit background from context */
@@ -37382,8 +37723,8 @@ body.pushable > .pusher {
   width: 150px;
 }
 
-.ui[class*="very thin"].left.sidebar,
-.ui[class*="very thin"].right.sidebar {
+.ui[class*='very thin'].left.sidebar,
+.ui[class*='very thin'].right.sidebar {
   width: 60px;
 }
 
@@ -37397,8 +37738,8 @@ body.pushable > .pusher {
   width: 350px;
 }
 
-.ui[class*="very wide"].left.sidebar,
-.ui[class*="very wide"].right.sidebar {
+.ui[class*='very wide'].left.sidebar,
+.ui[class*='very wide'].right.sidebar {
   width: 475px;
 }
 
@@ -37410,8 +37751,8 @@ body.pushable > .pusher {
   transform: translate3d(150px, 0, 0);
 }
 
-.ui.visible[class*="very thin"].left.sidebar ~ .fixed,
-.ui.visible[class*="very thin"].left.sidebar ~ .pusher {
+.ui.visible[class*='very thin'].left.sidebar ~ .fixed,
+.ui.visible[class*='very thin'].left.sidebar ~ .pusher {
   -webkit-transform: translate3d(60px, 0, 0);
   transform: translate3d(60px, 0, 0);
 }
@@ -37422,8 +37763,8 @@ body.pushable > .pusher {
   transform: translate3d(350px, 0, 0);
 }
 
-.ui.visible[class*="very wide"].left.sidebar ~ .fixed,
-.ui.visible[class*="very wide"].left.sidebar ~ .pusher {
+.ui.visible[class*='very wide'].left.sidebar ~ .fixed,
+.ui.visible[class*='very wide'].left.sidebar ~ .pusher {
   -webkit-transform: translate3d(475px, 0, 0);
   transform: translate3d(475px, 0, 0);
 }
@@ -37436,8 +37777,8 @@ body.pushable > .pusher {
   transform: translate3d(-150px, 0, 0);
 }
 
-.ui.visible[class*="very thin"].right.sidebar ~ .fixed,
-.ui.visible[class*="very thin"].right.sidebar ~ .pusher {
+.ui.visible[class*='very thin'].right.sidebar ~ .fixed,
+.ui.visible[class*='very thin'].right.sidebar ~ .pusher {
   -webkit-transform: translate3d(-60px, 0, 0);
   transform: translate3d(-60px, 0, 0);
 }
@@ -37448,8 +37789,8 @@ body.pushable > .pusher {
   transform: translate3d(-350px, 0, 0);
 }
 
-.ui.visible[class*="very wide"].right.sidebar ~ .fixed,
-.ui.visible[class*="very wide"].right.sidebar ~ .pusher {
+.ui.visible[class*='very wide'].right.sidebar ~ .fixed,
+.ui.visible[class*='very wide'].right.sidebar ~ .pusher {
   -webkit-transform: translate3d(-475px, 0, 0);
   transform: translate3d(-475px, 0, 0);
 }
@@ -38131,7 +38472,8 @@ body.pushable > .pusher {
 
   50% {
     z-index: -1;
-    -webkit-transform: translateX(-105%) rotateY(35deg) rotateX(10deg) translateZ(-10px);
+    -webkit-transform: translateX(-105%) rotateY(35deg) rotateX(10deg)
+      translateZ(-10px);
     transform: translateX(-105%) rotateY(35deg) rotateX(10deg) translateZ(-10px);
   }
 
@@ -38141,7 +38483,8 @@ body.pushable > .pusher {
 
   100% {
     z-index: -1;
-    -webkit-transform: translateX(0%) rotateY(0deg) rotateX(0deg) translateZ(-10px);
+    -webkit-transform: translateX(0%) rotateY(0deg) rotateX(0deg)
+      translateZ(-10px);
     transform: translateX(0%) rotateY(0deg) rotateX(0deg) translateZ(-10px);
     opacity: 0;
   }
@@ -38156,7 +38499,8 @@ body.pushable > .pusher {
 
   50% {
     z-index: -1;
-    -webkit-transform: translateX(-105%) rotateY(35deg) rotateX(10deg) translateZ(-10px);
+    -webkit-transform: translateX(-105%) rotateY(35deg) rotateX(10deg)
+      translateZ(-10px);
     transform: translateX(-105%) rotateY(35deg) rotateX(10deg) translateZ(-10px);
   }
 
@@ -38166,7 +38510,8 @@ body.pushable > .pusher {
 
   100% {
     z-index: -1;
-    -webkit-transform: translateX(0%) rotateY(0deg) rotateX(0deg) translateZ(-10px);
+    -webkit-transform: translateX(0%) rotateY(0deg) rotateX(0deg)
+      translateZ(-10px);
     transform: translateX(0%) rotateY(0deg) rotateX(0deg) translateZ(-10px);
     opacity: 0;
   }
@@ -38181,7 +38526,8 @@ body.pushable > .pusher {
 
   50% {
     z-index: 1;
-    -webkit-transform: translateX(105%) rotateY(35deg) rotateX(10deg) translateZ(-10px);
+    -webkit-transform: translateX(105%) rotateY(35deg) rotateX(10deg)
+      translateZ(-10px);
     transform: translateX(105%) rotateY(35deg) rotateX(10deg) translateZ(-10px);
   }
 
@@ -38191,7 +38537,8 @@ body.pushable > .pusher {
 
   100% {
     z-index: 1;
-    -webkit-transform: translateX(0%) rotateY(0deg) rotateX(0deg) translateZ(-10px);
+    -webkit-transform: translateX(0%) rotateY(0deg) rotateX(0deg)
+      translateZ(-10px);
     transform: translateX(0%) rotateY(0deg) rotateX(0deg) translateZ(-10px);
     opacity: 0;
   }
@@ -38206,7 +38553,8 @@ body.pushable > .pusher {
 
   50% {
     z-index: 1;
-    -webkit-transform: translateX(105%) rotateY(35deg) rotateX(10deg) translateZ(-10px);
+    -webkit-transform: translateX(105%) rotateY(35deg) rotateX(10deg)
+      translateZ(-10px);
     transform: translateX(105%) rotateY(35deg) rotateX(10deg) translateZ(-10px);
   }
 
@@ -38216,7 +38564,8 @@ body.pushable > .pusher {
 
   100% {
     z-index: 1;
-    -webkit-transform: translateX(0%) rotateY(0deg) rotateX(0deg) translateZ(-10px);
+    -webkit-transform: translateX(0%) rotateY(0deg) rotateX(0deg)
+      translateZ(-10px);
     transform: translateX(0%) rotateY(0deg) rotateX(0deg) translateZ(-10px);
     opacity: 0;
   }
@@ -38312,22 +38661,22 @@ body.pushable > .pusher {
   animation-name: fadeIn;
 }
 
-.transition[class*="fade up"].in {
+.transition[class*='fade up'].in {
   -webkit-animation-name: fadeInUp;
   animation-name: fadeInUp;
 }
 
-.transition[class*="fade down"].in {
+.transition[class*='fade down'].in {
   -webkit-animation-name: fadeInDown;
   animation-name: fadeInDown;
 }
 
-.transition[class*="fade left"].in {
+.transition[class*='fade left'].in {
   -webkit-animation-name: fadeInLeft;
   animation-name: fadeInLeft;
 }
 
-.transition[class*="fade right"].in {
+.transition[class*='fade right'].in {
   -webkit-animation-name: fadeInRight;
   animation-name: fadeInRight;
 }
@@ -38337,22 +38686,22 @@ body.pushable > .pusher {
   animation-name: fadeOut;
 }
 
-.transition[class*="fade up"].out {
+.transition[class*='fade up'].out {
   -webkit-animation-name: fadeOutUp;
   animation-name: fadeOutUp;
 }
 
-.transition[class*="fade down"].out {
+.transition[class*='fade down'].out {
   -webkit-animation-name: fadeOutDown;
   animation-name: fadeOutDown;
 }
 
-.transition[class*="fade left"].out {
+.transition[class*='fade left'].out {
   -webkit-animation-name: fadeOutLeft;
   animation-name: fadeOutLeft;
 }
 
-.transition[class*="fade right"].out {
+.transition[class*='fade right'].out {
   -webkit-animation-name: fadeOutRight;
   animation-name: fadeOutRight;
 }
@@ -38861,22 +39210,22 @@ body.pushable > .pusher {
   animation-name: flyIn;
 }
 
-.transition[class*="fly up"].in {
+.transition[class*='fly up'].in {
   -webkit-animation-name: flyInUp;
   animation-name: flyInUp;
 }
 
-.transition[class*="fly down"].in {
+.transition[class*='fly down'].in {
   -webkit-animation-name: flyInDown;
   animation-name: flyInDown;
 }
 
-.transition[class*="fly left"].in {
+.transition[class*='fly left'].in {
   -webkit-animation-name: flyInLeft;
   animation-name: flyInLeft;
 }
 
-.transition[class*="fly right"].in {
+.transition[class*='fly right'].in {
   -webkit-animation-name: flyInRight;
   animation-name: flyInRight;
 }
@@ -38888,22 +39237,22 @@ body.pushable > .pusher {
   animation-name: flyOut;
 }
 
-.transition[class*="fly up"].out {
+.transition[class*='fly up'].out {
   -webkit-animation-name: flyOutUp;
   animation-name: flyOutUp;
 }
 
-.transition[class*="fly down"].out {
+.transition[class*='fly down'].out {
   -webkit-animation-name: flyOutDown;
   animation-name: flyOutDown;
 }
 
-.transition[class*="fly left"].out {
+.transition[class*='fly left'].out {
   -webkit-animation-name: flyOutLeft;
   animation-name: flyOutLeft;
 }
 
-.transition[class*="fly right"].out {
+.transition[class*='fly right'].out {
   -webkit-animation-name: flyOutRight;
   animation-name: flyOutRight;
 }
@@ -39220,7 +39569,8 @@ body.pushable > .pusher {
     transform: scale3d(0.9, 0.9, 0.9);
   }
 
-  50%, 55% {
+  50%,
+  55% {
     opacity: 1;
     -webkit-transform: scale3d(1.1, 1.1, 1.1);
     transform: scale3d(1.1, 1.1, 1.1);
@@ -39239,7 +39589,8 @@ body.pushable > .pusher {
     transform: scale3d(0.9, 0.9, 0.9);
   }
 
-  50%, 55% {
+  50%,
+  55% {
     opacity: 1;
     -webkit-transform: scale3d(1.1, 1.1, 1.1);
     transform: scale3d(1.1, 1.1, 1.1);
@@ -39258,7 +39609,8 @@ body.pushable > .pusher {
     transform: translate3d(0, 10px, 0);
   }
 
-  40%, 45% {
+  40%,
+  45% {
     opacity: 1;
     -webkit-transform: translate3d(0, -20px, 0);
     transform: translate3d(0, -20px, 0);
@@ -39277,7 +39629,8 @@ body.pushable > .pusher {
     transform: translate3d(0, 10px, 0);
   }
 
-  40%, 45% {
+  40%,
+  45% {
     opacity: 1;
     -webkit-transform: translate3d(0, -20px, 0);
     transform: translate3d(0, -20px, 0);
@@ -39296,7 +39649,8 @@ body.pushable > .pusher {
     transform: translate3d(0, -10px, 0);
   }
 
-  40%, 45% {
+  40%,
+  45% {
     opacity: 1;
     -webkit-transform: translate3d(0, 20px, 0);
     transform: translate3d(0, 20px, 0);
@@ -39315,7 +39669,8 @@ body.pushable > .pusher {
     transform: translate3d(0, -10px, 0);
   }
 
-  40%, 45% {
+  40%,
+  45% {
     opacity: 1;
     -webkit-transform: translate3d(0, 20px, 0);
     transform: translate3d(0, 20px, 0);
@@ -39389,28 +39744,28 @@ body.pushable > .pusher {
 ---------------*/
 
 .transition.slide.in,
-.transition[class*="slide down"].in {
+.transition[class*='slide down'].in {
   -webkit-animation-name: slideInY;
   animation-name: slideInY;
   -webkit-transform-origin: top center;
   transform-origin: top center;
 }
 
-.transition[class*="slide up"].in {
+.transition[class*='slide up'].in {
   -webkit-animation-name: slideInY;
   animation-name: slideInY;
   -webkit-transform-origin: bottom center;
   transform-origin: bottom center;
 }
 
-.transition[class*="slide left"].in {
+.transition[class*='slide left'].in {
   -webkit-animation-name: slideInX;
   animation-name: slideInX;
   -webkit-transform-origin: center right;
   transform-origin: center right;
 }
 
-.transition[class*="slide right"].in {
+.transition[class*='slide right'].in {
   -webkit-animation-name: slideInX;
   animation-name: slideInX;
   -webkit-transform-origin: center left;
@@ -39418,28 +39773,28 @@ body.pushable > .pusher {
 }
 
 .transition.slide.out,
-.transition[class*="slide down"].out {
+.transition[class*='slide down'].out {
   -webkit-animation-name: slideOutY;
   animation-name: slideOutY;
   -webkit-transform-origin: top center;
   transform-origin: top center;
 }
 
-.transition[class*="slide up"].out {
+.transition[class*='slide up'].out {
   -webkit-animation-name: slideOutY;
   animation-name: slideOutY;
   -webkit-transform-origin: bottom center;
   transform-origin: bottom center;
 }
 
-.transition[class*="slide left"].out {
+.transition[class*='slide left'].out {
   -webkit-animation-name: slideOutX;
   animation-name: slideOutX;
   -webkit-transform-origin: center right;
   transform-origin: center right;
 }
 
-.transition[class*="slide right"].out {
+.transition[class*='slide right'].out {
   -webkit-animation-name: slideOutX;
   animation-name: slideOutX;
   -webkit-transform-origin: center left;
@@ -39571,28 +39926,28 @@ body.pushable > .pusher {
   animation-duration: 800ms;
 }
 
-.transition[class*="swing down"].in {
+.transition[class*='swing down'].in {
   -webkit-animation-name: swingInX;
   animation-name: swingInX;
   -webkit-transform-origin: top center;
   transform-origin: top center;
 }
 
-.transition[class*="swing up"].in {
+.transition[class*='swing up'].in {
   -webkit-animation-name: swingInX;
   animation-name: swingInX;
   -webkit-transform-origin: bottom center;
   transform-origin: bottom center;
 }
 
-.transition[class*="swing left"].in {
+.transition[class*='swing left'].in {
   -webkit-animation-name: swingInY;
   animation-name: swingInY;
   -webkit-transform-origin: center right;
   transform-origin: center right;
 }
 
-.transition[class*="swing right"].in {
+.transition[class*='swing right'].in {
   -webkit-animation-name: swingInY;
   animation-name: swingInY;
   -webkit-transform-origin: center left;
@@ -39600,28 +39955,28 @@ body.pushable > .pusher {
 }
 
 .transition.swing.out,
-.transition[class*="swing down"].out {
+.transition[class*='swing down'].out {
   -webkit-animation-name: swingOutX;
   animation-name: swingOutX;
   -webkit-transform-origin: top center;
   transform-origin: top center;
 }
 
-.transition[class*="swing up"].out {
+.transition[class*='swing up'].out {
   -webkit-animation-name: swingOutX;
   animation-name: swingOutX;
   -webkit-transform-origin: bottom center;
   transform-origin: bottom center;
 }
 
-.transition[class*="swing left"].out {
+.transition[class*='swing left'].out {
   -webkit-animation-name: swingOutY;
   animation-name: swingOutY;
   -webkit-transform-origin: center right;
   transform-origin: center right;
 }
 
-.transition[class*="swing right"].out {
+.transition[class*='swing right'].out {
   -webkit-animation-name: swingOutY;
   animation-name: swingOutY;
   -webkit-transform-origin: center left;
@@ -39999,21 +40354,27 @@ body.pushable > .pusher {
 /* Flash */
 
 @-webkit-keyframes flash {
-  0%, 50%, 100% {
+  0%,
+  50%,
+  100% {
     opacity: 1;
   }
 
-  25%, 75% {
+  25%,
+  75% {
     opacity: 0;
   }
 }
 
 @keyframes flash {
-  0%, 50%, 100% {
+  0%,
+  50%,
+  100% {
     opacity: 1;
   }
 
-  25%, 75% {
+  25%,
+  75% {
     opacity: 0;
   }
 }
@@ -40021,34 +40382,50 @@ body.pushable > .pusher {
 /* Shake */
 
 @-webkit-keyframes shake {
-  0%, 100% {
+  0%,
+  100% {
     -webkit-transform: translateX(0);
     transform: translateX(0);
   }
 
-  10%, 30%, 50%, 70%, 90% {
+  10%,
+  30%,
+  50%,
+  70%,
+  90% {
     -webkit-transform: translateX(-10px);
     transform: translateX(-10px);
   }
 
-  20%, 40%, 60%, 80% {
+  20%,
+  40%,
+  60%,
+  80% {
     -webkit-transform: translateX(10px);
     transform: translateX(10px);
   }
 }
 
 @keyframes shake {
-  0%, 100% {
+  0%,
+  100% {
     -webkit-transform: translateX(0);
     transform: translateX(0);
   }
 
-  10%, 30%, 50%, 70%, 90% {
+  10%,
+  30%,
+  50%,
+  70%,
+  90% {
     -webkit-transform: translateX(-10px);
     transform: translateX(-10px);
   }
 
-  20%, 40%, 60%, 80% {
+  20%,
+  40%,
+  60%,
+  80% {
     -webkit-transform: translateX(10px);
     transform: translateX(10px);
   }
@@ -40057,7 +40434,11 @@ body.pushable > .pusher {
 /* Bounce */
 
 @-webkit-keyframes bounce {
-  0%, 20%, 50%, 80%, 100% {
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
     -webkit-transform: translateY(0);
     transform: translateY(0);
   }
@@ -40074,7 +40455,11 @@ body.pushable > .pusher {
 }
 
 @keyframes bounce {
-  0%, 20%, 50%, 80%, 100% {
+  0%,
+  20%,
+  50%,
+  80%,
+  100% {
     -webkit-transform: translateY(0);
     transform: translateY(0);
   }
@@ -40098,17 +40483,23 @@ body.pushable > .pusher {
     transform: scale(1);
   }
 
-  10%, 20% {
+  10%,
+  20% {
     -webkit-transform: scale(0.9) rotate(-3deg);
     transform: scale(0.9) rotate(-3deg);
   }
 
-  30%, 50%, 70%, 90% {
+  30%,
+  50%,
+  70%,
+  90% {
     -webkit-transform: scale(1.1) rotate(3deg);
     transform: scale(1.1) rotate(3deg);
   }
 
-  40%, 60%, 80% {
+  40%,
+  60%,
+  80% {
     -webkit-transform: scale(1.1) rotate(-3deg);
     transform: scale(1.1) rotate(-3deg);
   }
@@ -40125,17 +40516,23 @@ body.pushable > .pusher {
     transform: scale(1);
   }
 
-  10%, 20% {
+  10%,
+  20% {
     -webkit-transform: scale(0.9) rotate(-3deg);
     transform: scale(0.9) rotate(-3deg);
   }
 
-  30%, 50%, 70%, 90% {
+  30%,
+  50%,
+  70%,
+  90% {
     -webkit-transform: scale(1.1) rotate(3deg);
     transform: scale(1.1) rotate(3deg);
   }
 
-  40%, 60%, 80% {
+  40%,
+  60%,
+  80% {
     -webkit-transform: scale(1.1) rotate(-3deg);
     transform: scale(1.1) rotate(-3deg);
   }
@@ -40268,29 +40665,29 @@ body.pushable > .pusher {
 
 @-webkit-keyframes glow {
   0% {
-    background-color: #FCFCFD;
+    background-color: #fcfcfd;
   }
 
   30% {
-    background-color: #FFF6CD;
+    background-color: #fff6cd;
   }
 
   100% {
-    background-color: #FCFCFD;
+    background-color: #fcfcfd;
   }
 }
 
 @keyframes glow {
   0% {
-    background-color: #FCFCFD;
+    background-color: #fcfcfd;
   }
 
   30% {
-    background-color: #FFF6CD;
+    background-color: #fff6cd;
   }
 
   100% {
-    background-color: #FCFCFD;
+    background-color: #fcfcfd;
   }
 }
 


### PR DESCRIPTION
## Contents
- improve structure of the .prettierignore file
- enable prettier for public/css folder
- enable prettier for public/api/swagger-source.js file
- enable prettier for public/img folder
- keep on prettierignore uglified / minified files (but tracked in the repo)

## Notes
Before reviewing, please hide whitespace changes:
![image](https://user-images.githubusercontent.com/1144075/113901823-87f5f600-97cf-11eb-9544-733de829925d.png)

The diff will go down from:
![image](https://user-images.githubusercontent.com/1144075/113901909-9ba15c80-97cf-11eb-90ea-a2b69d391e22.png)
to
![image](https://user-images.githubusercontent.com/1144075/113901962-a9ef7880-97cf-11eb-9b49-0431702dc697.png)


## Todos
- [x] Manually check every affected files