### PR TITLE
🔥 remove unused babel configs

### DIFF
--- a/support_scripts/grunt/.babelrc
+++ b/support_scripts/grunt/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["es2015", "react"]
-}

--- a/support_scripts/grunt/package.json
+++ b/support_scripts/grunt/package.json
@@ -52,11 +52,5 @@
   "devDependencies": {
     "babel-preset-stage-2": "^6.24.1",
     "grunt-cli": "^1.3.2"
-  },
-  "babel": {
-    "presets": [
-      "env",
-      "react"
-    ]
   }
 }


### PR DESCRIPTION
babel seems to be used throught grunt and babelify, so these other configs are redundant