### PR TITLE
Fix replaceAll with strings with a slash

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.181.1",
+            "version": "3.183.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "0829df420170e4994767860290a69487a18555f7"
+                "reference": "cf9c877e799c43e22d0e0cbc840e91d1885b13b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0829df420170e4994767860290a69487a18555f7",
-                "reference": "0829df420170e4994767860290a69487a18555f7",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/cf9c877e799c43e22d0e0cbc840e91d1885b13b6",
+                "reference": "cf9c877e799c43e22d0e0cbc840e91d1885b13b6",
                 "shasum": ""
             },
             "require": {
@@ -92,9 +92,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.181.1"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.183.7"
             },
-            "time": "2021-05-12T18:13:31+00:00"
+            "time": "2021-05-27T01:00:13+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -703,16 +703,16 @@
         },
         {
             "name": "matecat/whole-text-finder",
-            "version": "v1.0.13",
+            "version": "v1.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/whole-text-finder.git",
-                "reference": "47c636cebf074a7bd6e66b5ab45c74e31227d933"
+                "reference": "d5ff07d8eca4212eb214859ff7bf5f4b781ce11b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/whole-text-finder/zipball/47c636cebf074a7bd6e66b5ab45c74e31227d933",
-                "reference": "47c636cebf074a7bd6e66b5ab45c74e31227d933",
+                "url": "https://api.github.com/repos/matecat/whole-text-finder/zipball/d5ff07d8eca4212eb214859ff7bf5f4b781ce11b",
+                "reference": "d5ff07d8eca4212eb214859ff7bf5f4b781ce11b",
                 "shasum": ""
             },
             "require": {
@@ -750,22 +750,22 @@
             ],
             "support": {
                 "issues": "https://github.com/matecat/whole-text-finder/issues",
-                "source": "https://github.com/matecat/whole-text-finder/tree/v1.0.13"
+                "source": "https://github.com/matecat/whole-text-finder/tree/v1.0.14"
             },
-            "time": "2020-12-02T14:48:07+00:00"
+            "time": "2021-05-27T16:45:20+00:00"
         },
         {
             "name": "matecat/xliff-parser",
-            "version": "v1.0.61",
+            "version": "v1.0.64",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/xliff-parser.git",
-                "reference": "23e21767cf9363f3adc75cecb663e9a7cdec7e95"
+                "reference": "dfc9999bbf87945ec6f19954deb875c29e9b2005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/xliff-parser/zipball/23e21767cf9363f3adc75cecb663e9a7cdec7e95",
-                "reference": "23e21767cf9363f3adc75cecb663e9a7cdec7e95",
+                "url": "https://api.github.com/repos/matecat/xliff-parser/zipball/dfc9999bbf87945ec6f19954deb875c29e9b2005",
+                "reference": "dfc9999bbf87945ec6f19954deb875c29e9b2005",
                 "shasum": ""
             },
             "require": {
@@ -801,9 +801,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matecat/xliff-parser/issues",
-                "source": "https://github.com/matecat/xliff-parser/tree/v1.0.61"
+                "source": "https://github.com/matecat/xliff-parser/tree/v1.0.64"
             },
-            "time": "2021-05-13T19:21:06+00:00"
+            "time": "2021-05-25T12:18:44+00:00"
         },
         {
             "name": "monolog/monolog",


### PR DESCRIPTION
(Whole-text-finder v1.0.14)
- https://github.com/matecat/whole-text-finder/pull/2
