### PR TITLE
🔧 eslint :: enable es6 globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     {
       files: ['**/cat_source/**/*.js'],
       parser: '@babel/eslint-parser',
+      env: {es6: true},
       parserOptions: {
         sourceType: 'module',
         ecmaVersion: browserEcmaVersion,


### PR DESCRIPTION
Questa impostazione fa riconoscere ad eslint le globals introdotte in es6, tipo `Promise` ad esempio.