### PR TITLE
🔧 enable async await

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,7 @@
 const sass = require('node-sass')
 
+const {getBabelPresets} = require('./babel.utils')
+
 const basePath = 'public/js/'
 const buildPath = 'public/js/build/'
 const incPath = 'inc/'
@@ -30,10 +32,7 @@ const cssWatchFilesUploadPage = [
 ]
 const cssWatchManage = [cssBase + 'sass/commons/*']
 
-const babelifyTransform = [
-  'babelify',
-  {presets: ['@babel/preset-react', ['@babel/preset-env']]},
-]
+const babelifyTransform = ['babelify', getBabelPresets('browser')]
 
 module.exports = function (grunt) {
   const conf = grunt.file.read(incPath + 'version.ini')

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,16 +1,11 @@
+const {getBabelPresets} = require('./babel.utils')
+
 module.exports = (api) => {
   switch (api.env()) {
     case 'test':
-      return {
-        presets: [
-          '@babel/preset-react',
-          ['@babel/preset-env', {targets: {node: 'current'}}],
-        ],
-      }
+      return getBabelPresets('node')
     case 'development':
-      return {
-        presets: ['@babel/preset-react', ['@babel/preset-env']],
-      }
+      return getBabelPresets('browser')
 
     default:
       throw new Error('babel.config.js :: environment not supported, yet.')

--- a/babel.utils.js
+++ b/babel.utils.js
@@ -1,0 +1,21 @@
+const targetsMap = {
+  node: {node: 'current'},
+  browser: {browsers: ['defaults', 'not ie 11', 'not ie_mob 11']},
+}
+
+/**
+ * Util to generate the babel presets configuration used
+ * in the rest of the project.
+ *
+ * @param {'browser' | 'node'} env
+ */
+const getBabelPresets = (env = 'browser') => {
+  return {
+    presets: [
+      '@babel/preset-react',
+      ['@babel/preset-env', {targets: targetsMap[env]}],
+    ],
+  }
+}
+
+exports.getBabelPresets = getBabelPresets

--- a/public/js/cat_source/es6/api/getProjects/getProjects.js
+++ b/public/js/cat_source/es6/api/getProjects/getProjects.js
@@ -8,12 +8,13 @@ import {getMatecatApiDomain} from '../../utils/getMatecatApiDomain'
  * - the given team
  * - the given page
  *
+ * @param {object} param
  * @param {number} param.page
  * @param {object} param.searchFilter
  * @param {object} param.team
  * @returns {Promise<object>}
  */
-export const getProjects = ({
+export const getProjects = async ({
   searchFilter,
   team,
   page = searchFilter.currentPage,
@@ -31,9 +32,11 @@ export const getProjects = ({
     formData.append(key, data[key])
   })
 
-  return fetch(`${getMatecatApiDomain()}?action=getProjects`, {
+  const res = await fetch(`${getMatecatApiDomain()}?action=getProjects`, {
     method: 'POST',
     credentials: 'include',
     body: formData,
-  }).then((res) => res.json())
+  })
+
+  return await res.json()
 }


### PR DESCRIPTION
Come vedete dallo screen async await non viene toccato da babel (veniva transpilato perché non avevamo escluso ie11 dai targets).

![image](https://user-images.githubusercontent.com/1144075/126790788-dc67868e-00a6-4d8f-ba36-0c7e46d36c4c.png)
