### PR TITLE
ConvertFile refactoring

### DIFF
--- a/lib/Controller/API/NewController.php
+++ b/lib/Controller/API/NewController.php
@@ -1,7 +1,7 @@
 <?php
 
 use Constants\ConversionHandlerStatus;
-use Conversion\ConvertFileModel;
+use Conversion\ConvertedFileModel;
 use FilesStorage\AbstractFilesStorage;
 use FilesStorage\FilesStorageFactory;
 use LQA\ModelDao;
@@ -437,7 +437,7 @@ class NewController extends ajaxController {
 
                         $brokenFileName = ZipArchiveExtended::getFileName( $fileError->name );
 
-                        $this->result = new ConvertFileModel( $fileError->error[ 'code' ] );
+                        $this->result = new ConvertedFileModel( $fileError->error[ 'code' ] );
                         $this->result->addError($fileError->error[ 'message' ], $brokenFileName);
                     }
 
@@ -505,7 +505,7 @@ class NewController extends ajaxController {
                 $status = $errors = $converter->checkResult();
                 if ( count( $errors ) > 0 ) {
 
-                    $this->result = new ConvertFileModel(ConversionHandlerStatus::ZIP_ERRORS);
+                    $this->result = new ConvertedFileModel(ConversionHandlerStatus::ZIP_HANDLING);
                     foreach ( $errors as $__err ) {
 
                         $savedErrors = $this->result->getErrors();

--- a/lib/Controller/API/NewController.php
+++ b/lib/Controller/API/NewController.php
@@ -1,5 +1,7 @@
 <?php
 
+use Constants\ConversionHandlerStatus;
+use Conversion\ConvertFileModel;
 use FilesStorage\AbstractFilesStorage;
 use FilesStorage\FilesStorageFactory;
 use LQA\ModelDao;
@@ -435,20 +437,8 @@ class NewController extends ajaxController {
 
                         $brokenFileName = ZipArchiveExtended::getFileName( $fileError->name );
 
-                        /*
-                         * TODO
-                         * return error code is 2 because
-                         *      <=0 is for errors
-                         *      1   is OK
-                         *
-                         * In this case, we raise warnings, hence the return code must be a new code
-                         */
-                        $this->result[ 'code' ]                      = 2;
-                        $this->result[ 'errors' ][ $brokenFileName ] = [
-                                'code'    => $fileError->error[ 'code' ],
-                                'message' => $fileError->error[ 'message' ],
-                                'debug'   => $brokenFileName
-                        ];
+                        $this->result = new ConvertFileModel( $fileError->error[ 'code' ] );
+                        $this->result->addError($fileError->error[ 'message' ], $brokenFileName);
                     }
 
                 }
@@ -514,17 +504,15 @@ class NewController extends ajaxController {
 
                 $status = $errors = $converter->checkResult();
                 if ( count( $errors ) > 0 ) {
-//                    $this->result[ 'errors' ] = array_merge( $this->result[ 'errors' ], $errors );
-                    $this->result[ 'code' ] = 2;
+
+                    $this->result = new ConvertFileModel(ConversionHandlerStatus::ZIP_ERRORS);
                     foreach ( $errors as $__err ) {
+
+                        $savedErrors = $this->result->getErrors();
                         $brokenFileName = ZipArchiveExtended::getFileName( $__err[ 'debug' ] );
 
-                        if ( !isset( $this->result[ 'errors' ][ $brokenFileName ] ) ) {
-                            $this->result[ 'errors' ][ $brokenFileName ] = [
-                                    'code'    => $__err[ 'code' ],
-                                    'message' => $__err[ 'message' ],
-                                    'debug'   => $brokenFileName
-                            ];
+                        if( !isset( $savedErrors[$brokenFileName] ) ){
+                            $this->result->addError($__err[ 'message' ], $brokenFileName);
                         }
                     }
                 }
@@ -533,7 +521,7 @@ class NewController extends ajaxController {
                 $conversionHandler->doAction();
 
                 $result = $conversionHandler->getResult();
-                if ( $result[ 'code' ] < 0 ) {
+                if ( $result->getCode() < 0 ) {
                     $status[] = $result;
                 }
 

--- a/lib/Model/Conversion/ConvertFileModel.php
+++ b/lib/Model/Conversion/ConvertFileModel.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Conversion ;
+
+use Constants\ConversionHandlerStatus;
+
+class ConvertFileModel implements \JsonSerializable
+{
+    /**
+     * @var int
+     */
+    private $code;
+
+    /**
+     * @var array
+     */
+    private $errors;
+
+    /**
+     * ConvertFileModel constructor.
+     *
+     * @param null $code
+     *
+     * @throws \Exception
+     */
+    public function __construct($code = null)
+    {
+        if(empty($code)){
+            $this->code = ConversionHandlerStatus::NOT_CONVERTED;
+        } else {
+            $this->changeCode($code);
+        }
+
+        $this->errors = [];
+    }
+
+    /**
+     * @param $code
+     *
+     * @return bool
+     */
+    private function validateCode($code)
+    {
+        $allowed = [
+            ConversionHandlerStatus::OK ,
+            ConversionHandlerStatus::NOT_CONVERTED,
+            ConversionHandlerStatus::INVALID_FILE,
+            ConversionHandlerStatus::NESTED_ZIP_FILES_NOT_ALLOWED,
+            ConversionHandlerStatus::SOURCE_ERROR,
+            ConversionHandlerStatus::TARGET_ERROR,
+            ConversionHandlerStatus::UPLOAD_ERROR,
+            ConversionHandlerStatus::MISCONFIGURATION,
+            ConversionHandlerStatus::INVALID_TOKEN,
+            ConversionHandlerStatus::OCR_WARNING,
+            ConversionHandlerStatus::OCR_ERROR,
+            ConversionHandlerStatus::GENERIC_ERROR,
+            ConversionHandlerStatus::FILESYSTEM_ERROR,
+            ConversionHandlerStatus::S3_ERROR,
+        ];
+
+        return in_array($code, $allowed);
+    }
+
+    /**
+     * @param $code
+     *
+     * @throws \Exception
+     */
+    public function changeCode($code)
+    {
+        if(!$this->validateCode($code)){
+            throw new \Exception($code . ' is not a valid code');
+        }
+
+        $this->code = $code;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCode() {
+        return $this->code;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAnErrorCode()
+    {
+        return $this->code <= 0;
+    }
+
+    /**
+     * @param string $messageError
+     * @param null $debug
+     */
+    public function addError($messageError, $debug = null)
+    {
+        if($debug){
+            $this->errors[$debug] = [
+                'code' => $this->code,
+                'message' => $messageError,
+                'debug' => $debug
+            ];
+
+        } else {
+            $this->errors[] = [
+                    'code' => $this->code,
+                    'message' => $messageError,
+            ];
+        }
+
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors() {
+        return $this->errors;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasErrors()
+    {
+        return !empty($this->errors);
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'code' => $this->getCode(),
+            'errors' => $this->getErrors(),
+        ];
+    }
+}

--- a/lib/Model/Conversion/ConvertedFileModel.php
+++ b/lib/Model/Conversion/ConvertedFileModel.php
@@ -4,7 +4,7 @@ namespace Conversion ;
 
 use Constants\ConversionHandlerStatus;
 
-class ConvertFileModel implements \JsonSerializable
+class ConvertedFileModel implements \JsonSerializable
 {
     /**
      * @var int
@@ -15,6 +15,11 @@ class ConvertFileModel implements \JsonSerializable
      * @var array
      */
     private $errors;
+
+    /**
+     * @var array
+     */
+    private $data;
 
     /**
      * ConvertFileModel constructor.
@@ -32,6 +37,7 @@ class ConvertFileModel implements \JsonSerializable
         }
 
         $this->errors = [];
+        $this->data = [];
     }
 
     /**
@@ -42,6 +48,7 @@ class ConvertFileModel implements \JsonSerializable
     private function validateCode($code)
     {
         $allowed = [
+            ConversionHandlerStatus::ZIP_HANDLING,
             ConversionHandlerStatus::OK ,
             ConversionHandlerStatus::NOT_CONVERTED,
             ConversionHandlerStatus::INVALID_FILE,
@@ -130,11 +137,28 @@ class ConvertFileModel implements \JsonSerializable
     /**
      * @return array
      */
+    public function getData() {
+        return $this->data;
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     */
+    public function addData( $key, $value )
+    {
+        $this->data[$key] = $value;
+    }
+
+    /**
+     * @return array
+     */
     public function jsonSerialize()
     {
         return [
             'code' => $this->getCode(),
             'errors' => $this->getErrors(),
+            'data' => $this->getData(),
         ];
     }
 }

--- a/lib/Model/ConversionHandler.php
+++ b/lib/Model/ConversionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 use Constants\ConversionHandlerStatus;
-use Conversion\ConvertFileModel;
+use Conversion\ConvertedFileModel;
 use FilesStorage\AbstractFilesStorage;
 use FilesStorage\FilesStorageFactory;
 use FilesStorage\Exceptions\FileSystemException;
@@ -10,7 +10,7 @@ use Matecat\XliffParser\XliffUtils\XliffProprietaryDetect;
 class ConversionHandler {
 
     /**
-     * @var ConvertFileModel
+     * @var ConvertedFileModel
      */
     protected $result;
 
@@ -36,7 +36,7 @@ class ConversionHandler {
      * ConversionHandler constructor.
      */
     public function __construct() {
-        $this->result = new ConvertFileModel(ConversionHandlerStatus::OK);
+        $this->result = new ConvertedFileModel(ConversionHandlerStatus::OK);
     }
 
     public function doAction() {
@@ -309,7 +309,7 @@ class ConversionHandler {
 
 
     /**
-     * @return ConvertFileModel
+     * @return ConvertedFileModel
      */
     public function getResult() {
         return $this->result;

--- a/lib/Model/ConversionHandlerOld.php
+++ b/lib/Model/ConversionHandlerOld.php
@@ -1,30 +1,31 @@
 <?php
 
-use Constants\ConversionHandlerStatus;
-use Conversion\ConvertFileModel;
 use FilesStorage\AbstractFilesStorage;
 use FilesStorage\FilesStorageFactory;
 use FilesStorage\Exceptions\FileSystemException;
 use Matecat\XliffParser\XliffUtils\XliffProprietaryDetect;
 
-class ConversionHandler {
+class ConversionHandlerOld {
 
-    /**
-     * @var ConvertFileModel
-     */
     protected $result;
 
     protected $file_name;
     protected $source_lang;
     protected $target_lang;
     protected $segmentation_rule;
+
     protected $cache_days = 10;
+
     protected $intDir;
     protected $errDir;
+
     protected $cookieDir;
+
     protected $stopOnFileException = true;
+
     protected $uploadedFiles;
     public    $uploadError = false;
+
     protected $_userIsLogged;
 
     /**
@@ -36,7 +37,9 @@ class ConversionHandler {
      * ConversionHandler constructor.
      */
     public function __construct() {
-        $this->result = new ConvertFileModel(ConversionHandlerStatus::OK);
+        $this->result = [
+                'code' => 1 //set OK default
+        ];
     }
 
     public function doAction() {
@@ -46,8 +49,12 @@ class ConversionHandler {
         $file_path       = $this->intDir . DIRECTORY_SEPARATOR . $this->file_name;
 
         if ( !file_exists( $file_path ) ) {
-            $this->result->changeCode(ConversionHandlerStatus::UPLOAD_ERROR);
-            $this->result->addError("Error during upload. Please retry.", AbstractFilesStorage::basename_fix( $this->file_name ));
+            $this->result[ 'code' ]     = -6; // No Good, Default
+            $this->result[ 'errors' ][] = [
+                    "code"    => -6,
+                    "message" => "Error during upload. Please retry.",
+                    'debug'   => AbstractFilesStorage::basename_fix( $this->file_name )
+            ];
 
             return -1;
         }
@@ -63,6 +70,9 @@ class ConversionHandler {
                 //Continue with conversion
                 break;
             case false:
+                $this->result[ 'code' ]     = 1; // OK for client, do not convert
+                $this->result[ 'errors' ][] = [ "code" => 0, "message" => "OK" ];
+
                 return 0;
                 break;
             case -1:
@@ -73,10 +83,12 @@ class ConversionHandler {
                  * @see upload.class.php
                  */
                 unlink( $file_path );
-
-                $this->result->changeCode(ConversionHandlerStatus::MISCONFIGURATION);
-                $this->result->addError('Matecat Open-Source does not support ' . ucwords( XliffProprietaryDetect::getInfo( $file_path )[ 'proprietary_name' ] ) . '. Use MatecatPro.',
-                        AbstractFilesStorage::basename_fix( $this->file_name ));
+                $this->result[ 'code' ]     = -7; // No Good, Default
+                $this->result[ 'errors' ][] = [
+                        "code"    => -7,
+                        "message" => 'Matecat Open-Source does not support ' . ucwords( XliffProprietaryDetect::getInfo( $file_path )[ 'proprietary_name' ] ) . '. Use MatecatPro.',
+                        'debug'   => AbstractFilesStorage::basename_fix( $this->file_name )
+                ];
 
                 return -1;
                 break;
@@ -111,14 +123,20 @@ class ConversionHandler {
 
             $ocrCheck = new \Filters\OCRCheck( $this->source_lang );
             if ( $ocrCheck->thereIsError( $file_path ) ) {
-                $this->result->changeCode(ConversionHandlerStatus::OCR_ERROR);
-                $this->result->addError("File is not valid. OCR for RTL languages is not supported.");
+                $this->result[ 'code' ]     = -21; // No Good, Default
+                $this->result[ 'errors' ][] = [
+                        "code"    => -21,
+                        "message" => "File is not valid. OCR for RTL languages is not supported."
+                ];
 
                 return false; //break project creation
             }
             if ( $ocrCheck->thereIsWarning( $file_path ) ) {
-                $this->result->changeCode(ConversionHandlerStatus::OCR_WARNING);
-                $this->result->addError("File uploaded successfully. Before translating, download the Preview to check the conversion. OCR support for non-latin scripts is experimental.");
+                $this->result[ 'code' ]     = -20; // No Good, Default
+                $this->result[ 'errors' ][] = [
+                        "code"    => -20,
+                        "message" => "File uploaded successfully. Before translating, download the Preview to check the conversion. OCR support for non-latin scripts is experimental."
+                ];
             }
 
             if ( strpos( $this->target_lang, ',' ) !== false ) {
@@ -150,9 +168,12 @@ class ConversionHandler {
                     if ( !$res_insert ) {
                         //custom error message passed directly to javascript client and displayed as is
                         $convertResult[ 'errorMessage' ] = "Error: File upload failed because you have MateCat running in multiple tabs. Please close all other MateCat tabs in your browser.";
-
-                        $this->result->changeCode(ConversionHandlerStatus::FILESYSTEM_ERROR);
-                        $this->result->addError($convertResult[ 'errorMessage' ], AbstractFilesStorage::basename_fix( $this->file_name ));
+                        $this->result[ 'code' ]          = -103;
+                        $this->result[ 'errors' ][]      = [
+                                "code"    => -103,
+                                "message" => $convertResult[ 'errorMessage' ],
+                                'debug'   => AbstractFilesStorage::basename_fix( $this->file_name )
+                        ];
 
                         unset( $cachedXliffPath );
 
@@ -163,8 +184,11 @@ class ConversionHandler {
 
                     \Log::doJsonLog("FileSystem Exception: Message: " . $e->getMessage());
 
-                    $this->result->changeCode(ConversionHandlerStatus::FILESYSTEM_ERROR);
-                    $this->result->addError($e->getMessage());
+                    $this->result[ 'code' ]     = -103; // FileSystem Exception
+                    $this->result[ 'errors' ][] = [
+                            "code"    => -103,
+                            "message" => $e->getMessage()
+                    ];
 
                     return false;
 
@@ -172,16 +196,24 @@ class ConversionHandler {
 
                     \Log::doJsonLog("S3 Exception: Message: " . $e->getMessage());
 
-                    $this->result->changeCode(ConversionHandlerStatus::S3_ERROR);
-                    $this->result->addError('Sorry, file name too long. Try shortening it and try again.');
+                    $this->result[ 'code' ]     = -230; // S3 Exception
+                    $this->result[ 'errors' ][] = [
+                            "code"    => -230,
+                            "message" => 'Sorry, file name too long. Try shortening it and try again.'
+                    ];
 
                     return false;
                 }
 
             } else {
 
-                $this->result->changeCode(ConversionHandlerStatus::GENERIC_ERROR);
-                $this->result->addError($convertResult[ 'errorMessage' ], AbstractFilesStorage::basename_fix( $this->file_name ));
+                //custom error message passed directly to javascript client and displayed as is
+                $this->result[ 'code' ]     = -100;
+                $this->result[ 'errors' ][] = [
+                        "code"    => -100,
+                        "message" => $convertResult[ 'errorMessage' ],
+                        "debug"   => AbstractFilesStorage::basename_fix( $this->file_name )
+                ];
             }
 
         }
@@ -252,10 +284,12 @@ class ConversionHandler {
 
             } catch ( Exception $e ) {
 
-                $this->result->changeCode(ConversionHandlerStatus::INVALID_FILE);
-                $this->result->addError($e->getMessage());
+                $this->result = [
+                        'errors' => [
+                                [ "code" => -1, "message" => $e->getMessage() ]
+                        ]
+                ];
 
-                // ???
                 $this->api_output[ 'message' ] = $e->getMessage();
 
                 return null;
@@ -268,9 +302,11 @@ class ConversionHandler {
         } catch ( Exception $e ) {
 
             Log::doJsonLog( "ExtendedZipArchive Exception: {$e->getCode()} : {$e->getMessage()}" );
-
-            $this->result->changeCode($e->getCode());
-            $this->result->addError("Zip error: " . $e->getMessage(), $this->file_name);
+            $this->result[ 'errors' ] [] = [
+                    'code'    => $e->getCode(),
+                    'message' => "Zip error: " . $e->getMessage(),
+                    'debug'   => $this->file_name
+            ];
 
             return null;
         }
@@ -309,7 +345,7 @@ class ConversionHandler {
 
 
     /**
-     * @return ConvertFileModel
+     * @return mixed
      */
     public function getResult() {
         return $this->result;

--- a/lib/Utils/API/ConvertFileWrapper.php
+++ b/lib/Utils/API/ConvertFileWrapper.php
@@ -1,5 +1,7 @@
 <?php
 
+use Conversion\ConvertFileModel;
+
 /**
  * Created by PhpStorm.
  * User: domenico
@@ -46,27 +48,24 @@ class ConvertFileWrapper extends convertFileController {
 
     /**
      * Check on executed conversion results
-     *
-     * @throws Exception
+     * @return ConvertFileModel[]
      */
     public function checkResult() {
 
-//        Log::doJsonLog( $this->resultStack );
-
         $failure = false;
+
+        /** @var ConvertFileModel $res */
         foreach ( $this->resultStack as $res ) {
-            if ( $res[ 'code' ] <= 0 ) {
+            if ( $res->hasAnErrorCode() ) {
                 $failure = true;
             }
         }
 
-        $result = array( 'errors' => array() );
         if ( $failure ) {
-            $result = end( $this->resultStack );
+            return end( $this->resultStack );
         }
-        $this->resultStack = $result[ 'errors' ];
 
-        return $this->resultStack;
+        return [];
 
     }
 

--- a/lib/Utils/API/ConvertFileWrapper.php
+++ b/lib/Utils/API/ConvertFileWrapper.php
@@ -1,6 +1,6 @@
 <?php
 
-use Conversion\ConvertFileModel;
+use Conversion\ConvertedFileModel;
 
 /**
  * Created by PhpStorm.
@@ -48,13 +48,13 @@ class ConvertFileWrapper extends convertFileController {
 
     /**
      * Check on executed conversion results
-     * @return ConvertFileModel[]
+     * @return ConvertedFileModel[]
      */
     public function checkResult() {
 
         $failure = false;
 
-        /** @var ConvertFileModel $res */
+        /** @var ConvertedFileModel $res */
         foreach ( $this->resultStack as $res ) {
             if ( $res->hasAnErrorCode() ) {
                 $failure = true;

--- a/lib/Utils/Constants/ConversionHandlerStatus.php
+++ b/lib/Utils/Constants/ConversionHandlerStatus.php
@@ -4,7 +4,7 @@ namespace Constants;
 
 class ConversionHandlerStatus {
 
-    const ZIP_ERRORS                   = 2;
+    const ZIP_HANDLING                 = 2;
     const OK                           = 1;
     const NOT_CONVERTED                = 0;
 

--- a/lib/Utils/Constants/ConversionHandlerStatus.php
+++ b/lib/Utils/Constants/ConversionHandlerStatus.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Constants;
+
+class ConversionHandlerStatus {
+
+    const ZIP_ERRORS                   = 2;
+    const OK                           = 1;
+    const NOT_CONVERTED                = 0;
+
+    // ERRORS
+    const INVALID_FILE                 = -1;
+    const NESTED_ZIP_FILES_NOT_ALLOWED = -2;
+    const SOURCE_ERROR                 = -3;
+    const TARGET_ERROR                 = -4;
+    const UPLOAD_ERROR                 = -6;
+    const MISCONFIGURATION             = -7;
+    const INVALID_TOKEN                = -19;
+    const OCR_WARNING                  = -20;
+    const OCR_ERROR                    = -21;
+    const GENERIC_ERROR                = -100;
+    const FILESYSTEM_ERROR             = -103;
+    const S3_ERROR                     = -230;
+
+}

--- a/test/unit/Model/ConvertFileModelTest.php
+++ b/test/unit/Model/ConvertFileModelTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use Constants\ConversionHandlerStatus;
+use Conversion\ConvertFileModel;
+
+class ConvertFileModelTest extends PHPUnit_Framework_TestCase {
+
+    function test_model() {
+        $model = new ConvertFileModel();
+        $this->assertEquals($model->getCode(), ConversionHandlerStatus::NOT_CONVERTED);
+        $this->assertFalse($model->hasErrors());
+
+        $model->changeCode(ConversionHandlerStatus::OK);
+        $this->assertEquals($model->getCode(), ConversionHandlerStatus::OK);
+
+        try {
+            $model->changeCode(43434343);
+        } catch (\Exception $exception){
+            $this->assertEquals($exception->getMessage(), '43434343 is not a valid code');
+        }
+
+        $model->changeCode(ConversionHandlerStatus::SOURCE_ERROR);
+        $model->addError('Source not valid');
+
+        $this->assertCount(1, $model->getErrors());
+        $this->assertTrue($model->hasErrors());
+
+        $json = json_encode($model);
+
+        $this->assertEquals('{"code":-3,"errors":[{"code":-3,"message":"Source not valid"}]}', $json);
+    }
+}

--- a/test/unit/Model/ConvertFileModelTest.php
+++ b/test/unit/Model/ConvertFileModelTest.php
@@ -1,12 +1,12 @@
 <?php
 
 use Constants\ConversionHandlerStatus;
-use Conversion\ConvertFileModel;
+use Conversion\ConvertedFileModel;
 
 class ConvertFileModelTest extends PHPUnit_Framework_TestCase {
 
     function test_model() {
-        $model = new ConvertFileModel();
+        $model = new ConvertedFileModel();
         $this->assertEquals($model->getCode(), ConversionHandlerStatus::NOT_CONVERTED);
         $this->assertFalse($model->hasErrors());
 


### PR DESCRIPTION
`ConvertHandler` and `ConvertFileController` now returns the same model structure `Conversion\ConvertedFileModel`, which guarantees **data validation and consistency**:

```json
{
     "code": 1,
     "errors": [],
     "data": []
}
````

For more clarity I moved the Conversion status code here:

```php

namespace Constants;

class ConversionHandlerStatus {

    const ZIP_HANDLING                 = 2;
    const OK                           = 1;
    const NOT_CONVERTED                = 0;

    // ERRORS
    const INVALID_FILE                 = -1;
    const NESTED_ZIP_FILES_NOT_ALLOWED = -2;
    const SOURCE_ERROR                 = -3;
    const TARGET_ERROR                 = -4;
    const UPLOAD_ERROR                 = -6;
    const MISCONFIGURATION             = -7;
    const INVALID_TOKEN                = -19;
    const OCR_WARNING                  = -20;
    const OCR_ERROR                    = -21;
    const GENERIC_ERROR                = -100;
    const FILESYSTEM_ERROR             = -103;
    const S3_ERROR                     = -230;

}
```


