### PR TITLE
[MMT] Fix "Engine not found" error

### DIFF
--- a/lib/Plugins/Features/Mmt.php
+++ b/lib/Plugins/Features/Mmt.php
@@ -100,8 +100,6 @@ class Mmt extends BaseFeature {
             return $newCreatedDbRowStruct;
         }
 
-        $newTestCreatedMT = Engine::getInstance( $newCreatedDbRowStruct->id );
-
         try {
 
             $extraParams = $newCreatedDbRowStruct->getExtraParamsAsArray();


### PR DESCRIPTION
I removed a totally useless variable:

```php
$newTestCreatedMT = Engine::getInstance( $newCreatedDbRowStruct->id );
```

This could prevent the "engine not found" error due to `getInstance` method invocation.