### PR TITLE
Glossary import checks

### DIFF
--- a/lib/Routes/api_v2_routes.php
+++ b/lib/Routes/api_v2_routes.php
@@ -76,6 +76,7 @@ $klein->with('/api/v2/jobs/[:id_job]/[:password]', function() {
 
 $klein->with('/api/v2/glossaries', function() {
 
+    route( '/check/', 'POST', '\API\V2\GlossariesController', 'check' );
     route( '/import/', 'POST', '\API\V2\GlossariesController', 'import' );
     route( '/import/status/[:uuid]', 'GET', '\API\V2\GlossariesController', 'uploadStatus' );
     route( '/export/', 'POST', '\API\V2\GlossariesController', 'download' );

--- a/lib/Utils/TMS/TMSFile.php
+++ b/lib/Utils/TMS/TMSFile.php
@@ -18,6 +18,7 @@ class TMSFile extends stdClass {
     private $name;
     private $position;
     private $uuid;
+    private $numberOfLanguages;
 
     /**
      * @param $file_path
@@ -76,6 +77,22 @@ class TMSFile extends stdClass {
         $this->uuid = $uuid;
 
         return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getNumberOfLanguages()
+    {
+        return $this->numberOfLanguages;
+    }
+
+    /**
+     * @param mixed $numberOfLanguages
+     */
+    public function setNumberOfLanguages($numberOfLanguages)
+    {
+        $this->numberOfLanguages = $numberOfLanguages;
     }
 
 }

--- a/lib/Utils/TMS/TMSService.php
+++ b/lib/Utils/TMS/TMSService.php
@@ -13,6 +13,7 @@ use Engines_Results_MyMemory_ExportResponse;
 use Engines_Results_MyMemory_TmxResponse;
 use Exception;
 use FeatureSet;
+use Files\CSV;
 use INIT;
 use Log;
 use Matecat\SubFiltering\MateCatFilter;
@@ -21,6 +22,7 @@ use stdClass;
 use TMSService\TMSServiceDao;
 use Upload;
 use Utils;
+use Validator\GlossaryCSVValidator;
 
 class TMSService {
 
@@ -163,7 +165,10 @@ class TMSService {
             default:
         }
 
+        $numberOfLanguages = (new GlossaryCSVValidator())->getNumberOfLanguage( $file->getFilePath() );
+
         $file->setUuid( $importStatus->id );
+        $file->setNumberOfLanguages( $numberOfLanguages );
 
     }
 
@@ -206,7 +211,10 @@ class TMSService {
             default:
         }
 
+        $numberOfLanguages = (new GlossaryCSVValidator())->getNumberOfLanguage( $file->getFilePath() );
+
         $file->setUuid( $importStatus->id );
+        $file->setNumberOfLanguages( $numberOfLanguages );
 
     }
 

--- a/lib/Utils/Validator/GlossaryCSVValidator.php
+++ b/lib/Utils/Validator/GlossaryCSVValidator.php
@@ -55,6 +55,31 @@ class GlossaryCSVValidator extends AbstractValidator {
     }
 
     /**
+     * @param $filePath
+     * @return int
+     */
+    public function getNumberOfLanguage( $filePath ){
+
+        $headers = $this->getHeaders($filePath);
+        $skipKeys = [
+            "forbidden",
+            "domain",
+            "subdomain",
+            "definition",
+            "notes",
+            "example of use"
+        ];
+
+        $languages = array_diff( $headers, $skipKeys );
+
+        if(empty($languages)){
+            return 0;
+        }
+
+        return count($languages);
+    }
+
+    /**
      * @return array
      */
     private function allowedLanguages() {


### PR DESCRIPTION
This new endpoint is introduced:

```/api/v2/glossaries/check/```

The payload is the same as the old `/api/v2/glossaries/import/`:

```
uploaded_file[]
name
tm_key
```

The response payload is an object containing the CSV path of the processed Excel file:

```json
{
    "results": [
        {
            "name": "xxxx",
            "tmKey": "yyy",
            "filePath": "/tmp/MAT_EXCEL_GLOSS_xiX86I",
            "numberOfLanguages": 12
        }
    ]
}
```

The next step is to modify the call to `/api/v2/glossaries/import/`, using the CSV file path instead of uploading again the Excel file.


