### PR TITLE
Subfiltering 1.2.7

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -918,16 +918,16 @@
         },
         {
             "name": "matecat/subfiltering",
-            "version": "v1.2.4",
+            "version": "v1.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/subfiltering.git",
-                "reference": "ad6f491abf75251866f259a749cb95aee65f8447"
+                "reference": "b32c1aa39b3a9eedeb43cfccb8dbfb337872e854"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/ad6f491abf75251866f259a749cb95aee65f8447",
-                "reference": "ad6f491abf75251866f259a749cb95aee65f8447",
+                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/b32c1aa39b3a9eedeb43cfccb8dbfb337872e854",
+                "reference": "b32c1aa39b3a9eedeb43cfccb8dbfb337872e854",
                 "shasum": ""
             },
             "require": {
@@ -968,9 +968,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matecat/subfiltering/issues",
-                "source": "https://github.com/matecat/subfiltering/tree/v1.2.4"
+                "source": "https://github.com/matecat/subfiltering/tree/v1.2.5"
             },
-            "time": "2023-07-11T13:23:47+00:00"
+            "time": "2023-07-12T10:42:18+00:00"
         },
         {
             "name": "matecat/whole-text-finder",

--- a/composer.lock
+++ b/composer.lock
@@ -918,16 +918,16 @@
         },
         {
             "name": "matecat/subfiltering",
-            "version": "v1.2.6",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/subfiltering.git",
-                "reference": "b47e409562979b6988d63c1f0dd29a7b214efb2b"
+                "reference": "854143f7e718aa4750de25135d6e3bc56a767468"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/b47e409562979b6988d63c1f0dd29a7b214efb2b",
-                "reference": "b47e409562979b6988d63c1f0dd29a7b214efb2b",
+                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/854143f7e718aa4750de25135d6e3bc56a767468",
+                "reference": "854143f7e718aa4750de25135d6e3bc56a767468",
                 "shasum": ""
             },
             "require": {
@@ -968,9 +968,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matecat/subfiltering/issues",
-                "source": "https://github.com/matecat/subfiltering/tree/v1.2.6"
+                "source": "https://github.com/matecat/subfiltering/tree/v1.2.7"
             },
-            "time": "2023-07-13T08:07:22+00:00"
+            "time": "2023-07-14T07:23:29+00:00"
         },
         {
             "name": "matecat/whole-text-finder",

--- a/composer.lock
+++ b/composer.lock
@@ -918,16 +918,16 @@
         },
         {
             "name": "matecat/subfiltering",
-            "version": "v1.2.5",
+            "version": "v1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/subfiltering.git",
-                "reference": "b32c1aa39b3a9eedeb43cfccb8dbfb337872e854"
+                "reference": "b47e409562979b6988d63c1f0dd29a7b214efb2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/b32c1aa39b3a9eedeb43cfccb8dbfb337872e854",
-                "reference": "b32c1aa39b3a9eedeb43cfccb8dbfb337872e854",
+                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/b47e409562979b6988d63c1f0dd29a7b214efb2b",
+                "reference": "b47e409562979b6988d63c1f0dd29a7b214efb2b",
                 "shasum": ""
             },
             "require": {
@@ -968,9 +968,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matecat/subfiltering/issues",
-                "source": "https://github.com/matecat/subfiltering/tree/v1.2.5"
+                "source": "https://github.com/matecat/subfiltering/tree/v1.2.6"
             },
-            "time": "2023-07-12T10:42:18+00:00"
+            "time": "2023-07-13T08:07:22+00:00"
         },
         {
             "name": "matecat/whole-text-finder",

--- a/composer.lock
+++ b/composer.lock
@@ -918,16 +918,16 @@
         },
         {
             "name": "matecat/subfiltering",
-            "version": "v1.2.3",
+            "version": "v1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/subfiltering.git",
-                "reference": "d1bfeebd4c8e958ba084065b84d2ec6bd57a53fc"
+                "reference": "ad6f491abf75251866f259a749cb95aee65f8447"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/d1bfeebd4c8e958ba084065b84d2ec6bd57a53fc",
-                "reference": "d1bfeebd4c8e958ba084065b84d2ec6bd57a53fc",
+                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/ad6f491abf75251866f259a749cb95aee65f8447",
+                "reference": "ad6f491abf75251866f259a749cb95aee65f8447",
                 "shasum": ""
             },
             "require": {
@@ -968,9 +968,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matecat/subfiltering/issues",
-                "source": "https://github.com/matecat/subfiltering/tree/v1.2.3"
+                "source": "https://github.com/matecat/subfiltering/tree/v1.2.4"
             },
-            "time": "2023-06-06T14:06:39+00:00"
+            "time": "2023-07-11T13:23:47+00:00"
         },
         {
             "name": "matecat/whole-text-finder",


### PR DESCRIPTION
Support for:
- squared sprintf synthax (like `[%s:name%]`)
- sprintf exceptions for Turkish and Hebrew