### PR TITLE
Fix ts format extension

### DIFF
--- a/inc/INIT.php
+++ b/inc/INIT.php
@@ -415,7 +415,7 @@ class INIT {
                     'wix'         => [ '', '', 'extwix' ],
                     'po'          => [ '', '', 'extpo' ],
                     'g'           => [ '', '', 'extg' ],
-                    'QT linguist ts'          => [ '', '', 'exts' ],
+                    'ts'          => [ '', '', 'exts' ],
             ]
     ];
 


### PR DESCRIPTION
The [file extension check](https://github.com/matecat/MateCat/blob/23249789f8b385dab432d50b213fd53144cfb36f/lib/Utils/fileupload/upload.class.php#L619) uses the keys from `INIT::$SUPPORTED_FILE_TYPES` as the list of valid file extensions. But the key for .ts files is "QT linguist ts", which does not match the .ts extension, and in fact cannot match any extension because it has uppercase characters but is always compared to a lowercase version of the file extension. So it is impossible to upload .ts files right now.

This PR just renames the key to match the extension. I don't want to set up a development environment for this one change, so I have not tested this. But as far as I can tell it should fix the upload issue at least.