### PR TITLE
Fix invalid null property engine

### DIFF
--- a/inc/version.ini
+++ b/inc/version.ini
@@ -1,2 +1,2 @@
 [MATECAT_VERSION]
-version = "v2.22.21"
+version = "v2.22.22"

--- a/lib/Utils/AsyncTasks/Workers/SetContributionWorker.php
+++ b/lib/Utils/AsyncTasks/Workers/SetContributionWorker.php
@@ -31,9 +31,9 @@ class SetContributionWorker extends AbstractWorker {
     const ERR_NO_TM_ENGINE  = 5;
 
     /**
-     * @var Engines_EngineInterface
+     * @var ?Engines_EngineInterface
      */
-    protected Engines_EngineInterface $_engine;
+    protected ?Engines_EngineInterface $_engine = null;
 
     /**
      * This method is for testing purpose. Set a dependency injection
@@ -231,7 +231,7 @@ class SetContributionWorker extends AbstractWorker {
     protected function _raiseReQueueException( $type, array $config ) {
         //reset the engine
         $engineName    = get_class( $this->_engine );
-        $this->_engine = new Engines_NONE( [] );
+        $this->_engine = null;
 
         switch ( strtolower( $type ) ) {
             case 'update':

--- a/package.json
+++ b/package.json
@@ -90,5 +90,5 @@
   "resolutions": {
     "wrap-ansi": "^7.0.0"
   },
-  "version": "2.22.21"
+  "version": "2.22.22"
 }


### PR DESCRIPTION
`"Typed property AsyncTasks\\Workers\\SetContributionWorker::$_engine must be an instance of Engines_EngineInterface, null used"`