### PR TITLE
Fix DeepL (missing project_id)

### DIFF
--- a/lib/Utils/Analysis/Workers/FastAnalysis.php
+++ b/lib/Utils/Analysis/Workers/FastAnalysis.php
@@ -648,6 +648,7 @@ class FastAnalysis extends AbstractDaemon {
 
             foreach ( $this->segments as $k => $queue_element ) {
 
+                $queue_element[ 'project_id' ]       = $pid;
                 $queue_element[ 'id_segment' ]       = $queue_element[ 'id' ];
                 $queue_element[ 'pretranslate_100' ] = $this->actual_project_row[ 'pretranslate_100' ];
                 $queue_element[ 'tm_keys' ]          = $this->actual_project_row[ 'tm_keys' ];

--- a/lib/Utils/Analysis/Workers/TMAnalysisWorker.php
+++ b/lib/Utils/Analysis/Workers/TMAnalysisWorker.php
@@ -518,11 +518,12 @@ class TMAnalysisWorker extends AbstractWorker {
      */
     protected function _getMatches( QueueElement $queueElement ): array {
 
-        $_config              = [];
-        $_config[ 'segment' ] = $queueElement->params->segment;
-        $_config[ 'source' ]  = $queueElement->params->source;
-        $_config[ 'target' ]  = $queueElement->params->target;
-        $_config[ 'email' ]   = INIT::$MYMEMORY_TM_API_KEY;
+        $_config                 = [];
+        $_config[ 'project_id' ] = $queueElement->params->project_id;
+        $_config[ 'segment' ]    = $queueElement->params->segment;
+        $_config[ 'source' ]     = $queueElement->params->source;
+        $_config[ 'target' ]     = $queueElement->params->target;
+        $_config[ 'email' ]      = INIT::$MYMEMORY_TM_API_KEY;
 
         $_config[ 'context_before' ]    = $queueElement->params->context_before;
         $_config[ 'context_after' ]     = $queueElement->params->context_after;

--- a/lib/Utils/Engines/DeepL.php
+++ b/lib/Utils/Engines/DeepL.php
@@ -59,6 +59,10 @@ class Engines_DeepL extends Engines_AbstractEngine {
                 throw new Exception( "DeepL API key not set" );
             }
 
+            if ( !isset( $_config[ 'project_id' ] ) ) {
+                throw new Exception( "Missing project ID" );
+            }
+
             // glossaries (only for DeepL)
             $metadataDao     = new Projects_MetadataDao();
             $deepLFormality  = $metadataDao->get( $_config[ 'project_id' ], 'deepl_formality', 86400 );

--- a/lib/Utils/Engines/DeepL.php
+++ b/lib/Utils/Engines/DeepL.php
@@ -59,10 +59,6 @@ class Engines_DeepL extends Engines_AbstractEngine {
                 throw new Exception( "DeepL API key not set" );
             }
 
-            if ( !isset( $_config[ 'project_id' ] ) ) {
-                throw new Exception( "Missing project ID" );
-            }
-
             // glossaries (only for DeepL)
             $metadataDao     = new Projects_MetadataDao();
             $deepLFormality  = $metadataDao->get( $_config[ 'project_id' ], 'deepl_formality', 86400 );


### PR DESCRIPTION
Hotfix for:

```json
{"log":{"token_hash":"677e532eccf6d","context":{"ip":"172.18.0.3","class":"Bootstrap","function":"exceptionHandler","line":202,"file":"\/var\/www\/matecat\/inc\/Bootstrap.php"},"time":1736332079,"date":"2025-01-08T11:27:59+01:00","content":{"ExceptionType":"TypeError","error":"Argument 1 passed to Projects_MetadataDao::get() must be of the type int, null given, called in \/var\/www\/matecat\/lib\/Utils\/Engines\/DeepL.php on line 64","trace":[{"file":"\/var\/www\/matecat\/lib\/Utils\/Engines\/DeepL.php","line":64,"function":"get","class":"Projects_MetadataDao","type":"->"},{"file":"\/var\/www\/matecat\/lib\/Utils\/Analysis\/Workers\/TMAnalysisWorker.php","line":649,"function":"get","class":"Engines_DeepL","type":"->"},{"file":"\/var\/www\/matecat\/lib\/Utils\/Analysis\/Workers\/TMAnalysisWorker.php","line":599,"function":"_getMT","class":"Analysis\\Workers\\TMAnalysisWorker","type":"->"},{"file":"\/var\/www\/matecat\/lib\/Utils\/Analysis\/Workers\/TMAnalysisWorker.php","line":122,"function":"_getMatches","class":"Analysis\\Workers\\TMAnalysisWorker","type":"->"},{"file":"\/var\/www\/matecat\/lib\/Utils\/TaskRunner\/Executor.php","line":211,"function":"process","class":"Analysis\\Workers\\TMAnalysisWorker","type":"->"},{"file":"\/var\/www\/matecat\/lib\/Utils\/TaskRunner\/Executor.php","line":398,"function":"main","class":"TaskRunner\\Executor","type":"->"}]}}}
```