### PR TITLE
Adding `dialect_strict` to Project templates

### DIFF
--- a/inc/validation/schema/project_template.json
+++ b/inc/validation/schema/project_template.json
@@ -60,6 +60,9 @@
     },
     "filters_template_id": {
       "type": ["null", "integer", "string"]
+    },
+    "dialect_strict": {
+      "type":  ["null", "boolean"]
     }
   },
   "required": [

--- a/lib/Model/Projects/ProjectTemplateDao.php
+++ b/lib/Model/Projects/ProjectTemplateDao.php
@@ -53,6 +53,7 @@ class ProjectTemplateDao extends DataAccess_AbstractDao {
         $default->pretranslate_100         = false;
         $default->pretranslate_101         = true;
         $default->tm_prioritization        = false;
+        $default->dialect_strict           = false;
         $default->get_public_matches       = true;
         $default->payable_rate_template_id = 0;
         $default->qa_model_template_id     = 0;
@@ -380,9 +381,9 @@ class ProjectTemplateDao extends DataAccess_AbstractDao {
     public
     static function save( ProjectTemplateStruct $projectTemplateStruct ): ProjectTemplateStruct {
         $sql = "INSERT INTO " . self::TABLE .
-                " ( `name`, `is_default`, `uid`, `id_team`, `segmentation_rule`, `tm`, `mt`, `payable_rate_template_id`,`qa_model_template_id`, `filters_template_id`, `xliff_config_template_id`, `pretranslate_100`, `pretranslate_101`, `tm_prioritization`, `get_public_matches`, `subject`, `source_language`, `target_language`, `created_at` ) " .
+                " ( `name`, `is_default`, `uid`, `id_team`, `segmentation_rule`, `tm`, `mt`, `payable_rate_template_id`,`qa_model_template_id`, `filters_template_id`, `xliff_config_template_id`, `pretranslate_100`, `pretranslate_101`, `tm_prioritization`, `dialect_strict`, `get_public_matches`, `subject`, `source_language`, `target_language`, `created_at` ) " .
                 " VALUES " .
-                " ( :name, :is_default, :uid, :id_team, :segmentation_rule, :tm, :mt, :payable_rate_template_id, :qa_model_template_id, :filters_template_id, :xliff_config_template_id, :pretranslate_100, :pretranslate_101, :tm_prioritization, :get_public_matches, :subject, :source_language, :target_language, :now ); ";
+                " ( :name, :is_default, :uid, :id_team, :segmentation_rule, :tm, :mt, :payable_rate_template_id, :qa_model_template_id, :filters_template_id, :xliff_config_template_id, :pretranslate_100, :pretranslate_101, :tm_prioritization, :dialect_strict, :get_public_matches, :subject, :source_language, :target_language, :now ); ";
 
         $now = ( new DateTime() )->format( 'Y-m-d H:i:s' );
 
@@ -399,6 +400,7 @@ class ProjectTemplateDao extends DataAccess_AbstractDao {
                 "pretranslate_100"         => $projectTemplateStruct->pretranslate_100,
                 "pretranslate_101"         => $projectTemplateStruct->pretranslate_101,
                 "tm_prioritization"        => $projectTemplateStruct->tm_prioritization,
+                "dialect_strict"           => $projectTemplateStruct->dialect_strict,
                 "get_public_matches"       => $projectTemplateStruct->get_public_matches,
                 "payable_rate_template_id" => $projectTemplateStruct->payable_rate_template_id,
                 "qa_model_template_id"     => $projectTemplateStruct->qa_model_template_id,
@@ -444,6 +446,7 @@ class ProjectTemplateDao extends DataAccess_AbstractDao {
             `pretranslate_100` = :pretranslate_100,
             `pretranslate_101` = :pretranslate_101,
             `tm_prioritization` = :tm_prioritization,
+            `dialect_strict` = :dialect_strict,
             `get_public_matches` = :get_public_matches,
             `payable_rate_template_id` = :payable_rate_template_id, 
             `qa_model_template_id` = :qa_model_template_id, 
@@ -469,6 +472,7 @@ class ProjectTemplateDao extends DataAccess_AbstractDao {
                 "pretranslate_100"         => $projectTemplateStruct->pretranslate_100,
                 "pretranslate_101"         => $projectTemplateStruct->pretranslate_101,
                 "tm_prioritization"        => $projectTemplateStruct->tm_prioritization,
+                "dialect_strict"           => $projectTemplateStruct->dialect_strict,
                 "get_public_matches"       => $projectTemplateStruct->get_public_matches,
                 "payable_rate_template_id" => $projectTemplateStruct->payable_rate_template_id,
                 "qa_model_template_id"     => $projectTemplateStruct->qa_model_template_id,

--- a/lib/Model/Projects/ProjectTemplateStruct.php
+++ b/lib/Model/Projects/ProjectTemplateStruct.php
@@ -24,6 +24,7 @@ class ProjectTemplateStruct extends DataAccess_AbstractDaoSilentStruct implement
     public bool    $pretranslate_100         = false;
     public bool    $pretranslate_101         = false;
     public bool    $tm_prioritization        = false;
+    public bool    $dialect_strict           = false;
     public bool    $get_public_matches       = true;
     public string  $created_at;
     public ?string $modified_at              = null;
@@ -50,6 +51,7 @@ class ProjectTemplateStruct extends DataAccess_AbstractDaoSilentStruct implement
         $this->pretranslate_100         = $json->pretranslate_100;
         $this->pretranslate_101         = $json->pretranslate_101;
         $this->tm_prioritization        = $json->tm_prioritization;
+        $this->dialect_strict           = $json->dialect_strict;
         $this->get_public_matches       = $json->get_public_matches;
         $this->mt                       = json_encode( $json->mt );
         $this->tm                       = (!empty($json->tm)) ? json_encode( $json->tm ) : null;
@@ -127,6 +129,7 @@ class ProjectTemplateStruct extends DataAccess_AbstractDaoSilentStruct implement
                 'pretranslate_100'         => $this->pretranslate_100,
                 'pretranslate_101'         => $this->pretranslate_101,
                 'tm_prioritization'        => $this->tm_prioritization,
+                'dialect_strict'           => $this->dialect_strict,
                 'subject'                  => $this->subject,
                 'source_language'          => $this->source_language,
                 'target_language'          => $this->getTargetLanguage(),

--- a/migrations/20250127143100_add_dialect_strict_to_project_templates.php
+++ b/migrations/20250127143100_add_dialect_strict_to_project_templates.php
@@ -1,0 +1,14 @@
+<?php
+
+class AddDialectStrictToProjectTemplates extends AbstractMatecatMigration {
+
+    public $sql_up = [
+        'ALTER TABLE `project_templates` add column `dialect_strict` tinyint(1) NULL DEFAULT 0;',
+    ];
+
+    
+    public $sql_down = [
+        'ALTER TABLE `project_templates` DROP COLUMN `dialect_strict`;',
+    ];
+
+}

--- a/public/css/sass/components/settingsPanel/TranslationMemoryGlossaryTab.scss
+++ b/public/css/sass/components/settingsPanel/TranslationMemoryGlossaryTab.scss
@@ -28,15 +28,21 @@
   }
 }
 
-.translation-memory-glossary-tab-pre-translate {
+.translation-memory-glossary-checkbox-container {
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  gap: 10px;
   border-radius: 4px;
   border: 1px dashed $grey8;
   padding: 10px;
   margin-bottom: 20px;
   background: $white;
+}
+
+.translation-memory-glossary-checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .translation-memory-glossary-tab-table-title {

--- a/public/js/cat_source/es6/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/TranslationMemoryGlossaryTab.js
+++ b/public/js/cat_source/es6/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/TranslationMemoryGlossaryTab.js
@@ -121,6 +121,12 @@ export const TranslationMemoryGlossaryTab = () => {
       ...prevTemplate,
       pretranslate100: value,
     }))
+  const isDialectStrictActive = currentProjectTemplate.dialectStrict
+  const setIsDialectStrictActive = (value) =>
+    modifyingCurrentTemplate((prevTemplate) => ({
+      ...prevTemplate,
+      dialectStrict: value,
+    }))
   const tmPrioritization = currentProjectTemplate.tmPrioritization
   const [specialRows, setSpecialRows] = useState([
     {
@@ -401,16 +407,36 @@ export const TranslationMemoryGlossaryTab = () => {
         className="translation-memory-glossary-tab settings-panel-contentwrapper-tab-background"
       >
         {!config.is_cattool && (
-          <div className="translation-memory-glossary-tab-pre-translate">
-            <input
-              checked={isPretranslate100Active}
-              onChange={(e) =>
-                setIsPretranslate100Active(e.currentTarget.checked)
-              }
-              type="checkbox"
-              data-testid="pretranslate-checkbox"
-            />
-            Pre-translate 100% matches from TM
+          <div className="translation-memory-glossary-checkbox-container">
+            <div className="translation-memory-glossary-checkbox-item">
+              <input
+                checked={isPretranslate100Active}
+                onChange={(e) =>
+                  setIsPretranslate100Active(e.currentTarget.checked)
+                }
+                type="checkbox"
+                data-testid="pretranslate-checkbox"
+              />
+              Pre-translate 100% matches from TM
+            </div>
+            <div className="translation-memory-glossary-checkbox-item">
+              <input
+                checked={isDialectStrictActive}
+                onChange={(e) =>
+                  setIsDialectStrictActive(e.currentTarget.checked)
+                }
+                type="checkbox"
+                data-testid="dialect-strict-checkbox"
+              />
+              Activate variant-strict matching.{' '}
+              <a
+                href="https://guides.matecat.com/activ"
+                rel="noreferrer"
+                target="_blank"
+              >
+                More details
+              </a>
+            </div>
           </div>
         )}
         <div className="translation-memory-glossary-tab-active-resources">

--- a/public/js/cat_source/es6/hooks/useProjectTemplates.js
+++ b/public/js/cat_source/es6/hooks/useProjectTemplates.js
@@ -35,6 +35,8 @@ const STANDARD_TEMPLATE = {
   source_language: null,
   subject: null,
   target_language: [],
+  tm_prioritization: false,
+  dialect_strict: false,
 }
 
 const CATTOOL_TEMPLATE = {
@@ -64,6 +66,7 @@ export const SCHEMA_KEYS = {
   subject: 'subject',
   targetLanguage: 'target_language',
   tmPrioritization: 'tm_prioritization',
+  dialectStrict: 'dialect_strict',
 }
 
 function useProjectTemplates(tmKeys, isCattool = config.is_cattool) {

--- a/public/js/cat_source/es6/pages/NewProject.js
+++ b/public/js/cat_source/es6/pages/NewProject.js
@@ -416,6 +416,7 @@ const NewProject = () => {
       payableRateTemplateId,
       XliffConfigTemplateId,
       tmPrioritization,
+      dialectStrict,
     } = currentProjectTemplate
 
     // update store recently used target languages
@@ -455,6 +456,15 @@ const NewProject = () => {
       }),
       xliff_parameters_template_id: XliffConfigTemplateId,
       tm_prioritization: tmPrioritization ? 1 : 0,
+      ...(dialectStrict && {
+        dialect_strict: targetLangs.reduce(
+          (acc, {id}) => ({
+            ...acc,
+            [id]: true,
+          }),
+          {},
+        ),
+      }),
     })
 
     if (!projectSent) {

--- a/public/js/cat_source/es6/pages/NewProject.js
+++ b/public/js/cat_source/es6/pages/NewProject.js
@@ -457,12 +457,14 @@ const NewProject = () => {
       xliff_parameters_template_id: XliffConfigTemplateId,
       tm_prioritization: tmPrioritization ? 1 : 0,
       ...(dialectStrict && {
-        dialect_strict: targetLangs.reduce(
-          (acc, {id}) => ({
-            ...acc,
-            [id]: true,
-          }),
-          {},
+        dialect_strict: JSON.stringify(
+          targetLangs.reduce(
+            (acc, {id}) => ({
+              ...acc,
+              [id]: true,
+            }),
+            {},
+          ),
         ),
       }),
     })


### PR DESCRIPTION
## Documentation

### Project templates

One new optional parameters were introduced in project templates:

- `dialect_strict` (_bool_) - `true` of `false`

### Project creation

If the saved `dialect_strict` value of the project template is true, then a JSON string like this should be sent to the create project API:

```
{"it-IT":true, "fr-FR":true,"es-ES":true}
```

**The JSON MUST contain ONLY the project target language(s)**, instead an Exception will be thrown.

### DB Migrations

One migration is needed:

```sql
ALTER TABLE `project_templates` add column `dialect_strict` tinyint(1) NULL DEFAULT 0;
```
---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209235178742057