### PR TITLE
Job Metadata API endpoints

### DIFF
--- a/lib/Controller/API/App/JobMetadataController.php
+++ b/lib/Controller/API/App/JobMetadataController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace API\App;
+
+use API\Commons\KleinController;
+use API\Commons\Validators\ChunkPasswordValidator;
+use API\Commons\Validators\LoginValidator;
+use Exception;
+use Jobs\MetadataDao;
+
+class JobMetadataController extends KleinController {
+
+    protected function afterConstruct() {
+        $this->appendValidator( new LoginValidator( $this ) );
+        $this->appendValidator( new ChunkPasswordValidator( $this ) );
+    }
+
+    /**
+     * Delete metadata by key
+     */
+    public function delete()
+    {
+        $params = $this->sanitizeRequestParams();
+        $dao = new MetadataDao();
+
+        try {
+            $struct = $dao->get($params['id_job'], $params['password'], $params['key']);
+
+            if(empty($struct)){
+                throw new Exception( 'Metadata not found', 400 );
+            }
+
+            $dao->delete($params['id_job'], $params['password'], $params['key']);
+            $this->response->json([
+                'id' => $struct->id
+            ]);
+        } catch (Exception $exception){
+            $this->response->status()->setCode( $exception->getCode() >= 400 ? $exception->getCode() : 500 );
+            $this->response->json( [
+                'error' => $exception->getMessage()
+            ] );
+        }
+    }
+
+    /**
+     * Get all job metadata
+     */
+    public function get()
+    {
+        $params = $this->sanitizeRequestParams();
+        $dao = new MetadataDao();
+
+        try {
+            $this->response->json( $dao->getByJobIdAndPassword($params['id_job'], $params['password']) );
+        } catch (Exception $exception){
+            $this->response->status()->setCode( $exception->getCode() >= 400 ? $exception->getCode() : 500 );
+            $this->response->json( [
+                'error' => $exception->getMessage()
+            ] );
+        }
+    }
+
+    /**
+     * Upsert metadata
+     */
+    public function save()
+    {
+        $params = $this->sanitizeRequestParams();
+        $dao = new MetadataDao();
+        $json = $this->request->body();
+
+        try {
+            // accept only JSON
+            if ( !$this->isJsonRequest() ) {
+                throw new Exception( 'Bad request', 400 );
+            }
+
+            $json = json_decode($json, true);
+
+            if(!isset($json['key'])){
+                throw new Exception( 'Missing `key` property', 400 );
+            }
+
+            if(empty($json['key'])){
+                throw new Exception( 'Empty `key` property', 400 );
+            }
+
+            if(!isset($json['value'])){
+                throw new Exception( 'Missing `value` property', 400 );
+            }
+
+            if(empty($json['value'])){
+                throw new Exception( 'Empty `value` property', 400 );
+            }
+
+            $struct = $dao->set($params['id_job'], $params['password'], $json['key'], $json['value']);
+            $this->response->json($struct);
+        } catch (Exception $exception){
+            $this->response->status()->setCode( $exception->getCode() >= 400 ? $exception->getCode() : 500 );
+            $this->response->json( [
+                'error' => $exception->getMessage()
+            ] );
+        }
+    }
+
+    /**
+     * @return mixed
+     */
+    private function sanitizeRequestParams()
+    {
+        return filter_var_array( $this->request->params(), [
+            'id_job'   => FILTER_SANITIZE_STRING,
+            'password' => FILTER_SANITIZE_STRING,
+            'key'      => FILTER_SANITIZE_STRING,
+        ]);
+    }
+}

--- a/lib/Routes/utils_routes.php
+++ b/lib/Routes/utils_routes.php
@@ -119,3 +119,10 @@ $klein->with( '/api/app/project-template', function () {
 $klein->with( '/api/app/filters-config-template', function () {
     route( '/default', 'GET', [ '\API\V3\FiltersConfigTemplateController', 'default' ] );
 } );
+
+// Metadata
+$klein->with( '/api/app/jobs/[:id_job]/[:password]/metadata', function () {
+    route( '', 'GET', [ '\API\App\JobMetadataController', 'get' ] );
+    route( '', 'POST', [ '\API\App\JobMetadataController', 'save' ] );
+    route( '/[:key]', 'DELETE', [ '\API\App\JobMetadataController', 'delete' ] );
+} );

--- a/lib/Utils/Utils.php
+++ b/lib/Utils/Utils.php
@@ -873,7 +873,19 @@ class Utils {
         }
 
         return array_keys( $aValid );
+    }
 
+    /**
+     * @param array $arr
+     * @return bool
+     */
+    public static function arrayIsList(array $arr)
+    {
+        if ($arr === []) {
+            return true;
+        }
+
+        return array_keys($arr) === range(0, count($arr) - 1);
     }
 
     /**


### PR DESCRIPTION
### New endpoints

Three new endpoints are available to handle job metadata:

1) `[GET] api/app/jobs/[id]/[:password]/metadata` 

Use this endpoint to fetch all job metadata.

Response example:

```json
[
    {
        "id": "5",
        "id_job": "5",
        "password": "a9039454f5cc",
        "key": "character_counter_count_tags",
        "value": "1"
    },
    {
        "id": "6",
        "id_job": "5",
        "password": "a9039454f5cc",
        "key": "character_counter_mode",
        "value": "exclude_cjk"
    },
    {
        "id": "7",
        "id_job": "5",
        "password": "a9039454f5cc",
        "key": "tm_prioritization",
        "value": "0"
    }
]
```

2) `[POST] api/app/jobs/[id]/[:password]/metadata`

Use this endpoint to create or modify a single job metadata.

This endpoint requires a JSON payload like this:

```json
[
  {
        "key": "foo",
        "value": "bar"
    }
]
```
If everything worked fine, a response example like this is returned:

```json
 [
   {
        "id": "5",
        "id_job": "5",
        "password": "a9039454f5cc",
        "key": "foo",
        "value": "bar"
    }
]
```

3) `[DELETE] api/app/jobs/[:id]/[:password]/metadata/[:key]`

Use this endpoint to delete a job metadata by its key (example: `foo`).

If everything works fine, a response like this is returned:

```json
{
    "id": 45
}
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209375714528709