### PR TITLE
`stripTagsPreservingHrefs` improvement 

### DIFF
--- a/lib/Utils/Utils.php
+++ b/lib/Utils/Utils.php
@@ -805,12 +805,20 @@ class Utils {
         @$htmlDom->loadHTML( $html );
 
         $links = $htmlDom->getElementsByTagName( 'a' );
+        $images = $htmlDom->getElementsByTagName( 'img' );
 
         /** @var DOMElement $link */
         foreach ( $links as $link ) {
             $linkLabel       = $link->nodeValue;
             $linkHref        = $link->getAttribute( 'href' );
             $link->nodeValue = $linkLabel . "(" . str_replace( "\\\"", "", $linkHref ) . ")";
+        }
+
+        /** @var DOMElement $link */
+        foreach ( $images as $image ) {
+            $src = $image->getAttribute( 'src' );
+            $span = $htmlDom->createElement('span', $src);
+            $image->parentNode->insertBefore($span);
         }
 
         $html = $htmlDom->saveHtml( $htmlDom->documentElement );

--- a/lib/Utils/Utils.php
+++ b/lib/Utils/Utils.php
@@ -807,6 +807,7 @@ class Utils {
         $links = $htmlDom->getElementsByTagName( 'a' );
         $images = $htmlDom->getElementsByTagName( 'img' );
 
+        // replace <a> with a label(href)
         /** @var DOMElement $link */
         foreach ( $links as $link ) {
             $linkLabel       = $link->nodeValue;
@@ -814,11 +815,14 @@ class Utils {
             $link->nodeValue = $linkLabel . "(" . str_replace( "\\\"", "", $linkHref ) . ")";
         }
 
-        /** @var DOMElement $link */
-        foreach ( $images as $image ) {
+        // replace <img> with src
+        $i = $images->length - 1;
+        while ($i > -1) {
+            $image = $images->item($i);
             $src = $image->getAttribute( 'src' );
-            $span = $htmlDom->createElement('span', $src);
-            $image->parentNode->insertBefore($span);
+            $newElement = $htmlDom->createTextNode($src);
+            $image->parentNode->replaceChild($newElement, $image);
+            $i--;
         }
 
         $html = $htmlDom->saveHtml( $htmlDom->documentElement );

--- a/tests/unit/Utils/StripTagsPreservingHrefsTest.php
+++ b/tests/unit/Utils/StripTagsPreservingHrefsTest.php
@@ -42,4 +42,25 @@ class StripTagsPreservingHrefsTest extends AbstractTest {
 
         $this->assertEquals( $expected, $stripTags );
     }
+
+    public function testCanPreserveMultipleImgSrc() {
+        $html      = 'tags: Shift_completed_EWA, plugin.figma.2025-03-11.17-19-52
+                    screenshot: <img src="https://d20j2y33fgycdj.cloudfront.net/uploads/screenshots/e291c5153be4b268f0471bbf8fccb7f4/screenshot-2b201adbc23c19e5.jpg">;
+                    screenshot: <img src="https://d20j2y33fgycdj.cloudfront.net/uploads/screenshots/724d01f93ba1190dd73c3aafe7359a2c/screenshot-a24a7ac16eea3b9a.jpg">';
+
+        $stripTags = Utils::stripTagsPreservingHrefs( $html );
+        $expected  = 'tags: Shift_completed_EWA, plugin.figma.2025-03-11.17-19-52
+                    screenshot: https://d20j2y33fgycdj.cloudfront.net/uploads/screenshots/e291c5153be4b268f0471bbf8fccb7f4/screenshot-2b201adbc23c19e5.jpg;
+                    screenshot: https://d20j2y33fgycdj.cloudfront.net/uploads/screenshots/724d01f93ba1190dd73c3aafe7359a2c/screenshot-a24a7ac16eea3b9a.jpg';
+
+        $this->assertEquals( $expected, $stripTags );
+    }
+
+    public function testWithMoreImages() {
+        $html      = '<img src="https://placehold.co/600x400" alt="Test"/> test <img src="https://placehold.co/600x400" alt="Test"/> test <img src="https://placehold.co/600x400" alt="Test"/>';
+        $stripTags = Utils::stripTagsPreservingHrefs( $html );
+        $expected  = 'https://placehold.co/600x400 test https://placehold.co/600x400 test https://placehold.co/600x400';
+
+        $this->assertEquals( $expected, $stripTags );
+    }
 }

--- a/tests/unit/Utils/StripTagsPreservingHrefsTest.php
+++ b/tests/unit/Utils/StripTagsPreservingHrefsTest.php
@@ -34,4 +34,12 @@ class StripTagsPreservingHrefsTest extends AbstractTest {
 
         $this->assertEquals( $expected, $stripTags );
     }
+
+    public function testCanPreserveImgSrc() {
+        $html      = '<p>This is a simple test. <img src="https://placehold.co/600x400" alt="Test"/></p>';
+        $stripTags = Utils::stripTagsPreservingHrefs( $html );
+        $expected  = 'This is a simple test. https://placehold.co/600x400';
+
+        $this->assertEquals( $expected, $stripTags );
+    }
 }


### PR DESCRIPTION
Added support for `img` tags

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209782451908793