### PR TITLE
Fix: cursor position after deleting an entity that precedes another

### DIFF
--- a/public/js/cat_source/es6/components/segments/Editarea.js
+++ b/public/js/cat_source/es6/components/segments/Editarea.js
@@ -912,6 +912,7 @@ class Editarea extends React.Component {
           : this.state.editorState,
         direction,
         isShiftPressed: true,
+        deleteEntity: true,
       })
 
       if (updatedStateNearEntity) {
@@ -923,7 +924,7 @@ class Editarea extends React.Component {
           Modifier.replaceText(contentState, selectionState, null),
           'insert-characters',
         )
-        this.onChange(updatedEditorState)
+        this.onChange(updatedEditorState, true)
         return 'delete-entity'
       }
     }
@@ -1181,10 +1182,6 @@ class Editarea extends React.Component {
           [DraftMatecatConstants.QA_BLACKLIST_DECORATOR]: false,
         }
       }
-      editorState = EditorState.acceptSelection(
-        editorState,
-        editorState.getSelection().set('hasFocus', true),
-      )
       this.setState(
         () => ({
           activeDecorators: newActiveDecorators,

--- a/public/js/cat_source/es6/components/segments/Editarea.js
+++ b/public/js/cat_source/es6/components/segments/Editarea.js
@@ -912,7 +912,6 @@ class Editarea extends React.Component {
           : this.state.editorState,
         direction,
         isShiftPressed: true,
-        deleteEntity: true,
       })
 
       if (updatedStateNearEntity) {

--- a/public/js/cat_source/es6/components/segments/Editarea.js
+++ b/public/js/cat_source/es6/components/segments/Editarea.js
@@ -924,7 +924,7 @@ class Editarea extends React.Component {
           Modifier.replaceText(contentState, selectionState, null),
           'insert-characters',
         )
-        this.onChange(updatedEditorState, true)
+        this.onChange(updatedEditorState)
         return 'delete-entity'
       }
     }


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210069935978507