### PR TITLE
Support for Intento routing

### DIFF
--- a/lib/Controller/API/App/EngineController.php
+++ b/lib/Controller/API/App/EngineController.php
@@ -182,6 +182,7 @@ class EngineController extends KleinController {
                 $newEngineStruct->uid                                    = $this->user->uid;
                 $newEngineStruct->type                                   = Constants_Engines::MT;
                 $newEngineStruct->extra_parameters[ 'apikey' ]           = $engineData[ 'secret' ];
+                $newEngineStruct->extra_parameters[ 'service' ]          = $engineData[ 'service' ];
                 $newEngineStruct->extra_parameters[ 'provider' ]         = $engineData[ 'provider' ];
                 $newEngineStruct->extra_parameters[ 'providerkey' ]      = $engineData[ 'providerkey' ];
                 $newEngineStruct->extra_parameters[ 'providercategory' ] = $engineData[ 'providercategory' ];


### PR DESCRIPTION
## New Intento parameter

The new Intento (extra)parameter is called `service`. This allows the customers to use the [Intento Smart Routing](https://help.inten.to/article/360016598320-intento-smart-routing) feature.

To get the list of routings, call this endpoint:

```
curl --location 'https://api.inten.to/routing-designer' \
--header 'apikey: xxxxxxxxx' \
--header 'Content-Type: application/json' \
--data ''
```

Response example:

```json
{
    "data": [
        {
            "rt_id": 1,
            "name": "best",
            "description": "Intento routing for the General domain",
            "updated_at": "2024-12-18T14:07:43.171Z",
            "updated_by": "04ebba4b-d03f-418d-9593-97e699f21a63",
            "is_public": true,
            "is_active": true,
            "is_allowed": true
        },
        {
            "rt_id": 9,
            "name": "best_healthcare",
            "description": "Intento routing for the Healthcare domain",
            "updated_at": "2024-12-18T14:12:35.306Z",
            "updated_by": "04ebba4b-d03f-418d-9593-97e699f21a63",
            "is_public": true,
            "is_active": true,
            "is_allowed": true
        },
        {
            "rt_id": 10,
            "name": "best_financials",
            "description": "Intento routing for the Financial domain",
            "updated_at": "2024-12-18T14:14:40.777Z",
            "updated_by": "04ebba4b-d03f-418d-9593-97e699f21a63",
            "is_public": true,
            "is_active": true,
            "is_allowed": true
        },
        {
            "rt_id": 11,
            "name": "best_legal_services",
            "description": "Intento routing for the Legal domain",
            "updated_at": "2024-12-18T14:19:23.644Z",
            "updated_by": "04ebba4b-d03f-418d-9593-97e699f21a63",
            "is_public": true,
            "is_active": true,
            "is_allowed": true
        },
        {
            "rt_id": 221,
            "name": "best_education",
            "description": "Intento routing for the Education domain",
            "updated_at": "2024-12-18T14:21:23.134Z",
            "updated_by": "04ebba4b-d03f-418d-9593-97e699f21a63",
            "is_public": true,
            "is_active": true,
            "is_allowed": true
        },
        {
            "rt_id": 222,
            "name": "best_it",
            "description": "Intento routing for the IT domain",
            "updated_at": "2024-12-18T14:23:10.070Z",
            "updated_by": "04ebba4b-d03f-418d-9593-97e699f21a63",
            "is_public": true,
            "is_active": true,
            "is_allowed": true
        },
        {
            "rt_id": 227,
            "name": "best_entertainment",
            "description": "Intento routing for the Entertainment domain",
            "updated_at": "2024-12-18T14:25:11.266Z",
            "updated_by": "04ebba4b-d03f-418d-9593-97e699f21a63",
            "is_public": true,
            "is_active": true,
            "is_allowed": true
        },
        {
            "rt_id": 228,
            "name": "best_hospitality",
            "description": "Intento routing for the Hospitality domain",
            "updated_at": "2024-12-18T14:27:06.691Z",
            "updated_by": "04ebba4b-d03f-418d-9593-97e699f21a63",
            "is_public": true,
            "is_active": true,
            "is_allowed": true
        },
        {
            "rt_id": 229,
            "name": "best_colloquial",
            "description": "Intento routing for the Colloquial domain",
            "updated_at": "2024-12-18T14:28:31.409Z",
            "updated_by": "04ebba4b-d03f-418d-9593-97e699f21a63",
            "is_public": true,
            "is_active": true,
            "is_allowed": true
        }
    ],
    "total": 9
}
```

The `name` is unique and must be used for translation calls.

@riccio82 I suggest implementing in the UI a checkbox, or something like that, to allow the user to choose between a routing OR a provider.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210328496621340