### PR TITLE
Typization on project matadata struct

### DIFF
--- a/lib/Controller/API/V3/MetaDataController.php
+++ b/lib/Controller/API/V3/MetaDataController.php
@@ -55,7 +55,7 @@ class MetaDataController extends KleinController {
 
         foreach ( $project->getMetadata() as $metadatum ) {
             $key            = $metadatum->key;
-            $metadata->$key = Utils::formatStringValue( $metadatum->getValue() );
+            $metadata->$key = Utils::formatStringValue( $metadatum->value );
         }
 
         return $metadata;

--- a/lib/Model/Projects/MetadataStruct.php
+++ b/lib/Model/Projects/MetadataStruct.php
@@ -4,26 +4,12 @@ namespace Model\Projects;
 
 use Model\DataAccess\AbstractDaoSilentStruct;
 use Model\DataAccess\IDaoStruct;
-use Utils\Tools\Utils;
 
 class MetadataStruct extends AbstractDaoSilentStruct implements IDaoStruct {
 
-    public $id;
-    public $id_project;
-    public $key;
-    public $value;
+    public ?string $id = null;
+    public int     $id_project;
+    public string  $key;
+    public string  $value;
 
-    /**
-     * @return mixed
-     */
-    public function getValue() {
-
-        $this->value = html_entity_decode($this->value);
-
-        if ( Utils::isJson( $this->value ) ) {
-            return json_decode( $this->value );
-        }
-
-        return $this->value;
-    }
 }


### PR DESCRIPTION
- Fixed Utils::formatStringValue() must be of the type string, object given, called in Controller\API\V3\MetaDataController 58