### PR TITLE
Fixed buggy `match` expression in `statusAsSourcePage`.

### DIFF
--- a/lib/Controller/Abstracts/Authentication/SessionTokenStoreHandler.php
+++ b/lib/Controller/Abstracts/Authentication/SessionTokenStoreHandler.php
@@ -12,6 +12,7 @@
 
 namespace Controller\Abstracts\Authentication;
 
+use Exception;
 use Model\DataAccess\DaoCacheTrait;
 use ReflectionException;
 use Utils\Logger\LoggerFactory;
@@ -37,12 +38,13 @@ class SessionTokenStoreHandler {
     /**
      * Log cache operations for debugging and monitoring purposes.
      *
-     * @param string $type     The type of cache operation (e.g., set, get, remove).
-     * @param string $key      The cache key being operated on.
-     * @param mixed  $value    The value associated with the cache key.
+     * @param string $type The type of cache operation (e.g., set, get, remove).
+     * @param string $key The cache key being operated on.
+     * @param mixed $value The value associated with the cache key.
      * @param string $sqlQuery The SQL query related to the cache operation.
      *
      * @return void
+     * @throws Exception
      */
     protected function _logCache( string $type, string $key, mixed $value, string $sqlQuery ): void {
         LoggerFactory::getLogger( "login_cookie_cache" )->debug( [

--- a/lib/Plugins/Features/TranslationEvents/Model/TranslationEvent.php
+++ b/lib/Plugins/Features/TranslationEvents/Model/TranslationEvent.php
@@ -304,16 +304,16 @@ class TranslationEvent
     }
 
     /**
-     * @param $status
+     * @param string $status
      *
      * @return int
      */
-    private function statusAsSourcePage($status): int
+    private function statusAsSourcePage(string $status): int
     {
         return match ($status) {
-            $status == TranslationStatus::STATUS_TRANSLATED => SourcePages::SOURCE_PAGE_TRANSLATE,
-            $status == TranslationStatus::STATUS_APPROVED => SourcePages::SOURCE_PAGE_REVISION,
-            $status == TranslationStatus::STATUS_APPROVED2 => SourcePages::SOURCE_PAGE_REVISION_2,
+            TranslationStatus::STATUS_TRANSLATED => SourcePages::SOURCE_PAGE_TRANSLATE,
+            TranslationStatus::STATUS_APPROVED => SourcePages::SOURCE_PAGE_REVISION,
+            TranslationStatus::STATUS_APPROVED2 => SourcePages::SOURCE_PAGE_REVISION_2,
             default => 0,
         };
     }


### PR DESCRIPTION
- Fixed buggy `match` expression in `statusAsSourcePage`.
- Updated PHPDoc annotations in `SessionTokenStoreHandler` and `TranslationEvent`.
- Added missing `use Exception` import in `SessionTokenStoreHandler`.- 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212198688963956
  - https://app.asana.com/0/0/1212198650246662