### PR TITLE
Used get translation to validate api key instead of glossaries()

### DIFF
--- a/lib/Utils/Engines/Validators/DeepLEngineValidator.php
+++ b/lib/Utils/Engines/Validators/DeepLEngineValidator.php
@@ -21,7 +21,13 @@ class DeepLEngineValidator extends AbstractValidator
         /** @var DeepL $newTestCreatedMT */
         $newTestCreatedMT = EnginesFactory::createTempInstance($object->engineStruct);
         try {
-            $newTestCreatedMT->glossaries();
+            $config = $newTestCreatedMT->getConfigStruct();
+            $config['segment'] = "Hello World";
+            $config['source'] = "en-US";
+            $config['target'] = "fr-FR";
+            $config['pid'] = -(mt_rand(1000, PHP_INT_MAX));
+
+            $newTestCreatedMT->get($config);
         } catch (Exception $e) {
             throw new Exception("Invalid DeepL API key.");
         }


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212253087425351