### PR TITLE
Removed ext-json dependency in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "symfony/console": "^5",
         "ext-curl": "*",
         "ext-pcntl": "*",
-        "ext-json": "*",
         "ext-libxml": "*",
         "ext-dom": "*",
         "ext-pdo": "*",


### PR DESCRIPTION
In PHP 8.3, ext-json is a core extension that is bundled, compiled by default, and cannot be disabled. It is always available, meaning no separate installation.

https://github.com/matecat/MateCat/issues/4375