### PR TITLE
🔧 chore(ci): opt into Node.js 24 for JavaScript-based actions in _ci-…

### DIFF
--- a/.github/workflows/_ci-cd.yml
+++ b/.github/workflows/_ci-cd.yml
@@ -30,6 +30,9 @@ on:
 env:
   AWS_REGION: 'eu-central-1'
   APP_NAME: matecat
+  # Opt into Node.js 24 for all JavaScript-based actions (checkout@v4, etc.)
+  # Remove once actions/checkout@v5 is released with native Node 24 support.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
…cd.yml

- add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 environment variable for compatibility
- include temporary comment to clarify its purpose pending actions/checkout@v5 release