### PR TITLE
🐛 fix(qa): validate ICU patterns on locked segments at project creation

### DIFF
--- a/lib/Controller/API/App/GetSegmentsController.php
+++ b/lib/Controller/API/App/GetSegmentsController.php
@@ -25,6 +25,7 @@ use Model\Segments\SegmentUIStruct;
 use ReflectionException;
 use Utils\TaskRunner\Exceptions\EndQueueException;
 use Utils\TaskRunner\Exceptions\ReQueueException;
+use Utils\LQA\ICUSourceSegmentDetector;
 use Utils\Tools\CatUtils;
 
 class GetSegmentsController extends KleinController
@@ -127,7 +128,7 @@ class GetSegmentsController extends KleinController
                     language: $job->source,
                     patternString: $seg['segment']
                 );
-                $string_contains_icu = $analyzer->containsComplexSyntax() && $analyzer->isValidSyntax();
+                $string_contains_icu = ICUSourceSegmentDetector::sourceContainsIcu($analyzer, $icu_enabled);
             }
 
             /** @var MateCatFilter $Filter */

--- a/lib/Model/ProjectCreation/ProjectManager.php
+++ b/lib/Model/ProjectCreation/ProjectManager.php
@@ -32,6 +32,7 @@ use Model\Xliff\DTO\XliffRulesModel;
 use Plugins\Features\SecondPassReview;
 use ReflectionException;
 use Throwable;
+use TypeError;
 use Utils\ActiveMQ\AMQHandler;
 use Utils\ActiveMQ\WorkerClient;
 use Utils\AsyncTasks\Workers\ActivityLogWorker;
@@ -215,7 +216,11 @@ class ProjectManager
      */
     protected function getQAProcessor(): QAProcessor
     {
-        return $this->qaProcessor ??= new QAProcessor($this->filter, $this->features);
+        return $this->qaProcessor ??= new QAProcessor(
+            $this->filter,
+            $this->features,
+            (bool) ($this->projectStructure->metadata[ProjectsMetadataMarshaller::ICU_ENABLED->value] ?? false),
+        );
     }
 
     /**
@@ -1017,6 +1022,7 @@ class ProjectManager
 
     /**
      * @throws Exception
+     * @throws TypeError
      */
     private function insertSegmentNotesForFile(): void
     {

--- a/lib/Model/ProjectCreation/QAProcessor.php
+++ b/lib/Model/ProjectCreation/QAProcessor.php
@@ -2,6 +2,9 @@
 
 namespace Model\ProjectCreation;
 
+use Exception;
+use Matecat\ICU\MessagePatternComparator;
+use Matecat\ICU\MessagePatternValidator;
 use Matecat\SubFiltering\MateCatFilter;
 use Model\FeaturesBase\FeatureSet;
 use Utils\LQA\QA;
@@ -12,6 +15,10 @@ use Utils\LQA\QA;
  * Converts source/target from Layer 0 to Layer 1, runs {@see QA::performConsistencyCheck()},
  * selects the appropriate target string, converts back to Layer 0, and writes the results
  * onto each {@see TranslationTuple} in place.
+ *
+ * When ICU is enabled for the project, the processor also detects ICU MessageFormat
+ * patterns in each segment and passes a {@see MessagePatternComparator} to QA so that
+ * ICU consistency is validated alongside tag checks.
  *
  * Produces 4 scalars per tuple:
  * - translationLayer0: the QA-processed target (Layer 0)
@@ -24,6 +31,7 @@ class QAProcessor
     public function __construct(
         private readonly MateCatFilter $filter,
         private readonly FeatureSet $features,
+        private readonly bool $icuEnabled = false,
     ) {
     }
 
@@ -35,6 +43,8 @@ class QAProcessor
      * @param ProjectStructure $projectStructure contains translations to process
      * @param string $sourceLang source language code (e.g. 'en-US')
      * @param string $targetLang target language code (e.g. 'it-IT')
+     *
+     * @throws Exception
      */
     public function process(
         ProjectStructure $projectStructure,
@@ -50,7 +60,14 @@ class QAProcessor
                 $source = $this->filter->fromLayer0ToLayer1($tuple->source);
                 $target = $this->filter->fromLayer0ToLayer1($tuple->target);
 
-                $check = $this->createQA($source, $target);
+                [$comparator, $sourceContainsIcu] = $this->detectIcu(
+                    $sourceLang,
+                    $targetLang,
+                    $tuple->source,
+                    $tuple->target,
+                );
+
+                $check = $this->createQA($source, $target, $comparator, $sourceContainsIcu);
                 $check->setFeatureSet($this->features);
                 $check->setSourceSegLang($sourceLang);
                 $check->setTargetSegLang($targetLang);
@@ -71,11 +88,62 @@ class QAProcessor
     }
 
     /**
+     * Detect ICU MessageFormat patterns in the source segment.
+     *
+     * Uses the raw Layer 0 content for detection because curly-bracket filter
+     * handlers are disabled by default at project-creation time, so ICU syntax
+     * survives the L0→L1 round-trip.
+     *
+     * @param string $sourceLang source language code
+     * @param string $targetLang target language code
+     * @param string $rawSource  raw Layer 0 source content
+     * @param string $rawTarget  raw Layer 0 target content
+     *
+     * @return array{0: ?MessagePatternComparator, 1: bool}
+     *         [comparator (null when ICU is not detected), sourceContainsIcu flag]
+     */
+    private function detectIcu(
+        string $sourceLang,
+        string $targetLang,
+        string $rawSource,
+        string $rawTarget,
+    ): array {
+        if (!$this->icuEnabled) {
+            return [null, false];
+        }
+
+        $sourceValidator = new MessagePatternValidator($sourceLang, $rawSource);
+
+        $sourceContainsIcu = $sourceValidator->containsComplexSyntax()
+            && $sourceValidator->isValidSyntax();
+
+        if (!$sourceContainsIcu) {
+            return [null, false];
+        }
+
+        $targetValidator = new MessagePatternValidator($targetLang, $rawTarget);
+
+        return [
+            MessagePatternComparator::fromValidators($sourceValidator, $targetValidator),
+            true,
+        ];
+    }
+
+    /**
      * Create a new QA instance.
      * Protected so test subclasses can override to inject stubs.
+     *
+     * @param string                        $source            Layer 1 source segment
+     * @param string                        $target            Layer 1 target segment
+     * @param MessagePatternComparator|null $comparator        ICU pattern comparator (null when ICU not detected)
+     * @param bool                          $sourceContainsIcu whether the source contains ICU patterns
      */
-    protected function createQA(string $source, string $target): QA
-    {
-        return new QA($source, $target);
+    protected function createQA(
+        string $source,
+        string $target,
+        ?MessagePatternComparator $comparator = null,
+        bool $sourceContainsIcu = false,
+    ): QA {
+        return new QA($source, $target, $comparator, $sourceContainsIcu);
     }
 }

--- a/lib/Model/ProjectCreation/QAProcessor.php
+++ b/lib/Model/ProjectCreation/QAProcessor.php
@@ -7,6 +7,7 @@ use Matecat\ICU\MessagePatternComparator;
 use Matecat\ICU\MessagePatternValidator;
 use Matecat\SubFiltering\MateCatFilter;
 use Model\FeaturesBase\FeatureSet;
+use Utils\LQA\ICUSourceSegmentDetector;
 use Utils\LQA\QA;
 
 /**
@@ -114,8 +115,7 @@ class QAProcessor
 
         $sourceValidator = new MessagePatternValidator($sourceLang, $rawSource);
 
-        $sourceContainsIcu = $sourceValidator->containsComplexSyntax()
-            && $sourceValidator->isValidSyntax();
+        $sourceContainsIcu = ICUSourceSegmentDetector::sourceContainsIcu($sourceValidator, $this->icuEnabled);
 
         if (!$sourceContainsIcu) {
             return [null, false];

--- a/lib/Utils/LQA/ICUSourceSegmentChecker.php
+++ b/lib/Utils/LQA/ICUSourceSegmentChecker.php
@@ -44,9 +44,10 @@ trait ICUSourceSegmentChecker
             $sourceSegment,
         );
 
-        if ($this->icuEnabled($projectStruct)) {
-            $this->sourceContainsIcu = $this->icuSourcePatternValidator->containsComplexSyntax() && $this->icuSourcePatternValidator->isValidSyntax();
-        }
+        $this->sourceContainsIcu = ICUSourceSegmentDetector::sourceContainsIcu(
+            $this->icuSourcePatternValidator,
+            $this->icuEnabled($projectStruct)
+        );
 
         return $this->sourceContainsIcu;
 

--- a/lib/Utils/LQA/ICUSourceSegmentDetector.php
+++ b/lib/Utils/LQA/ICUSourceSegmentDetector.php
@@ -11,6 +11,11 @@ final class ICUSourceSegmentDetector
 {
     /**
      * Determines whether a source segment contains valid ICU MessageFormat patterns.
+     *
+     * @param MessagePatternValidator $validator ICU validator for the source segment
+     * @param bool                    $icuEnabled Whether ICU support is enabled for the current project
+     *
+     * @return bool True when ICU is enabled and the source has valid complex ICU syntax
      */
     public static function sourceContainsIcu(MessagePatternValidator $validator, bool $icuEnabled): bool
     {

--- a/lib/Utils/LQA/ICUSourceSegmentDetector.php
+++ b/lib/Utils/LQA/ICUSourceSegmentDetector.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Utils\LQA;
+
+use Matecat\ICU\MessagePatternValidator;
+
+/**
+ * Shared ICU source-segment detection logic.
+ */
+final class ICUSourceSegmentDetector
+{
+    /**
+     * Determines whether a source segment contains valid ICU MessageFormat patterns.
+     */
+    public static function sourceContainsIcu(MessagePatternValidator $validator, bool $icuEnabled): bool
+    {
+        return $icuEnabled
+            && $validator->containsComplexSyntax()
+            && $validator->isValidSyntax();
+    }
+}

--- a/tests/unit/Model/ProjectCreation/QAProcessorTest.php
+++ b/tests/unit/Model/ProjectCreation/QAProcessorTest.php
@@ -50,7 +50,7 @@ class QAProcessorTest extends AbstractTest
      *
      * @throws MockException
      */
-    private function buildProcessor(?QA $qa = null): TestableQAProcessor
+    private function buildProcessor(?QA $qa = null, bool $icuEnabled = false): TestableQAProcessor
     {
         $filter = $this->createStub(MateCatFilter::class);
         $filter->method('fromLayer0ToLayer1')
@@ -61,6 +61,7 @@ class QAProcessorTest extends AbstractTest
         $processor = new TestableQAProcessor(
             $filter,
             $this->createStub(FeatureSet::class),
+            $icuEnabled,
         );
 
         if ($qa !== null) {
@@ -246,5 +247,98 @@ class QAProcessorTest extends AbstractTest
 
         // fromLayer1ToLayer0('L1:target text') → 'L0:L1:target text'
         $this->assertSame('L0:L1:target text', $tuple->translationLayer0);
+    }
+
+    // ── Test 6: ICU enabled + ICU source → comparator passed to createQA ─
+
+    /**
+     * @throws MockException
+     */
+    #[Test]
+    public function passesComparatorWhenIcuEnabledAndSourceContainsIcu(): void
+    {
+        $qa = $this->buildQAStub(normalizedTarget: 'norm');
+
+        $icuSource = '{count, plural, one{# item} other{# items}}';
+        $icuTarget = '{count, plural, one{# elemento} other{# elementi}}';
+
+        $tuple = $this->makeTuple(source: $icuSource, target: $icuTarget);
+        $this->projectStructure->translations = [
+            'tu-1' => [0 => $tuple],
+        ];
+
+        $processor = $this->buildProcessor($qa, icuEnabled: true);
+        $processor->process($this->projectStructure, 'en-US', 'it-IT');
+
+        $this->assertNotNull($processor->lastComparator);
+        $this->assertTrue($processor->lastSourceContainsIcu);
+    }
+
+    // ── Test 7: ICU disabled + ICU source → no comparator ────────────
+
+    /**
+     * @throws MockException
+     */
+    #[Test]
+    public function skipsIcuDetectionWhenIcuDisabled(): void
+    {
+        $qa = $this->buildQAStub(normalizedTarget: 'norm');
+
+        $icuSource = '{count, plural, one{# item} other{# items}}';
+        $icuTarget = '{count, plural, one{# elemento} other{# elementi}}';
+
+        $tuple = $this->makeTuple(source: $icuSource, target: $icuTarget);
+        $this->projectStructure->translations = [
+            'tu-1' => [0 => $tuple],
+        ];
+
+        $processor = $this->buildProcessor($qa, icuEnabled: false);
+        $processor->process($this->projectStructure, 'en-US', 'it-IT');
+
+        $this->assertNull($processor->lastComparator);
+        $this->assertFalse($processor->lastSourceContainsIcu);
+    }
+
+    // ── Test 8: ICU enabled + non-ICU source → no comparator ─────────
+
+    /**
+     * @throws MockException
+     */
+    #[Test]
+    public function skipsIcuDetectionWhenSourceHasNoIcuPatterns(): void
+    {
+        $qa = $this->buildQAStub(normalizedTarget: 'norm');
+
+        $tuple = $this->makeTuple(source: 'plain source text', target: 'plain target text');
+        $this->projectStructure->translations = [
+            'tu-1' => [0 => $tuple],
+        ];
+
+        $processor = $this->buildProcessor($qa, icuEnabled: true);
+        $processor->process($this->projectStructure, 'en-US', 'it-IT');
+
+        $this->assertNull($processor->lastComparator);
+        $this->assertFalse($processor->lastSourceContainsIcu);
+    }
+
+    // ── Test 9: ICU enabled + broken target → QA reports ICU errors ──
+
+    #[Test]
+    public function reportsIcuValidationErrorsForBrokenTarget(): void
+    {
+        $icuSource = '{count, plural, one{# item} other{# items}}';
+        $brokenTarget = '{count, plural, one{# elemento}}';
+
+        $tuple = $this->makeTuple(source: $icuSource, target: $brokenTarget);
+        $this->projectStructure->translations = [
+            'tu-1' => [0 => $tuple],
+        ];
+
+        // No QA stub — uses real QA so ICU validation actually runs
+        $processor = $this->buildProcessor(icuEnabled: true);
+        $processor->process($this->projectStructure, 'en-US', 'it-IT');
+
+        $this->assertSame(1, $tuple->warning);
+        $this->assertNotEmpty($tuple->serializedErrors);
     }
 }

--- a/tests/unit/Model/ProjectCreation/TestableQAProcessor.php
+++ b/tests/unit/Model/ProjectCreation/TestableQAProcessor.php
@@ -2,6 +2,7 @@
 
 namespace unit\Model\ProjectCreation;
 
+use Matecat\ICU\MessagePatternComparator;
 use Model\ProjectCreation\QAProcessor;
 use Utils\LQA\QA;
 
@@ -12,19 +13,26 @@ class TestableQAProcessor extends QAProcessor
 {
     private ?QA $qaInstance = null;
 
-    /**
-     * Inject a QA stub/mock for tests.
-     */
+    /** @var ?MessagePatternComparator Captures the comparator passed to the last createQA() call */
+    public ?MessagePatternComparator $lastComparator = null;
+
+    /** @var ?bool Captures the sourceContainsIcu flag passed to the last createQA() call */
+    public ?bool $lastSourceContainsIcu = null;
+
     public function setQA(QA $qa): void
     {
         $this->qaInstance = $qa;
     }
 
-    /**
-     * Override to return the injected QA instance instead of creating a real one.
-     */
-    protected function createQA(string $source, string $target): QA
-    {
-        return $this->qaInstance ?? parent::createQA($source, $target);
+    protected function createQA(
+        string $source,
+        string $target,
+        ?MessagePatternComparator $comparator = null,
+        bool $sourceContainsIcu = false,
+    ): QA {
+        $this->lastComparator        = $comparator;
+        $this->lastSourceContainsIcu = $sourceContainsIcu;
+
+        return $this->qaInstance ?? parent::createQA($source, $target, $comparator, $sourceContainsIcu);
     }
 }


### PR DESCRIPTION
## Summary

ICU string validation was silently skipped on locked (101% ICE) segments during project creation. `QAProcessor::createQA()` instantiated `QA` without passing `MessagePatternComparator` or the `$string_contains_icu` flag, causing `ICUChecker::hasIcuPatterns()` to always return `false`.

This PR fixes the bug and consolidates all ICU source-segment detection into a single shared utility (`ICUSourceSegmentDetector`), eliminating the last inline `containsComplexSyntax() && isValidSyntax()` duplication in `GetSegmentsController`.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Model/ProjectCreation/QAProcessor.php` | Add `$icuEnabled` param, use `ICUSourceSegmentDetector::sourceContainsIcu()`, pass comparator + flag to `QA` |
| `lib/Model/ProjectCreation/ProjectManager.php` | Pass `icuEnabled` from project metadata to `QAProcessor` |
| `lib/Utils/LQA/ICUSourceSegmentDetector.php` | New shared static utility — single source of truth for ICU source detection |
| `lib/Utils/LQA/ICUSourceSegmentChecker.php` | Refactored to delegate to `ICUSourceSegmentDetector` |
| `lib/Controller/API/App/GetSegmentsController.php` | Replace inline ICU detection with `ICUSourceSegmentDetector::sourceContainsIcu()` |
| `tests/unit/Model/ProjectCreation/QAProcessorTest.php` | 4 new ICU detection regression tests |
| `tests/unit/Model/ProjectCreation/TestableQAProcessor.php` | Updated constructor signature + spy fields |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan analyse` passes (2 pre-existing errors in `View/APIDoc.php`)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

2118 tests, 17699 assertions — all green.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — details below

Claude Code (claude-opus-4-6) — ICU fix, shared detector extraction, codebase-wide refactoring audit, test generation.

## Notes

Codebase audit confirmed all ICU detection sites now use the shared utility:
- **QAProcessor** — calls `ICUSourceSegmentDetector::sourceContainsIcu()` directly
- **GetSegmentsController** — calls `ICUSourceSegmentDetector::sourceContainsIcu()` directly (this PR)
- **SetTranslationController, GetWarningController, XliffReplacerCallback** — via `ICUSourceSegmentChecker` trait, which delegates to the detector

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214028216264294