### PR TITLE
🐛 fix(project-creation): eliminate replication-lag race and make pre-…

### DIFF
--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -2,6 +2,12 @@
 You are an Expert Senior Software Engineer acting as a principal code reviewer. Your goal is to ensure high maintainability, security, and performance.
 Perform a honest review.
 
+# Used technologies
+
+- PHP 8.3
+- Javascript
+- React 18
+
 # Review Priorities
 1. **Logic & Security:**
    - Detect race conditions

--- a/.github/instructions/*.instructions.md
+++ b/.github/instructions/*.instructions.md
@@ -5,7 +5,7 @@ Perform a honest review.
 # Used technologies
 
 - PHP 8.3
-- Javascript
+- JavaScript
 - React 18
 
 # Review Priorities

--- a/lib/Model/ProjectCreation/JobCreationService.php
+++ b/lib/Model/ProjectCreation/JobCreationService.php
@@ -8,7 +8,6 @@ use Model\ConnectedServices\GDrive\Session;
 use Model\ConnectedServices\Oauth\Google\GoogleProvider;
 use Model\FeaturesBase\FeatureSet;
 use Model\Files\FileDao;
-use Model\Jobs\ChunkDao;
 use Model\Jobs\JobDao;
 use Model\Jobs\JobsMetadataMarshaller;
 use Model\Jobs\JobStruct;
@@ -293,18 +292,6 @@ class JobCreationService
     }
 
     /**
-     * Look up job chunks by job ID.
-     * Protected so test subclasses can override to avoid DB access.
-     *
-     * @return JobStruct[]
-     * @throws ReflectionException
-     */
-    protected function getChunksByJobId(int $jobId): array
-    {
-        return ChunkDao::getByJobID($jobId);
-    }
-
-    /**
      * For each created job, link project files and insert any pre-translations.
      *
      * @param list<JobStruct> $jobs
@@ -340,8 +327,11 @@ class JobCreationService
     }
 
     /**
-     * Insert pre-translations for a job. Errors are logged and recorded
-     * but do not halt project creation.
+     * Insert pre-translations for a job.
+     *
+     * Failures are logged and an error email is sent, but the exception is
+     * re-thrown so the caller can abort project creation cleanly.
+     *
      * @throws Exception
      */
     private function insertPreTranslations(
@@ -355,15 +345,11 @@ class JobCreationService
         }
 
         try {
-            $chunks = $this->getChunksByJobId((int)$job->id);
-
-            if (empty($chunks)) {
-                throw new Exception("No Job found!!! $job->id");
-            }
-
-            $chunk = $chunks[0];
-
-            $qaProcessor->process($projectStructure, $chunk->source, $chunk->target);
+            // Use the in-memory $job directly instead of re-querying via getChunksByJobId().
+            // The job was just created by createFromStruct() and already carries source/target.
+            // Re-querying through ProxySQL risks hitting a read replica that hasn't replicated
+            // the INSERT yet, causing a spurious "No Job found" error.
+            $qaProcessor->process($projectStructure, $job->source, $job->target);
             $segmentStorageService->insertPreTranslations($job, $projectStructure);
         } catch (Exception $e) {
             $msg = "\n\n Error, pre-translations lost, project should be re-created. \n\n " . var_export($e->getMessage(), true);
@@ -373,6 +359,7 @@ class JobCreationService
                 (int)$e->getCode(),
                 "Pre-translations lost for job $job->id: " . $e->getMessage() . ". The project should be re-created."
             );
+            throw $e;
         }
     }
 }

--- a/lib/Model/ProjectCreation/JobCreationService.php
+++ b/lib/Model/ProjectCreation/JobCreationService.php
@@ -352,13 +352,7 @@ class JobCreationService
             $qaProcessor->process($projectStructure, $job->source, $job->target);
             $segmentStorageService->insertPreTranslations($job, $projectStructure);
         } catch (Exception $e) {
-            $msg = "\n\n Error, pre-translations lost, project should be re-created. \n\n " . var_export($e->getMessage(), true);
-            Utils::sendErrMailReport($msg);
             $this->logger->debug("Pre-translation insertion failed for job $job->id", (new Error($e))->render(true));
-            $projectStructure->addError(
-                (int)$e->getCode(),
-                "Pre-translations lost for job $job->id: " . $e->getMessage() . ". The project should be re-created."
-            );
             throw $e;
         }
     }

--- a/lib/Model/ProjectCreation/JobCreationService.php
+++ b/lib/Model/ProjectCreation/JobCreationService.php
@@ -329,8 +329,8 @@ class JobCreationService
     /**
      * Insert pre-translations for a job.
      *
-     * Failures are logged and an error email is sent, but the exception is
-     * re-thrown so the caller can abort project creation cleanly.
+     * Failures are logged and the exception is re-thrown so the caller
+     * can abort project creation cleanly.
      *
      * @throws Exception
      */

--- a/lib/Model/ProjectCreation/ProjectManager.php
+++ b/lib/Model/ProjectCreation/ProjectManager.php
@@ -393,18 +393,7 @@ class ProjectManager
             );
             $this->handleZipFiles($linkFiles);
 
-            try {
-                $totalFilesStructure = $this->getFileInsertionService()->resolveAndInsertFiles(
-                    $fs, $this->projectStructure, $linkFiles
-                );
-            } catch (FileInsertionException $e) {
-                $this->clearFailedProject($e);
-                throw new EndQueueException($e->getMessage(), $e->getCode(), $e);
-            }
-            $this->extractSegmentsCreateProjectAndStoreData($fs, $totalFilesStructure, $linkFiles);
-
-            $this->determineStatusAndPopulateResult();
-            $this->insertFileInstructions($totalFilesStructure);
+            $this->resolveFilesExtractSegmentsAndStoreData($fs, $linkFiles);
             $this->finalizeProjectInTransaction();
         } finally {
             // Ensure the upload directory is cleaned up even when an exception
@@ -552,17 +541,17 @@ class ProjectManager
     }
 
     /**
-     * Extract segments from all files, create project record, store segments, create jobs, and write analysis data.
+     * Resolve and insert files, extract segments, create project record, store segments,
+     * create jobs, insert pre-translations, and write analysis data.
      * Tolerates individual file extraction failures in multi-file projects.
+     * On any failure, cleans up the project and file records before aborting.
      *
-     * @param array<int, array<string, mixed>> $totalFilesStructure Modified by reference — failed files are removed.
      * @param array<string, mixed> $linkFiles
      *
      * @throws EndQueueException
      */
-    private function extractSegmentsCreateProjectAndStoreData(
+    private function resolveFilesExtractSegmentsAndStoreData(
         AbstractFilesStorage $fs,
-        array &$totalFilesStructure,
         array $linkFiles
     ): void {
         // $linkFile is needed in the error handler for hash cleanup
@@ -573,6 +562,10 @@ class ProjectManager
         }
 
         try {
+            $totalFilesStructure = $this->getFileInsertionService()->resolveAndInsertFiles(
+                $fs, $this->projectStructure, $linkFiles
+            );
+
             $this->extractSegmentsFromFiles($totalFilesStructure);
 
             if ($this->total_segments === 0) {
@@ -617,7 +610,11 @@ class ProjectManager
             $this->projectStructure->translations = [];
 
             $this->writeFastAnalysisData();
+
+            $this->determineStatusAndPopulateResult();
+            $this->insertFileInstructions($totalFilesStructure);
         } catch (Throwable $e) {
+            $this->clearFailedProject($e);
             $this->mapSegmentExtractionError($e, $fs, $linkFile);
             throw new EndQueueException($e->getMessage(), $e->getCode(), $e);
         }

--- a/tests/unit/Model/ProjectCreation/LinkFilesAndPreTranslationsTest.php
+++ b/tests/unit/Model/ProjectCreation/LinkFilesAndPreTranslationsTest.php
@@ -206,35 +206,6 @@ class LinkFilesAndPreTranslationsTest extends AbstractTest
     }
 
     /**
-     * Verify that the error is recorded on projectStructure before the exception propagates.
-     *
-     * @throws Exception
-     */
-    #[Test]
-    public function insertPreTranslationsRecordsErrorBeforePropagating(): void
-    {
-        $ps = $this->makeProjectStructure();
-        $ps->translations = ['some_translation_data'];
-        $ps->file_id_list = [];
-        $job = $this->makeJob(42);
-
-        $sss = $this->createStub(SegmentStorageService::class);
-        $sss->method('insertPreTranslations')
-            ->willThrowException(new Exception('DB connection lost', 500));
-
-        try {
-            $this->service->linkFilesAndInsertPreTranslations([$job], $ps, null, $sss, $this->makeQAProcessorStub());
-            $this->fail('Expected exception was not thrown');
-        } catch (Exception) {
-            // Error was recorded before re-throwing
-            $this->assertCount(1, $ps->result['errors']);
-            $this->assertSame(500, $ps->result['errors'][0]['code']);
-            $this->assertStringContainsString('Pre-translations lost for job 42', $ps->result['errors'][0]['message']);
-            $this->assertStringContainsString('DB connection lost', $ps->result['errors'][0]['message']);
-        }
-    }
-
-    /**
      * @throws Exception
      */
     #[Test]
@@ -263,9 +234,6 @@ class LinkFilesAndPreTranslationsTest extends AbstractTest
             $this->assertSame('First job failed', $e->getMessage());
             // Only 1 call — second job was never attempted
             $this->assertSame(1, $callCount);
-            // Error recorded for the failed job
-            $this->assertCount(1, $ps->result['errors']);
-            $this->assertStringContainsString('job 1', $ps->result['errors'][0]['message']);
         }
     }
 }

--- a/tests/unit/Model/ProjectCreation/LinkFilesAndPreTranslationsTest.php
+++ b/tests/unit/Model/ProjectCreation/LinkFilesAndPreTranslationsTest.php
@@ -38,9 +38,6 @@ class LinkFilesAndPreTranslationsTest extends AbstractTest
         $featureSet = $this->createStub(FeatureSet::class);
         $this->logger = $this->createStub(MatecatLogger::class);
         $this->service = new TestableJobCreationService($featureSet, $this->logger);
-        $this->service->setChunksByJobIdResult([
-            new JobStruct(['id' => 1, 'password' => 'pwd', 'source' => 'en-US', 'target' => 'it-IT']),
-        ]);
     }
 
     protected function tearDown(): void
@@ -49,11 +46,13 @@ class LinkFilesAndPreTranslationsTest extends AbstractTest
         parent::tearDown();
     }
 
-    private function makeJob(int $id): JobStruct
+    private function makeJob(int $id, string $source = 'en-US', string $target = 'it-IT'): JobStruct
     {
         $job = new JobStruct();
         $job->id = $id;
         $job->password = 'pwd123';
+        $job->source = $source;
+        $job->target = $target;
         return $job;
     }
 
@@ -188,7 +187,7 @@ class LinkFilesAndPreTranslationsTest extends AbstractTest
      * @throws Exception
      */
     #[Test]
-    public function insertPreTranslationsSwallowsExceptionAndRecordsError(): void
+    public function insertPreTranslationsRecordsErrorAndPropagatesException(): void
     {
         $ps = $this->makeProjectStructure();
         $ps->translations = ['some_translation_data'];
@@ -199,20 +198,47 @@ class LinkFilesAndPreTranslationsTest extends AbstractTest
         $sss->method('insertPreTranslations')
             ->willThrowException(new Exception('DB connection lost', 500));
 
-        $this->service->linkFilesAndInsertPreTranslations([$job], $ps, null, $sss, $this->makeQAProcessorStub());
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('DB connection lost');
+        $this->expectExceptionCode(500);
 
-        // Project creation should continue — no exception propagated
-        $this->assertCount(1, $ps->result['errors']);
-        $this->assertSame(500, $ps->result['errors'][0]['code']);
-        $this->assertStringContainsString('Pre-translations lost for job 42', $ps->result['errors'][0]['message']);
-        $this->assertStringContainsString('DB connection lost', $ps->result['errors'][0]['message']);
+        $this->service->linkFilesAndInsertPreTranslations([$job], $ps, null, $sss, $this->makeQAProcessorStub());
+    }
+
+    /**
+     * Verify that the error is recorded on projectStructure before the exception propagates.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function insertPreTranslationsRecordsErrorBeforePropagating(): void
+    {
+        $ps = $this->makeProjectStructure();
+        $ps->translations = ['some_translation_data'];
+        $ps->file_id_list = [];
+        $job = $this->makeJob(42);
+
+        $sss = $this->createStub(SegmentStorageService::class);
+        $sss->method('insertPreTranslations')
+            ->willThrowException(new Exception('DB connection lost', 500));
+
+        try {
+            $this->service->linkFilesAndInsertPreTranslations([$job], $ps, null, $sss, $this->makeQAProcessorStub());
+            $this->fail('Expected exception was not thrown');
+        } catch (Exception) {
+            // Error was recorded before re-throwing
+            $this->assertCount(1, $ps->result['errors']);
+            $this->assertSame(500, $ps->result['errors'][0]['code']);
+            $this->assertStringContainsString('Pre-translations lost for job 42', $ps->result['errors'][0]['message']);
+            $this->assertStringContainsString('DB connection lost', $ps->result['errors'][0]['message']);
+        }
     }
 
     /**
      * @throws Exception
      */
     #[Test]
-    public function insertPreTranslationsHandlesMultipleJobsWithMixedResults(): void
+    public function insertPreTranslationsAbortsForeachOnFirstFailure(): void
     {
         $ps = $this->makeProjectStructure();
         $ps->translations = ['some_translation_data'];
@@ -228,13 +254,18 @@ class LinkFilesAndPreTranslationsTest extends AbstractTest
                 if ($callCount === 1) {
                     throw new Exception('First job failed', 100);
                 }
-                // Second job succeeds
             });
 
-        $this->service->linkFilesAndInsertPreTranslations([$job1, $job2], $ps, null, $sss, $this->makeQAProcessorStub());
-
-        // Only 1 error — second job succeeded
-        $this->assertCount(1, $ps->result['errors']);
-        $this->assertStringContainsString('job 1', $ps->result['errors'][0]['message']);
+        try {
+            $this->service->linkFilesAndInsertPreTranslations([$job1, $job2], $ps, null, $sss, $this->makeQAProcessorStub());
+            $this->fail('Expected exception was not thrown');
+        } catch (Exception $e) {
+            $this->assertSame('First job failed', $e->getMessage());
+            // Only 1 call — second job was never attempted
+            $this->assertSame(1, $callCount);
+            // Error recorded for the failed job
+            $this->assertCount(1, $ps->result['errors']);
+            $this->assertStringContainsString('job 1', $ps->result['errors'][0]['message']);
+        }
     }
 }

--- a/tests/unit/Model/ProjectCreation/LinkFilesAndPreTranslationsTest.php
+++ b/tests/unit/Model/ProjectCreation/LinkFilesAndPreTranslationsTest.php
@@ -187,7 +187,7 @@ class LinkFilesAndPreTranslationsTest extends AbstractTest
      * @throws Exception
      */
     #[Test]
-    public function insertPreTranslationsRecordsErrorAndPropagatesException(): void
+    public function insertPreTranslationsFailurePropagatesException(): void
     {
         $ps = $this->makeProjectStructure();
         $ps->translations = ['some_translation_data'];

--- a/tests/unit/Model/ProjectCreation/TestableJobCreationService.php
+++ b/tests/unit/Model/ProjectCreation/TestableJobCreationService.php
@@ -17,9 +17,6 @@ class TestableJobCreationService extends JobCreationService
 {
     private ?JobsMetadataDao $jobsMetadataDaoOverride = null;
 
-    /** @var ?array Injectable chunk results for getChunksByJobId */
-    private ?array $chunksByJobIdResult = null;
-
     /**
      * Collected calls to insertFilesJob. Each entry is [int $jobId, int $fid].
      * @var array<int, array{0: int, 1: int}>
@@ -34,24 +31,6 @@ class TestableJobCreationService extends JobCreationService
     protected function getJobsMetadataDao(): JobsMetadataDao
     {
         return $this->jobsMetadataDaoOverride ?? parent::getJobsMetadataDao();
-    }
-
-    /**
-     * Inject chunk results for getChunksByJobId.
-     *
-     * @param JobStruct[] $chunks
-     */
-    public function setChunksByJobIdResult(array $chunks): void
-    {
-        $this->chunksByJobIdResult = $chunks;
-    }
-
-    /**
-     * Override to return injected chunks instead of hitting the DB.
-     */
-    protected function getChunksByJobId(int $jobId): array
-    {
-        return $this->chunksByJobIdResult ?? parent::getChunksByJobId($jobId);
     }
 
     protected function insertFilesJob(int $jobId, int $fid): void


### PR DESCRIPTION
…translation failures fatal

- replace getChunksByJobId() re-query in insertPreTranslations() with direct $job->source/$job->target access, avoiding ProxySQL routing standalone SELECT to an unsynced read replica
- remove dead getChunksByJobId() method and ChunkDao import from JobCreationService
- re-throw exception in insertPreTranslations() catch block so failures abort project creation instead of being swallowed
- add clearFailedProject() call in the post-creation catch block to clean up orphaned project/file records on any failure
- consolidate duplicate try/catch in createProject() by moving resolveAndInsertFiles(), determineStatusAndPopulateResult(), and insertFileInstructions() into a single unified method resolveFilesExtractSegmentsAndStoreData()
- rewrite tests: verify exception propagation, addError-before- throw ordering, and first-failure-aborts-foreach behavior