### PR TITLE
👷 ci(commit-check): add labeled trigger so bypass label takes effect immediately

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -2,7 +2,7 @@ name: Commit Message Check
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, synchronize, labeled]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Add `labeled` to the `pull_request` trigger types in the commit message check workflow so that applying the `commit-message-exception` label re-runs the check and takes effect immediately — without needing a new push.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `.github/workflows/commit-message-check.yml` | Add `labeled` to `pull_request.types` |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — details below

Claude Code (claude-opus-4-6)

## Notes

Previously, the workflow only triggered on `opened, edited, reopened, synchronize`. Adding the `commit-message-exception` label required a subsequent push or manual rerun — and reruns replay the original event payload (without the label). Now the `labeled` event triggers a fresh run that sees the current label set.