### PR TITLE
✨feat: add support for 3 new English language variants

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1682,16 +1682,16 @@
         },
         {
             "name": "matecat/icu-intl",
-            "version": "v1.1.28",
+            "version": "v1.1.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/icu-intl.git",
-                "reference": "4cc293cc195c4d3c8d85338dcc426b230d9f413f"
+                "reference": "74366ceae6b32dc906d3f18d80cc1e5a376ab4cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/icu-intl/zipball/4cc293cc195c4d3c8d85338dcc426b230d9f413f",
-                "reference": "4cc293cc195c4d3c8d85338dcc426b230d9f413f",
+                "url": "https://api.github.com/repos/matecat/icu-intl/zipball/74366ceae6b32dc906d3f18d80cc1e5a376ab4cd",
+                "reference": "74366ceae6b32dc906d3f18d80cc1e5a376ab4cd",
                 "shasum": ""
             },
             "require": {
@@ -1728,9 +1728,9 @@
             "description": "A PHP port of ICU4J's MessagePattern parser with locale utilities. Parses ICU MessageFormat patterns into an inspectable AST and provides locale data support for internationalization in PHP.",
             "support": {
                 "issues": "https://github.com/matecat/icu-intl/issues",
-                "source": "https://github.com/matecat/icu-intl/tree/v1.1.28"
+                "source": "https://github.com/matecat/icu-intl/tree/v1.1.29"
             },
-            "time": "2026-04-20T09:19:42+00:00"
+            "time": "2026-04-28T09:58:27+00:00"
         },
         {
             "name": "matecat/klein",


### PR DESCRIPTION
## Summary

Added support for 3 new English language variants: English (Germany), English (Norway), and English (Philippines).

## Type

- [x] `feat` — add support for 3 new English language variants

## Changes

| File | Change |
|------|--------|
| `composer.lock` | Added support for English language variants |

## Migration Notes

- [ ] No migration required

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)

## AI Disclosure

- [x] No AI tools were used in this PR

## Notes

Support added for:
- English (Germany)
- English (Norway)
- English (Philippines)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214121393056896