### PR TITLE
🐛 fix: friendlySlug returns empty string for non-Latin project names

### DIFF
--- a/lib/Utils/Tools/Utils.php
+++ b/lib/Utils/Tools/Utils.php
@@ -202,14 +202,15 @@ class Utils
             $string = "-";
         }
 
-        // Percent-encode Unicode letters/numbers that fall outside ASCII slug characters;
-        // drop any other special characters (punctuation, symbols, etc.).
-        // The named 'encode' capture group identifies characters to percent-encode;
-        // the fallback branch catches remaining special chars to drop.
+        // Percent-encode non-ASCII Unicode letters/numbers that fall outside ASCII slug
+        // characters; drop any other special characters (punctuation, symbols, etc.).
+        // The negative lookahead (?![a-z0-9]) excludes ASCII alphanumerics from the
+        // 'encode' branch so they are left untouched by the callback. The fallback
+        // branch catches remaining non-slug characters to drop.
         $slug = preg_replace_callback(
-            '/(?P<encode>[\p{L}\p{N}])|[^a-z0-9\-<>]/u',
+            '/(?P<encode>(?![a-z0-9])[\p{L}\p{N}])|[^a-z0-9\-<>]/u',
             static function (array $matches): string {
-                return $matches['encode'] !== '' ? rawurlencode($matches['encode']) : '';
+                return !empty($matches['encode']) ? rawurlencode($matches['encode']) : '';
             },
             $string
         ) ?? '';

--- a/lib/Utils/Tools/Utils.php
+++ b/lib/Utils/Tools/Utils.php
@@ -225,10 +225,8 @@ class Utils
         // case where every character was a non-letter/non-number special char
         // (e.g. '@!#'). Whitespace-only input ($originalForEncoding === '') keeps
         // the '-' placeholder for backward compatibility.
-        if (($slug === '-' || $slug === '') && $originalForEncoding !== '') {
+        if (($slug === '-' || empty($slug)) && $originalForEncoding !== '') {
             $slug = rawurlencode($originalForEncoding);
-        if ($slug === '-' || empty($slug)) {
-            $slug = rawurlencode($string);
         }
 
         return $slug;

--- a/lib/Utils/Tools/Utils.php
+++ b/lib/Utils/Tools/Utils.php
@@ -212,6 +212,9 @@ class Utils
         // Only fall back to rawurlencode when the original input was non-empty
         // (i.e. non-Latin characters were stripped). Truly empty/whitespace-only
         // input keeps the '-' placeholder for backward compatibility.
+        // Note: $slug === '' can happen when non-empty non-Latin input (e.g. Cyrillic)
+        // has all its characters removed by the ASCII-only preg_replace above;
+        // $slug === '-' can happen when such input contained spaces that became dashes.
         if (($slug === '-' || $slug === '') && $originalForEncoding !== '') {
             $slug = rawurlencode($originalForEncoding);
         }

--- a/lib/Utils/Tools/Utils.php
+++ b/lib/Utils/Tools/Utils.php
@@ -198,14 +198,14 @@ class Utils
             $string = "-";
         }
 
-        //delete and replace rest of special chars
+        // delete and replace rest of special chars
         $find = ['/[^a-z0-9\-<>]/', '/-+/', '/<[^>]*>/'];
         $repl = ['', '-', ''];
 
-        //return the friendly url
+        // return the friendly url
         $slug = preg_replace($find, $repl, $string);
 
-        if ($slug === '-' || $slug === '') {
+        if ($slug === '-' || empty($slug)) {
             $slug = rawurlencode($string);
         }
 

--- a/lib/Utils/Tools/Utils.php
+++ b/lib/Utils/Tools/Utils.php
@@ -202,19 +202,28 @@ class Utils
             $string = "-";
         }
 
-        //delete and replace rest of special chars
-        $find = ['/[^a-z0-9\-<>]/', '/-+/', '/<[^>]*>/'];
-        $repl = ['', '-', ''];
+        // Percent-encode Unicode letters/numbers that fall outside ASCII slug characters;
+        // drop any other special characters (punctuation, symbols, etc.).
+        // The named 'encode' capture group identifies characters to percent-encode;
+        // the fallback branch catches remaining special chars to drop.
+        $slug = preg_replace_callback(
+            '/(?P<encode>[\p{L}\p{N}])|[^a-z0-9\-<>]/u',
+            static function (array $matches): string {
+                return $matches['encode'] !== '' ? rawurlencode($matches['encode']) : '';
+            },
+            $string
+        ) ?? '';
 
-        //return the friendly url
-        $slug = preg_replace($find, $repl, $string);
+        // Consolidate multiple consecutive dashes
+        $slug = preg_replace('/-+/', '-', $slug) ?? '';
 
-        // Only fall back to rawurlencode when the original input was non-empty
-        // (i.e. non-Latin characters were stripped). Truly empty/whitespace-only
-        // input keeps the '-' placeholder for backward compatibility.
-        // Note: $slug === '' can happen when non-empty non-Latin input (e.g. Cyrillic)
-        // has all its characters removed by the ASCII-only preg_replace above;
-        // $slug === '-' can happen when such input contained spaces that became dashes.
+        // Remove HTML tags
+        $slug = preg_replace('/<[^>]*>/', '', $slug) ?? '';
+
+        // Fall back to encoding the whole pre-placeholder value only for the rare
+        // case where every character was a non-letter/non-number special char
+        // (e.g. '@!#'). Whitespace-only input ($originalForEncoding === '') keeps
+        // the '-' placeholder for backward compatibility.
         if (($slug === '-' || $slug === '') && $originalForEncoding !== '') {
             $slug = rawurlencode($originalForEncoding);
         }

--- a/lib/Utils/Tools/Utils.php
+++ b/lib/Utils/Tools/Utils.php
@@ -203,7 +203,13 @@ class Utils
         $repl = ['', '-', ''];
 
         //return the friendly url
-        return preg_replace($find, $repl, $string);
+        $slug = preg_replace($find, $repl, $string);
+
+        if ($slug === '-' || $slug === '') {
+            $slug = rawurlencode($string);
+        }
+
+        return $slug;
     }
 
     /**

--- a/lib/Utils/Tools/Utils.php
+++ b/lib/Utils/Tools/Utils.php
@@ -193,6 +193,10 @@ class Utils
         $find = [' ', '&', '\r\n', '\n', '+', ','];
         $string = str_replace($find, '-', $string);
 
+        // Preserve original value before the empty-string placeholder is applied,
+        // so we can percent-encode it if the slug ends up empty or dash-only.
+        $originalForEncoding = $string;
+
         // avoid empty strings
         if (empty($string)) {
             $string = "-";
@@ -205,8 +209,11 @@ class Utils
         //return the friendly url
         $slug = preg_replace($find, $repl, $string);
 
-        if ($slug === '-' || $slug === '') {
-            $slug = rawurlencode($string);
+        // Only fall back to rawurlencode when the original input was non-empty
+        // (i.e. non-Latin characters were stripped). Truly empty/whitespace-only
+        // input keeps the '-' placeholder for backward compatibility.
+        if (($slug === '-' || $slug === '') && $originalForEncoding !== '') {
+            $slug = rawurlencode($originalForEncoding);
         }
 
         return $slug;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27445,12 +27445,6 @@ parameters:
 			path: lib/Utils/Tools/Utils.php
 
 		-
-			message: '#^Method Utils\\Tools\\Utils\:\:friendlySlug\(\) should return string but returns string\|null\.$#'
-			identifier: return.type
-			count: 1
-			path: lib/Utils/Tools/Utils.php
-
-		-
 			message: '#^Method Utils\\Tools\\Utils\:\:getBrowser\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/tests/unit/Utils/Url/CanonicalRoutesTest.php
+++ b/tests/unit/Utils/Url/CanonicalRoutesTest.php
@@ -76,8 +76,8 @@ class CanonicalRoutesTest extends AbstractTest
         ]);
 
         // Latin chars are slugified; non-Latin (Cyrillic) chars are percent-encoded
-        // per codepoint by friendlySlug(). PHP's strtolower() is ASCII-only, so the
-        // uppercase 'П' from the original project name is preserved in the slug.
+        // per codepoint by friendlySlug(). PHP's strtolower() is ASCII-only, so 'П'
+        // is not lowercased and is encoded as uppercase '%D0%9F' (not lowercase '%D0%BF').
         $expectedSlug = 'project-' . rawurlencode('Проф');
         $this->assertEquals('https://example.org/analyze/' . $expectedSlug . '/101-jkl', $url);
     }

--- a/tests/unit/Utils/Url/CanonicalRoutesTest.php
+++ b/tests/unit/Utils/Url/CanonicalRoutesTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace unit\Utils\Url;
+
+use PHPUnit\Framework\Attributes\Test;
+use TestHelpers\AbstractTest;
+use Utils\Registry\AppConfig;
+use Utils\Url\CanonicalRoutes;
+
+class CanonicalRoutesTest extends AbstractTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        AppConfig::$HTTPHOST = 'https://example.org';
+    }
+
+    #[Test]
+    public function analyzeWithLatinProjectName(): void
+    {
+        $url = CanonicalRoutes::analyze([
+            'project_name' => 'My Project',
+            'id_project' => 123,
+            'password' => 'abc',
+        ]);
+
+        $this->assertEquals('https://example.org/analyze/my-project/123-abc', $url);
+    }
+
+    #[Test]
+    public function analyzeWithCyrillicProjectName(): void
+    {
+        $url = CanonicalRoutes::analyze([
+            'project_name' => 'Проф',
+            'id_project' => 456,
+            'password' => 'def',
+        ]);
+
+        $this->assertEquals('https://example.org/analyze/' . rawurlencode('Проф') . '/456-def', $url);
+    }
+
+    #[Test]
+    public function analyzeWithChineseProjectName(): void
+    {
+        $url = CanonicalRoutes::analyze([
+            'project_name' => '项目',
+            'id_project' => 789,
+            'password' => 'ghi',
+        ]);
+
+        $this->assertEquals('https://example.org/analyze/' . rawurlencode('项目') . '/789-ghi', $url);
+    }
+
+    #[Test]
+    public function analyzeWithMixedLatinAndCyrillicProjectName(): void
+    {
+        $url = CanonicalRoutes::analyze([
+            'project_name' => 'Project Проф',
+            'id_project' => 101,
+            'password' => 'jkl',
+        ]);
+
+        // friendlySlug keeps latin chars, so "project-" remains (not just "-")
+        $this->assertStringStartsWith('https://example.org/analyze/', $url);
+        $this->assertStringEndsWith('/101-jkl', $url);
+        $this->assertStringNotContainsString('/analyze/-/', $url);
+    }
+}
+

--- a/tests/unit/Utils/Url/CanonicalRoutesTest.php
+++ b/tests/unit/Utils/Url/CanonicalRoutesTest.php
@@ -76,7 +76,8 @@ class CanonicalRoutesTest extends AbstractTest
         ]);
 
         // Latin chars are slugified; non-Latin (Cyrillic) chars are percent-encoded
-        // per codepoint. PHP strtolower() is ASCII-only, so 'П' stays uppercase.
+        // per codepoint by friendlySlug(). PHP's strtolower() is ASCII-only, so the
+        // uppercase 'П' from the original project name is preserved in the slug.
         $expectedSlug = 'project-' . rawurlencode('Проф');
         $this->assertEquals('https://example.org/analyze/' . $expectedSlug . '/101-jkl', $url);
     }

--- a/tests/unit/Utils/Url/CanonicalRoutesTest.php
+++ b/tests/unit/Utils/Url/CanonicalRoutesTest.php
@@ -9,10 +9,25 @@ use Utils\Url\CanonicalRoutes;
 
 class CanonicalRoutesTest extends AbstractTest
 {
+    private ?string $originalHttpHost = null;
+
     protected function setUp(): void
     {
         parent::setUp();
+        try {
+            $this->originalHttpHost = AppConfig::$HTTPHOST;
+        } catch (\Error) {
+            $this->originalHttpHost = null;
+        }
         AppConfig::$HTTPHOST = 'https://example.org';
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalHttpHost !== null) {
+            AppConfig::$HTTPHOST = $this->originalHttpHost;
+        }
+        parent::tearDown();
     }
 
     #[Test]

--- a/tests/unit/Utils/Url/CanonicalRoutesTest.php
+++ b/tests/unit/Utils/Url/CanonicalRoutesTest.php
@@ -75,10 +75,10 @@ class CanonicalRoutesTest extends AbstractTest
             'password' => 'jkl',
         ]);
 
-        // friendlySlug keeps latin chars, so "project-" remains (not just "-")
-        $this->assertStringStartsWith('https://example.org/analyze/', $url);
-        $this->assertStringEndsWith('/101-jkl', $url);
-        $this->assertStringNotContainsString('/analyze/-/', $url);
+        // Latin chars are slugified; non-Latin (Cyrillic) chars are percent-encoded
+        // per codepoint. PHP strtolower() is ASCII-only, so 'П' stays uppercase.
+        $expectedSlug = 'project-' . rawurlencode('Проф');
+        $this->assertEquals('https://example.org/analyze/' . $expectedSlug . '/101-jkl', $url);
     }
 }
 

--- a/tests/unit/Utils/Url/CanonicalRoutesTest.php
+++ b/tests/unit/Utils/Url/CanonicalRoutesTest.php
@@ -14,10 +14,10 @@ class CanonicalRoutesTest extends AbstractTest
     protected function setUp(): void
     {
         parent::setUp();
-        try {
+        // $HTTPHOST is a typed static property with no default, so it may be
+        // uninitialized. isset() returns false (without throwing) in that case.
+        if (isset(AppConfig::$HTTPHOST)) {
             $this->originalHttpHost = AppConfig::$HTTPHOST;
-        } catch (\Error) {
-            $this->originalHttpHost = null;
         }
         AppConfig::$HTTPHOST = 'https://example.org';
     }


### PR DESCRIPTION
## Summary

`Fix Utils::friendlySlug()` returning an empty string for non-Latin project names (e.g. Cyrillic \"Проф\", Chinese \"项目\"), which broke analyze URLs by producing paths like /analyze//456-def.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| lib/Utils/Tools/Utils.php | Fall back to rawurlencode() when slug is empty or dash-only after ASCII regex strip |
| tests/unit/Utils/Url/CanonicalRoutesTest.php | New tests for CanonicalRoutes::analyze() with Latin, Cyrillic, Chinese, and mixed names |

## Testing

- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

## AI Disclosure

- [x] AI tools were used — details below

GitHub Copilot (Claude)

## Notes

Non-Latin characters that cannot be transliterated to ASCII are now
percent-encoded in the slug instead of being silently dropped."

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213876854751602