### PR TITLE
🐛 fix: apply friendlySlug to project_name in CattoolController config

### DIFF
--- a/lib/Controller/Views/CattoolController.php
+++ b/lib/Controller/Views/CattoolController.php
@@ -186,7 +186,7 @@ class CattoolController extends BaseKleinViewController
             'pageTitle' => $this->buildPageTitle($revisionNumber, $chunkStruct),
             'password' => $chunkStruct->password,
             'project' => $chunkStruct->getProject(),
-            'project_name' => $chunkStruct->getProject()->name,
+            'project_name' => Utils::friendlySlug($chunkStruct->getProject()->name),
             'quality_report_href' => AppConfig::$BASEURL . "revise-summary/$chunkStruct->id-$chunkStruct->password",
             'review_extended' => new PHPTalBoolean(true),
             'review_password' => $isRevision ? $chunkReviewStruct->review_password : (new ChunkReviewDao())->findChunkReviewsForSourcePage(

--- a/tests/unit/Utils/Tools/UtilsTest.php
+++ b/tests/unit/Utils/Tools/UtilsTest.php
@@ -241,6 +241,45 @@ class UtilsTest extends AbstractTest
         $this->assertMatchesRegularExpression('/^[a-z0-9\-]+$/', $result);
     }
 
+    #[Test]
+    public function testFriendlySlugReturnsHyphenForEmptyStringInput(): void
+    {
+        $result = Utils::friendlySlug('');
+        $this->assertEquals('-', $result);
+    }
+
+    #[Test]
+    public function testFriendlySlugHandlesValidAsciiSymbol(): void
+    {
+        $result = Utils::friendlySlug('hello-world');
+        $this->assertEquals('hello-world', $result);
+    }
+
+    #[Test]
+    public function testFriendlySlugStripsLogicalNegationSymbol(): void
+    {
+        $result = Utils::friendlySlug('hello¬world');
+        $this->assertMatchesRegularExpression('/^[a-z0-9\-]+$/', $result);
+        $this->assertStringNotContainsString('¬', $result);
+    }
+
+    #[Test]
+    public function testFriendlySlugStripsBoxDrawingCharacter(): void
+    {
+        $result = Utils::friendlySlug('╚══test══╝');
+        $this->assertMatchesRegularExpression('/^[a-z0-9\-]+$/', $result);
+        $this->assertStringNotContainsString('╚', $result);
+        $this->assertStringNotContainsString('═', $result);
+    }
+
+    #[Test]
+    public function testFriendlySlugStripsBlockGraphicSymbol(): void
+    {
+        $result = Utils::friendlySlug('hello░world');
+        $this->assertMatchesRegularExpression('/^[a-z0-9\-]+$/', $result);
+        $this->assertStringNotContainsString('░', $result);
+    }
+
     // =========================================================================
     // Tests for replace_accents()
     // =========================================================================


### PR DESCRIPTION
## Summary
Apply Utils::friendlySlug() to project_name in CattoolController view params,
ensuring the slug used in the cattool config is sanitized consistently.
Add edge case tests for friendlySlug() (empty string, ASCII symbol, extended
ASCII graphic characters).

## Type
- [x] \`fix\` — bug fix
- [x] \`test\` — test coverage

## Changes
| File | Change |
|------|--------|
| lib/Controller/Views/CattoolController.php | Wrap project name with Utils::friendlySlug() |
| tests/unit/Utils/Tools/UtilsTest.php | Add edge case tests: empty string, valid ASCII symbol, graphic chars (¬, ╚, ═, ░) |

## Testing
- [x] New tests added for changed behavior
- [x] phpstan: no new errors introduced

## AI Disclosure
- [x] AI tools were used — GitHub Copilot (claude-sonnet-4-20250514)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212442214298268