### PR TITLE
🐛 fix: migrate Microsoft OAuth to v2.0 endpoints and Graph API

### DIFF
--- a/lib/Model/ConnectedServices/Oauth/Microsoft/MicrosoftProvider.php
+++ b/lib/Model/ConnectedServices/Oauth/Microsoft/MicrosoftProvider.php
@@ -2,19 +2,23 @@
 
 namespace Model\ConnectedServices\Oauth\Microsoft;
 
+use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use Model\ConnectedServices\Oauth\AbstractProvider;
 use Model\ConnectedServices\Oauth\ProviderUser;
 use Stevenmaguire\OAuth2\Client\Provider\Microsoft;
-use Stevenmaguire\OAuth2\Client\Provider\MicrosoftResourceOwner;
 use Utils\Registry\AppConfig;
 
 class MicrosoftProvider extends AbstractProvider
 {
 
     const string PROVIDER_NAME = 'microsoft';
+
+    private const string AUTHORIZE_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize';
+    private const string TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
+    private const string RESOURCE_OWNER_URL = 'https://graph.microsoft.com/v1.0/me';
+    private const string SCOPES = 'openid email profile User.Read';
 
     /**
      * @param string|null $redirectUrl
@@ -27,6 +31,9 @@ class MicrosoftProvider extends AbstractProvider
             'clientId' => AppConfig::$MICROSOFT_OAUTH_CLIENT_ID,
             'clientSecret' => AppConfig::$MICROSOFT_OAUTH_CLIENT_SECRET,
             'redirectUri' => $redirectUrl ?? AppConfig::$MICROSOFT_OAUTH_REDIRECT_URL,
+            'urlAuthorize' => self::AUTHORIZE_URL,
+            'urlAccessToken' => self::TOKEN_URL,
+            'urlResourceOwnerDetails' => self::RESOURCE_OWNER_URL,
         ]);
     }
 
@@ -37,53 +44,71 @@ class MicrosoftProvider extends AbstractProvider
      */
     public function getAuthorizationUrl(string $csrfTokenState): string
     {
-        $options = [
+        $params = [
+            'client_id' => AppConfig::$MICROSOFT_OAUTH_CLIENT_ID,
+            'redirect_uri' => $this->redirectUrl ?? AppConfig::$MICROSOFT_OAUTH_REDIRECT_URL,
+            'response_type' => 'code',
+            'scope' => self::SCOPES,
             'state' => $csrfTokenState,
-            'prompt' => 'select_account'
+            'prompt' => 'select_account',
         ];
 
-        $microsoftClient = static::getClient($this->redirectUrl);
-
-        return $microsoftClient->getAuthorizationUrl($options);
+        return self::AUTHORIZE_URL . '?' . http_build_query($params);
     }
 
     /**
      * @param string $code
      *
      * @return AccessToken
-     * @throws IdentityProviderException
      * @throws GuzzleException
+     * @throws \RuntimeException
+     * @throws \InvalidArgumentException
      */
     public function getAccessTokenFromAuthCode(string $code): AccessToken
     {
-        $microsoftClient = static::getClient($this->redirectUrl);
+        $httpClient = new Client();
 
-        /** @var AccessToken $token */
-        $token = $microsoftClient->getAccessToken('authorization_code', [
-            'code' => $code
+        $response = $httpClient->post(self::TOKEN_URL, [
+            'form_params' => [
+                'client_id' => AppConfig::$MICROSOFT_OAUTH_CLIENT_ID,
+                'client_secret' => AppConfig::$MICROSOFT_OAUTH_CLIENT_SECRET,
+                'code' => $code,
+                'redirect_uri' => $this->redirectUrl ?? AppConfig::$MICROSOFT_OAUTH_REDIRECT_URL,
+                'grant_type' => 'authorization_code',
+                'scope' => self::SCOPES,
+            ],
         ]);
 
-        return $token;
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return new AccessToken($data);
     }
 
     /**
      * @param AccessToken $token
      *
-     * @return mixed
+     * @return ProviderUser
      * @throws GuzzleException
-     * @throws IdentityProviderException
+     * @throws \RuntimeException
+     * @throws \TypeError
      */
     public function getResourceOwner(AccessToken $token): ProviderUser
     {
-        $microsoftClient = static::getClient($this->redirectUrl);
-        /** @var MicrosoftResourceOwner $fetched */
-        $fetched = $microsoftClient->getResourceOwner($token);
+        $httpClient = new Client();
+
+        $response = $httpClient->get(self::RESOURCE_OWNER_URL, [
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token->getToken(),
+            ],
+        ]);
+
+        $data = json_decode($response->getBody()->getContents(), true);
 
         $user = new ProviderUser();
-        $user->email = $fetched->getEmail();
-        $user->name = $fetched->getFirstname();
-        $user->lastName = $fetched->getLastname();
-        $user->picture = null; // profile picture is not publicly accessible
+        $user->email = $data['mail'] ?? $data['userPrincipalName'] ?? null;
+        $user->name = $data['givenName'] ?? null;
+        $user->lastName = $data['surname'] ?? null;
+        $user->picture = null;
         $user->authToken = $token;
         $user->provider = self::PROVIDER_NAME;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8713,48 +8713,6 @@ parameters:
 			path: lib/Model/ConnectedServices/Oauth/LinkedIn/LinkedInProvider.php
 
 		-
-			message: '#^Method Model\\ConnectedServices\\Oauth\\LinkedIn\\LinkedInProvider\:\:getResourceOwner\(\) throws checked exception TypeError but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 5
-			path: lib/Model/ConnectedServices/Oauth/LinkedIn/LinkedInProvider.php
-
-		-
-			message: '#^Method Model\\ConnectedServices\\Oauth\\Microsoft\\MicrosoftProvider\:\:getAccessTokenFromAuthCode\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 1
-			path: lib/Model/ConnectedServices/Oauth/Microsoft/MicrosoftProvider.php
-
-		-
-			message: '#^Method Model\\ConnectedServices\\Oauth\\Microsoft\\MicrosoftProvider\:\:getAuthorizationUrl\(\) throws checked exception InvalidArgumentException but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 1
-			path: lib/Model/ConnectedServices/Oauth/Microsoft/MicrosoftProvider.php
-
-		-
-			message: '#^Method Model\\ConnectedServices\\Oauth\\Microsoft\\MicrosoftProvider\:\:getResourceOwner\(\) throws checked exception TypeError but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 3
-			path: lib/Model/ConnectedServices/Oauth/Microsoft/MicrosoftProvider.php
-
-		-
-			message: '#^Method Model\\ConnectedServices\\Oauth\\Microsoft\\MicrosoftProvider\:\:getResourceOwner\(\) throws checked exception UnexpectedValueException but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 1
-			path: lib/Model/ConnectedServices/Oauth/Microsoft/MicrosoftProvider.php
-
-		-
-			message: '#^PHPDoc tag @return with type mixed is not subtype of native type Model\\ConnectedServices\\Oauth\\ProviderUser\.$#'
-			identifier: return.phpDocType
-			count: 1
-			path: lib/Model/ConnectedServices/Oauth/Microsoft/MicrosoftProvider.php
-
-		-
-			message: '#^Property Model\\ConnectedServices\\Oauth\\ProviderUser\:\:\$email \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: lib/Model/ConnectedServices/Oauth/Microsoft/MicrosoftProvider.php
-
-		-
 			message: '#^Property Model\\ConnectedServices\\Oauth\\ProviderUser\:\:\$name \(string\) does not accept string\|null\.$#'
 			identifier: assign.propertyType
 			count: 1


### PR DESCRIPTION
## Summary

Fixes Microsoft OAuth login by migrating from the deprecated Live API endpoints to Microsoft Identity Platform v2.0 and Microsoft Graph API.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Model/ConnectedServices/Oauth/Microsoft/MicrosoftProvider.php` | Replaced deprecated `login.live.com` / `apis.live.net` endpoints with Microsoft v2.0 (`login.microsoftonline.com`) and Graph API (`graph.microsoft.com/v1.0/me`). Bypassed the broken `stevenmaguire/oauth2-microsoft` library by using direct Guzzle HTTP calls for token exchange and user info retrieval. |
| `phpstan-baseline.neon` | Removed obsolete baseline entries for `MicrosoftProvider` that no longer apply after the rewrite. |

## Migration Notes

_No migrations needed._

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

Manual testing: requires a valid (non-expired) Microsoft OAuth client secret configured in `inc/oauth_config.ini`.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — details below

GitHub Copilot (Claude)

## Notes

- The `stevenmaguire/oauth2-microsoft` library is outdated and uses dead endpoints (`apis.live.net/v5.0/me`). This fix bypasses it with direct HTTP calls rather than replacing the dependency, to minimize risk.
- The Azure AD app registration must use Microsoft Identity Platform v2.0 with `User.Read` permission granted.
- If the client secret has expired, a new one must be generated in the Azure Portal and updated in `inc/oauth_config.ini`.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213876854467703