### PR TITLE
🐛  fix: bypass DAO cache in isSegmentDisabled to prevent stale disabled …

### DIFF
--- a/lib/Controller/Traits/SegmentDisabledTrait.php
+++ b/lib/Controller/Traits/SegmentDisabledTrait.php
@@ -50,7 +50,7 @@ trait SegmentDisabledTrait
 
         // retrieve from cache fails, we need to check the database and update the cache accordingly
         if (empty($cachedValue)) {
-            $metadataList = SegmentMetadataDao::get($id_segment, 'translation_disabled');
+            $metadataList = SegmentMetadataDao::get($id_segment, 'translation_disabled', 0);
             $metadata = $metadataList[0] ?? null;
             $isDisabled = (($metadata->meta_value ?? '0') === '1');
             $this->_setInCacheMap($cache['key'], $cache['query'], [$isDisabled ? 1 : 0]);


### PR DESCRIPTION
## Summary

Fix `isSegmentDisabled` returning stale `false` values due to DAO-level cache (1-week TTL) not being invalidated when a segment is disabled.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `lib/Controller/Traits/SegmentDisabledTrait.php` | Pass `ttl: 0` to `SegmentMetadataDao::get()` to bypass the DAO cache, which was serving stale results for up to 1 week |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

Verified that after disabling a segment via `setTranslationDisabled`, the `segment-analysis` API correctly returns `disabled: true` without waiting for cache expiry.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — details below

GitHub Copilot

## Notes

**Root cause:** `SegmentMetadataDao::get()` defaults to a 604800s (1 week) TTL. When `isSegmentDisabled` queried a segment *before* it was disabled, the DAO cache stored an empty result for 1 week. Subsequent calls to `setTranslationDisabled` wrote the DB row but never invalidated this specific DAO cache entry, so `isSegmentDisabled` kept returning `false`.

**Fix:** Since `isSegmentDisabled` already manages its own Redis cache layer (1-hour TTL) with proper invalidation via `destroySegmentDisabledCache` and `saveSegmentDisabledInCache`, the DAO-level cache is redundant. Setting `ttl: 0` bypasses it.
