### PR TITLE
👷 ci: add Slack notification step to CI/CD workflow

### DIFF
--- a/.github/workflows/_ci-cd.yml
+++ b/.github/workflows/_ci-cd.yml
@@ -223,3 +223,14 @@ jobs:
           coverage-threshold: '80'
           exclude-patterns: '.github/**'
           ai-enabled: 'true'
+
+  slackNotification:
+    name: Slack Notification
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: travis-ci
+          SLACK_TITLE: Github CI/CD Pipeline Complete for ${{ github.ref_name }}

--- a/.github/workflows/_ci-cd.yml
+++ b/.github/workflows/_ci-cd.yml
@@ -231,7 +231,9 @@ jobs:
       - tests
       - deploy
       - test-guard
-    if: always()
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
     permissions: {}
     steps:
       - name: Slack Notification
@@ -239,4 +241,4 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: travis-ci
-          SLACK_TITLE: Github CI/CD Pipeline Complete for ${{ github.head_ref || github.ref_name }}
+          SLACK_TITLE: GitHub CI/CD Pipeline Complete for ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/_ci-cd.yml
+++ b/.github/workflows/_ci-cd.yml
@@ -234,4 +234,4 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: travis-ci
-          SLACK_TITLE: Github CI/CD Pipeline Complete for ${{ github.ref_name }}
+          SLACK_TITLE: Github CI/CD Pipeline Complete for ${{ github.base_ref || github.ref_name }}

--- a/.github/workflows/_ci-cd.yml
+++ b/.github/workflows/_ci-cd.yml
@@ -227,6 +227,11 @@ jobs:
   slack-notification:
     name: Slack Notification
     runs-on: ubuntu-24.04
+    needs:
+      - tests
+      - deploy
+      - test-guard
+    if: always()
     permissions: {}
     steps:
       - name: Slack Notification

--- a/.github/workflows/_ci-cd.yml
+++ b/.github/workflows/_ci-cd.yml
@@ -227,6 +227,7 @@ jobs:
   slackNotification:
     name: Slack Notification
     runs-on: ubuntu-24.04
+    permissions: {}
     steps:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/_ci-cd.yml
+++ b/.github/workflows/_ci-cd.yml
@@ -224,7 +224,7 @@ jobs:
           exclude-patterns: '.github/**'
           ai-enabled: 'true'
 
-  slackNotification:
+  slack-notification:
     name: Slack Notification
     runs-on: ubuntu-24.04
     permissions: {}

--- a/.github/workflows/_ci-cd.yml
+++ b/.github/workflows/_ci-cd.yml
@@ -239,4 +239,4 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: travis-ci
-          SLACK_TITLE: Github CI/CD Pipeline Complete for ${{ github.base_ref || github.ref_name }}
+          SLACK_TITLE: Github CI/CD Pipeline Complete for ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary
Add a Slack notification job to the reusable CI/CD pipeline (`_ci-cd.yml`).
On every workflow run, the `slackNotification` job posts a message to the `travis-ci` Slack channel via `rtCamp/action-slack-notify@v2`, reporting the completed pipeline and the triggering ref name.
## Type
- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage
## Changes
| File | Change |
|------|--------|
| `.github/workflows/_ci-cd.yml` | Add `slackNotification` job using `rtCamp/action-slack-notify@v2` |
## Testing
- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes
## AI Disclosure
- [x] AI tools were used — details below
GitHub Copilot (claude-sonnet-4-20250514) assisted with PR description drafting.
## Notes
- The job runs unconditionally (no `needs` or `if` guard) so notifications fire regardless of test/deploy outcome.
- Requires the `SLACK_WEBHOOK` secret to be configured in the repository settings.