### PR TITLE
🔧 chore(lara): temporarily disable Lara Think feature

### DIFF
--- a/public/js/components/segments/utils/translationMatches.js
+++ b/public/js/components/segments/utils/translationMatches.js
@@ -54,10 +54,7 @@ let TranslationMatches = {
         segment: segment,
       })
 
-      modifiedTranslation(
-        segment.sid,
-        segment.translation !== '',
-      )
+      modifiedTranslation(segment.sid, segment.translation !== '')
     }
   },
 
@@ -66,11 +63,7 @@ let TranslationMatches = {
     var segmentObj = SegmentStore.getSegmentByIdToJS(sid)
     if (isUndefined(segmentObj)) return
 
-    setSegmentContributions(
-      segmentObj.sid,
-      data.matches,
-      data.errors,
-    )
+    setSegmentContributions(segmentObj.sid, data.matches, data.errors)
 
     this.useSuggestionInEditArea(sid)
 
@@ -309,14 +302,15 @@ let TranslationMatches = {
 
     const jobLanguages = [config.source_code, config.target_code]
     // Keep only languages whose base code is 'en' or 'it'.
-    let allowed =
+    /*const allowed =
       jobLanguages
         .map((x) => x.split('-')[0])
         .filter((x) => ['en', 'it'].includes(x))
         .filter(
           // Remove duplicates, then check we have exactly two distinct matches.
           (value, index, array) => array.indexOf(value) === index,
-        ).length === 2
+        ).length === 2*/
+    const allowed = false //Temp disable Lara Think
 
     if (
       this.segmentsWaitingForContributions.indexOf(id_segment_original) > -1


### PR DESCRIPTION
## Summary

Temporarily disable the Lara Think (reasoning) feature by bypassing the language-pair eligibility check. Sets `allowed = false` unconditionally until the feature is ready to re-enable.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/segments/utils/translationMatches.js` | disable Lara Think by setting `allowed = false`; collapse multi-line calls to single-line |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

Verified Lara Think panel no longer appears in the editor for en→it segments.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — details below

Sisyphus (OpenCode, claude-opus-4-6)

## Notes

This is a temporary kill-switch. The commented-out logic should be restored or removed once a decision is made on the feature rollout.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214706522997838