### PR TITLE
👷 ci(workflows): skip PR checks for dependabot and renovate bot actors

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -12,7 +12,10 @@ jobs:
   pr-title:
     name: Validate PR title (required)
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false
+      && github.actor != 'dependabot[bot]'
+      && github.actor != 'renovate[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +51,10 @@ jobs:
   commit-messages:
     name: Validate commit messages (hygiene)
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false
+      && github.actor != 'dependabot[bot]'
+      && github.actor != 'renovate[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr-readiness-check.yml
+++ b/.github/workflows/pr-readiness-check.yml
@@ -12,7 +12,10 @@ jobs:
   readiness-checklist:
     name: Validate mandatory PR checklist
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false
+      && github.actor != 'dependabot[bot]'
+      && github.actor != 'renovate[bot]'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Skip PR readiness checklist and commit message validation for Dependabot and Renovate bot PRs
- Adds `github.actor` guards to the `if` conditions on 3 workflow jobs across 2 files

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)

Ran `node --test .github/scripts/pr-readiness-check.test.js` and `node --test .github/scripts/commit-message-check.test.js` — 0 failures.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — details below

AI was used to identify the workflow files, analyze the bot actor names, and apply the `if` condition changes.

## Notes

Bot PRs (Dependabot, Renovate) don't follow conventional-commit title format and have no PR checklist in the body, causing these checks to always fail. Since these are automated dependency bumps, the checks are not applicable. The label-based bypass (`checklist-exception`, `commit-message-exception`) still works for any other cases.

Affected jobs:
- `pr-readiness-check.yml` → `readiness-checklist`
- `commit-message-check.yml` → `pr-title`, `commit-messages`

Unit test jobs (`readiness-tests`, `commit-message-tests`) are NOT skipped — they validate the JS logic itself.