### PR TITLE
🔧 chore(docs): add Swagger documentation for the TMX import and export API endpoints

### DIFF
--- a/public/api/swagger-source.js
+++ b/public/api/swagger-source.js
@@ -4367,6 +4367,164 @@ var spec = {
         },
       },
     },
+    '/api/v3/tmx/import': {
+      post: {
+        tags: ['TMX'],
+        summary: 'Import TMX file',
+        description:
+          'Upload a TMX file into a translation memory. Requires authentication.',
+        consumes: ['multipart/form-data'],
+        parameters: [
+          {
+            name: 'tm_key',
+            in: 'formData',
+            description:
+              'The TM key where the TMX will be imported. If not provided, the default MyMemory key will be used.',
+            required: false,
+            type: 'string',
+          },
+          {
+            name: 'name',
+            in: 'formData',
+            description: 'The name for the TM key.',
+            required: false,
+            type: 'string',
+          },
+          {
+            name: 'disable_upload_limit',
+            in: 'formData',
+            description: 'Whether to disable the upload size limit.',
+            required: false,
+            type: 'boolean',
+          },
+          {
+            name: 'file',
+            in: 'formData',
+            description: 'The TMX file to upload.',
+            required: true,
+            type: 'file',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'TMX import started successfully.',
+            schema: {
+              type: 'object',
+              properties: {
+                errors: {
+                  type: 'array',
+                  items: {type: 'object'},
+                },
+                data: {
+                  type: 'object',
+                  properties: {
+                    uuids: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          uuid: {type: 'string'},
+                          name: {type: 'string'},
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
+    '/api/v3/tmx/export': {
+      post: {
+        tags: ['TMX'],
+        summary: 'Export TMX file',
+        description:
+          'Request the export of a TMX file. The exported file will be sent via email. Requires authentication.',
+        parameters: [
+          {
+            name: 'tm_key',
+            in: 'formData',
+            description: 'The TM key to export.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'tm_name',
+            in: 'formData',
+            description: 'The name of the TM.',
+            required: true,
+            type: 'string',
+          },
+          {
+            name: 'email',
+            in: 'formData',
+            description: 'The email address to send the exported TMX to.',
+            required: false,
+            type: 'string',
+          },
+          {
+            name: 'strip_tags',
+            in: 'formData',
+            description: 'Whether to strip tags from the exported TMX.',
+            required: false,
+            type: 'boolean',
+          },
+          {
+            name: 'id_job',
+            in: 'formData',
+            description: 'The job ID (optional context).',
+            required: false,
+            type: 'integer',
+          },
+          {
+            name: 'password',
+            in: 'formData',
+            description: 'The job password (optional context).',
+            required: false,
+            type: 'string',
+          },
+          {
+            name: 'source',
+            in: 'formData',
+            description: 'The source language.',
+            required: false,
+            type: 'string',
+          },
+          {
+            name: 'target',
+            in: 'formData',
+            description: 'The target language.',
+            required: false,
+            type: 'string',
+          },
+        ],
+        responses: {
+          200: {
+            description: 'TMX export request accepted.',
+            schema: {
+              type: 'object',
+              properties: {
+                errors: {
+                  type: 'array',
+                  items: {type: 'object'},
+                },
+                data: {
+                  type: 'object',
+                },
+              },
+            },
+          },
+          default: {
+            description: 'Unexpected error',
+          },
+        },
+      },
+    },
   },
   definitions: {
     MMTGlossary: {


### PR DESCRIPTION
## Summary

Add Swagger documentation for the TMX import and export API endpoints.

## Type

- [x] `chore` — build, deps, config, docs

## Changes

| File | Change |
|------|--------|
| public/api/swagger-source.js | Added Swagger specs for POST /api/v3/tmx/import and POST /api/v3/tmx/export under a new TMX tag |

## Testing

- [x] Manual testing performed (describe below)

Opened API docs page (`/api/docs`)

## AI Disclosure

- [x] AI tools were used — name the agent/tool below

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214390115028565