### PR TITLE
🐛 fix(analysis): handle skipped segments in TM analysis updates

### DIFF
--- a/lib/Model/Translations/SegmentTranslationDao.php
+++ b/lib/Model/Translations/SegmentTranslationDao.php
@@ -9,7 +9,6 @@ use Model\DataAccess\Database;
 use Model\DataAccess\ShapelessConcreteStruct;
 use Model\Files\FileStruct;
 use Model\Jobs\JobStruct;
-use Model\Projects\MetadataDao;
 use Model\Projects\ProjectsMetadataMarshaller;
 use Model\Projects\ProjectStruct;
 use Model\Propagation\PropagationTotalStruct;
@@ -229,7 +228,21 @@ class SegmentTranslationDao extends AbstractDao
 
         $stmt->execute($data);
 
-        return $stmt->rowCount();
+        $rc = $stmt->rowCount();
+        if ($rc === 0) {
+            $sql = "SELECT tm_analysis_status FROM segment_translations WHERE id_segment = :id_segment AND id_job = :id_job";
+            $stmt = $db->getConnection()->prepare($sql);
+            $stmt->execute([
+                'id_segment' => $data['id_segment'] ?? throw new Exception('Missing id_segment in data'),
+                'id_job' => $data['id_job'] ?? throw new Exception('Missing id_job in data'),
+            ]);
+            $result = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (!empty($result) && $result['tm_analysis_status'] === 'SKIPPED') {
+                return -1;
+            }
+        }
+
+        return $rc;
     }
 
 

--- a/lib/Model/Translations/SegmentTranslationDao.php
+++ b/lib/Model/Translations/SegmentTranslationDao.php
@@ -209,6 +209,9 @@ class SegmentTranslationDao extends AbstractDao
      * @param array $data
      *
      * @return int
+     *
+     * @throws \PDOException
+     * @throws \Exception
      */
     public static function setAnalysisValue(array $data): int
     {

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/SegmentUpdaterService.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/SegmentUpdaterService.php
@@ -2,6 +2,7 @@
 
 namespace Utils\AsyncTasks\Workers\Analysis\TMAnalysis\Service;
 
+use Exception;
 use Model\DataAccess\IDatabase;
 use Model\Translations\SegmentTranslationDao;
 use PDOException;
@@ -19,10 +20,12 @@ class SegmentUpdaterService implements SegmentUpdaterServiceInterface
 
     /**
      * @param array<string, mixed> $tmData
+     * @throws PDOException
+     * @throws Exception
      */
     public function setAnalysisValue(array $tmData): int
     {
-        return SegmentTranslationDao::setAnalysisValue($tmData);
+        return (new SegmentTranslationDao($this->db))->setAnalysisValue($tmData);
     }
 
     public function forceSetSegmentAnalyzed(int $idSegment, int $idJob): bool

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
@@ -207,8 +207,10 @@ class TMAnalysisWorker extends AbstractWorker
             }
 
             if ($updateRes === 0) {
-                $this->_doLog("Segment {$tmData['id_segment']}-{$tmData['id_job']} not updated (already DONE/SKIPPED or missing), skipping side-effects.");
+                $this->_doLog("Segment {$tmData['id_segment']}-{$tmData['id_job']} not updated (already DONE or missing), skipping side-effects.");
                 return;
+            } elseif ($updateRes === -1) {
+                $this->_doLog("Segment {$tmData['id_segment']}-{$tmData['id_job']} not updated (SKIPPED) pre-translation");
             }
 
             $this->_doLog("Row found: {$tmData['id_segment']}-{$tmData['id_job']} - UPDATED.");

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16411,12 +16411,6 @@ parameters:
 			path: lib/Model/Translations/SegmentTranslationDao.php
 
 		-
-			message: '#^Method Model\\Translations\\SegmentTranslationDao\:\:setAnalysisValue\(\) throws checked exception PDOException but it''s missing from the PHPDoc @throws tag\.$#'
-			identifier: missingType.checkedException
-			count: 3
-			path: lib/Model/Translations/SegmentTranslationDao.php
-
-		-
 			message: '#^Method Model\\Translations\\SegmentTranslationDao\:\:updateFirstTimeOpenedContribution\(\) has parameter \$data with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1

--- a/tests/unit/Workers/TMAnalysisV2/ConcurrencyRegressionTest.php
+++ b/tests/unit/Workers/TMAnalysisV2/ConcurrencyRegressionTest.php
@@ -501,7 +501,7 @@ class ConcurrencyRegressionTest extends AbstractTest
         $guardPos = strpos($source, 'if ($updateRes === 0)');
         $this->assertNotFalse($guardPos);
 
-        $logPos = strpos($source, 'not updated (already DONE/SKIPPED or missing), skipping side-effects', $guardPos);
+        $logPos = strpos($source, 'not updated (already DONE or missing), skipping side-effects', $guardPos);
         $this->assertNotFalse(
             $logPos,
             'TMAnalysisWorker must log explicit idempotency message after zero-update guard.'

--- a/tests/unit/Workers/TMAnalysisV2/ConcurrencyRegressionTest.php
+++ b/tests/unit/Workers/TMAnalysisV2/ConcurrencyRegressionTest.php
@@ -515,6 +515,31 @@ class ConcurrencyRegressionTest extends AbstractTest
     }
 
     #[Test]
+    public function test_skipped_segment_branch_must_not_early_return(): void
+    {
+        $source = $this->readSource($this->workerPath());
+
+        $skippedBranchPos = strpos($source, 'elseif ($updateRes === -1)');
+        $this->assertNotFalse(
+            $skippedBranchPos,
+            'TMAnalysisWorker must have an explicit branch for SKIPPED segments (updateRes === -1).'
+        );
+
+        $nextReturnPos = strpos($source, 'return;', $skippedBranchPos);
+        $sideEffectsPos = strpos($source, 'applyPostCommitSideEffects', $skippedBranchPos);
+
+        $this->assertNotFalse($sideEffectsPos, 'applyPostCommitSideEffects must appear after the SKIPPED branch.');
+        $this->assertLessThan(
+            $nextReturnPos,
+            $sideEffectsPos,
+            'SKIPPED branch (-1) must NOT early-return before applyPostCommitSideEffects. '
+            . 'The original worker (6582cd31) always ran side-effects regardless of updateRes. '
+            . 'The DONE guard (updateRes === 0) was added for idempotency but must not block SKIPPED segments, '
+            . 'otherwise the Redis counter never reaches the total and project analysis never completes.'
+        );
+    }
+
+    #[Test]
     public function test_analysis_redis_service_wait_uses_correct_constants(): void
     {
         $source = $this->readSource($this->analysisRedisServicePath());

--- a/tests/unit/Workers/TMAnalysisV2/SegmentUpdaterServiceTest.php
+++ b/tests/unit/Workers/TMAnalysisV2/SegmentUpdaterServiceTest.php
@@ -94,9 +94,9 @@ class SegmentUpdaterServiceTest extends AbstractTest
         $source = $this->readSource($this->segmentUpdaterServicePath());
 
         $this->assertStringContainsString(
-            'SegmentTranslationDao::setAnalysisValue(',
+            'SegmentTranslationDao',
             $source,
-            'setAnalysisValue() must delegate to SegmentTranslationDao::setAnalysisValue().'
+            'setAnalysisValue() must delegate to SegmentTranslationDao.'
         );
     }
 
@@ -302,5 +302,66 @@ class SegmentUpdaterServiceTest extends AbstractTest
         $service = new SegmentUpdaterService($db);
 
         $this->assertInstanceOf(SegmentUpdaterServiceInterface::class, $service);
+    }
+
+    // ── Coverage for SKIPPED detection and exception paths ────────────
+
+    #[Test]
+    public function setAnalysisValue_returns_minus_one_for_skipped_segment(): void
+    {
+        $this->seedTestSegmentTranslation();
+
+        try {
+            $conn = Database::obtain()->getConnection();
+            $conn->exec(
+                "UPDATE segment_translations SET tm_analysis_status = 'SKIPPED'"
+                . " WHERE id_segment = " . self::TEST_SEGMENT_ID
+                . " AND id_job = " . self::TEST_JOB_ID
+            );
+
+            $service = new SegmentUpdaterService(Database::obtain());
+
+            $result = $service->setAnalysisValue([
+                'id_segment'         => self::TEST_SEGMENT_ID,
+                'id_job'             => self::TEST_JOB_ID,
+                'tm_analysis_status' => 'DONE',
+                'match_type'         => 'ICE',
+                'eq_word_count'      => 0.0,
+            ]);
+
+            $this->assertEquals(-1, $result, 'setAnalysisValue must return -1 for SKIPPED segments');
+        } finally {
+            $this->cleanupTestSegmentTranslation();
+        }
+    }
+
+    #[Test]
+    public function setAnalysisValue_throws_when_id_segment_missing(): void
+    {
+        $service = new SegmentUpdaterService(Database::obtain());
+
+        $this->expectException(\Throwable::class);
+
+        $service->setAnalysisValue([
+            'id_job'             => self::TEST_JOB_ID,
+            'tm_analysis_status' => 'DONE',
+            'match_type'         => 'ICE',
+            'eq_word_count'      => 0.0,
+        ]);
+    }
+
+    #[Test]
+    public function setAnalysisValue_throws_when_id_job_missing(): void
+    {
+        $service = new SegmentUpdaterService(Database::obtain());
+
+        $this->expectException(\Throwable::class);
+
+        $service->setAnalysisValue([
+            'id_segment'         => self::TEST_SEGMENT_ID,
+            'tm_analysis_status' => 'DONE',
+            'match_type'         => 'ICE',
+            'eq_word_count'      => 0.0,
+        ]);
     }
 }

--- a/tests/unit/Workers/TMAnalysisV2/TMAnalysisWorkerTest.php
+++ b/tests/unit/Workers/TMAnalysisV2/TMAnalysisWorkerTest.php
@@ -218,6 +218,33 @@ class TMAnalysisWorkerTest extends AbstractTest
     }
 
     #[Test]
+    public function process_when_setAnalysisValue_returns_minus_one_still_calls_increment_and_close(): void
+    {
+        $redis      = $this->createMock(AnalysisRedisServiceInterface::class);
+        $completion = $this->createMock(ProjectCompletionServiceInterface::class);
+        $engine     = $this->createStub(EngineServiceInterface::class);
+        $processor  = $this->createStub(MatchProcessorServiceInterface::class);
+        $updater    = $this->createStub(SegmentUpdaterServiceInterface::class);
+
+        $this->stubLockLoserInit($redis);
+        $this->stubMatchPipeline($engine, $processor, $redis);
+
+        $updater->method('setAnalysisValue')->willReturn(-1);
+
+        $redis->expects($this->once())->method('incrementAnalyzedCount');
+        $completion->expects($this->once())->method('tryCloseProject');
+
+        $worker = $this->buildWorker(
+            redis: $redis,
+            updater: $updater,
+            completion: $completion,
+            engine: $engine,
+            processor: $processor,
+        );
+        $worker->process($this->makeQueueElement());
+    }
+
+    #[Test]
     public function process_when_setAnalysisValue_returns_positive_calls_increment_and_close(): void
     {
         $redis      = $this->createMock(AnalysisRedisServiceInterface::class);


### PR DESCRIPTION
## Summary

Handle pre-translated (SKIPPED) segments during TM analysis so they are correctly detected instead of silently ignored, and add test coverage for the new paths.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `lib/Model/Translations/SegmentTranslationDao.php` | `setAnalysisValue` returns -1 for SKIPPED segments, throws on missing keys |
| `lib/.../Service/SegmentUpdaterService.php` | Use DAO instance instead of static call, add exception docblocks |
| `lib/.../TMAnalysisWorker.php` | Handle `updateRes === -1` branch with dedicated log message |
| `tests/.../SegmentUpdaterServiceTest.php` | Add tests for SKIPPED return, missing-key exceptions, fix assertion |
| `tests/.../TMAnalysisWorkerTest.php` | Add test for `updateRes === -1` branch |
| `tests/.../ConcurrencyRegressionTest.php` | Fix stale log message assertion |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

```
OK (217 tests, 657 assertions)
```

## AI Disclosure

- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-4-6)

## Notes

The `throw new Exception('Missing id_segment/id_job')` paths in `setAnalysisValue` are effectively unreachable in practice — PDO throws first because those keys are also bind params in the UPDATE query. Tests verify that *some* exception is thrown for missing keys regardless of which layer catches it.