### PR TITLE
🐛 fix(gdrive): correct hydration of `$projectStructure->session` object

### DIFF
--- a/lib/Controller/API/App/CreateProjectController.php
+++ b/lib/Controller/API/App/CreateProjectController.php
@@ -841,7 +841,7 @@ class CreateProjectController extends AbstractStatefulKleinController
 
         // GDrive session
         if ($gdriveSession !== null) {
-            $projectStructure->session = $gdriveSession;
+            $projectStructure->session[Session::SESSION_KEY] = $gdriveSession;
             $projectStructure->session['uid'] = $user->uid;
             $projectStructure->session['user'] = $user;
         }

--- a/lib/Controller/Abstracts/AbstractDownloadController.php
+++ b/lib/Controller/Abstracts/AbstractDownloadController.php
@@ -169,7 +169,7 @@ abstract class AbstractDownloadController extends AbstractStatefulKleinControlle
                 $this->_filename = $this->getDefaultFileName($this->project);
             }
 
-            $isGDriveProject = ProjectDao::isGDriveProject($this->project->id);
+            $isGDriveProject = ProjectDao::isGDriveProject((int)$this->project->id);
 
             if (!$isGDriveProject || $forceXliff === true) {
                 ob_get_contents();

--- a/lib/Model/Projects/ProjectDao.php
+++ b/lib/Model/Projects/ProjectDao.php
@@ -481,7 +481,12 @@ class ProjectDao extends AbstractDao
         return $stmt->fetchAll();
     }
 
-    static function isGDriveProject($id_project): bool
+    /**
+     * @param int $id_project The ID of the project to check.
+     *
+     * @return bool Returns true if the project is a Google Drive project, otherwise false.
+     */
+    static function isGDriveProject(int $id_project): bool
     {
         $conn = Database::obtain()->getConnection();
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13969,12 +13969,6 @@ parameters:
 			path: lib/Model/Projects/ProjectDao.php
 
 		-
-			message: '#^Method Model\\Projects\\ProjectDao\:\:isGDriveProject\(\) has parameter \$id_project with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: lib/Model/Projects/ProjectDao.php
-
-		-
 			message: '#^Method Model\\Projects\\ProjectDao\:\:isGDriveProject\(\) throws checked exception PDOException but it''s missing from the PHPDoc @throws tag\.$#'
 			identifier: missingType.checkedException
 			count: 4

--- a/tests/unit/Controllers/BuildProjectStructureTest.php
+++ b/tests/unit/Controllers/BuildProjectStructureTest.php
@@ -1326,7 +1326,7 @@ class BuildProjectStructureTest extends AbstractTest
         );
 
         $this->assertNotNull($ps->session);
-        $this->assertSame('gdrive@test.com', $ps->session['service_account']);
+        $this->assertSame('gdrive@test.com', $ps->session['gdrive_session']['service_account']);
         // uid should be injected into the session
         $this->assertSame(42, $ps->session['uid']);
     }


### PR DESCRIPTION
## Summary

Fix the correct hydration of `$projectStructure->session` object with the right GDrive key (`Session::SESSION_KEY`).

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `lib/Model/Projects/ProjectDao.php` | Added missing type hint and PHPDocs section to the function |
| `lib/Controller/API/App/CreateProjectController.php` | Fix correct hydrataion of $projectStructure->session object with the right GDrive key (`Session::SESSION_KEY`). |
| `tests/unit/Controllers/BuildProjectStructureTest.php` | Fixed broken test |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes

```
PHPUnit 12.5.23 — OK (12 tests, 16 assertions)
```

## AI Disclosure

- [x] AI tools were used — name the agent/tool below

GitHub Copilot (Claude)

## Notes

**Root cause:** `$projectStructure->session` object was not hydrated with the right GDrive key (`Session::SESSION_KEY`).



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214228534020852
  - https://app.asana.com/0/0/1214480878137754