### PR TITLE
fix(gdrive): correct hydration of $projectStructure->session object [DEVELOP]

### DIFF
--- a/lib/Controller/API/App/CreateProjectController.php
+++ b/lib/Controller/API/App/CreateProjectController.php
@@ -874,7 +874,7 @@ class CreateProjectController extends AbstractStatefulKleinController
 
         // GDrive session
         if ($gdriveSession !== null) {
-            $projectStructure->session = $gdriveSession;
+            $projectStructure->session[Session::SESSION_KEY] = $gdriveSession;
             $projectStructure->session['uid'] = $user->uid;
             $projectStructure->session['user'] = $user;
         }

--- a/tests/unit/Core/Controllers/BuildProjectStructureTest.php
+++ b/tests/unit/Core/Controllers/BuildProjectStructureTest.php
@@ -1326,7 +1326,7 @@ class BuildProjectStructureTest extends AbstractTest
         );
 
         $this->assertNotNull($ps->session);
-        $this->assertSame('gdrive@test.com', $ps->session['service_account']);
+        $this->assertSame('gdrive@test.com', $ps->session['gdrive_session']['service_account']);
         // uid should be injected into the session
         $this->assertSame(42, $ps->session['uid']);
     }


### PR DESCRIPTION
## Summary

Fix the correct hydration of `$projectStructure->session` object with the right GDrive key (`Session::SESSION_KEY`).

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `tests/unit/Core/Controllers/BuildProjectStructureTest.php ` | Fixed broken test |
| `lib/Controller/API/App/CreateProjectController.php` | Fix correct hydrataion of $projectStructure->session object with the right GDrive key (`Session::SESSION_KEY`). |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes

```
PHPUnit 12.5.23 — OK (12 tests, 16 assertions)
```

## AI Disclosure

- [x] AI tools were used — name the agent/tool below

GitHub Copilot (Claude)

## Notes

**Root cause:** `$projectStructure->session` object was not hydrated with the right GDrive key (`Session::SESSION_KEY`).



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214228534020852
  - https://app.asana.com/0/0/1214480878137754