### PR TITLE
🐛 fix(lqa): detect `<ph>` tag attribute mismatches beyond the `id` attribute

### DIFF
--- a/lib/Utils/LQA/QA/TagChecker.php
+++ b/lib/Utils/LQA/QA/TagChecker.php
@@ -357,6 +357,12 @@ class TagChecker
                 unset($src[$index]);
             }
         }
+
+        // If source has leftover attributes that target did not match, the tag attribute set differs
+        // (e.g. <ph id="1"/> in source vs <ph x="test"/> in target).
+        if (!empty($src)) {
+            $this->errorManager->addError(ErrorManager::ERR_TAG_MISMATCH);
+        }
     }
 
     /**

--- a/tests/unit/Core/Utils/XliffReplacerCallbackTest.php
+++ b/tests/unit/Core/Utils/XliffReplacerCallbackTest.php
@@ -76,6 +76,36 @@ class XliffReplacerCallbackTest extends AbstractTest
      * @throws Exception
      */
     #[Test]
+    public function testSegmentsWithDifferentTagPh()
+    {
+        $jobStructMock = $this->getStubBuilder(JobStruct::class)
+            ->setConstructorArgs([
+                [
+                    'id' => '1',
+                    'password' => 'password',
+                    'source' => 'en-US',
+                    'target' => 'it-IT'
+                ]
+            ])->getStub();
+
+        $projectStructMock = $this->getStubBuilder(ProjectStruct::class)->getStub();
+        $projectStructMock->method('getMetadataValue')->willReturn(false);
+
+        $jobStructMock->method('getProject')->willReturn($projectStructMock);
+
+        $segment = '<ph id="1"/> Hello';
+        $target = '<ph x="test"/> Hola';
+
+        /** @noinspection PhpParamsInspection */
+        $xliffReplacerCallback = new XliffReplacerCallback(new FeatureSet(), 'en-EN', 'es-ES', $jobStructMock);
+
+        $this->assertTrue($xliffReplacerCallback->thereAreErrors(1, $segment, $target));
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
     public function testAMoreComplexCase()
     {
         $jobStructMock = $this->getStubBuilder(JobStruct::class)


### PR DESCRIPTION
## Summary

Fix a bug in `TagChecker` where two tags with the same name but different attribute sets
(e.g. `<ph id="1"/>` vs `<ph x="test"/>`) were not flagged as a tag mismatch error,
allowing segments with structurally inconsistent inline tags to pass XLIFF replacement.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `lib/Utils/LQA/QA/TagChecker.php` | After iterating `$trg`, also flag `ERR_TAG_MISMATCH` when `$src` has leftover unmatched id/equiv-text entries. Makes the previously asymmetric attribute comparison symmetric. |
| `tests/unit/Core/Utils/XliffReplacerCallbackTest.php` | Added `testSegmentsWithDifferentTagPh` covering the regression case. |

### Root cause

`TagChecker::checkContentAndAddTagMismatchError()` only iterated the **target** id/equiv-text
list looking for matches in source. When the target tag had no `id` attribute at all
(e.g. `<ph x="test"/>`), `$trgAllTagId` was empty, the foreach never executed, and any
unmatched source ids were silently dropped.

The leftover difference was caught downstream by `checkTagPositionsAndAddTagOrderError`
as `ERR_TAG_ORDER`, but that code is registered at `WARNING` level — and
`XliffReplacerCallback::thereAreErrors()` only consults `ERROR` level via
`QA::thereAreErrors()`. Hence the segment passed validation despite clearly mismatched
tag attributes, leading to potential `UNTRANSLATED_CONTENT` issues downstream.

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

None.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214971555711215