### PR TITLE
🐛 fix(lqa): escape stray angle brackets so plain-text segments are not flagged as tag mismatch

### DIFF
--- a/lib/Utils/LQA/QA/ContentPreprocessor.php
+++ b/lib/Utils/LQA/QA/ContentPreprocessor.php
@@ -27,6 +27,23 @@ class ContentPreprocessor
     /** @var string Placeholder used to fill empty HTML tags */
     public const string EMPTY_HTML_TAGS_PLACEHOLDER = '##$$##______EMPTY_HTML_TAG______##$$##';
 
+    /**
+     * Matches a single, well-formed XLIFF tag (opening, closing or self-closing).
+     *
+     * Only the tag names actually used by MateCat at Layer 1 are recognized
+     * (the same set protected by the subfiltering {@see \Matecat\SubFiltering\Filters\PlaceHoldXliffTags}).
+     * Any other angle-bracketed sequence is treated as literal text.
+     *
+     * @var string
+     */
+    private const string XLIFF_TAG_REGEX = '#</?(?:g|bx|ex|x|bpt|ept|sub|it|mrk|sc|ec|pc|ph)(?:\s[^>]*?)?/?>#si';
+
+    /** @var string Prefix of the temporary placeholder used to shield valid XLIFF tags while escaping stray brackets */
+    private const string XLIFF_TAG_PLACEHOLDER_PREFIX = '##$$##__QA_XLIFF_TAG_';
+
+    /** @var string Suffix of the temporary placeholder used to shield valid XLIFF tags while escaping stray brackets */
+    private const string XLIFF_TAG_PLACEHOLDER_SUFFIX = '__##$$##';
+
     private const array ASCII_PLACE_HOLD_MAP = [
         '00' => ['symbol' => 'NULL', 'placeHold' => '##$_00$##', 'numeral' => 0x00],
         '01' => ['symbol' => 'SOH', 'placeHold' => '##$_01$##', 'numeral' => 0x01],
@@ -93,8 +110,57 @@ class ContentPreprocessor
         // Do it again for entities
         $segment = $this->replaceHexEntities($segment);
 
+        // Escape angle brackets that do not form a valid XLIFF tag so that plain-text
+        // sequences like "<Expiry date symbol>" are not misinterpreted as malformed XML
+        // (which would surface to the translator as a false-positive "Tag mismatch" error).
+        $segment = $this->escapeStrayAngleBrackets($segment);
+
         // Fill empty HTML tags with placeholder to avoid contraction by saveXML()
         return $this->fillEmptyHTMLTagsWithPlaceholder($segment);
+    }
+
+    /**
+     * Escapes angle brackets that are not part of a valid XLIFF tag.
+     *
+     * Valid XLIFF tags (see {@see self::XLIFF_TAG_REGEX}) are temporarily shielded with
+     * placeholders, every remaining literal `<`/`>` is converted to its entity
+     * (`&lt;`/`&gt;`), and the shielded tags are then restored untouched.
+     *
+     * This makes the QA DOM parsing resilient against plain-text segments that merely
+     * look like markup (e.g. `<Expiry date symbol>`): such content is loaded as text
+     * instead of failing XML parsing and being reported as a tag mismatch. Already
+     * encoded entities (`&lt;`, `&gt;`) and genuine XLIFF tags are left unchanged, so
+     * real tag errors are still detected.
+     *
+     * @param string $seg The segment to sanitize
+     * @return string The segment with stray angle brackets escaped
+     */
+    public function escapeStrayAngleBrackets(string $seg): string
+    {
+        if (!str_contains($seg, '<') && !str_contains($seg, '>')) {
+            return $seg;
+        }
+
+        $placeholders = [];
+        $index = 0;
+
+        // Shield valid XLIFF tags so the escaping step cannot touch them
+        $shielded = preg_replace_callback(
+            self::XLIFF_TAG_REGEX,
+            function (array $matches) use (&$placeholders, &$index): string {
+                $token = self::XLIFF_TAG_PLACEHOLDER_PREFIX . $index . self::XLIFF_TAG_PLACEHOLDER_SUFFIX;
+                $placeholders[$token] = $matches[0];
+                $index++;
+                return $token;
+            },
+            $seg
+        ) ?? $seg;
+
+        // Escape every remaining (stray) angle bracket
+        $shielded = str_replace(['<', '>'], ['&lt;', '&gt;'], $shielded);
+
+        // Restore the shielded XLIFF tags
+        return strtr($shielded, $placeholders);
     }
 
     /**

--- a/tests/unit/Core/LQA/ContentPreprocessorTest.php
+++ b/tests/unit/Core/LQA/ContentPreprocessorTest.php
@@ -373,5 +373,77 @@ class ContentPreprocessorTest extends AbstractTest
         $this->assertStringContainsString('##$_09$##', $result);
         $this->assertStringContainsString(ContentPreprocessor::EMPTY_HTML_TAGS_PLACEHOLDER, $result);
     }
+
+    // ========== Escape Stray Angle Brackets Tests ==========
+
+    #[Test]
+    public function escapeStrayAngleBracketsEscapesPseudoTag(): void
+    {
+        // Plain text that merely looks like markup must be escaped, not treated as a tag
+        $result = $this->preprocessor->escapeStrayAngleBrackets('<Expiry date symbol>');
+        $this->assertEquals('&lt;Expiry date symbol&gt;', $result);
+    }
+
+    #[Test]
+    public function escapeStrayAngleBracketsEscapesUnknownSingleWordTag(): void
+    {
+        $result = $this->preprocessor->escapeStrayAngleBrackets('<Expiry>');
+        $this->assertEquals('&lt;Expiry&gt;', $result);
+    }
+
+    #[Test]
+    public function escapeStrayAngleBracketsEscapesLooseBrackets(): void
+    {
+        $result = $this->preprocessor->escapeStrayAngleBrackets('a < b and c > d');
+        $this->assertEquals('a &lt; b and c &gt; d', $result);
+    }
+
+    #[Test]
+    public function escapeStrayAngleBracketsPreservesValidXliffTags(): void
+    {
+        $input = '<g id="1"><x id="2"/></g>';
+        $result = $this->preprocessor->escapeStrayAngleBrackets($input);
+        $this->assertEquals($input, $result);
+    }
+
+    #[Test]
+    public function escapeStrayAngleBracketsPreservesPhTag(): void
+    {
+        $input = '<ph id="mtc_1" equiv-text="base64:eA=="/>';
+        $result = $this->preprocessor->escapeStrayAngleBrackets($input);
+        $this->assertEquals($input, $result);
+    }
+
+    #[Test]
+    public function escapeStrayAngleBracketsDoesNotDoubleEncodeEntities(): void
+    {
+        $input = 'Already &lt;encoded&gt; text';
+        $result = $this->preprocessor->escapeStrayAngleBrackets($input);
+        $this->assertEquals($input, $result);
+    }
+
+    #[Test]
+    public function escapeStrayAngleBracketsKeepsValidTagAndEscapesPseudoTag(): void
+    {
+        $input = '<g id="1"><Expiry date symbol></g>';
+        $result = $this->preprocessor->escapeStrayAngleBrackets($input);
+        $this->assertEquals('<g id="1">&lt;Expiry date symbol&gt;</g>', $result);
+    }
+
+    #[Test]
+    public function escapeStrayAngleBracketsLeavesPlainTextUntouched(): void
+    {
+        $input = 'Hello World';
+        $result = $this->preprocessor->escapeStrayAngleBrackets($input);
+        $this->assertEquals($input, $result);
+    }
+
+    #[Test]
+    public function preprocessEscapesPseudoTag(): void
+    {
+        // Full preprocess pipeline must escape stray pseudo tags as well
+        $result = $this->preprocessor->preprocess('<Expiry date symbol>');
+        $this->assertEquals('&lt;Expiry date symbol&gt;', $result);
+    }
 }
 

--- a/tests/unit/Core/LQA/QATest.php
+++ b/tests/unit/Core/LQA/QATest.php
@@ -254,6 +254,28 @@ class QATest extends AbstractTest
     }
 
     #[Test]
+    public function performConsistencyCheckWithPseudoTagSourceReturnsNoError(): void
+    {
+        // "<Expiry date symbol>" is plain text, not an XLIFF tag: it must not
+        // produce a false-positive tag mismatch regardless of the translation.
+        $qa = new QA('<Expiry date symbol>', 'Simbolo data di scadenza');
+        $errors = $qa->performConsistencyCheck();
+
+        $this->assertFalse($qa->thereAreErrors());
+        $this->assertCount(1, $errors);
+        $this->assertEquals(QA::ERR_NONE, $errors[0]->outcome);
+    }
+
+    #[Test]
+    public function performConsistencyCheckWithPseudoTagInBothSegmentsReturnsNoError(): void
+    {
+        $qa = new QA('Value: <Expiry date symbol>', 'Valore: <Expiry date symbol>');
+        $qa->performConsistencyCheck();
+
+        $this->assertFalse($qa->thereAreErrors());
+    }
+
+    #[Test]
     public function performConsistencyCheckWithMismatchedTagIdHasErrors(): void
     {
         $qa = new QA('<g id="1">Source</g>', '<g id="2">Target</g>');


### PR DESCRIPTION
🐛 fix(lqa): escape stray angle brackets so plain-text segments are not flagged as tag mismatch

## Summary

A plain-text source segment that merely *looks* like markup (e.g. `<Expiry date symbol>`) was raising a false-positive "Tag mismatch" QA error regardless of the translation. QA now escapes angle brackets that don't form a valid XLIFF tag before DOM loading, so such content is treated as text while genuine tag errors are still detected.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `lib/Utils/LQA/QA/ContentPreprocessor.php` | Add `escapeStrayAngleBrackets()` and call it from `preprocess()`: shields valid XLIFF tags (`g, x, bx, ex, ph, bpt, ept, sub, it, mrk, sc, ec, pc`), converts remaining literal `<`/`>` to `&lt;`/`&gt;`, then restores the shielded tags |
| `tests/unit/Core/LQA/ContentPreprocessorTest.php` | Add 9 tests for the new escaping behavior (pseudo-tags, loose brackets, valid-tag preservation, no double-encoding) |
| `tests/unit/Core/LQA/QATest.php` | Add 2 end-to-end regression tests covering pseudo-tag source/target |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Root cause: QA loads each segment as `<root>…</root>`; a literal `<Expiry date symbol>` is invalid XML, so `DomHandler::loadDom()` failed with `ERR_SOURCE`, which `ErrorManager` maps to the user-facing `ERR_TAG_MISMATCH` (outcome `1000`).

Verified:
- Reproduced the false positive, then confirmed it is gone end-to-end.
- Genuine tag mismatches / count mismatches / unclosed tags still error (outcome `1000`).
- Already-encoded entities (`&lt;`/`&gt;`) are not double-encoded; real XLIFF tags are preserved.
- LQA + tag position suite: **462 tests pass**. PHPStan (`phpstan-no-baseline.neon`) on the edited file: **clean**.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

GitHub Copilot

## Notes

No database migrations. The fix lives entirely in QA preprocessing and is applied to both source and target, so tag comparison stays consistent and no upstream subfiltering change is required.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215627700395924