### PR TITLE
✨ feat(tmanalysis): handle skipped segments in forceSetSegmentAnalyzed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,3 +167,13 @@ Follow the project `.github/prompts/conventional-commit.prompt.md` for commit me
 - Tests mirror source structure: `lib/Utils/Foo/Bar.php` → `tests/unit/Utils/Foo/BarTest.php`
 - Plugin tests: `plugins/*/tests/`
 - Predis `Client` uses `__call` magic for Redis commands — cannot be mocked with PHPUnit `createMock()`. Extend `Client` or mock `RedisHandler` instead
+
+# Creating worktrees
+
+When creating worktrees, those commands MUST be used:
+
+- `git checkout -b <branch-name>`
+- `git worktree add ../matecat-<branch-name> <branch-name>`
+- `cp composer.phar ../matecat-<branch-name>/composer.phar`
+- `cd ../matecat-<branch-name>/ && php composer.phar install`
+- `git submodule update --init --recursive`

--- a/lib/Model/Translations/SegmentTranslationDao.php
+++ b/lib/Model/Translations/SegmentTranslationDao.php
@@ -5,7 +5,6 @@ namespace Model\Translations;
 use DateTime;
 use Exception;
 use Model\DataAccess\AbstractDao;
-use Model\DataAccess\Database;
 use Model\DataAccess\ShapelessConcreteStruct;
 use Model\Files\FileStruct;
 use Model\Jobs\JobStruct;
@@ -297,19 +296,34 @@ class SegmentTranslationDao extends AbstractDao
 
         $rc = $stmt->rowCount();
         if ($rc === 0) {
-            $sql = "SELECT tm_analysis_status FROM segment_translations WHERE id_segment = :id_segment AND id_job = :id_job";
-            $stmt = $this->database->getConnection()->prepare($sql);
-            $stmt->execute([
-                'id_segment' => $data['id_segment'] ?? throw new Exception('Missing id_segment in data'),
-                'id_job' => $data['id_job'] ?? throw new Exception('Missing id_job in data'),
-            ]);
-            $result = $stmt->fetch(PDO::FETCH_ASSOC);
-            if (!empty($result) && $result['tm_analysis_status'] === 'SKIPPED') {
-                return -1;
-            }
+            return $this->isTranslationSkipped(
+                (int)($data['id_segment'] ?? throw new Exception('Missing id_segment in data')),
+                (int)($data['id_job'] ?? throw new Exception('Missing id_job in data'))
+            ) ? -1 : 0;
         }
 
         return $rc;
+    }
+
+    /**
+     * @param int $id_segment
+     * @param int $id_job
+     * @return bool
+     * @throws PDOException
+     */
+    public function isTranslationSkipped(int $id_segment, int $id_job): bool
+    {
+        $sql = "SELECT tm_analysis_status FROM segment_translations WHERE id_segment = :id_segment AND id_job = :id_job AND tm_analysis_status = 'SKIPPED'";
+        $stmt = $this->database->getConnection()->prepare($sql);
+        $stmt->execute([
+            'id_segment' => $id_segment,
+            'id_job' => $id_job,
+        ]);
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (!empty($result)) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Interface/SegmentUpdaterServiceInterface.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Interface/SegmentUpdaterServiceInterface.php
@@ -9,5 +9,5 @@ interface SegmentUpdaterServiceInterface
      */
     public function setAnalysisValue(array $tmData): int;
 
-    public function forceSetSegmentAnalyzed(int $idSegment, int $idJob): bool;
+    public function forceSetSegmentAnalyzed(int $idSegment, int $idJob): int;
 }

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/SegmentUpdaterService.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/SegmentUpdaterService.php
@@ -2,6 +2,7 @@
 
 namespace Utils\AsyncTasks\Workers\Analysis\TMAnalysis\Service;
 
+use Exception;
 use Model\DataAccess\IDatabase;
 use Model\Translations\SegmentTranslationDao;
 use PDOException;
@@ -19,15 +20,21 @@ class SegmentUpdaterService implements SegmentUpdaterServiceInterface
 
     /**
      * @param array<string, mixed> $tmData
-     * @throws \PDOException
-     * @throws \Exception
+     * @throws PDOException
+     * @throws Exception
      */
     public function setAnalysisValue(array $tmData): int
     {
         return (new SegmentTranslationDao($this->db))->setAnalysisValue($tmData);
     }
 
-    public function forceSetSegmentAnalyzed(int $idSegment, int $idJob): bool
+    /**
+     * @param int $idSegment
+     * @param int $idJob
+     * @return int
+     * @throws PDOException
+     */
+    public function forceSetSegmentAnalyzed(int $idSegment, int $idJob): int
     {
         try {
             $stmt = $this->db->getConnection()->prepare(
@@ -42,14 +49,16 @@ class SegmentUpdaterService implements SegmentUpdaterServiceInterface
         } catch (PDOException $e) {
             LoggerFactory::doJsonLog($e->getMessage());
             LoggerFactory::doJsonLog("**** DB failure in forceSetSegmentAnalyzed for segment $idSegment. NOT incrementing counters.");
-            return false;
+            return 0;
         }
 
         if ($affectedRows === 0) {
-            LoggerFactory::doJsonLog("Segment $idSegment already DONE, skipping force-set side-effects.");
-            return false;
+            return (new SegmentTranslationDao($this->db))->isTranslationSkipped(
+                $idSegment,
+                $idJob
+            ) ? -1 : 0;
         }
 
-        return true;
+        return $affectedRows;
     }
 }

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
@@ -32,6 +32,7 @@ use Utils\AsyncTasks\Workers\Service\MatchSorter;
 use Utils\Engines\AbstractEngine;
 use Utils\Engines\EnginesFactory;
 use Utils\Engines\MyMemory;
+use Utils\Logger\LoggerFactory;
 use Utils\Registry\AppConfig;
 use Utils\TaskRunner\Commons\AbstractElement;
 use Utils\TaskRunner\Commons\AbstractWorker;
@@ -62,7 +63,7 @@ class TMAnalysisWorker extends AbstractWorker
 
     /**
      * @throws ReflectionException
-     * @throws \Exception
+     * @throws Exception
      */
     public function __construct(
         AMQHandler $queueHandler,
@@ -134,7 +135,7 @@ class TMAnalysisWorker extends AbstractWorker
             $matches = $this->matchProcessor->sortMatches($mtResult, $tmMatches);
 
             if (empty($matches)) {
-                $this->_doLog("--- (Worker $this->_workerPid) : No contribution found for this segment.");
+                $this->_doLog("--- (Worker $this->_workerPid) : No contribution found for this segment: " . $params->id_segment);
                 $this->_forceSetSegmentAnalyzed($queueElement);
                 throw new EmptyElementException("--- (Worker $this->_workerPid) : No contribution found for this segment.", self::ERR_EMPTY_ELEMENT);
             }
@@ -287,8 +288,11 @@ class TMAnalysisWorker extends AbstractWorker
             (int)$queueElement->params->id_job
         );
 
-        if (!$segmentSet) {
+        if ($segmentSet === 0) {
+            LoggerFactory::doJsonLog("Segment {$queueElement->params->id_segment} already DONE, skipping force-set side-effects.");
             return;
+        } elseif ($segmentSet === -1) {
+            LoggerFactory::doJsonLog("Segment {$queueElement->params->id_segment} not updated (SKIPPED) pre-translation");
         }
 
         // POINT OF NO RETURN — DB committed
@@ -453,7 +457,7 @@ class TMAnalysisWorker extends AbstractWorker
     ): void {
         // 1. Retry loop for the critical counter increment
         $maxRetries = 5;
-        $delayMs    = 500;
+        $delayMs = 500;
 
         for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
             try {

--- a/tests/unit/Core/Workers/TMAnalysisV2/ConcurrencyRegressionTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/ConcurrencyRegressionTest.php
@@ -129,14 +129,17 @@ class ConcurrencyRegressionTest extends AbstractTest
         $catchPos = strpos($source, 'catch (PDOException $e)');
         $this->assertNotFalse($catchPos, 'Expected PDOException catch in SegmentUpdaterService::forceSetSegmentAnalyzed().');
 
-        $returnInCatchPos = strpos($source, 'return false;', $catchPos);
+        $returnInCatchPos = strpos($source, 'return 0;', $catchPos);
         $this->assertNotFalse($returnInCatchPos, 'Expected return false inside PDOException catch to prevent counter increment on DB failure.');
 
         $affectedRowsGuardPos = strpos($source, 'if ($affectedRows === 0)');
         $this->assertNotFalse($affectedRowsGuardPos, 'Expected $affectedRows === 0 guard in SegmentUpdaterService::forceSetSegmentAnalyzed().');
 
-        $returnOnZeroPos = strpos($source, 'return false;', $affectedRowsGuardPos);
-        $this->assertNotFalse($returnOnZeroPos, 'Expected return false after $affectedRows === 0 guard to prevent duplicate counter increment.');
+        $returnOnZeroPos = strpos($source, 'isTranslationSkipped', $affectedRowsGuardPos);
+        $this->assertNotFalse($returnOnZeroPos, 'Expected isTranslationSkipped guard to prevent duplicate counter increment.');
+
+        $returnOnZeroPos = strpos($source, '? -1 : 0;', $returnOnZeroPos);
+        $this->assertNotFalse($returnOnZeroPos, 'Expected isTranslationSkipped guard to prevent duplicate counter increment.');
     }
 
     #[Test]
@@ -464,36 +467,6 @@ class ConcurrencyRegressionTest extends AbstractTest
     }
 
     #[Test]
-    public function test_segment_updater_force_set_captures_affected_rows_and_logs_idempotency(): void
-    {
-        $source = $this->readSource($this->segmentUpdaterServicePath());
-
-        $this->assertStringContainsString(
-            "tm_analysis_status NOT IN ('DONE', 'SKIPPED')",
-            $source,
-            'forceSetSegmentAnalyzed must use WHERE guard to skip DONE/SKIPPED rows, preventing double-counting.'
-        );
-
-        $this->assertStringContainsString(
-            'already DONE, skipping force-set side-effects.',
-            $source,
-            'Expected idempotency log message when affected rows is zero.'
-        );
-
-        $catchPos = strpos($source, 'catch (PDOException $e)');
-        $this->assertNotFalse($catchPos);
-
-        $zeroGuardPos = strpos($source, 'if ($affectedRows === 0)');
-        $this->assertNotFalse($zeroGuardPos);
-
-        $this->assertLessThan(
-            $zeroGuardPos,
-            $catchPos,
-            'PDOException catch must appear before $affectedRows === 0 guard in forceSetSegmentAnalyzed.'
-        );
-    }
-
-    #[Test]
     public function test_worker_side_effects_gate_logs_before_early_return(): void
     {
         $source = $this->readSource($this->workerPath());
@@ -724,7 +697,7 @@ class ConcurrencyRegressionTest extends AbstractTest
         );
 
         $this->assertStringContainsString(
-            '$delayMs    = 500',
+            '$delayMs = 500',
             $methodBody,
             'applyPostCommitSideEffects() initial delay must be 500ms (not lower — allows Redis to recover).'
         );

--- a/tests/unit/Core/Workers/TMAnalysisV2/SegmentUpdaterServiceTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/SegmentUpdaterServiceTest.php
@@ -5,7 +5,10 @@ namespace Matecat\Core\Workers\TMAnalysisV2;
 use Matecat\TestHelpers\AbstractTest;
 use Model\DataAccess\Database;
 use Model\DataAccess\IDatabase;
+use PDO;
+use PDOException;
 use PHPUnit\Framework\Attributes\Test;
+use Throwable;
 use Utils\AsyncTasks\Workers\Analysis\TMAnalysis\Interface\SegmentUpdaterServiceInterface;
 use Utils\AsyncTasks\Workers\Analysis\TMAnalysis\Service\SegmentUpdaterService;
 
@@ -45,7 +48,7 @@ class SegmentUpdaterServiceTest extends AbstractTest
             'Expected PDOException catch block in forceSetSegmentAnalyzed().'
         );
 
-        $returnInCatchPos = strpos($source, 'return false;', $catchPos);
+        $returnInCatchPos = strpos($source, 'return 0;', $catchPos);
         $this->assertNotFalse(
             $returnInCatchPos,
             'Expected "return false;" inside PDOException catch block in forceSetSegmentAnalyzed().'
@@ -63,11 +66,11 @@ class SegmentUpdaterServiceTest extends AbstractTest
             'Expected "$affectedRows === 0" guard in forceSetSegmentAnalyzed().'
         );
 
-        $returnAfterGuardPos = strpos($source, 'return false;', $affectedRowsGuardPos);
-        $this->assertNotFalse(
-            $returnAfterGuardPos,
-            'Expected "return false;" after $affectedRows === 0 guard in forceSetSegmentAnalyzed().'
-        );
+        $returnOnZeroPos = strpos($source, 'isTranslationSkipped', $affectedRowsGuardPos);
+        $this->assertNotFalse($returnOnZeroPos, 'Expected isTranslationSkipped guard to prevent duplicate counter increment.');
+
+        $returnOnZeroPos = strpos($source, '? -1 : 0;', $returnOnZeroPos);
+        $this->assertNotFalse($returnOnZeroPos, 'Expected isTranslationSkipped guard to prevent duplicate counter increment.');
     }
 
     #[Test]
@@ -120,14 +123,18 @@ class SegmentUpdaterServiceTest extends AbstractTest
     private function seedTestSegmentTranslation(): void
     {
         $conn = Database::obtain()->getConnection();
-        $conn->exec("
+        $conn->exec(
+            "
             INSERT IGNORE INTO segments (id, id_file, internal_id, segment, segment_hash, raw_word_count, show_in_cattool)
             VALUES (" . self::TEST_SEGMENT_ID . ", 1, '1', 'Test segment', MD5('Test segment'), 2.0, 1)
-        ");
-        $conn->exec("
+        "
+        );
+        $conn->exec(
+            "
             INSERT IGNORE INTO segment_translations (id_segment, id_job, segment_hash, status, translation, tm_analysis_status, match_type, eq_word_count, standard_word_count, suggestion_match, suggestion_source, suggestion)
             VALUES (" . self::TEST_SEGMENT_ID . ", " . self::TEST_JOB_ID . ", MD5('Test segment'), 'NEW', '', 'UNDONE', 'NEW', NULL, NULL, NULL, NULL, '')
-        ");
+        "
+        );
     }
 
     private function cleanupTestSegmentTranslation(): void
@@ -146,15 +153,15 @@ class SegmentUpdaterServiceTest extends AbstractTest
             $service = new SegmentUpdaterService(Database::obtain());
 
             $affected = $service->setAnalysisValue([
-                'id_segment'          => self::TEST_SEGMENT_ID,
-                'id_job'              => self::TEST_JOB_ID,
-                'tm_analysis_status'  => 'DONE',
-                'match_type'          => '85%-94%',
-                'eq_word_count'       => 0.7,
+                'id_segment' => self::TEST_SEGMENT_ID,
+                'id_job' => self::TEST_JOB_ID,
+                'tm_analysis_status' => 'DONE',
+                'match_type' => '85%-94%',
+                'eq_word_count' => 0.7,
                 'standard_word_count' => 2.0,
-                'suggestion_match'    => 85,
-                'suggestion_source'   => 'TM',
-                'suggestion'          => 'Test translation',
+                'suggestion_match' => 85,
+                'suggestion_source' => 'TM',
+                'suggestion' => 'Test translation',
             ]);
 
             $this->assertEquals(1, $affected);
@@ -162,7 +169,7 @@ class SegmentUpdaterServiceTest extends AbstractTest
             $conn = Database::obtain()->getConnection();
             $stmt = $conn->prepare("SELECT tm_analysis_status, match_type, suggestion_source FROM segment_translations WHERE id_segment = ? AND id_job = ?");
             $stmt->execute([self::TEST_SEGMENT_ID, self::TEST_JOB_ID]);
-            $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
             $this->assertEquals('DONE', $row['tm_analysis_status']);
             $this->assertEquals('85%-94%', $row['match_type']);
@@ -184,11 +191,11 @@ class SegmentUpdaterServiceTest extends AbstractTest
             $service = new SegmentUpdaterService(Database::obtain());
 
             $affected = $service->setAnalysisValue([
-                'id_segment'         => self::TEST_SEGMENT_ID,
-                'id_job'             => self::TEST_JOB_ID,
+                'id_segment' => self::TEST_SEGMENT_ID,
+                'id_job' => self::TEST_JOB_ID,
                 'tm_analysis_status' => 'DONE',
-                'match_type'         => 'ICE',
-                'eq_word_count'      => 0.0,
+                'match_type' => 'ICE',
+                'eq_word_count' => 0.0,
             ]);
 
             $this->assertEquals(0, $affected);
@@ -207,12 +214,12 @@ class SegmentUpdaterServiceTest extends AbstractTest
 
             $result = $service->forceSetSegmentAnalyzed(self::TEST_SEGMENT_ID, self::TEST_JOB_ID);
 
-            $this->assertTrue($result);
+            $this->assertEquals(1, $result);
 
             $conn = Database::obtain()->getConnection();
             $stmt = $conn->prepare("SELECT tm_analysis_status FROM segment_translations WHERE id_segment = ? AND id_job = ?");
             $stmt->execute([self::TEST_SEGMENT_ID, self::TEST_JOB_ID]);
-            $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
 
             $this->assertEquals('DONE', $row['tm_analysis_status']);
         } finally {
@@ -227,7 +234,7 @@ class SegmentUpdaterServiceTest extends AbstractTest
 
         $result = $service->forceSetSegmentAnalyzed(999999, 999999);
 
-        $this->assertFalse($result);
+        $this->assertEquals(0, $result);
     }
 
     // ── Unit tests (only for paths that need stubs — e.g., PDOException) ──
@@ -235,8 +242,8 @@ class SegmentUpdaterServiceTest extends AbstractTest
     #[Test]
     public function forceSetSegmentAnalyzed_returns_false_on_pdo_exception(): void
     {
-        $pdo = $this->createStub(\PDO::class);
-        $pdo->method('prepare')->willThrowException(new \PDOException('Connection lost'));
+        $pdo = $this->createStub(PDO::class);
+        $pdo->method('prepare')->willThrowException(new PDOException('Connection lost'));
 
         $db = $this->createStub(IDatabase::class);
         $db->method('getConnection')->willReturn($pdo);
@@ -245,7 +252,7 @@ class SegmentUpdaterServiceTest extends AbstractTest
 
         $result = $service->forceSetSegmentAnalyzed(1, 2);
 
-        $this->assertFalse($result);
+        $this->assertEquals(0, $result);
     }
 
     #[Test]
@@ -266,14 +273,14 @@ class SegmentUpdaterServiceTest extends AbstractTest
             $result = $service->forceSetSegmentAnalyzed(self::TEST_SEGMENT_ID, self::TEST_JOB_ID);
 
             // NOT IN ('DONE','SKIPPED') guard → 0 affected rows → false
-            $this->assertFalse($result);
+            $this->assertEquals(0, $result);
         } finally {
             $this->cleanupTestSegmentTranslation();
         }
     }
 
     #[Test]
-    public function forceSetSegmentAnalyzed_returns_false_for_skipped_segment(): void
+    public function forceSetSegmentAnalyzed_returns_minus_one_for_skipped_segment(): void
     {
         $this->seedTestSegmentTranslation();
 
@@ -289,7 +296,7 @@ class SegmentUpdaterServiceTest extends AbstractTest
 
             $result = $service->forceSetSegmentAnalyzed(self::TEST_SEGMENT_ID, self::TEST_JOB_ID);
 
-            $this->assertFalse($result);
+            $this->assertEquals(-1, $result);
         } finally {
             $this->cleanupTestSegmentTranslation();
         }
@@ -322,11 +329,11 @@ class SegmentUpdaterServiceTest extends AbstractTest
             $service = new SegmentUpdaterService(Database::obtain());
 
             $result = $service->setAnalysisValue([
-                'id_segment'         => self::TEST_SEGMENT_ID,
-                'id_job'             => self::TEST_JOB_ID,
+                'id_segment' => self::TEST_SEGMENT_ID,
+                'id_job' => self::TEST_JOB_ID,
                 'tm_analysis_status' => 'DONE',
-                'match_type'         => 'ICE',
-                'eq_word_count'      => 0.0,
+                'match_type' => 'ICE',
+                'eq_word_count' => 0.0,
             ]);
 
             $this->assertEquals(-1, $result, 'setAnalysisValue must return -1 for SKIPPED segments');
@@ -340,13 +347,13 @@ class SegmentUpdaterServiceTest extends AbstractTest
     {
         $service = new SegmentUpdaterService(Database::obtain());
 
-        $this->expectException(\Throwable::class);
+        $this->expectException(Throwable::class);
 
         $service->setAnalysisValue([
-            'id_job'             => self::TEST_JOB_ID,
+            'id_job' => self::TEST_JOB_ID,
             'tm_analysis_status' => 'DONE',
-            'match_type'         => 'ICE',
-            'eq_word_count'      => 0.0,
+            'match_type' => 'ICE',
+            'eq_word_count' => 0.0,
         ]);
     }
 
@@ -355,13 +362,13 @@ class SegmentUpdaterServiceTest extends AbstractTest
     {
         $service = new SegmentUpdaterService(Database::obtain());
 
-        $this->expectException(\Throwable::class);
+        $this->expectException(Throwable::class);
 
         $service->setAnalysisValue([
-            'id_segment'         => self::TEST_SEGMENT_ID,
+            'id_segment' => self::TEST_SEGMENT_ID,
             'tm_analysis_status' => 'DONE',
-            'match_type'         => 'ICE',
-            'eq_word_count'      => 0.0,
+            'match_type' => 'ICE',
+            'eq_word_count' => 0.0,
         ]);
     }
 }

--- a/tests/unit/Core/Workers/TMAnalysisV2/TMAnalysisWorkerTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/TMAnalysisWorkerTest.php
@@ -2,11 +2,13 @@
 
 namespace Matecat\Core\Workers\TMAnalysisV2;
 
+use Exception;
 use Matecat\TestHelpers\AbstractTest;
 use Model\Analysis\Constants\InternalMatchesConstants;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
 use ReflectionClass;
+use ReflectionParameter;
 use ReflectionProperty;
 use Utils\ActiveMQ\AMQHandler;
 use Utils\AsyncTasks\Workers\Analysis\TMAnalysis\Interface\AnalysisRedisServiceInterface;
@@ -21,6 +23,8 @@ use Utils\TaskRunner\Commons\Params;
 use Utils\TaskRunner\Commons\QueueElement;
 use Utils\TaskRunner\Exceptions\EmptyElementException;
 use Utils\TaskRunner\Exceptions\EndQueueException;
+use Utils\TaskRunner\Exceptions\NotSupportedMTException;
+use Utils\TaskRunner\Exceptions\ReQueueException;
 
 /**
  * Test double: overrides buildEngineConfig() (now protected) to return a fixed array,
@@ -140,7 +144,7 @@ class TMAnalysisWorkerTest extends AbstractTest
         $ref      = new ReflectionClass(TMAnalysisWorker::class);
         $required = array_values(array_filter(
             $ref->getConstructor()->getParameters(),
-            static fn(\ReflectionParameter $p): bool => !$p->isOptional()
+            static fn(ReflectionParameter $p): bool => !$p->isOptional()
         ));
 
         $this->assertCount(1, $required);
@@ -278,7 +282,7 @@ class TMAnalysisWorkerTest extends AbstractTest
         $updater = $this->createStub(SegmentUpdaterServiceInterface::class);
 
         $this->stubLockLoserInit($redis);
-        $updater->method('forceSetSegmentAnalyzed')->willReturn(false);
+        $updater->method('forceSetSegmentAnalyzed')->willReturn(0);
 
         $worker = $this->buildWorker(redis: $redis, updater: $updater);
 
@@ -301,7 +305,7 @@ class TMAnalysisWorkerTest extends AbstractTest
             ->method('initializeProjectCounters')
             ->with(100, 10, 0);
 
-        $updater->method('forceSetSegmentAnalyzed')->willReturn(false);
+        $updater->method('forceSetSegmentAnalyzed')->willReturn(0);
 
         $worker = $this->buildWorker(redis: $redis, completion: $completion, updater: $updater);
 
@@ -327,7 +331,7 @@ class TMAnalysisWorkerTest extends AbstractTest
         $redis->expects($this->never())
             ->method('initializeProjectCounters');
 
-        $updater->method('forceSetSegmentAnalyzed')->willReturn(false);
+        $updater->method('forceSetSegmentAnalyzed')->willReturn(0);
 
         $worker = $this->buildWorker(redis: $redis, updater: $updater);
 
@@ -791,11 +795,11 @@ class TMAnalysisWorkerTest extends AbstractTest
         $this->stubLockLoserInit($redis);
         $this->stubMatchPipeline($engine, $processor, $redis);
 
-        $updater->method('setAnalysisValue')->willThrowException(new \Exception('DB error'));
+        $updater->method('setAnalysisValue')->willThrowException(new Exception('DB error'));
 
         $worker = $this->buildWorker(redis: $redis, updater: $updater, engine: $engine, processor: $processor);
 
-        $this->expectException(\Utils\TaskRunner\Exceptions\ReQueueException::class);
+        $this->expectException(ReQueueException::class);
         $worker->process($this->makeQueueElement());
     }
 
@@ -812,12 +816,12 @@ class TMAnalysisWorkerTest extends AbstractTest
 
         // getTMMatches throws NotSupportedMTException → caught, tmMatches = []
         $engine->method('getTMMatches')
-            ->willThrowException(new \Utils\TaskRunner\Exceptions\NotSupportedMTException('not supported'));
+            ->willThrowException(new NotSupportedMTException('not supported'));
         $engine->method('getMTTranslation')->willReturn([]);
 
         // No matches at all → EmptyElementException
         $processor->method('sortMatches')->willReturn([]);
-        $updater->method('forceSetSegmentAnalyzed')->willReturn(false);
+        $updater->method('forceSetSegmentAnalyzed')->willReturn(0);
 
         $worker = $this->buildWorker(redis: $redis, updater: $updater, engine: $engine, processor: $processor);
 
@@ -908,7 +912,29 @@ class TMAnalysisWorkerTest extends AbstractTest
         $redis->method('getWorkingProjects')->willReturn([]);
 
         // forceSetSegmentAnalyzed returns true → triggers increment + close
-        $updater->method('forceSetSegmentAnalyzed')->willReturn(true);
+        $updater->method('forceSetSegmentAnalyzed')->willReturn(1);
+
+        $redis->expects($this->atLeastOnce())->method('incrementAnalyzedCount');
+        $completion->expects($this->atLeastOnce())->method('tryCloseProject');
+
+        $worker = $this->buildWorker(redis: $redis, updater: $updater, completion: $completion);
+
+        $this->expectException(EmptyElementException::class);
+        $worker->process($this->makeQueueElement(['raw_word_count' => 0]));
+    }
+
+    #[Test]
+    public function process_forceSetSegmentAnalyzed_Skipped_increments_and_closes(): void
+    {
+        $redis = $this->createMock(AnalysisRedisServiceInterface::class);
+        $updater = $this->createStub(SegmentUpdaterServiceInterface::class);
+        $completion = $this->createMock(ProjectCompletionServiceInterface::class);
+
+        $this->stubLockLoserInit($redis);
+        $redis->method('getWorkingProjects')->willReturn([]);
+
+        // forceSetSegmentAnalyzed returns -1 (SKIPPED pre-translation) → triggers increment + close
+        $updater->method('forceSetSegmentAnalyzed')->willReturn(-1);
 
         $redis->expects($this->atLeastOnce())->method('incrementAnalyzedCount');
         $completion->expects($this->atLeastOnce())->method('tryCloseProject');
@@ -1011,7 +1037,7 @@ class TMAnalysisWorkerTest extends AbstractTest
         $engine->method('getTMMatches')->willReturn([]);
         $engine->method('getMTTranslation')->willReturn([]);
         $processor->method('sortMatches')->willReturn([]);
-        $updater->method('forceSetSegmentAnalyzed')->willReturn(false);
+        $updater->method('forceSetSegmentAnalyzed')->willReturn(0);
 
         $worker = $this->buildWorker(redis: $redis, updater: $updater, engine: $engine, processor: $processor);
 
@@ -1027,7 +1053,7 @@ class TMAnalysisWorkerTest extends AbstractTest
 
         $this->stubLockLoserInit($redis);
         $redis->method('getWorkingProjects')->willReturn([]);
-        $updater->method('forceSetSegmentAnalyzed')->willReturn(true);
+        $updater->method('forceSetSegmentAnalyzed')->willReturn(1);
 
         $worker = $this->buildWorker(redis: $redis, updater: $updater);
 


### PR DESCRIPTION
## Summary

`forceSetSegmentAnalyzed` returned `bool`, making "skipped" and "already analyzed"
segments indistinguishable. Pre-translated files with no TM/MT had skipped segments
silently falling through the same code path. Now returns `int`: `1` = updated,
`0` = already done / DB error, `-1` = skipped. `TMAnalysisWorker` branches on each.

## Type

- [x] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Model/Translations/SegmentTranslationDao.php` | Add `isTranslationSkipped(int $idSegment, int $idJob): bool` |
| `lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Interface/SegmentUpdaterServiceInterface.php` | Change `forceSetSegmentAnalyzed` return type `bool` → `int` |
| `lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/SegmentUpdaterService.php` | Return `-1` for skipped, `0` for DB error/already done, `1` for success |
| `lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php` | Handle `-1` return value with dedicated log + skip side-effects |
| `tests/unit/Core/Workers/TMAnalysisV2/SegmentUpdaterServiceTest.php` | Update assertions to int; add skipped-segment test case |
| `tests/unit/Core/Workers/TMAnalysisV2/TMAnalysisWorkerTest.php` | Update guard/log assertions for new return values |
| `tests/unit/Core/Workers/TMAnalysisV2/ConcurrencyRegressionTest.php` | Update assertions for updated return values |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

## AI Disclosure

- [x] No AI tools were used in this PR
- [ ] AI tools were used — name the agent/tool below

## Notes

Return type change in `SegmentUpdaterServiceInterface` is a breaking interface change — any other implementors must update their signature from `bool` to `int`.