### PR TITLE
🐛 fix(setTranslation): normalize emoji in suggestion_array to \uXXXX escapes

### DIFF
--- a/lib/Controller/API/App/SetTranslationController.php
+++ b/lib/Controller/API/App/SetTranslationController.php
@@ -619,7 +619,14 @@ class SetTranslationController extends AbstractStatefulKleinController
             FILTER_UNSAFE_RAW,
             ['flags' => FILTER_NULL_ON_FAILURE]
         );
-        $suggestion_array = (is_string($suggestion_array) && $suggestion_array !== '' && json_decode($suggestion_array) === null) ? null : $suggestion_array;
+        if (is_string($suggestion_array) && $suggestion_array !== '') {
+            $decoded = json_decode($suggestion_array);
+            // Re-encode without JSON_UNESCAPED_UNICODE: 4-byte UTF-8 chars (emojis) become
+            // \uXXXX sequences, making the string safe for MySQL utf8 connections.
+            $suggestion_array = ($decoded !== null) ? json_encode($decoded, JSON_UNESCAPED_SLASHES) : null;
+        } else {
+            $suggestion_array = null;
+        }
         $status = filter_var($this->request->param('status'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
         $splitStatuses = filter_var($this->request->param('splitStatuses'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
         $context_before = (string)filter_var($this->request->param('context_before'), FILTER_UNSAFE_RAW);

--- a/tests/unit/Core/Controllers/SetTranslationControllerTest.php
+++ b/tests/unit/Core/Controllers/SetTranslationControllerTest.php
@@ -2620,14 +2620,15 @@ class SetTranslationControllerTest extends AbstractTest
     }
 
     /**
-     * Migrated from the legacy unit\Controllers\SetTranslationControllerTest (§6
-     * reconciliation): valid suggestion_array JSON — including 4-byte unicode /
-     * emoji payloads — must be preserved intact through the REAL validateTheRequest().
+     * suggestion_array JSON containing 4-byte UTF-8 characters (emojis, supplementary
+     * Unicode) must be re-encoded to \uXXXX escape sequences so that the stored bytes
+     * are ASCII-safe for MySQL utf8 connections. The semantic content (decoded values)
+     * must remain identical.
      *
      * @throws ReflectionException
      */
     #[Test]
-    public function validateTheRequestPreservesEmojiSuggestionArray(): void
+    public function validateTheRequestNormalizesEmojiInSuggestionArrayToUnicodeEscapes(): void
     {
         $projectId = 9027151;
         $jobId = 9027152;
@@ -2636,6 +2637,7 @@ class SetTranslationControllerTest extends AbstractTest
         $fileId = 9027154;
         $this->seedMinimalProjectJobAndSegment($projectId, $jobId, $jobPassword, $segmentId, $fileId, 'Hello emoji', 2);
 
+        // Contains a mix of 3-byte (✨ U+2728) and 4-byte (🛒 U+1F6D2, 𝄞 U+1D11E) chars.
         $jsonWithEmoji = '[{"match":"MT","created_by":"MT-Lara","translation":"Tvoja kupovina 🛒✨ 𝄞"}]';
 
         $controller = $this->createControllerWithoutConstructor();
@@ -2654,10 +2656,17 @@ class SetTranslationControllerTest extends AbstractTest
         $method = $this->getAccessibleMethod('validateTheRequest');
         $data = $method->invoke($controller);
 
-        self::assertSame($jsonWithEmoji, $data['suggestion_array'], 'Valid emoji JSON must pass through unchanged');
+        // Raw emoji bytes must NOT be present in the stored string (they would truncate
+        // in MySQL utf8 connections at the first 4-byte sequence).
+        self::assertStringNotContainsString('🛒', $data['suggestion_array'], '4-byte emoji must be escaped, not stored as raw bytes');
+        self::assertStringNotContainsString('𝄞', $data['suggestion_array'], '4-byte char must be escaped, not stored as raw bytes');
+
+        // The stored string must still be valid JSON.
         $decoded = json_decode($data['suggestion_array'], true);
-        self::assertIsArray($decoded);
-        self::assertStringContainsString('🛒✨', $decoded[0]['translation']);
+        self::assertIsArray($decoded, 'Normalized suggestion_array must decode to a valid array');
+
+        // Semantic content is preserved: json_decode restores \uXXXX back to the original chars.
+        self::assertSame('Tvoja kupovina 🛒✨ 𝄞', $decoded[0]['translation'], 'Decoded translation must equal the original emoji string');
     }
 
     /**


### PR DESCRIPTION
## Summary

  Saving a translation whose `suggestion_array` contains emoji (e.g. 🍕🔥) caused the JSON stored
  in `segment_translations.suggestions_array` to be silently truncated at the first emoji character.

  Root cause: the PDO connection is initialised with `SET NAMES utf8` (MySQL's 3-byte charset).
  Any 4-byte UTF-8 character — emoji, supplementary Unicode — causes MySQL to truncate the string
  at that byte when writing to the column.

  Fix: in `SetTranslationController::validateTheRequest()`, after extracting `suggestion_array`
  from the request, the JSON is decoded and re-encoded with `json_encode($decoded, JSON_UNESCAPED_SLASHES)`.
  This converts raw 4-byte bytes to `\uXXXX` escape sequences (pure ASCII), stored safely regardless
  of the connection charset. `json_decode()` on read restores the original emoji values transparently.

  ## Type

  - [x] `fix` — bug fix

  ## Changes
  
  | File | Change |
  |------|--------|
  | `lib/Controller/API/App/SetTranslationController.php` | Re-encode `suggestion_array` JSON to replace 4-byte UTF-8 chars with `\uXXXX` escapes |
  | `tests/unit/Core/Controllers/SetTranslationControllerTest.php` | Rename and update emoji test to assert normalization instead of passthrough |

  ## Testing
  
  - [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
  - [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
  - [ ] Manual testing performed (describe below)
  - [x] New tests added for changed behavior
  - [x] Regression tests added for bug fixes

  Reproducer payload — `suggestion_array` with 🍕🔥 was truncated before this fix:
  
  ```json
  [{"translation":"Profitez de 1+1 sur TOUTES LES PIZZAS 🍕🔥","raw_translation":"Profitez de 1+1 sur TOUTES LES PIZZAS &#127829;&#128293;",...}]
  ```

  ## AI Disclosure
  
  - [ ] No AI tools were used in this PR
  - [x] AI tools were used — Claude Code (claude-sonnet-4-6)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214480878137754