### PR TITLE
🐛 fix(xliff): disambiguate trans-unit ids duplicated across <file> tags

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2043,16 +2043,16 @@
         },
         {
             "name": "matecat/xliff-parser",
-            "version": "v3.0.6",
+            "version": "v3.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/xliff-parser.git",
-                "reference": "500e940162d5de36b4d9877ee26c07d4c78c258e"
+                "reference": "b0f6350954b865bc6aa377568792dea71e382b11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/xliff-parser/zipball/500e940162d5de36b4d9877ee26c07d4c78c258e",
-                "reference": "500e940162d5de36b4d9877ee26c07d4c78c258e",
+                "url": "https://api.github.com/repos/matecat/xliff-parser/zipball/b0f6350954b865bc6aa377568792dea71e382b11",
+                "reference": "b0f6350954b865bc6aa377568792dea71e382b11",
                 "shasum": ""
             },
             "require": {
@@ -2103,9 +2103,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matecat/xliff-parser/issues",
-                "source": "https://github.com/matecat/xliff-parser/tree/v3.0.6"
+                "source": "https://github.com/matecat/xliff-parser/tree/v3.0.7"
             },
-            "time": "2026-04-13T09:27:19+00:00"
+            "time": "2026-07-01T15:06:58+00:00"
         },
         {
             "name": "matecat/xml-dom-parser",

--- a/lib/Model/ProjectCreation/SegmentExtractor.php
+++ b/lib/Model/ProjectCreation/SegmentExtractor.php
@@ -161,8 +161,17 @@ class SegmentExtractor
         $_fileCounter_Show_In_Cattool = 0;
 
         // Creating the Query
+        // $internalFileIndex is the 0-based ordinal position of this <file> element within the
+        // document, used to disambiguate trans-unit ids that are only unique per-<file>, not
+        // document-wide (see SegmentExtractor::processXliffFile()). It must be a manually
+        // incremented counter rather than the array's own key: XliffParser::xliffToArray()
+        // returns $xliff['files'] as a 1-indexed array, but the XliffReplacer counts <file>
+        // elements from 0 while replaying the raw XML at download time, so the two must agree
+        // on a 0-based convention independent of the parser's internal array indexing.
+        $internalFileIndex = 0;
         foreach ($xliff['files'] as $xliff_file) {
-            $_fileCounter_Show_In_Cattool += $this->processXliffFile($xliff_file, $fid, $projectStructure);
+            $_fileCounter_Show_In_Cattool += $this->processXliffFile($xliff_file, $fid, $internalFileIndex, $projectStructure);
+            $internalFileIndex++;
         }
 
         // use generic
@@ -183,6 +192,7 @@ class SegmentExtractor
      *
      * @param array<string, mixed> $xliff_file
      * @param int $fid
+     * @param int $internalFileIndex 0-based ordinal position of this <file> element within the document
      * @param ProjectStructure $projectStructure
      *
      * @return int Number of segments marked as show-in-cattool in this file element
@@ -191,7 +201,7 @@ class SegmentExtractor
      * @throws PDOException
      * @throws TypeError
      */
-    private function processXliffFile(array $xliff_file, int $fid, ProjectStructure $projectStructure): int
+    private function processXliffFile(array $xliff_file, int $fid, int $internalFileIndex, ProjectStructure $projectStructure): int
     {
         $filePartsId = $this->persistXliffFileAttributes($xliff_file, $fid);
 
@@ -216,7 +226,13 @@ class SegmentExtractor
 
             $this->manageAlternativeTranslations($xliff_trans_unit, $xliff_file['attr']);
 
-            $trans_unit_reference = self::sanitizedUnitId($xliff_trans_unit['attr']['id'], $fid);
+            // A trans-unit id is only guaranteed unique within its own <file> element (OASIS
+            // XLIFF 1.2 §2.4), not across the whole document, so disambiguate it with the
+            // ordinal position of the enclosing <file>. This must match the key format expected
+            // by the XliffReplacer at download time (see matecat/xliff-parser).
+            $disambiguatedId = $internalFileIndex . '|' . $xliff_trans_unit['attr']['id'];
+
+            $trans_unit_reference = self::sanitizedUnitId($disambiguatedId, $fid);
 
             $dataRefMap = $this->buildDataRefMap($xliff_trans_unit);
 
@@ -225,6 +241,7 @@ class SegmentExtractor
                 $fileCounterShowInCattool += $this->processSegSourceTransUnit(
                     $xliff_trans_unit,
                     $trans_unit_reference,
+                    $disambiguatedId,
                     $dataRefMap,
                     $fid,
                     $filePartsId,
@@ -234,6 +251,7 @@ class SegmentExtractor
                 $fileCounterShowInCattool += $this->processNonSegSourceTransUnit(
                     $xliff_trans_unit,
                     $trans_unit_reference,
+                    $disambiguatedId,
                     $dataRefMap,
                     $fid,
                     $filePartsId,
@@ -305,6 +323,7 @@ class SegmentExtractor
      *
      * @param array<string, mixed> $xliff_trans_unit
      * @param string $trans_unit_reference
+     * @param string $disambiguatedId
      * @param array<string, string> $dataRefMap
      * @param int $fid
      * @param int|null $filePartsId
@@ -321,6 +340,7 @@ class SegmentExtractor
     private function processSegSourceTransUnit(
         array $xliff_trans_unit,
         string $trans_unit_reference,
+        string $disambiguatedId,
         array $dataRefMap,
         int $fid,
         ?int $filePartsId,
@@ -365,6 +385,7 @@ class SegmentExtractor
                 fid: $fid,
                 filePartsId: $filePartsId,
                 xliff_trans_unit: $xliff_trans_unit,
+                disambiguatedId: $disambiguatedId,
                 rawContent: $seg_source['raw-content'],
                 sourceLayer0: $sourceLayer0,
                 dataRefMap: $dataRefMap,
@@ -382,7 +403,7 @@ class SegmentExtractor
             $cattoolCount += $counters['show_in_cattool'];
         } // end foreach seg-source
 
-        $this->extractNotesAndContexts($xliff_trans_unit, $fid, $projectStructure);
+        $this->extractNotesAndContexts($xliff_trans_unit, $trans_unit_reference, $projectStructure);
 
         return $cattoolCount;
     }
@@ -395,6 +416,7 @@ class SegmentExtractor
      *
      * @param array<string, mixed> $xliff_trans_unit
      * @param string $trans_unit_reference
+     * @param string $disambiguatedId
      * @param array<string, string> $dataRefMap
      * @param int $fid
      * @param int|null $filePartsId
@@ -406,6 +428,7 @@ class SegmentExtractor
     private function processNonSegSourceTransUnit(
         array $xliff_trans_unit,
         string $trans_unit_reference,
+        string $disambiguatedId,
         array $dataRefMap,
         int $fid,
         ?int $filePartsId,
@@ -434,12 +457,13 @@ class SegmentExtractor
             );
         }
 
-        $this->extractNotesAndContexts($xliff_trans_unit, $fid, $projectStructure);
+        $this->extractNotesAndContexts($xliff_trans_unit, $trans_unit_reference, $projectStructure);
 
         $counters = $this->buildAndAppendSegment(
             fid: $fid,
             filePartsId: $filePartsId,
             xliff_trans_unit: $xliff_trans_unit,
+            disambiguatedId: $disambiguatedId,
             rawContent: $xliff_trans_unit['source']['raw-content'],
             sourceLayer0: $sourceLayer0,
             dataRefMap: $dataRefMap,
@@ -659,6 +683,7 @@ class SegmentExtractor
      * @param int $fid
      * @param int|null $filePartsId
      * @param array<string, mixed> $xliff_trans_unit
+     * @param string $disambiguatedId
      * @param string $rawContent
      * @param string $sourceLayer0
      * @param array<string, string> $dataRefMap
@@ -676,6 +701,7 @@ class SegmentExtractor
         int $fid,
         ?int $filePartsId,
         array $xliff_trans_unit,
+        string $disambiguatedId,
         string $rawContent,
         string $sourceLayer0,
         array $dataRefMap,
@@ -707,7 +733,7 @@ class SegmentExtractor
             'id_file' => $fid,
             'id_file_part' => $filePartsId,
             'id_project' => $this->idProject,
-            'internal_id' => $xliff_trans_unit['attr']['id'],
+            'internal_id' => $disambiguatedId,
             'xliff_mrk_id' => $xliffMrkId,
             'xliff_ext_prec_tags' => $xliffExtPrecTags,
             'xliff_mrk_ext_prec_tags' => $xliffMrkExtPrecTags,
@@ -776,16 +802,16 @@ class SegmentExtractor
      * with consistent error handling.
      *
      * @param array<string, mixed> $xliff_trans_unit
-     * @param int $fid
+     * @param string $trans_unit_reference
      * @param ProjectStructure $projectStructure
      *
      * @throws Exception
      */
-    private function extractNotesAndContexts(array $xliff_trans_unit, int $fid, ProjectStructure $projectStructure): void
+    private function extractNotesAndContexts(array $xliff_trans_unit, string $trans_unit_reference, ProjectStructure $projectStructure): void
     {
         try {
-            $this->addNotesToProjectStructure($xliff_trans_unit, $fid, $projectStructure);
-            $this->addTUnitContextsToProjectStructure($xliff_trans_unit, $fid, $projectStructure);
+            $this->addNotesToProjectStructure($xliff_trans_unit, $trans_unit_reference, $projectStructure);
+            $this->addTUnitContextsToProjectStructure($xliff_trans_unit, $trans_unit_reference, $projectStructure);
         } catch (Exception $exception) {
             throw new Exception($exception->getMessage(), ProjectCreationError::NO_TRANSLATABLE_TEXT->value, $exception);
         }
@@ -795,14 +821,14 @@ class SegmentExtractor
      * Add notes from a trans-unit to the projectStructure.
      *
      * @param array<string, mixed> $trans_unit
-     * @param int $fid
+     * @param string $trans_unit_reference
      * @param ProjectStructure $projectStructure
      *
      * @throws Exception
      */
-    private function addNotesToProjectStructure(array $trans_unit, int $fid, ProjectStructure $projectStructure): void
+    private function addNotesToProjectStructure(array $trans_unit, string $trans_unit_reference, ProjectStructure $projectStructure): void
     {
-        $internal_id = self::sanitizedUnitId($trans_unit['attr']['id'], $fid);
+        $internal_id = $trans_unit_reference;
         if (isset($trans_unit['notes'])) {
             if (count($trans_unit['notes']) > self::SEGMENT_NOTES_LIMIT) {
                 throw new Exception('File upload failed: a segment can have a maximum of ' . self::SEGMENT_NOTES_LIMIT . ' notes.', ProjectCreationError::TOO_MANY_NOTES->value);
@@ -856,12 +882,12 @@ class SegmentExtractor
      * Add context-group data from a trans-unit to the projectStructure.
      *
      * @param array<string, mixed> $trans_unit
-     * @param int $fid
+     * @param string $trans_unit_reference
      * @param ProjectStructure $projectStructure
      */
-    private function addTUnitContextsToProjectStructure(array $trans_unit, int $fid, ProjectStructure $projectStructure): void
+    private function addTUnitContextsToProjectStructure(array $trans_unit, string $trans_unit_reference, ProjectStructure $projectStructure): void
     {
-        $internal_id = self::sanitizedUnitId($trans_unit['attr']['id'], $fid);
+        $internal_id = $trans_unit_reference;
         if (isset($trans_unit['context-group'])) {
             $projectStructure->context_group[$internal_id] ??= [];
 

--- a/tests/resources/files/xliff/duplicate-trans-unit-id-across-files.xliff
+++ b/tests/resources/files/xliff/duplicate-trans-unit-id-across-files.xliff
@@ -1,0 +1,19 @@
+<xliff version='1.2'
+       xmlns='urn:oasis:names:tc:xliff:document:1.2'>
+    <file original='first.txt' source-language='en-US' target-language='it-IT'
+          datatype='plaintext'>
+        <body>
+            <trans-unit id='tu1'>
+                <source xml:lang="en-US">Hello from the first file</source>
+            </trans-unit>
+        </body>
+    </file>
+    <file original='second.txt' source-language='en-US' target-language='it-IT'
+          datatype='plaintext'>
+        <body>
+            <trans-unit id='tu1'>
+                <source xml:lang="en-US">Hello from the second file</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/tests/unit/Core/Model/ProjectCreation/ExtractSegmentsTest.php
+++ b/tests/unit/Core/Model/ProjectCreation/ExtractSegmentsTest.php
@@ -141,7 +141,10 @@ class ExtractSegmentsTest extends AbstractTest
 
         /** @var SegmentStruct $seg0 */
         $seg0 = $segments[0];
-        $this->assertEquals('tu1', $seg0->internal_id);
+        // internal_id is prefixed with the 0-based ordinal of the enclosing <file> element
+        // ("0|") to disambiguate trans-unit ids that are only unique per-<file>, not
+        // document-wide (see SegmentExtractor::processXliffFile()).
+        $this->assertEquals('0|tu1', $seg0->internal_id);
     }
 
     /**
@@ -330,7 +333,7 @@ class ExtractSegmentsTest extends AbstractTest
         $ps = $this->pm->getTestProjectStructure();
 
         // The reference key is "{fid}|{tu_id}"
-        $unitRef = $fid . '|tu1';
+        $unitRef = $fid . '|0|tu1';
         $this->assertArrayHasKey($unitRef, $ps->translations);
 
         $tuplesByMrk = $ps->translations[$unitRef];
@@ -356,7 +359,7 @@ class ExtractSegmentsTest extends AbstractTest
         ]);
 
         $ps = $this->pm->getTestProjectStructure();
-        $unitRef = $fid . '|tu1';
+        $unitRef = $fid . '|0|tu1';
         $tuplesByMrk = $ps->translations[$unitRef];
 
         /** @var TranslationTuple $tuple0 */
@@ -409,7 +412,7 @@ class ExtractSegmentsTest extends AbstractTest
         $ps = $this->pm->getTestProjectStructure();
 
         // tu1 has target (state="translated"), tu2 has no target
-        $unitRef = $fid . '|tu1';
+        $unitRef = $fid . '|0|tu1';
         $this->assertArrayHasKey($unitRef, $ps->translations);
 
         $tuples = $ps->translations[$unitRef];
@@ -434,7 +437,7 @@ class ExtractSegmentsTest extends AbstractTest
         ]);
 
         $ps = $this->pm->getTestProjectStructure();
-        $unitRef = $fid . '|tu1';
+        $unitRef = $fid . '|0|tu1';
         $tuples = $ps->translations[$unitRef];
 
         /** @var TranslationTuple $tuple */
@@ -578,11 +581,14 @@ class ExtractSegmentsTest extends AbstractTest
 
         /** @var SegmentStruct $seg0 */
         $seg0 = $segments[0];
-        $this->assertEquals('tu1', $seg0->internal_id);
+        // internal_id is prefixed with the 0-based ordinal of the enclosing <file> element
+        // ("0|") to disambiguate trans-unit ids that are only unique per-<file>, not
+        // document-wide (see SegmentExtractor::processXliffFile()).
+        $this->assertEquals('0|tu1', $seg0->internal_id);
 
         /** @var SegmentStruct $seg1 */
         $seg1 = $segments[1];
-        $this->assertEquals('tu2', $seg1->internal_id);
+        $this->assertEquals('0|tu2', $seg1->internal_id);
     }
 
     // =========================================================================
@@ -624,7 +630,7 @@ class ExtractSegmentsTest extends AbstractTest
         $notes = $ps->notes;
 
         // tu1 has 2 notes. The key is "{fid}|{tu_id}"
-        $tu1Key = $fid . '|tu1';
+        $tu1Key = $fid . '|0|tu1';
         $this->assertArrayHasKey($tu1Key, $notes, "Notes key '$tu1Key' should exist");
 
         $tu1Notes = $notes[$tu1Key];
@@ -647,7 +653,7 @@ class ExtractSegmentsTest extends AbstractTest
         $ps = $this->pm->getTestProjectStructure();
         $notes = $ps->notes;
 
-        $tu1Key = $fid . '|tu1';
+        $tu1Key = $fid . '|0|tu1';
         $tu1From = $notes[$tu1Key]['from']['entries'];
 
         // First note has no 'from' → 'NO_FROM'
@@ -671,7 +677,7 @@ class ExtractSegmentsTest extends AbstractTest
         $ps = $this->pm->getTestProjectStructure();
         $contextGroup = $ps->context_group;
 
-        $tu1Key = $fid . '|tu1';
+        $tu1Key = $fid . '|0|tu1';
         $this->assertArrayHasKey($tu1Key, $contextGroup, "Context-group key '$tu1Key' should exist");
 
         $tu1Ctx = $contextGroup[$tu1Key];
@@ -703,6 +709,44 @@ class ExtractSegmentsTest extends AbstractTest
         } finally {
             unlink($tmpFile);
         }
+    }
+
+    /**
+     * A trans-unit id is only guaranteed unique within its own <file> element (OASIS XLIFF
+     * 1.2 §2.4), not across the whole document — two <file> elements are allowed to reuse the
+     * same trans-unit id. Without disambiguating by the enclosing <file>'s ordinal position,
+     * both segments would collide under the same `internal_id`, causing one file's translated
+     * content to be lost or duplicated at download time (see SegmentExtractor::extract()).
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function testDuplicateTransUnitIdAcrossFilesProducesDistinctInternalIds(): void
+    {
+        $fid = 1;
+        $this->pm->callExtractSegments($fid, [
+            'path_cached_xliff' => self::FIXTURES_DIR . 'duplicate-trans-unit-id-across-files.xliff',
+            'original_filename' => 'duplicate-trans-unit-id-across-files.xliff',
+        ]);
+
+        $ps = $this->pm->getTestProjectStructure();
+        $segments = $ps->segments[$fid];
+
+        $this->assertCount(2, $segments);
+
+        /** @var SegmentStruct $seg0 */
+        $seg0 = $segments[0];
+        /** @var SegmentStruct $seg1 */
+        $seg1 = $segments[1];
+
+        // Both trans-units share the raw id "tu1", but each must be disambiguated by the
+        // 0-based ordinal of its enclosing <file> element.
+        $this->assertEquals('0|tu1', $seg0->internal_id);
+        $this->assertEquals('1|tu1', $seg1->internal_id);
+        $this->assertNotEquals($seg0->internal_id, $seg1->internal_id);
+
+        $this->assertEquals('Hello from the first file', $seg0->segment);
+        $this->assertEquals('Hello from the second file', $seg1->segment);
     }
 
     /**
@@ -902,11 +946,11 @@ class ExtractSegmentsTest extends AbstractTest
 
         /** @var SegmentStruct $seg0 */
         $seg0 = $segments[0];
-        $this->assertEquals('tu1', $seg0->internal_id);
+        $this->assertEquals('0|tu1', $seg0->internal_id);
 
         /** @var SegmentStruct $seg1 */
         $seg1 = $segments[1];
-        $this->assertEquals('tu3', $seg1->internal_id);
+        $this->assertEquals('0|tu3', $seg1->internal_id);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where downloading a job whose XLIFF contains two `<file>` elements with duplicate `trans-unit@id` values (valid per OASIS XLIFF 1.2 §2.4 — ids are only unique *within* a `<file>`, not document-wide) silently drops or duplicates one file's translated content in the final downloaded file, even though it's correctly translated in the editor. Fixed at both layers: the `matecat/xliff-parser` replacer (upgraded to v3.0.7) now disambiguates trans-units by the ordinal position of their enclosing `<file>`, and `SegmentExtractor` now stores a matching file-scoped `internal_id`.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `lib/Model/ProjectCreation/SegmentExtractor.php` | `internal_id` is now `"{fileIndex}\|{trans-unit id}"` instead of the raw id, so duplicate ids across `<file>` elements no longer collide. `$internalFileIndex` is a manually incremented 0-based counter (not `xliffToArray()`'s own 1-indexed array keys) to stay consistent with the replacer's own counter. Threaded through `extract()` -> `processXliffFile()` -> `processSegSourceTransUnit()`/`processNonSegSourceTransUnit()` -> `buildAndAppendSegment()`, and reused for the notes/context-group/pre-translation reference key so those stay consistent too. |
| `composer.json` / `composer.lock` | Bumped `matecat/xliff-parser` to `v3.0.7`, which contains the matching replacer-side fix (tracks `<file>` ordinal during SAX replay, file-scoped lookup key with plain-id fallback for backward compatibility). |
| `tests/resources/files/xliff/duplicate-trans-unit-id-across-files.xliff` | New fixture: two `<file>` elements, each with a `trans-unit id="tu1"`. |
| `tests/unit/Core/Model/ProjectCreation/ExtractSegmentsTest.php` | New regression test asserting the two duplicated segments get distinct `internal_id` values. Updated existing `internal_id`/notes/context-group/translations key assertions to the new format. |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes (8665 tests, 0 new failures — verified against a real DB/Redis; the only pre-existing failures/errors were confirmed identical on unmodified code)
- [x] `./vendor/bin/phpstan` passes (0 errors) on the changed file, both with baseline and with `phpstan-no-baseline.neon`
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

New test verified to fail against pre-fix code (`internal_id` collides as `'tu1'` for both segments) and pass after the fix (`'0|tu1'` / `'1|tu1'`). Companion fix and regression tests in matecat/xliff-parser (branch `fix/duplicate-trans-unit-id-across-files`, 232/232 tests passing there), released as v3.0.7 and pulled in via this PR's composer bump.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

Root-caused from a customer ticket reporting missing translated content in a downloaded file. The actual replacer fix lives in the separate `matecat/xliff-parser` package (github.com/matecat/xliff-parser) and is merged/released separately as v3.0.7 — this PR only needs the `SegmentExtractor` change plus the composer bump.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214845565074053
