### PR TITLE
🐛 fix(lara): stop implode() TypeError on glossaries debug log

### DIFF
--- a/lib/Utils/Engines/Lara.php
+++ b/lib/Utils/Engines/Lara.php
@@ -348,7 +348,7 @@ class Lara extends AbstractEngine
                     'style' => $laraStyle,
                     'style_guideline_id' => $laraStyleGuidelineId,
                     'model' => $laraModel,
-                    'glossaries' => isset($laraGlossaries) ? implode(",", $laraGlossaries->value) : null,
+                    'glossaries' => is_array($laraGlossaries ?? null) ? implode(",", $laraGlossaries) : null,
                     'multiline' => false,
                     'translation' => $translation,
                     'score' => $score ?? null,

--- a/tests/unit/Core/Engines/LaraEngineTest.php
+++ b/tests/unit/Core/Engines/LaraEngineTest.php
@@ -33,6 +33,8 @@ use Utils\Engines\Lara\LaraClient;
 use Utils\Engines\MMT;
 use Utils\Engines\MMT\MMTServiceApiException;
 use Utils\Engines\Results\MyMemory\GetMemoryResponse;
+use Model\Projects\MetadataDao;
+use Model\Projects\ProjectsMetadataMarshaller;
 use Utils\Redis\RedisHandler;
 use Utils\TmKeyManagement\TmKeyStruct;
 
@@ -86,6 +88,67 @@ class LaraEngineTest extends AbstractTest
         self::assertCount(1, $response->matches);
         self::assertSame('translated segment', $response->matches[0]->raw_translation);
         self::assertSame('ext_my_k1,ext_my_k2', $httpClient->capturedHeaders[Headers::LARA_MEMORIES_IDS] ?? null);
+    }
+    /**
+     * Regression test for the Lara "glossaries" implode() crash.
+     *
+     * MetadataDao::getValue() returns the ALREADY-unmarshalled LARA_GLOSSARIES value.
+     * For that key the marshaller decodes it to a string[] array (not a MetadataStruct),
+     * so the debug-log line in get() must implode the array itself. Because that debug
+     * array is built unconditionally (regardless of log level), the previous
+     * `implode(",", $laraGlossaries->value)` dereferenced ->value on a plain array and
+     * raised an Error/TypeError, aborting EVERY Lara get() contribution for any project
+     * that had lara_glossaries metadata set. This test drives get() with a project whose
+     * lara_glossaries metadata is a real JSON array and asserts it completes normally.
+     *
+     * @throws LaraException
+     * @throws Exception
+     */
+    #[Test]
+    public function getWithProjectLaraGlossariesMetadataDoesNotThrowBuildingDebugLog(): void
+    {
+        $idProject  = 1;
+        $glossaryKey = ProjectsMetadataMarshaller::LARA_GLOSSARIES->value;
+
+        // Seed real project_metadata: LARA_GLOSSARIES is persisted as a JSON array string
+        // and getValue() unmarshalls it back into a string[] array.
+        $metadataDao = new MetadataDao(obtainTestDatabase());
+        $metadataDao->delete($idProject, $glossaryKey);
+        $metadataDao->set($idProject, $glossaryKey, json_encode(['mem_abc', 'mem_def']));
+
+        // Contract lock (the exact assumption line 351 of Lara::get() depends on):
+        // the value get() reads back is a string[] array, NOT a struct nor a string.
+        self::assertSame(['mem_abc', 'mem_def'], $metadataDao->getValue($idProject, $glossaryKey));
+
+        $httpClient = new TestHttpClient();
+        $client = $this->createMock(LaraClient::class);
+        $client->method('getHttpClient')->willReturn($httpClient);
+        $client->expects(self::once())
+            ->method('translate')
+            ->willReturn(new TextResult('application/xliff+xml', 'en-US', [
+                new TextBlock('glossary translation', true),
+            ]));
+        $this->engine->setMockClient($client);
+
+        try {
+            $response = $this->engine->get([
+                'segment' => 'source segment',
+                'source' => 'en-US',
+                'target' => 'it-IT',
+                'keys' => ['k1'],
+                'id_project' => $idProject,
+                'context_list_before' => [],
+                'context_list_after' => [],
+            ]);
+        } finally {
+            // Keep project 1 metadata clean so sibling suites are unaffected.
+            $metadataDao->delete($idProject, $glossaryKey);
+        }
+
+        self::assertInstanceOf(GetMemoryResponse::class, $response);
+        self::assertSame(200, $response->responseStatus);
+        self::assertCount(1, $response->matches);
+        self::assertSame('glossary translation', $response->matches[0]->raw_translation);
     }
     /**
      * @throws LaraException


### PR DESCRIPTION
## Summary

Getting a contribution via the **Lara** engine crashed with `implode(): Argument #1 ($array) must be of type array, string given` at `lib/Utils/Engines/Lara.php:351`, aborting every Lara `get()`. The `$this->logger->debug([...])` array — built unconditionally — dereferenced `$laraGlossaries->value`, but `MetadataDao::getValue()` returns the already-unmarshalled glossary array (`string[]|null`), not the `MetadataStruct`, so `implode()` received a non-array. Fix uses the value directly, guarded by `is_array()`, matching the `setGlossaries()` call above. Adds the first test to cover the glossaries branch of `get()`.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Utils/Engines/Lara.php` | Drop stale `->value` in the `get()` debug-log array; `is_array($laraGlossaries ?? null) ? implode(",", $laraGlossaries) : null` |
| `tests/unit/Core/Engines/LaraEngineTest.php` | Add `getWithProjectLaraGlossariesMetadataDoesNotThrowBuildingDebugLog` covering the glossaries branch (lines 280-286, 351) and locking the `getValue()` → `string[]` contract |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Ran `tests/unit/Core/Engines/LaraEngineTest.php` (the affected suite) — the phpunit box above refers to this run, not the whole suite. Regression proven RED→GREEN: reverting only the fixed line reproduces the exact production `TypeError`; restoring passes.

```
RED  (pre-fix): TypeError: implode(): Argument #1 ($array) must be of type array, string given
                lib/Utils/Engines/Lara.php:351  — Tests: 1, Errors: 1
GREEN (fix):    OK (1 test, 6 assertions)
LaraEngineTest: OK (47 tests, 154 assertions)
```

The full `--exclude-group=ExternalServices` suite and phpstan are deferred to CI. phpstan was not run in this fresh worktree (no local `vendor`; cross-checkout run of the custom Bootstrap rule failed to autoload) — deferred to CI. The change is `php -l` clean and `is_array()` narrows `mixed`→`array` before `implode`, so no residual type risk.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-4-8)

## Notes

Root cause was a stale property access left over from when `MetadataDao::getValue()` returned the `MetadataStruct`; it now returns the unmarshalled value directly (`MetadataDao.php:101`). No schema/migration changes.
