### PR TITLE
🐛 fix(users): accept array values in user metadata update endpoint

### DIFF
--- a/lib/Controller/API/V2/UserController.php
+++ b/lib/Controller/API/V2/UserController.php
@@ -123,7 +123,9 @@ class UserController extends AbstractStatefulKleinController
             throw new InvalidArgumentException('`key` required', 400);
         }
 
-        if (!isset($filtered['value']) || !is_string($filtered['value'])) {
+        if (!isset($filtered['value']) ||
+            (!is_string($filtered['value']) && !is_array($filtered['value']))
+        ) {
             throw new InvalidArgumentException('`value` required', 400);
         }
 

--- a/tests/unit/Core/Controllers/UserV2ControllerTest.php
+++ b/tests/unit/Core/Controllers/UserV2ControllerTest.php
@@ -225,6 +225,39 @@ class UserV2ControllerTest extends AbstractTest
     /**
      * @throws ReflectionException
      * @throws InvalidArgumentException
+     * @throws PDOException
+     * @throws PHPUnitException
+     */
+    #[Test]
+    public function setMetadata_returns_metadata_struct_payload_on_success_with_array_value(): void
+    {
+        $this->setBody(['key' => 'preferences', 'value' => ['theme' => 'dark', 'notifications' => 'enabled']]);
+
+        $captured = [];
+        $this->responseMock->method('json')
+            ->willReturnCallback(function (mixed $data) use (&$captured) {
+                $captured[] = $data;
+                return $this->responseMock;
+            });
+
+        $this->controller->setMetadata();
+
+        $conn = $this->seedConnection();
+        $conn->exec("DELETE FROM user_metadata WHERE uid = " . $this->userId(self::BASE));
+
+        $this->assertCount(1, $captured, 'setMetadata must emit exactly one json payload');
+        $payload = $captured[0];
+        $this->assertInstanceOf(MetadataStruct::class, $payload);
+        $this->assertSame((string) $this->userId(self::BASE), (string) $payload->uid);
+        $this->assertSame('preferences', $payload->key);
+        $this->assertIsArray($payload->value);
+        $this->assertSame('dark', $payload->value['theme']);
+        $this->assertSame('enabled', $payload->value['notifications']);
+    }
+
+    /**
+     * @throws ReflectionException
+     * @throws InvalidArgumentException
      */
     #[Test]
     public function setMetadata_throws_when_key_missing(): void


### PR DESCRIPTION
## Summary

`UserController::setMetadata()` rejected any `value` that wasn't a string, even though
`Model\Users\MetadataDao::set()` is typed `array|string` and already handles arrays
(serializing them before persisting). This widens the controller's validation to accept
arrays too, so JSON-object payloads for `value` are no longer incorrectly rejected with a
400 `` `value` required `` error.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Controller/API/V2/UserController.php` | Widen `setMetadata` value validation to accept `array` in addition to `string` |
| `tests/unit/Core/Controllers/UserV2ControllerTest.php` | Add regression test covering a successful array-value payload |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Ran the full `UserV2ControllerTest` suite (including the new
`setMetadata_returns_metadata_struct_payload_on_success_with_array_value` test) inside the
project's Docker test environment — all tests pass.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

None.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216229311087906