### PR TITLE
🐛 fix(lqa): update qa_chunk_reviews counters when no lqa model is resolved

### DIFF
--- a/lib/Model/LQA/ChunkReviewDao.php
+++ b/lib/Model/LQA/ChunkReviewDao.php
@@ -604,10 +604,13 @@ class ChunkReviewDao extends AbstractDao
         $chunkReview = $data['chunkReview'];
         $project = $chunkReview->getChunk(new JobDao($this->database))->getProject(new ProjectDao($this->database));
         $lqaModel = $project->id_qa_model !== null ? (new ModelDao($this->database))->findById($project->id_qa_model) : null;
-        if ($lqaModel === null) {
-            return;
-        }
-        $data['force_pass_at'] = ReviewUtils::filterLQAModelLimit($lqaModel, $chunkReview->source_page);
+
+        // No QA model resolvable (unset or stale id) -> no threshold to gate against, always pass;
+        // still update penalty_points/reviewed_words_count/total_tte below (mirrors
+        // ChunkReviewModel::recountAndUpdatePassFailResult()'s is_pass = true fallback).
+        $data['force_pass_at'] = $lqaModel !== null
+            ? ReviewUtils::filterLQAModelLimit($lqaModel, $chunkReview->source_page)
+            : PHP_INT_MAX;
 
         // in MySQL a sum of a null value to an integer returns 0
         // in MySQL, division by zero returns NULL, so we have to coalesce null values from is_pass division

--- a/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php
+++ b/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php
@@ -415,28 +415,86 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
     }
 
     #[Test]
-    public function passFailCountsAtomicUpdate_returns_early_when_no_qa_model(): void
+    public function passFailCountsAtomicUpdate_updates_counters_and_forces_pass_when_no_qa_model(): void
     {
-        // project without a qa model -> lqaModel null -> no INSERT.
+        // project without a qa model -> lqaModel null -> counters still written, is_pass forced to 1.
+        //
+        // The chunk review row is pre-created via createRecord() first, exactly like production
+        // does when a review round starts: passFailCountsAtomicUpdate's INSERT then collides on
+        // the (id_job, password, source_page) unique key and takes the ON DUPLICATE KEY UPDATE
+        // branch, which is the only branch that actually computes is_pass (it is not part of the
+        // plain INSERT column list).
         $project = $this->fixtures->makeProjectDetailed();
         $job = $this->fixtures->makeJob($project['id'], ['password' => 'pf_null', 'owner' => $this->ownerEmail]);
+
+        $created = $this->dao->createRecord([
+            'id_project'  => $project['id'],
+            'id_job'      => $job['id'],
+            'password'    => 'pf_null',
+            'source_page' => SourcePages::SOURCE_PAGE_REVISION,
+        ]);
+        $this->fixtures->trackExisting('qa_chunk_reviews', ['id' => $created->id]);
 
         $chunkReview = new ChunkReviewStruct();
         $chunkReview->id_job = $job['id'];
         $chunkReview->id_project = $project['id'];
         $chunkReview->password = 'pf_null';
-        $chunkReview->review_password = 'pf_null_rev';
+        $chunkReview->review_password = $created->review_password;
         $chunkReview->source_page = SourcePages::SOURCE_PAGE_REVISION;
 
-        $chunkReviewId = self::ASSIGNABLE_ID_FLOOR + 7001;
-        $this->dao->passFailCountsAtomicUpdate($chunkReviewId, [
+        $this->dao->passFailCountsAtomicUpdate($created->id, [
             'chunkReview'          => $chunkReview,
+            'penalty_points'       => 12,
             'reviewed_words_count' => 100,
             'total_tte'            => 500,
         ]);
 
-        // early return -> nothing written.
-        $this->assertNull($this->dao->findById($chunkReviewId));
+        $row = $this->dao->findById($created->id);
+        $this->assertInstanceOf(ChunkReviewStruct::class, $row);
+        $this->assertSame(12, (int)$row->penalty_points);
+        $this->assertSame(100, $row->reviewed_words_count);
+        $this->assertSame(500, $row->total_tte);
+        $this->assertSame(1, (int)$row->is_pass);
+    }
+
+    #[Test]
+    public function passFailCountsAtomicUpdate_updates_counters_and_forces_pass_when_qa_model_is_stale(): void
+    {
+        // id_qa_model points at a non-existent qa_models row -> ModelDao::findById returns null,
+        // same forced-pass fallback as the no-model case must apply even though the score
+        // (30 points / 100 words * 1000 = 300) would fail any real limit.
+        $project = $this->fixtures->makeProjectDetailed();
+        $staleModelId = self::ASSIGNABLE_ID_FLOOR + 999999;
+        $this->realSqlDb()->getConnection()
+            ->exec("UPDATE projects SET id_qa_model = {$staleModelId} WHERE id = {$project['id']}");
+        $job = $this->fixtures->makeJob($project['id'], ['password' => 'pf_stale', 'owner' => $this->ownerEmail]);
+
+        $created = $this->dao->createRecord([
+            'id_project'  => $project['id'],
+            'id_job'      => $job['id'],
+            'password'    => 'pf_stale',
+            'source_page' => SourcePages::SOURCE_PAGE_REVISION,
+        ]);
+        $this->fixtures->trackExisting('qa_chunk_reviews', ['id' => $created->id]);
+
+        $chunkReview = new ChunkReviewStruct();
+        $chunkReview->id_job = $job['id'];
+        $chunkReview->id_project = $project['id'];
+        $chunkReview->password = 'pf_stale';
+        $chunkReview->review_password = $created->review_password;
+        $chunkReview->source_page = SourcePages::SOURCE_PAGE_REVISION;
+
+        $this->dao->passFailCountsAtomicUpdate($created->id, [
+            'chunkReview'          => $chunkReview,
+            'penalty_points'       => 30,
+            'reviewed_words_count' => 100,
+            'total_tte'            => 500,
+        ]);
+
+        $row = $this->dao->findById($created->id);
+        $this->assertInstanceOf(ChunkReviewStruct::class, $row);
+        $this->assertSame(30, (int)$row->penalty_points);
+        $this->assertSame(1, (int)$row->is_pass);
     }
 
     #[Test]

--- a/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php
+++ b/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php
@@ -425,7 +425,7 @@ class ChunkReviewDaoTest extends AbstractTest
     }
 
     #[Test]
-    public function passFailCountsAtomicUpdateReturnsEarlyWhenLqaModelIsNull(): void
+    public function passFailCountsAtomicUpdateStillUpdatesCountersWhenLqaModelIsNull(): void
     {
         $projectStub = $this->createStub(ProjectStruct::class);
         $projectStub->id_qa_model = null;
@@ -436,16 +436,23 @@ class ChunkReviewDaoTest extends AbstractTest
         $chunkReview = $this->createStub(ChunkReviewStruct::class);
         $chunkReview->method('getChunk')->willReturn($chunkStub);
         $chunkReview->source_page = 2;
+        $chunkReview->id_job = 5;
+        $chunkReview->id_project = 1;
+        $chunkReview->password = 'p';
+        $chunkReview->review_password = 'rp';
 
         $stmtMock = $this->createMock(PDOStatement::class);
         $stmtMock->queryString = '';
-        $stmtMock->expects($this->never())->method('execute');
+        $stmtMock->expects($this->once())->method('execute')->willReturn(true);
 
-        $pdoStub = $this->createStub(PDO::class);
-        $pdoStub->method('prepare')->willReturn($stmtMock);
+        $pdoMock = $this->createMock(PDO::class);
+        $pdoMock->expects($this->once())
+            ->method('prepare')
+            ->with($this->stringContains((string)PHP_INT_MAX))
+            ->willReturn($stmtMock);
 
         $dbStub = $this->createStub(IDatabase::class);
-        $dbStub->method('getConnection')->willReturn($pdoStub);
+        $dbStub->method('getConnection')->willReturn($pdoMock);
 
         $this->setDatabaseInstance($dbStub);
 


### PR DESCRIPTION
## Summary

After a recent deploy, `qa_chunk_reviews` sometimes stopped reflecting new LQA
issues (e.g. adding 3 issues left `penalty_points=0`, `is_pass=1`). The cause
was a silent early return in `ChunkReviewDao::passFailCountsAtomicUpdate()`
whenever the project's LQA model couldn't be resolved (unset or stale
`id_qa_model`), which skipped the whole counters update instead of just the
pass/fail threshold check.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Model/LQA/ChunkReviewDao.php` | Remove early return when no LQA model is resolved; default `force_pass_at` to `PHP_INT_MAX` so counters are always updated and `is_pass` is forced to pass |
| `tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php` | Rewrite the null-model test to assert the update now executes, instead of asserting the previous (buggy) early-return no-op |
| `tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php` | Rewrite the null-model real-DB test to assert counters/`is_pass` are written; add a new real-DB test for a stale/deleted `qa_model` id |

## Migration Notes

_No migrations involved._

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Ran inside the `matecat` container:
- `vendor/bin/phpunit tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php --no-coverage` → 70/70 passing
- `vendor/bin/phpstan analyse lib/Model/LQA/ChunkReviewDao.php --configuration=phpstan-no-baseline.neon` → 0 errors
- Full suite `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` → 8980 tests, only 4 pre-existing failures in `CommentControllerTest` (ActiveMQ broker-unavailable scenarios), unrelated to this change and reproducible on this branch's parent commit too

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

Root cause investigation traced the regression to a May 2026 PHPStan cleanup
commit that replaced a loud `TypeError` (when the LQA model was null) with a
silent early `return`. The fix mirrors the fallback already used in the
sibling method `ChunkReviewModel::recountAndUpdatePassFailResult()` (force
`is_pass` to pass when no model is available, but always update counters).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216293926363037