### PR TITLE
🐛 fix(qa): preserve decimal penalty points in chunk review updates

### DIFF
--- a/lib/Model/LQA/ChunkReviewDao.php
+++ b/lib/Model/LQA/ChunkReviewDao.php
@@ -595,7 +595,7 @@ class ChunkReviewDao extends AbstractDao
     /**
      *
      * @param int $chunkReviewID
-     * @param array{chunkReview: ChunkReviewStruct, penalty_points?: int, reviewed_words_count: int, total_tte: int} $data
+     * @param array{chunkReview: ChunkReviewStruct, penalty_points?: float, reviewed_words_count: int, total_tte: int} $data
      *
      * @throws Exception
      */

--- a/lib/Plugins/Features/ReviewExtended/ChunkReviewModel.php
+++ b/lib/Plugins/Features/ReviewExtended/ChunkReviewModel.php
@@ -94,7 +94,7 @@ class ChunkReviewModel implements IChunkReviewModel
     {
         $data = [
             'chunkReview' => $this->chunk_review,
-            'penalty_points' => (int)$penalty_points,
+            'penalty_points' => $penalty_points,
             'reviewed_words_count' => $reviewed_word_count,
             'total_tte' => $tte,
         ];
@@ -131,7 +131,7 @@ class ChunkReviewModel implements IChunkReviewModel
      * Used only by ChunkReviewModel::[subtractPenaltyPoints, addPenaltyPoints]
      *
      * @param ProjectStruct $project
-     * @param array{chunkReview: ChunkReviewStruct, penalty_points?: int, reviewed_words_count: int, total_tte: int} $data
+     * @param array{chunkReview: ChunkReviewStruct, penalty_points?: float, reviewed_words_count: int, total_tte: int} $data
      *
      * @throws Exception
      */

--- a/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php
+++ b/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php
@@ -480,4 +480,48 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
         $this->assertInstanceOf(ChunkReviewStruct::class, $updated);
         $this->assertSame(250, $updated->reviewed_words_count); // GREATEST(200 + 50)
     }
+
+    #[Test]
+    public function passFailCountsAtomicUpdate_preserves_decimal_penalty_points(): void
+    {
+        // regression: a (int) cast on penalty_points used to truncate 0.5 -> 0 before this INSERT.
+        $modelId = $this->makeQaModel('{"limit":[15,10]}');
+        $project = $this->fixtures->makeProjectDetailed();
+        $this->realSqlDb()->getConnection()
+            ->exec("UPDATE projects SET id_qa_model = {$modelId} WHERE id = {$project['id']}");
+        $job = $this->fixtures->makeJob($project['id'], ['password' => 'pf_dec', 'owner' => $this->ownerEmail]);
+
+        $chunkReview = new ChunkReviewStruct();
+        $chunkReview->id_job = $job['id'];
+        $chunkReview->id_project = $project['id'];
+        $chunkReview->password = 'pf_dec';
+        $chunkReview->review_password = 'pf_dec_rev';
+        $chunkReview->source_page = SourcePages::SOURCE_PAGE_REVISION;
+
+        $chunkReviewId = self::ASSIGNABLE_ID_FLOOR + 7003;
+        $this->fixtures->trackExisting('qa_chunk_reviews', ['id' => $chunkReviewId]);
+
+        $this->dao->passFailCountsAtomicUpdate($chunkReviewId, [
+            'chunkReview'          => $chunkReview,
+            'penalty_points'       => 0.5,
+            'reviewed_words_count' => 100,
+            'total_tte'            => 500,
+        ]);
+
+        $row = $this->dao->findById($chunkReviewId);
+        $this->assertInstanceOf(ChunkReviewStruct::class, $row);
+        $this->assertSame(0.5, $row->penalty_points);
+
+        // a second decimal addition should accumulate, not stay truncated at 0.
+        $this->dao->passFailCountsAtomicUpdate($chunkReviewId, [
+            'chunkReview'          => $chunkReview,
+            'penalty_points'       => 0.5,
+            'reviewed_words_count' => 0,
+            'total_tte'            => 0,
+        ]);
+
+        $updated = $this->dao->findById($chunkReviewId);
+        $this->assertInstanceOf(ChunkReviewStruct::class, $updated);
+        $this->assertSame(1.0, $updated->penalty_points);
+    }
 }

--- a/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php
+++ b/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php
@@ -527,6 +527,50 @@ class ChunkReviewDaoTest extends AbstractTest
     }
 
     #[Test]
+    public function passFailCountsAtomicUpdatePreservesDecimalPenaltyPoints(): void
+    {
+        // regression: penalty_points used to be (int)-cast upstream in ChunkReviewModel before
+        // reaching this DAO, truncating e.g. 0.5 -> 0. Assert the bound param stays a float here.
+        $lqaModel = $this->createStub(ModelStruct::class);
+        $lqaModel->method('getLimit')->willReturn([10]);
+
+        $projectStub = $this->createStub(ProjectStruct::class);
+        $projectStub->id_qa_model = 1;
+
+        $chunkStub = $this->createStub(JobStruct::class);
+        $chunkStub->method('getProject')->willReturn($projectStub);
+
+        $chunkReview = $this->createStub(ChunkReviewStruct::class);
+        $chunkReview->method('getChunk')->willReturn($chunkStub);
+        $chunkReview->source_page = 2;
+        $chunkReview->id_job = 5;
+        $chunkReview->id_project = 1;
+        $chunkReview->password = 'p';
+        $chunkReview->review_password = 'rp';
+
+        $capturedParams = null;
+        $this->stmtStub->method('execute')->willReturnCallback(function (array $params) use (&$capturedParams) {
+            if (array_key_exists('penalty_points', $params)) {
+                $capturedParams = $params;
+            }
+
+            return true;
+        });
+        $this->stmtStub->method('fetchAll')->willReturn([$lqaModel]);
+
+        $dao = new ChunkReviewDao($this->dbStub);
+        $dao->passFailCountsAtomicUpdate(101, [
+            'chunkReview'          => $chunkReview,
+            'penalty_points'       => 0.5,
+            'reviewed_words_count' => 200,
+            'total_tte'            => 1000,
+        ]);
+
+        $this->assertNotNull($capturedParams, 'execute() was never called with a penalty_points param');
+        $this->assertSame(0.5, $capturedParams['penalty_points']);
+    }
+
+    #[Test]
     public function destroyCacheForFindChunkReviewsDoesNotThrow(): void
     {
         $chunk = new JobStruct();

--- a/tests/unit/Core/Plugins/Features/ReviewExtended/ChunkReviewModelTest.php
+++ b/tests/unit/Core/Plugins/Features/ReviewExtended/ChunkReviewModelTest.php
@@ -245,14 +245,58 @@ class ChunkReviewModelTest extends AbstractTest
     }
 
     #[Test]
-    public function updateChunkReviewCountersAndPassFailCastsPenaltyPointsToInt(): void
+    public function updateChunkReviewCountersAndPassFailPreservesDecimalPenaltyPoints(): void
     {
-        $this->stmtStub->method('execute')->willReturn(true);
-        $this->stmtStub->method('fetchAll')->willReturn([]);
+        // regression: penalty_points used to be (int)-cast here, truncating 0.5 -> 0 before
+        // reaching the DAO's INSERT. A project with a null id_qa_model (like $this->nullLqaProject)
+        // makes passFailCountsAtomicUpdate return early without ever building that INSERT, so this
+        // test needs a resolvable qa model to actually reach the code path being fixed.
+        $lqaModel = new ModelStruct([
+            'pass_options' => json_encode(['limit' => [8, 5]]),
+            'pass_type'    => 'combined',
+            'label'        => 'test',
+            'create_date'  => '2024-01-01',
+            'hash'         => 'abc',
+        ]);
 
-        $model = new ChunkReviewModel($this->chunkReviewStruct, $this->dbStub);
-        $model->updateChunkReviewCountersAndPassFail(7.9, 10, 500, $this->nullLqaProject);
-        $this->assertTrue(true);
+        // passFailCountsAtomicUpdate() resolves its own project via
+        // $chunkReview->getChunk()->getProject() (NOT the $projectStruct passed to
+        // updateChunkReviewCountersAndPassFail), so the qa model must be reachable from there.
+        $project = new ProjectStruct();
+        $project->id = 10;
+        $project->id_qa_model = 1;
+
+        $jobStruct = new StubJobStruct([
+            'id'       => 1,
+            'password' => 'testpw',
+        ], $project);
+
+        $chunkReviewStruct = new StubChunkReviewStruct([
+            'id'                   => 42,
+            'id_project'           => 10,
+            'id_job'               => 1,
+            'password'             => 'testpw',
+            'review_password'      => 'rev_pw',
+            'source_page'          => 2,
+            'reviewed_words_count' => 100,
+            'total_tte'            => 0,
+        ], $jobStruct);
+
+        $capturedParams = null;
+        $this->stmtStub->method('execute')->willReturnCallback(function (array $params) use (&$capturedParams) {
+            if (array_key_exists('penalty_points', $params)) {
+                $capturedParams = $params;
+            }
+
+            return true;
+        });
+        $this->stmtStub->method('fetchAll')->willReturn([$lqaModel]);
+
+        $model = new ChunkReviewModel($chunkReviewStruct, $this->dbStub);
+        $model->updateChunkReviewCountersAndPassFail(0.5, 10, 500, $project);
+
+        $this->assertNotNull($capturedParams, 'execute() was never called with a penalty_points param');
+        $this->assertSame(0.5, $capturedParams['penalty_points']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Removes an `(int)` cast on `penalty_points` in `ChunkReviewModel::updateChunkReviewCountersAndPassFail()`
that silently truncated fractional LQA penalty points (e.g. `0.5` → `0`) before they reached the
DB, under/over-counting penalties and skewing the pass/fail score. `penalty_points` is a
`double(20,2)` column and `ChunkReviewStruct::$penalty_points` is `?float`, so decimals are valid.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `lib/Plugins/Features/ReviewExtended/ChunkReviewModel.php` | remove `(int)` cast on `penalty_points`; fix `penalty_points?: int` → `float` in array-shape docblock; drop unused `LoggerFactory` import |
| `lib/Model/LQA/ChunkReviewDao.php` | fix `penalty_points?: int` → `float` in `passFailCountsAtomicUpdate` array-shape docblock |
| `tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php` | add real-DB regression test round-tripping decimal `penalty_points` (0.5 → accumulates to 1.0) |
| `tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php` | add mocked-DB test asserting the bound `penalty_points` param stays a float |
| `tests/unit/Core/Plugins/Features/ReviewExtended/ChunkReviewModelTest.php` | fix a previously-broken test that used a null `id_qa_model` project and never actually reached the INSERT it claimed to test; now verifies the decimal is preserved end-to-end |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Ran the full suite in the `matecat` container: 8981 tests, 29126 assertions, 4 pre-existing
failures in `CommentControllerTest` (broker/ActiveMQ availability assertions), unrelated to this
change. Verified the new/updated tests actually catch the regression by temporarily reintroducing
the `(int)` cast — `ChunkReviewModelTest::updateChunkReviewCountersAndPassFailPreservesDecimalPenaltyPoints`
failed as expected, then restored the fix and re-confirmed green.

## AI Disclosure

- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

`MateCat-docs` submodule pointer and `tests/inc/config.local.ini` had pre-existing local changes
unrelated to this fix and were intentionally left out of this PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216293926363037