### PR TITLE
🐛 fix(project-creation): gate XLIFF alt-trans TM import behind flag and match-quality check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,34 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Matecat is an enterprise-level web-based Computer-Assisted Translation (CAT) tool. PHP 8.3+ backend with a React/Vite frontend. Uses Redis for caching, MySQL for persistence, and ActiveMQ for async job processing.
 
-## Commands
+## Architecture
 
-### Tests
+### PHP Autoloading
+
+PSR-4 root is `lib/` with empty namespace prefix. Classes in `lib/Controller/API/App/FooController.php` have namespace `Controller\API\App`. Plugin classes in `plugins/*/lib/` follow the same pattern (e.g., `Features\Translated`).
+
+### Directory Structure
+
+- `lib/Controller/` — HTTP controllers. `Abstracts/` contains the base chain: `KleinController` → `BaseKleinViewController` → concrete controllers
+- `lib/Model/` — Domain models, DAOs, structs. DAOs extend `AbstractDao` with `DaoCacheTrait` for Redis caching
+- `lib/Utils/` — Engines (MT/TM integrations), async workers, LQA, subfiltering, task runner
+- `lib/Plugins/Features/` — Internal features (ReviewExtended, TranslationVersions, SegmentFilter, ProjectCompletion)
+- `plugins/` — External plugin submodules (translated, airbnb, uber, aligner, vite). Each has `lib/Features/` with a class extending `BaseFeature`
+- `lib/Model/FeaturesBase/` — Event system. `Hook/Event/Filter/` for data-transforming events, `Hook/Event/Run/` for side-effect events. `FeatureSet` dispatches events to registered features
+
+### Engine Hierarchy
+
+`AbstractEngine` → concrete engines (MyMemory, MMT, DeepL, Lara, Google, etc.) → `Results/` response classes → `EnginesFactory`. Widest inheritance tree in the codebase.
+
+### Async Workers
+
+Workers in `lib/Utils/AsyncTasks/Workers/` process queued jobs via ActiveMQ. Key workers: `TMAnalysisWorker`, `GetContributionWorker`, `SetContributionWorker`, `FastAnalysis`, `ProjectCreationWorker`. Daemon entry points in `daemons/`.
+
+### DataAccess Layer
+
+`AbstractDao` → concrete DAOs. `DaoCacheTrait` provides Redis-backed caching with XFetch early recomputation. Structs extend `AbstractDaoObjectStruct` with `ArrayAccessTrait`. `ShapelessConcreteStruct` for untyped data.
+
+## Testing
 
 ```bash
 # Full test suite (excludes tests needing external services)
@@ -77,7 +102,11 @@ vendor/bin/phpunit --filter testMethodName --no-coverage
 XDEBUG_MODE=coverage vendor/bin/phpunit tests/unit/Path/To/TestFile.php --coverage-clover /tmp/coverage.xml
 ```
 
-### Static Analysis
+- Tests mirror source structure: `lib/Utils/Foo/Bar.php` → `tests/unit/Utils/Foo/BarTest.php`
+- Plugin tests: `plugins/*/tests/`
+- Predis `Client` uses `__call` magic for Redis commands — cannot be mocked with PHPUnit `createMock()`. Extend `Client` or mock `RedisHandler` instead
+
+## Static Analysis
 
 ```bash
 # Full codebase with baseline
@@ -87,54 +116,22 @@ vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress --error-fo
 vendor/bin/phpstan analyse path/to/File.php --configuration=phpstan-no-baseline.neon --no-progress --error-format=table
 ```
 
-### Frontend
-
-```bash
-yarn watch          # Dev server with HMR
-yarn build:dev      # Development build
-yarn build:production  # Production build
-```
-
-## Architecture
-
-### PHP Autoloading
-
-PSR-4 root is `lib/` with empty namespace prefix. Classes in `lib/Controller/API/App/FooController.php` have namespace `Controller\API\App`. Plugin classes in `plugins/*/lib/` follow the same pattern (e.g., `Features\Translated`).
-
-### Directory Structure
-
-- `lib/Controller/` — HTTP controllers. `Abstracts/` contains the base chain: `KleinController` → `BaseKleinViewController` → concrete controllers
-- `lib/Model/` — Domain models, DAOs, structs. DAOs extend `AbstractDao` with `DaoCacheTrait` for Redis caching
-- `lib/Utils/` — Engines (MT/TM integrations), async workers, LQA, subfiltering, task runner
-- `lib/Plugins/Features/` — Internal features (ReviewExtended, TranslationVersions, SegmentFilter, ProjectCompletion)
-- `plugins/` — External plugin submodules (translated, airbnb, uber). Each has `lib/Features/` with a class extending `BaseFeature`
-- `lib/Model/FeaturesBase/` — Event system. `Hook/Event/Filter/` for data-transforming events, `Hook/Event/Run/` for side-effect events. `FeatureSet` dispatches events to registered features
-
-### Engine Hierarchy
-
-`AbstractEngine` → concrete engines (MyMemory, MMT, DeepL, Lara, Google, etc.) → `Results/` response classes → `EnginesFactory`. Widest inheritance tree in the codebase.
-
-### Async Workers
-
-Workers in `lib/Utils/AsyncTasks/Workers/` process queued jobs via ActiveMQ. Key workers: `TMAnalysisWorker`, `GetContributionWorker`, `SetContributionWorker`, `FastAnalysis`, `ProjectCreationWorker`. Daemon entry points in `daemons/`.
-
-### DataAccess Layer
-
-`AbstractDao` → concrete DAOs. `DaoCacheTrait` provides Redis-backed caching with XFetch early recomputation. Structs extend `AbstractDaoObjectStruct` with `ArrayAccessTrait`. `ShapelessConcreteStruct` for untyped data.
-
-## PHPStan Configuration
+### PHPStan Configuration
 
 - Level 8 with `phpstan-baseline.neon` for known errors
 - `phpstan-no-baseline.neon` exists for verifying individual files are fully clean
 - `checkTooWideThrowTypesInProtectedAndPublicMethods: true` — must use precise exception types in `@throws`
 - `missingCheckedExceptionInThrows: true` — all thrown exceptions must be declared
 - `UnknownPropertyException` is unchecked (used by struct `ArrayAccessTrait`)
+- When adding exceptions to PHPDoc, prefer `use` imports over FQCN
 
-## API Testing
-When testing or calling HTTP/API endpoints, use the bruno-mcp MCP server first.
-Workflow: list_collections → list_requests → run_collection.
-Do not use curl or direct HTTP calls when Bruno collections exist. 
-Use `dev` environment for testing.
+## Frontend
+
+```bash
+yarn watch          # Dev server with HMR
+yarn build:dev      # Development build
+yarn build:production  # Production build
+```
 
 ## Git
 
@@ -146,6 +143,25 @@ Follow the project `.github/prompts/conventional-commit.prompt.md` for commit me
 - Use `git commit -a` (lowercase), never `-A`
 - 100 character line limit
 - Imperative mood, no capitalization, no period
+
+Follow the `.github/PULL_REQUEST_TEMPLATE.md` AND the `.github/scripts/pr-readiness-check.js` when creating a Pull Request.
+
+### Creating worktrees
+
+When creating worktrees, those commands MUST be used:
+
+- `cd <project-root> && git branch --show-current`
+- `git branch <branch-name> <current-branch-name>`
+- `git worktree add ../matecat-<branch-name> <branch-name>`
+- `cp composer.phar ../matecat-<branch-name>/composer.phar`
+- `cd ../matecat-<branch-name>/ && php composer.phar install`
+- `git submodule update --init --recursive`
+
+## API Testing
+When testing or calling HTTP/API endpoints, use the bruno-mcp MCP server first.
+Workflow: list_collections → list_requests → run_collection.
+Do not use curl or direct HTTP calls when Bruno collections exist.
+Use `dev` environment for testing.
 
 ## MCP Tools: code-review-graph
 
@@ -160,21 +176,3 @@ Follow the project `.github/prompts/conventional-commit.prompt.md` for commit me
 | `query_graph`               | Tracing callers, callees, imports, tests            |
 | `semantic_search_nodes`     | Finding functions/classes by name or keyword        |
 | `get_architecture_overview` | Understanding high-level codebase structure         |
-
-## Key Conventions
-
-- When adding exceptions to PHPDoc, prefer `use` imports over FQCN
-- Tests mirror source structure: `lib/Utils/Foo/Bar.php` → `tests/unit/Utils/Foo/BarTest.php`
-- Plugin tests: `plugins/*/tests/`
-- Predis `Client` uses `__call` magic for Redis commands — cannot be mocked with PHPUnit `createMock()`. Extend `Client` or mock `RedisHandler` instead
-
-# Creating worktrees
-
-When creating worktrees, those commands MUST be used:
-
-- `cd <project-root> && git branch --show-current`
-- `git branch <branch-name> <current-branch-name>`
-- `git worktree add ../matecat-<branch-name> <branch-name>`
-- `cp composer.phar ../matecat-<branch-name>/composer.phar`
-- `cd ../matecat-<branch-name>/ && php composer.phar install`
-- `git submodule update --init --recursive`

--- a/lib/Model/Conversion/Filters.php
+++ b/lib/Model/Conversion/Filters.php
@@ -9,6 +9,8 @@ use Model\FilesStorage\AbstractFilesStorage;
 use Model\Filters\DTO\IDto;
 use Model\Jobs\JobStruct;
 use PDO;
+use Psr\Log\InvalidArgumentException;
+use RuntimeException;
 use Utils\Logger\LoggerFactory;
 use Utils\Network\MultiCurlHandler;
 use Utils\Registry\AppConfig;
@@ -27,8 +29,8 @@ class Filters
      *
      * @return array<int|string, array<string, mixed>>
      *
-     * @throws \Psr\Log\InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
      */
     protected function sendToFilters(array $dataGroups, string $endpoint): array
     {
@@ -165,8 +167,8 @@ class Filters
      *
      * @return mixed
      *
-     * @throws \Psr\Log\InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
      */
     public function sourceToXliff(
         string $filePath,
@@ -218,8 +220,8 @@ class Filters
      *
      * @return array<int|string, array<string, mixed>>
      *
-     * @throws \Psr\Log\InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
      */
     public function xliffToTarget(array $xliffsData): array
     {
@@ -382,7 +384,7 @@ class Filters
      *
      * @param string $sentFile
      *
-     * @throws \Psr\Log\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     protected function backupFailedConversion(string &$sentFile): void
     {

--- a/lib/Model/ProjectCreation/SegmentExtractor.php
+++ b/lib/Model/ProjectCreation/SegmentExtractor.php
@@ -922,7 +922,7 @@ class SegmentExtractor
      *
      * @throws Exception
      */
-    private function manageAlternativeTranslations(array $xliff_trans_unit, ?array $xliff_file_attributes): void
+    protected function manageAlternativeTranslations(array $xliff_trans_unit, ?array $xliff_file_attributes): void
     {
         $privateTmKeys = $this->config->private_tm_key;
 
@@ -931,13 +931,15 @@ class SegmentExtractor
             !isset($xliff_trans_unit['alt-trans']) ||
             empty($xliff_file_attributes['source-language']) ||
             empty($xliff_file_attributes['target-language']) ||
-            empty($privateTmKeys)
+            empty($privateTmKeys) ||
+            // feature is off by default: do not import XLIFF alt-trans into the private TM
+            AppConfig::$IMPORT_ALT_TRANS_FROM_XLIFF === false
         ) {
             return;
         }
 
         // set the contribution for every key in the job belonging to the user
-        $engine = EnginesFactory::getInstance(1, $this->dbHandler, MyMemory::class);
+        $engine = $this->getPrivateTmEngine();
         $config = $engine->getConfigStruct();
 
         foreach ($privateTmKeys as $tm_info) {
@@ -953,7 +955,12 @@ class SegmentExtractor
         $configsList = [];
 
         foreach ($xliff_trans_unit['alt-trans'] as $altTrans) {
-            if (!empty($altTrans['attr']['match-quality']) && (float)$altTrans['attr']['match-quality'] < 50) {
+            // Only import an alt-trans with a usable match-quality of at least 50%.
+            // Skip when the attribute is absent — the external filters converter drops
+            // match-quality when it is 0% or non-numeric (e.g. "high"/"xhigh"), so a missing
+            // value must not be treated as a valid match — and when it is present but < 50
+            // (a bare "0" also lands here via the < 50 branch).
+            if (!isset($altTrans['attr']['match-quality']) || (float)$altTrans['attr']['match-quality'] < 50) {
                 continue;
             }
 
@@ -1008,5 +1015,16 @@ class SegmentExtractor
         if (!empty($configsList)) {
             $engine->setMulti($configsList);
         }
+    }
+
+    /**
+     * Resolve the MyMemory engine used to push alt-trans contributions to the private TM.
+     * Isolated as a seam so it can be overridden in tests.
+     *
+     * @throws Exception
+     */
+    protected function getPrivateTmEngine(): MyMemory
+    {
+        return EnginesFactory::getInstance(1, $this->dbHandler, MyMemory::class);
     }
 }

--- a/lib/Utils/Registry/AppConfig.php
+++ b/lib/Utils/Registry/AppConfig.php
@@ -224,6 +224,12 @@ class AppConfig
      */
     public static string $MYMEMORY_TM_API_KEY = 'tmanalysis@matecat.com';
 
+
+    /**
+     * Enable or disable the import of alternative translations from XLIFF files.
+     */
+    public static bool $IMPORT_ALT_TRANS_FROM_XLIFF = false;
+
     /**
      * Default key used to call the TM Server on an Import TMX panel
      * @var string

--- a/tests/unit/Core/Model/ProjectCreation/ManageAlternativeTranslationsTest.php
+++ b/tests/unit/Core/Model/ProjectCreation/ManageAlternativeTranslationsTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Matecat\Core\Model\ProjectCreation;
+
+use Matecat\SubFiltering\MateCatFilter;
+use Matecat\TestHelpers\AbstractTest;
+use Model\FeaturesBase\FeatureSet;
+use Model\Files\MetadataDao;
+use Model\ProjectCreation\ProjectStructure;
+use Utils\Engines\MyMemory;
+use Utils\Logger\MatecatLogger;
+use Utils\Registry\AppConfig;
+
+/**
+ * Covers SegmentExtractor::manageAlternativeTranslations() — the import of
+ * XLIFF <alt-trans> entries into the private TM.
+ *
+ * Focus of these tests (the recently changed behaviour):
+ *  - the AppConfig::$IMPORT_ALT_TRANS_FROM_XLIFF feature flag (off by default);
+ *  - the match-quality guard `!isset(...) || (float)... < 50`, which must skip
+ *    an alt-trans whose match-quality is absent (the external filters converter
+ *    strips it when it is 0% or non-numeric, e.g. "high"/"xhigh") or below 50.
+ *
+ * The engine is stubbed via TestableSegmentExtractor::setStubEngine(), so the
+ * behaviour is observed directly on MyMemory::setMulti(): an entry that survives
+ * every guard produces a setMulti() contribution; a skipped entry does not.
+ */
+class ManageAlternativeTranslationsTest extends AbstractTest
+{
+    private ProjectStructure $projectStructure;
+
+    /** @var array<string, mixed>|null */
+    private ?array $fileAttributes;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->projectStructure = new ProjectStructure([
+            'id_project'      => 42,
+            'source_language' => 'en-US',
+            // one writable private TM key so the "public area" guard passes
+            'private_tm_key'  => [['key' => 'test-private-key', 'r' => 1, 'w' => 1]],
+        ]);
+
+        $this->fileAttributes = [
+            'source-language' => 'en-US',
+            'target-language' => 'de-DE',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        // static flag: reset so the state never leaks into other tests
+        AppConfig::$IMPORT_ALT_TRANS_FROM_XLIFF = false;
+        parent::tearDown();
+    }
+
+    /**
+     * @param MyMemory $engine stub engine wired into the extractor
+     * @param MateCatFilter|null $filter optional filter override (defaults to a stub)
+     */
+    private function buildExtractor(MyMemory $engine, ?MateCatFilter $filter = null): TestableSegmentExtractor
+    {
+        $extractor = new TestableSegmentExtractor(
+            $this->projectStructure,
+            $filter ?? $this->createStub(MateCatFilter::class),
+            $this->createStub(FeatureSet::class),
+            $this->createStub(MetadataDao::class),
+            $this->createStub(MatecatLogger::class),
+        );
+        $extractor->setStubEngine($engine);
+
+        return $extractor;
+    }
+
+    /**
+     * A stub engine whose getConfigStruct() returns an empty config array.
+     */
+    private function stubEngine(): MyMemory
+    {
+        $engine = $this->createMock(MyMemory::class);
+        $engine->method('getConfigStruct')->willReturn([]);
+
+        return $engine;
+    }
+
+    /**
+     * @param string $matchQuality
+     * @return array<string, mixed>
+     */
+    private function transUnitWithMatchQuality(string $matchQuality): array
+    {
+        return [
+            'source'    => ['raw-content' => 'A system for automated oven configuration.'],
+            'alt-trans' => [
+                [
+                    'attr'   => ['match-quality' => $matchQuality],
+                    'source' => 'A system for automated oven configuration.',
+                    'target' => 'Ein System zur automatisierten Ofenkonfiguration.',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Feature disabled (the default): the method must return before resolving the
+     * engine, so setMulti() is never called even for a valid high-quality alt-trans.
+     */
+    public function testDisabledByFeatureFlagImportsNothing(): void
+    {
+        AppConfig::$IMPORT_ALT_TRANS_FROM_XLIFF = false;
+
+        $engine = $this->stubEngine();
+        $engine->expects($this->never())->method('setMulti');
+
+        $this->buildExtractor($engine)
+            ->callManageAlternativeTranslations($this->transUnitWithMatchQuality('90'), $this->fileAttributes);
+    }
+
+    /**
+     * Flag on, but the alt-trans has no match-quality attribute (the converter
+     * drops it for 0% / non-numeric values): the `!isset` branch must skip it.
+     */
+    public function testAltTransWithoutMatchQualityIsSkipped(): void
+    {
+        AppConfig::$IMPORT_ALT_TRANS_FROM_XLIFF = true;
+
+        $engine = $this->stubEngine();
+        $engine->expects($this->never())->method('setMulti');
+
+        $transUnit = [
+            'source'    => ['raw-content' => 'A system for automated oven configuration.'],
+            'alt-trans' => [
+                [
+                    // no 'match-quality' key at all
+                    'attr'   => ['extype' => 'MACHINE-TRANSLATION'],
+                    'source' => 'A system for automated oven configuration.',
+                    'target' => 'Ein System zur automatisierten Ofenkonfiguration.',
+                ],
+            ],
+        ];
+
+        $this->buildExtractor($engine)
+            ->callManageAlternativeTranslations($transUnit, $this->fileAttributes);
+    }
+
+    /**
+     * Flag on, match-quality present but below the 50 threshold: the `< 50`
+     * branch must skip it.
+     */
+    public function testAltTransBelowThresholdIsSkipped(): void
+    {
+        AppConfig::$IMPORT_ALT_TRANS_FROM_XLIFF = true;
+
+        $engine = $this->stubEngine();
+        $engine->expects($this->never())->method('setMulti');
+
+        $this->buildExtractor($engine)
+            ->callManageAlternativeTranslations($this->transUnitWithMatchQuality('30'), $this->fileAttributes);
+    }
+
+    /**
+     * A bare "0" (PHP empty("0") === true) must also be skipped by the `< 50`
+     * branch — the reason the guard uses `!isset || < 50` rather than `!empty`.
+     */
+    public function testAltTransWithZeroMatchQualityIsSkipped(): void
+    {
+        AppConfig::$IMPORT_ALT_TRANS_FROM_XLIFF = true;
+
+        $engine = $this->stubEngine();
+        $engine->expects($this->never())->method('setMulti');
+
+        $this->buildExtractor($engine)
+            ->callManageAlternativeTranslations($this->transUnitWithMatchQuality('0'), $this->fileAttributes);
+    }
+
+    /**
+     * A match-quality >= 50 passes the guard and is submitted to the TM engine.
+     * The contribution must carry the segment/translation (filtered to layer 0)
+     * and the match-quality inside its serialized 'prop'.
+     */
+    public function testAltTransAtOrAboveThresholdIsImported(): void
+    {
+        AppConfig::$IMPORT_ALT_TRANS_FROM_XLIFF = true;
+
+        $filter = $this->createStub(MateCatFilter::class);
+        $filter->method('fromRawXliffToLayer0')->willReturnArgument(0);
+
+        $engine = $this->stubEngine();
+        $engine->expects($this->once())
+            ->method('setMulti')
+            ->with($this->callback(function (array $configsList): bool {
+                $this->assertCount(1, $configsList);
+                $contribution = $configsList[0];
+                $this->assertSame('A system for automated oven configuration.', $contribution['segment']);
+                $this->assertSame('Ein System zur automatisierten Ofenkonfiguration.', $contribution['translation']);
+                $this->assertSame('{"match-quality":"75"}', $contribution['prop']);
+
+                return true;
+            }));
+
+        $this->buildExtractor($engine, $filter)
+            ->callManageAlternativeTranslations($this->transUnitWithMatchQuality('75'), $this->fileAttributes);
+    }
+}

--- a/tests/unit/Core/Model/ProjectCreation/TestableSegmentExtractor.php
+++ b/tests/unit/Core/Model/ProjectCreation/TestableSegmentExtractor.php
@@ -10,6 +10,7 @@ use Model\Files\MetadataDao;
 use Model\ProjectCreation\ProjectStructure;
 use Model\ProjectCreation\SegmentExtractor;
 use Model\Segments\SegmentMetadataMapper;
+use Utils\Engines\MyMemory;
 use Utils\Logger\MatecatLogger;
 
 /**
@@ -49,5 +50,34 @@ class TestableSegmentExtractor extends SegmentExtractor
             $position,
             $projectStructure,
         );
+    }
+
+    /**
+     * Public wrapper for the protected manageAlternativeTranslations().
+     *
+     * @param array<string, mixed> $xliff_trans_unit
+     * @param array<string, mixed>|null $xliff_file_attributes
+     *
+     * @throws Exception
+     */
+    public function callManageAlternativeTranslations(array $xliff_trans_unit, ?array $xliff_file_attributes): void
+    {
+        $this->manageAlternativeTranslations($xliff_trans_unit, $xliff_file_attributes);
+    }
+
+    private ?MyMemory $stubEngine = null;
+
+    /**
+     * Inject a stub engine so manageAlternativeTranslations() can run without a
+     * database-backed EnginesFactory lookup.
+     */
+    public function setStubEngine(MyMemory $engine): void
+    {
+        $this->stubEngine = $engine;
+    }
+
+    protected function getPrivateTmEngine(): MyMemory
+    {
+        return $this->stubEngine ?? parent::getPrivateTmEngine();
     }
 }


### PR DESCRIPTION
## Summary

XLIFF `<alt-trans>` entries without a numeric `match-quality` were being imported into the private TM. Foreign XLIFFs are converted by the external filters service (`original2xliff`), which **drops `match-quality` when it is `0%` or non-numeric** (e.g. `high`/`xhigh`) and strips the `%` from numeric values. The existing `< 50` filter is a no-op on a `null` value, so those zero/low-quality MT suggestions leaked into the private TM with a `null` prop.

This PR gates the whole feature behind a flag (off by default) and hardens the per-entry guard.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Utils/Registry/AppConfig.php` | add `$IMPORT_ALT_TRANS_FROM_XLIFF` (default `false`) to disable XLIFF alt-trans → private TM import |
| `lib/Model/ProjectCreation/SegmentExtractor.php` | gate `manageAlternativeTranslations()` behind the flag; skip an alt-trans unless `match-quality` is set and `>= 50` (also catches a bare `"0"`); extract `getPrivateTmEngine()` as a test seam; add explanatory comments |
| `lib/Model/Conversion/Filters.php` | import `@throws` exception classes instead of FQCN (no behavior change) |
| `tests/unit/Core/Model/ProjectCreation/ManageAlternativeTranslationsTest.php` | new — flag off, `!isset`, `< 50`, bare `"0"`, and `>= 50` → `setMulti` with `prop` |
| `tests/unit/Core/Model/ProjectCreation/TestableSegmentExtractor.php` | expose `manageAlternativeTranslations()` + `setStubEngine()` seam |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite: `OK (8994 tests, 29146 assertions)`. New `ManageAlternativeTranslationsTest`: `OK (5 tests, 10 assertions)`. Root cause reproduced against the live dev filters server (`original2xliff`): `match-quality` `0%`/`high`/`xhigh` dropped, `65%`→`65`, `77`→`77`.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-4-8)

## Notes

The `<target state="translated">` pre-translation path is unaffected — it only writes `segment_translations` and is never pushed to the TM. The only TM-write in `SegmentExtractor` is the alt-trans `setMulti`, which this PR guards. The `CLAUDE.md` change on this branch also carries a pre-existing tooling restructure of that file plus a `lugin` → `Plugin` typo fix.
