### PR TITLE
🐛 fix(tm-analysis): finalize projects stuck at FAST_OK from the last-segment completion race

### DIFF
--- a/lib/Utils/AsyncTasks/Workers/Analysis/RedisKeys.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/RedisKeys.php
@@ -72,4 +72,13 @@ class RedisKeys
      */
     const int WORD_COUNT_SCALE = 1000;
 
+    /**
+     * Key (Redis SET) holding the ids of segments already counted as analyzed for a project.
+     * Makes the analyzed-count increment idempotent: the retry loop in
+     * applyPostCommitSideEffects can re-run the increment for the same segment without
+     * inflating PROJECT_NUM_SEGMENTS_DONE past PROJECT_TOT_SEGMENTS (which used to trigger
+     * the completion close prematurely and strand projects at FAST_OK).
+     */
+    const string PROJECT_ANALYZED_SEGMENTS_SET = 'p_analyzed_seg:';
+
 }

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Interface/AnalysisRedisServiceInterface.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Interface/AnalysisRedisServiceInterface.php
@@ -17,6 +17,12 @@ interface AnalysisRedisServiceInterface
     public function acquireInitLock(int $pid): bool;
 
     /**
+     * Release the init semaphore eagerly so the next worker can re-attempt init
+     * without waiting out the lock TTL. Called on failed/incomplete doInit().
+     */
+    public function releaseInitLock(int $pid): void;
+
+    /**
      * Atomically initialize all project counters in a single MULTI/EXEC transaction.
      * Writes PROJECT_TOT_SEGMENTS first, PROJECT_NUM_SEGMENTS_DONE last.
      */
@@ -34,7 +40,7 @@ interface AnalysisRedisServiceInterface
      */
     public function waitForInitialization(int $pid, int $maxWaitMs = 5000): bool;
 
-    public function incrementAnalyzedCount(int $pid, int $numSegments, float $eqWc, float $stWc): void;
+    public function incrementAnalyzedCount(int $pid, int $idSegment, float $eqWc, float $stWc): void;
 
     public function setProjectAnalyzedCountTTL(int $pid, int $ttlSeconds = 86400): void;
 

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/AnalysisRedisService.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/AnalysisRedisService.php
@@ -12,6 +12,26 @@ use Utils\Logger\LoggerFactory;
 
 class AnalysisRedisService implements AnalysisRedisServiceInterface
 {
+    /**
+     * TTL of the per-project init semaphore. Must exceed the worst-case duration of
+     * doInit() so a slow-but-alive winner is never overtaken by a re-init. A crashed
+     * winner's lock self-heals after this window; a winner that fails cleanly releases
+     * it eagerly via releaseInitLock().
+     */
+    private const INIT_LOCK_TTL_SECONDS = 30;
+
+    /**
+     * TTL of the per-project completion semaphore. The lock is held across the WHOLE
+     * finalization critical section: the gate-retry loop, the DB transaction, the
+     * per-job word-count loops, cache invalidation and removeProjectFromQueue. That is a
+     * seconds-long burst whose duration scales with the JOB count — NOT the multi-minute
+     * analysis itself, which does not hold this lock. 300s gives a wide margin over that
+     * burst even for large multi-job projects, while still letting a worker crashed mid
+     * critical-section self-heal in ~5min (vs the old 24h) so finalization is never
+     * blocked for long.
+     */
+    private const COMPLETION_LOCK_TTL_SECONDS = 300;
+
     private Client $redis;
 
     /**
@@ -33,9 +53,19 @@ class AnalysisRedisService implements AnalysisRedisServiceInterface
         return (bool)$this->redis->set(
             RedisKeys::PROJECT_INIT_SEMAPHORE . $pid,
             1,
-            'EX', 30,
+            'EX', self::INIT_LOCK_TTL_SECONDS,
             'NX'
         );
+    }
+
+    /**
+     * Release the init semaphore eagerly. Called when doInit() fails or finds the
+     * segment count not yet available, so the next worker for this PID can re-attempt
+     * initialization immediately instead of waiting out the TTL.
+     */
+    public function releaseInitLock(int $pid): void
+    {
+        $this->redis->del(RedisKeys::PROJECT_INIT_SEMAPHORE . $pid);
     }
 
     /**
@@ -48,10 +78,18 @@ class AnalysisRedisService implements AnalysisRedisServiceInterface
     public function initializeProjectCounters(int $pid, int $projectSegments, int $numAnalyzed): void
     {
         $this->redis->transaction(function ($tx) use ($pid, $projectSegments, $numAnalyzed) {
+            // Start each analysis run with an empty idempotency set, otherwise segment ids
+            // left over from a previous run of the same project (within the 24h TTL) would
+            // make incrementAnalyzedCount skip their increments and undercount this run.
+            $tx->del(RedisKeys::PROJECT_ANALYZED_SEGMENTS_SET . $pid);
             $tx->setex(RedisKeys::PROJECT_TOT_SEGMENTS . $pid, 86400, $projectSegments);
-            $tx->incrby(RedisKeys::PROJ_EQ_WORD_COUNT . $pid, 0);
-            $tx->incrby(RedisKeys::PROJ_ST_WORD_COUNT . $pid, 0);
-            $tx->incrby(RedisKeys::PROJECT_NUM_SEGMENTS_DONE . $pid, $numAnalyzed);
+            // Absolute resets (not incrby): re-analysis of the same PID within the 24h TTL
+            // must not accumulate onto stale counters, otherwise a stale-high num_done keeps
+            // re-triggering the completion lock. On first init the key does not exist yet, so
+            // setex is equivalent to the old incrby-from-zero.
+            $tx->setex(RedisKeys::PROJ_EQ_WORD_COUNT . $pid, 86400, 0);
+            $tx->setex(RedisKeys::PROJ_ST_WORD_COUNT . $pid, 86400, 0);
+            $tx->setex(RedisKeys::PROJECT_NUM_SEGMENTS_DONE . $pid, 86400, $numAnalyzed);
         });
 
         $this->setProjectAnalyzedCountTTL($pid);
@@ -87,6 +125,15 @@ class AnalysisRedisService implements AnalysisRedisServiceInterface
             if ($tot !== null && $count !== null) {
                 return true;
             }
+
+            // The init semaphore is gone but the counters were never written: the winner
+            // abandoned initialization (failed doInit released the lock, or crashed and the
+            // TTL expired). Stop polling now so the caller re-acquires and re-inits, instead
+            // of blocking for the full maxWaitMs waiting on counters that will never arrive.
+            if (!$this->redis->exists(RedisKeys::PROJECT_INIT_SEMAPHORE . $pid)) {
+                return false;
+            }
+
             usleep($sleepMs * 1000);
             $waited  += $sleepMs;
             $sleepMs  = min($sleepMs * 2, 500);
@@ -98,15 +145,46 @@ class AnalysisRedisService implements AnalysisRedisServiceInterface
     }
 
     /**
+     * Idempotently record one analyzed segment: add $idSegment to the per-project set and,
+     * ONLY if it was not already present, bump the analyzed counter and word-count totals.
+     *
+     * Runs as a single Lua script, so it executes atomically server-side: on a connection
+     * error the whole script either ran or did not. The retry loop in
+     * applyPostCommitSideEffects can therefore re-invoke it with the same segment id without
+     * ever double-counting — the second SADD returns 0 and the INCRBYs are skipped. This
+     * keeps PROJECT_NUM_SEGMENTS_DONE from overshooting PROJECT_TOT_SEGMENTS, which used to
+     * trigger the completion close prematurely and strand projects at FAST_OK.
+     *
      * @throws Exception on Predis connection error
      */
-    public function incrementAnalyzedCount(int $pid, int $numSegments, float $eqWc, float $stWc): void
+    public function incrementAnalyzedCount(int $pid, int $idSegment, float $eqWc, float $stWc): void
     {
-        $this->redis->transaction(function ($tx) use ($pid, $numSegments, $eqWc, $stWc) {
-            $tx->incrby(RedisKeys::PROJ_EQ_WORD_COUNT . $pid, (int)($eqWc * RedisKeys::WORD_COUNT_SCALE));
-            $tx->incrby(RedisKeys::PROJ_ST_WORD_COUNT . $pid, (int)($stWc * RedisKeys::WORD_COUNT_SCALE));
-            $tx->incrby(RedisKeys::PROJECT_NUM_SEGMENTS_DONE . $pid, $numSegments);
-        });
+        static $script = <<<'LUA'
+            if redis.call('SADD', KEYS[1], ARGV[1]) == 1 then
+                redis.call('INCRBY', KEYS[2], ARGV[2])
+                redis.call('INCRBY', KEYS[3], ARGV[3])
+                redis.call('INCRBY', KEYS[4], ARGV[4])
+            end
+            redis.call('EXPIRE', KEYS[1], ARGV[5])
+            redis.call('EXPIRE', KEYS[2], ARGV[5])
+            redis.call('EXPIRE', KEYS[3], ARGV[5])
+            redis.call('EXPIRE', KEYS[4], ARGV[5])
+            return redis.call('SCARD', KEYS[1])
+            LUA;
+
+        $this->redis->eval(
+            $script,
+            4,
+            RedisKeys::PROJECT_ANALYZED_SEGMENTS_SET . $pid, // KEYS[1] idempotency set
+            RedisKeys::PROJECT_NUM_SEGMENTS_DONE . $pid,     // KEYS[2] analyzed counter
+            RedisKeys::PROJ_EQ_WORD_COUNT . $pid,            // KEYS[3] equivalent word count
+            RedisKeys::PROJ_ST_WORD_COUNT . $pid,            // KEYS[4] standard word count
+            (string)$idSegment,                              // ARGV[1]
+            '1',                                             // ARGV[2] analyzed delta
+            (string)(int)($eqWc * RedisKeys::WORD_COUNT_SCALE), // ARGV[3]
+            (string)(int)($stWc * RedisKeys::WORD_COUNT_SCALE), // ARGV[4]
+            '86400',                                         // ARGV[5] set TTL (matches counters)
+        );
     }
 
     public function setProjectAnalyzedCountTTL(int $pid, int $ttlSeconds = 86400): void
@@ -137,7 +215,7 @@ class AnalysisRedisService implements AnalysisRedisServiceInterface
         return (bool)$this->redis->set(
             RedisKeys::PROJECT_ENDING_SEMAPHORE . $pid,
             1,
-            'EX', 86400,
+            'EX', self::COMPLETION_LOCK_TTL_SECONDS,
             'NX'
         );
     }

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/ProjectCompletionService.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/ProjectCompletionService.php
@@ -2,6 +2,7 @@
 
 namespace Utils\AsyncTasks\Workers\Analysis\TMAnalysis\Service;
 
+use Closure;
 use Model\FeaturesBase\FeatureSet;
 use RuntimeException;
 use Throwable;
@@ -9,30 +10,70 @@ use Utils\AsyncTasks\Workers\Analysis\TMAnalysis\Interface\AnalysisRedisServiceI
 use Utils\AsyncTasks\Workers\Analysis\TMAnalysis\Interface\ProjectCompletionRepositoryInterface;
 use Utils\AsyncTasks\Workers\Analysis\TMAnalysis\Interface\ProjectCompletionServiceInterface;
 use Utils\Constants\ProjectStatus;
-use Utils\Logger\LoggerFactory;
 
 class ProjectCompletionService implements ProjectCompletionServiceInterface
 {
     private AnalysisRedisServiceInterface $redisService;
     private ProjectCompletionRepositoryInterface $repository;
 
+    /**
+     * Sink for completion log messages. Injected by the worker so these lines land in the
+     * analysis-queue log (via the worker's _doLog observer) alongside the rest of the
+     * analysis logs, instead of the global general_log.txt. Null → logging is skipped
+     * (e.g. isolated unit tests that don't assert on log output).
+     *
+     * @var (Closure(string): void)|null
+     */
+    private ?Closure $logger;
+
+    /**
+     * Number of times the DB-authoritative completion gate is polled before giving up.
+     * Injectable so tests can drive the exhaustion path without a real wait.
+     */
+    private int $maxGateRetries;
+
+    /**
+     * Microseconds slept between gate polls. Injectable so tests can pass 0 to avoid real sleeps.
+     */
+    private int $gateRetrySleepMicros;
+
+    /**
+     * @param AnalysisRedisServiceInterface $redisService
+     * @param ProjectCompletionRepositoryInterface $repository
+     * @param (Closure(string): void)|null $logger
+     * @param int $maxGateRetries
+     * @param int $gateRetrySleepMicros
+     */
     public function __construct(
         AnalysisRedisServiceInterface $redisService,
         ProjectCompletionRepositoryInterface $repository,
+        ?Closure $logger = null,
+        int $maxGateRetries = 6,
+        int $gateRetrySleepMicros = 1_000_000,
     ) {
         $this->redisService = $redisService;
         $this->repository = $repository;
+        $this->logger = $logger;
+        $this->maxGateRetries = $maxGateRetries;
+        $this->gateRetrySleepMicros = $gateRetrySleepMicros;
+    }
+
+    private function log(string $message): void
+    {
+        if ($this->logger !== null) {
+            ($this->logger)($message);
+        }
     }
 
     public function tryCloseProject(int $pid, string $projectPassword, string $queueKey, FeatureSet $featureSet): void
     {
         $projectTotals = $this->redisService->getProjectWordCounts($pid);
 
-        LoggerFactory::doJsonLog("--- trying to close project $pid: project_segments=" . ($projectTotals['project_segments'] ?? 'NULL'));
-        LoggerFactory::doJsonLog("--- trying to close project $pid: num_analyzed=" . ($projectTotals['num_analyzed'] ?? 'NULL'));
+        $this->log("--- trying to close project $pid: project_segments=" . ($projectTotals['project_segments'] ?? 'NULL'));
+        $this->log("--- trying to close project $pid: num_analyzed=" . ($projectTotals['num_analyzed'] ?? 'NULL'));
 
         if (empty($projectTotals['project_segments'])) {
-            LoggerFactory::doJsonLog("--- WARNING !!! error while counting segments in project $pid, skipping and continue");
+            $this->log("--- WARNING !!! error while counting segments in project $pid, skipping and continue");
             return;
         }
 
@@ -42,23 +83,63 @@ class ProjectCompletionService implements ProjectCompletionServiceInterface
             try {
                 // DB-authoritative gate: Redis triggered the close attempt, but MySQL
                 // is the source of truth. Verify all segments are actually DONE/SKIPPED
-                // before proceeding. This handles Redis/MySQL drift from issue #1
-                // (lost INCRBY after sustained Redis outage).
+                // before proceeding. This handles Redis/MySQL drift: a sustained Redis
+                // outage can lose an INCRBY, so the Redis counters can disagree with the
+                // real per-segment state in MySQL.
                 // Uses self-call to force master-read via transaction wrapper
                 // (ProxySQL routes reads outside transactions to slave).
-                $_full_report = $this->getProjectSegmentsTranslationSummary($pid);
-                $rollup       = array_pop($_full_report);
+                //
+                // Bounded gate-retry (last-segment race): with concurrent workers, the
+                // one holding this lock can read the gate a moment before another worker
+                // commits the truly-final segment, so it sees "segments remain". The
+                // other worker — whose commit actually completed the project — is denied
+                // this lock and drops its close attempt without retrying, and no segment
+                // is set DONE afterwards, so no later trigger ever fires: the project
+                // hangs at FAST_OK forever. Because we are the single lock holder, poll
+                // the gate for a short bounded window so the concurrent final commit can
+                // land, instead of releasing on a stale snapshot.
+                // getProjectSegmentsTranslationSummary is a heavy GROUP BY ... WITH ROLLUP
+                // over three joined tables, so poll sparingly: 6 checks 1s apart (~5s
+                // window). That covers realistic inter-worker commit skew while keeping
+                // master load to a few queries, and stays well under COMPLETION_LOCK_TTL
+                // (300s) so this holder is never evicted mid-retry. The first check runs
+                // immediately, so the common (no-drift) close path does a single query.
+                $maxAttempts = $this->maxGateRetries;
+                $sleepMicros = $this->gateRetrySleepMicros;
 
-                if ($rollup === null) {
-                    LoggerFactory::doJsonLog("--- WARNING: empty rollup for project $pid. Releasing lock.");
-                    $this->redisService->releaseCompletionLock($pid);
+                $rollup       = null;
+                $_full_report = [];
 
-                    return;
+                for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+                    $_full_report = $this->getProjectSegmentsTranslationSummary($pid);
+                    $rollup       = array_pop($_full_report);
+
+                    if ($rollup === null) {
+                        $this->log("--- WARNING: empty rollup for project $pid. Releasing lock.");
+                        $this->redisService->releaseCompletionLock($pid);
+
+                        return;
+                    }
+
+                    $dbRemaining = (int)$rollup['project_segments'] - (int)$rollup['num_analyzed'];
+                    if ($dbRemaining <= 0) {
+                        break; // MySQL confirms completion → finalize
+                    }
+
+                    if ($attempt === $maxAttempts) {
+                        $this->log("--- Redis triggered close for project $pid but MySQL still reports $dbRemaining segments after $maxAttempts checks. Releasing lock.");
+                        $this->redisService->releaseCompletionLock($pid);
+
+                        return;
+                    }
+
+                    usleep($sleepMicros);
                 }
 
-                $dbRemaining = (int)$rollup['project_segments'] - (int)$rollup['num_analyzed'];
-                if ($dbRemaining > 0) {
-                    LoggerFactory::doJsonLog("--- Redis triggered close for project $pid but MySQL says $dbRemaining segments remain. Releasing lock.");
+                // Defensive: the loop only leaves $rollup null if it never ran (a
+                // misconfigured maxGateRetries < 1). Bail without finalizing rather than
+                // dereference a null rollup.
+                if ($rollup === null) {
                     $this->redisService->releaseCompletionLock($pid);
 
                     return;
@@ -66,11 +147,11 @@ class ProjectCompletionService implements ProjectCompletionServiceInterface
 
                 $_analyzed_report = $_full_report;
 
-                LoggerFactory::doJsonLog("--- trying to initialize job total word count for project $pid.");
+                $this->log("--- trying to initialize job total word count for project $pid.");
 
                 $this->repository->beginTransaction();
 
-                LoggerFactory::doJsonLog("--- analysis project $pid finished: change status to DONE");
+                $this->log("--- analysis project $pid finished: change status to DONE");
 
                 $this->repository->updateProjectAnalysisStatus(
                     $pid,
@@ -103,7 +184,7 @@ class ProjectCompletionService implements ProjectCompletionServiceInterface
 
                 $this->repository->destroyAllCaches($pid, $projectPassword);
             } catch (Throwable $e) {
-                LoggerFactory::doJsonLog("**** Finalization failed for project $pid: " . $e->getMessage());
+                $this->log("**** Finalization failed for project $pid: " . $e->getMessage());
 
                 try {
                     $this->repository->rollback();

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
@@ -203,7 +203,9 @@ class TMAnalysisWorker extends AbstractWorker
             $tmData['tm_analysis_status'] = 'DONE';
             $tmData['warning'] = (int)($postProcessed['warning'] ?? 0);
             $tmData['serialized_errors_list'] = $postProcessed['serialized_errors_list'] ?? '';
-            $tmData['mt_qe'] = $bestMatch['score'] ?? null;
+            // mt_qe is a NOT NULL DEFAULT 0 column; default to 0 (no MT score) so the
+            // UPDATE never binds null and MySQL/ProxySQL cannot raise 1048.
+            $tmData['mt_qe'] = $bestMatch['score'] ?? 0;
 
             $tmData['suggestion_source'] = $bestMatch['created_by'] ?? null;
             if (!empty($tmData['suggestion_source'])) {

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
@@ -32,7 +32,6 @@ use Utils\AsyncTasks\Workers\Service\MatchSorter;
 use Utils\Engines\AbstractEngine;
 use Utils\Engines\EnginesFactory;
 use Utils\Engines\MyMemory;
-use Utils\Logger\LoggerFactory;
 use Utils\Registry\AppConfig;
 use Utils\TaskRunner\Commons\AbstractElement;
 use Utils\TaskRunner\Commons\AbstractWorker;
@@ -42,6 +41,7 @@ use Utils\TaskRunner\Exceptions\EndQueueException;
 use Utils\TaskRunner\Exceptions\NotSupportedMTException;
 use Utils\TaskRunner\Exceptions\ReQueueException;
 use Utils\TmKeyManagement\TmKeyManager;
+use Throwable;
 
 class TMAnalysisWorker extends AbstractWorker
 {
@@ -86,7 +86,10 @@ class TMAnalysisWorker extends AbstractWorker
                 new JobDao($this->database),
                 new AnalysisDao($this->database),
                 new CounterModel($this->database),
-            )
+            ),
+            // Route completion logs to the analysis-queue log (via _doLog observer),
+            // alongside the rest of the analysis logs, instead of the global general_log.txt.
+            fn(string $message) => $this->_doLog($message)
         );
         $this->engineService = $engineService ?? new EngineService(new DefaultEngineResolver($this->database), $this->database);
         $this->matchProcessor = $matchProcessor ?? new MatchProcessorService(new MatchSorter(), $this->database);
@@ -236,11 +239,13 @@ class TMAnalysisWorker extends AbstractWorker
             // MySQL committed. Redis failures MUST NOT escape to the Executor.
             // If they did, the Executor would requeue the message, but on retry
             // setAnalysisValue() returns 0 (segment already DONE) → early return →
-            // counter permanently lost → project never completes.
-            // See: KNOWN_CONCURRENCY_ISSUES.md #1
+            // counter permanently lost → project never completes. Hence Redis side
+            // effects are applied post-commit and their failures are swallowed/retried
+            // in-process rather than propagated back to the queue.
             // ─────────────────────────────────────────────────────────────────────
             $this->applyPostCommitSideEffects(
                 (int)$params->pid,
+                (int)$params->id_segment,
                 (string)$params->ppassword,
                 $eqWords,
                 $standardWords
@@ -290,15 +295,16 @@ class TMAnalysisWorker extends AbstractWorker
         );
 
         if ($segmentSet === 0) {
-            LoggerFactory::doJsonLog("Segment {$queueElement->params->id_segment} already DONE, skipping force-set side-effects.");
+            $this->_doLog("Segment {$queueElement->params->id_segment} already DONE, skipping force-set side-effects.");
             return;
         } elseif ($segmentSet === -1) {
-            LoggerFactory::doJsonLog("Segment {$queueElement->params->id_segment} not updated (SKIPPED) pre-translation");
+            $this->_doLog("Segment {$queueElement->params->id_segment} not updated (SKIPPED) pre-translation");
         }
 
         // POINT OF NO RETURN — DB committed
         $this->applyPostCommitSideEffects(
             (int)$queueElement->params->pid,
+            (int)$queueElement->params->id_segment,
             (string)$queueElement->params->ppassword,
             (float)$queueElement->params->raw_word_count,
             (float)$queueElement->params->raw_word_count
@@ -317,8 +323,10 @@ class TMAnalysisWorker extends AbstractWorker
         } else {
             $ready = $this->redisService->waitForInitialization($pid);
             if (!$ready) {
-                // Winner likely crashed — init lock TTL (30s) may have expired. Re-try.
-                $this->_doLog("--- (Worker $this->_workerPid) : init timeout for PID $pid, attempting re-init");
+                // Winner abandoned init: waitForInitialization returns false as soon as the
+                // init semaphore is gone (failed doInit released it, or a crash let its TTL
+                // expire) with no counters written. Try to become the initializer ourselves.
+                $this->_doLog("--- (Worker $this->_workerPid) : init not ready for PID $pid, attempting re-init");
                 if ($this->redisService->acquireInitLock($pid)) {
                     $this->doInit($pid);
                 } else {
@@ -337,18 +345,38 @@ class TMAnalysisWorker extends AbstractWorker
 
     private function doInit(int $pid): void
     {
-        $totalSegmentsData = $this->projectCompletion->getProjectSegmentsTranslationSummary($pid);
-        $totalSegments = array_pop($totalSegmentsData);
-        assert($totalSegments !== null);
+        try {
+            $totalSegmentsData = $this->projectCompletion->getProjectSegmentsTranslationSummary($pid);
+            $totalSegments = array_pop($totalSegmentsData);
 
-        $this->_doLog($totalSegments);
+            $projectSegments = (int)($totalSegments['project_segments'] ?? 0);
+            $numAnalyzed = (int)($totalSegments['num_analyzed'] ?? 0);
 
-        $projectSegments = (int)($totalSegments['project_segments'] ?? 0);
-        $numAnalyzed = (int)($totalSegments['num_analyzed'] ?? 0);
+            // Never persist a zero/empty total. The summary query can run before the
+            // project's segment rows are visible; writing 0 would set PROJECT_TOT_SEGMENTS
+            // with a 24h TTL and permanently block completion — tryCloseProject treats
+            // empty("0") as "count failed" and bails — while the mere presence of the key
+            // suppresses any re-init. Release the lock so the next segment retries init.
+            if ($projectSegments <= 0) {
+                $this->_doLog("--- (Worker $this->_workerPid) : segment count for PID $pid not available yet (got $projectSegments). Releasing init lock for retry.");
+                $this->redisService->releaseInitLock($pid);
 
-        $this->redisService->initializeProjectCounters($pid, $projectSegments, $numAnalyzed);
+                return;
+            }
 
-        $this->_doLog("--- (Worker $this->_workerPid) : found $projectSegments segments for PID $pid");
+            $this->redisService->initializeProjectCounters($pid, $projectSegments, $numAnalyzed);
+
+            $this->_doLog("--- (Worker $this->_workerPid) : found $projectSegments segments for PID $pid");
+        } catch (Throwable $e) {
+            // doInit failed after acquiring the init lock. Leaving the lock held would make
+            // every other worker for this PID a loser reading NULL counters until the TTL
+            // expires. Release it so init can be retried. Swallow the error: the current
+            // segment is analyzed on its own and must not be nacked just because project
+            // init failed — a later segment will initialize the counters. Completion
+            // correctness stays gated by the DB-authoritative check in tryCloseProject.
+            $this->redisService->releaseInitLock($pid);
+            $this->_doLog("--- (Worker $this->_workerPid) : doInit failed for PID $pid: {$e->getMessage()}. Init lock released for retry.");
+        }
     }
 
     /**
@@ -446,23 +474,28 @@ class TMAnalysisWorker extends AbstractWorker
      * 3. tryCloseProject — ALWAYS RUNS after increment succeeds. Has its own
      *    internal catch-all (never throws). Idempotent via completion lock.
      *
-     * See: KNOWN_CONCURRENCY_ISSUES.md #1
+     * These side effects run AFTER the DB commit precisely because the analyzed-count
+     * increment must never be lost or replayed against an already-DONE segment (which
+     * would strand the project short of completion).
      *
      * @throws Exception only if $pid is empty (programming error in caller)
      */
     private function applyPostCommitSideEffects(
         int $pid,
+        int $idSegment,
         string $projectPassword,
         float $eqWords,
         float $standardWords
     ): void {
-        // 1. Retry loop for the critical counter increment
+        // 1. Retry loop for the critical counter increment. The increment is idempotent
+        //    per segment id, so re-running it after a Redis connection error cannot
+        //    double-count (see AnalysisRedisService::incrementAnalyzedCount).
         $maxRetries = 5;
         $delayMs = 500;
 
         for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
             try {
-                $this->redisService->incrementAnalyzedCount($pid, 1, $eqWords, $standardWords);
+                $this->redisService->incrementAnalyzedCount($pid, $idSegment, $eqWords, $standardWords);
 
                 break;
             } catch (PredisConnectionException|PredisServerException $e) {

--- a/tests/unit/Core/Workers/TMAnalysisV2/AnalysisRedisServiceTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/AnalysisRedisServiceTest.php
@@ -177,30 +177,39 @@ class AnalysisRedisServiceTest extends AbstractTest
     }
 
     #[Test]
-    public function incrementAnalyzedCount_callsThreeIncrbyWithScaledValues(): void
+    public function incrementAnalyzedCount_runsIdempotentEvalWithScaledValues(): void
     {
-        $pid         = 42;
-        $numSegments = 5;
-        $eqWc        = 10;
-        $stWc        = 8;
+        $pid       = 42;
+        $idSegment = 777;
+        $eqWc      = 10;
+        $stWc      = 8;
 
-        $this->service->incrementAnalyzedCount($pid, $numSegments, $eqWc, $stWc);
+        $this->service->incrementAnalyzedCount($pid, $idSegment, $eqWc, $stWc);
 
-        $calls = $this->redisSpy->getCallsFor('incrby');
-        $this->assertCount(3, $calls);
+        // The counter update must be a single atomic Lua script (idempotent under the
+        // applyPostCommitSideEffects retry loop), not a bare MULTI of INCRBYs.
+        $this->assertCount(0, $this->redisSpy->getCallsFor('incrby'));
 
-        $this->assertSame(
-            [RedisKeys::PROJ_EQ_WORD_COUNT . $pid, $eqWc * RedisKeys::WORD_COUNT_SCALE],
-            $calls[0]['args']
-        );
-        $this->assertSame(
-            [RedisKeys::PROJ_ST_WORD_COUNT . $pid, $stWc * RedisKeys::WORD_COUNT_SCALE],
-            $calls[1]['args']
-        );
-        $this->assertSame(
-            [RedisKeys::PROJECT_NUM_SEGMENTS_DONE . $pid, $numSegments],
-            $calls[2]['args']
-        );
+        $calls = $this->redisSpy->getCallsFor('eval');
+        $this->assertCount(1, $calls);
+
+        $args = $calls[0]['args'];
+        // args: [script, numkeys, KEYS..., ARGV...]
+        $this->assertIsString($args[0]);
+        $this->assertStringContainsString('SADD', $args[0]);
+        $this->assertStringContainsString('SCARD', $args[0]);
+        $this->assertSame(4, $args[1]);
+        // KEYS: idempotency set, analyzed counter, eq wc, st wc
+        $this->assertSame(RedisKeys::PROJECT_ANALYZED_SEGMENTS_SET . $pid, $args[2]);
+        $this->assertSame(RedisKeys::PROJECT_NUM_SEGMENTS_DONE . $pid, $args[3]);
+        $this->assertSame(RedisKeys::PROJ_EQ_WORD_COUNT . $pid, $args[4]);
+        $this->assertSame(RedisKeys::PROJ_ST_WORD_COUNT . $pid, $args[5]);
+        // ARGV: id_segment, analyzed delta, scaled eq, scaled st, ttl
+        $this->assertSame((string)$idSegment, $args[6]);
+        $this->assertSame('1', $args[7]);
+        $this->assertSame((string)($eqWc * RedisKeys::WORD_COUNT_SCALE), $args[8]);
+        $this->assertSame((string)($stWc * RedisKeys::WORD_COUNT_SCALE), $args[9]);
+        $this->assertSame('86400', $args[10]);
     }
 
     #[Test]
@@ -214,7 +223,9 @@ class AnalysisRedisServiceTest extends AbstractTest
         $calls = $this->redisSpy->getCallsFor('set');
         $this->assertCount(1, $calls);
         $this->assertSame(
-            [RedisKeys::PROJECT_ENDING_SEMAPHORE . $pid, 1, 'EX', 86400, 'NX'],
+            // Bounded TTL (300s) for crash-safety; wide margin over the finalization
+            // critical section it guards. NX preserved. Was 86400s.
+            [RedisKeys::PROJECT_ENDING_SEMAPHORE . $pid, 1, 'EX', 300, 'NX'],
             $calls[0]['args']
         );
     }
@@ -316,7 +327,9 @@ class AnalysisRedisServiceTest extends AbstractTest
     public function waitForInitialization_returnsFalse_whenTimeout(): void
     {
         $pid = 42;
-        // Don't set either key — both stay null
+        // Winner holds the init lock but has not published the counters yet, so waiting
+        // is correct. Neither counter is set — the loser should poll until the timeout.
+        $this->redisSpy->setReturnForKey(RedisKeys::PROJECT_INIT_SEMAPHORE . $pid, '1');
 
         $start = hrtime(true);
         $result = $this->service->waitForInitialization($pid, 100);
@@ -327,15 +340,78 @@ class AnalysisRedisServiceTest extends AbstractTest
     }
 
     #[Test]
+    public function waitForInitialization_returnsFalseImmediately_whenInitLockAbandoned(): void
+    {
+        $pid = 42;
+        // No init semaphore and no counters: the winner abandoned initialization (failed
+        // doInit released the lock, or crashed and its TTL expired). The loser must bail
+        // immediately so it can re-acquire and re-init — not block for the full timeout
+        // waiting on counters that will never arrive.
+        $start = hrtime(true);
+        $result = $this->service->waitForInitialization($pid, 5000);
+        $elapsedMs = (hrtime(true) - $start) / 1_000_000;
+
+        $this->assertFalse($result);
+        $this->assertLessThan(100, $elapsedMs);
+    }
+
+    #[Test]
     public function waitForInitialization_waits_whenOnlyTotSegmentsExists(): void
     {
         $pid = 42;
-        // Only set PROJECT_TOT_SEGMENTS — PROJECT_NUM_SEGMENTS_DONE is missing (TOCTOU scenario)
+        // Winner still holds the init lock, and only PROJECT_TOT_SEGMENTS is set —
+        // PROJECT_NUM_SEGMENTS_DONE is missing (TOCTOU scenario). The loser must keep
+        // polling (not early-exit) because init is still in progress.
+        $this->redisSpy->setReturnForKey(RedisKeys::PROJECT_INIT_SEMAPHORE . $pid, '1');
         $this->redisSpy->setReturnForKey(RedisKeys::PROJECT_TOT_SEGMENTS . $pid, '50');
 
         $result = $this->service->waitForInitialization($pid, 100);
 
         // Should timeout because second key is missing
         $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function releaseInitLock_callsDelWithInitSemaphoreKey(): void
+    {
+        $pid = 42;
+
+        $this->service->releaseInitLock($pid);
+
+        $calls = $this->redisSpy->getCallsFor('del');
+        $this->assertCount(1, $calls);
+        $this->assertSame([RedisKeys::PROJECT_INIT_SEMAPHORE . $pid], $calls[0]['args']);
+    }
+
+    #[Test]
+    public function initializeProjectCounters_delsAnalyzedSegmentsSetInsideTransaction(): void
+    {
+        $pid = 42;
+
+        $this->service->initializeProjectCounters($pid, 100, 10);
+
+        // The spy runs the transaction closure against itself, so the inner commands are
+        // recorded. Each run must start with an empty idempotency set, so the closure
+        // deletes PROJECT_ANALYZED_SEGMENTS_SET before writing the counters.
+        $delCalls = $this->redisSpy->getCallsFor('del');
+        $this->assertCount(1, $delCalls);
+        $this->assertSame([RedisKeys::PROJECT_ANALYZED_SEGMENTS_SET . $pid], $delCalls[0]['args']);
+
+        // The counters are written as ABSOLUTE resets (setex, not incrby) so re-analysis of
+        // the same PID within the 24h TTL does not accumulate onto stale values. Expect four
+        // setex calls: tot_segments, eq_wc, st_wc and num_segments_done. No incrby.
+        $setexCalls = $this->redisSpy->getCallsFor('setex');
+        $this->assertCount(4, $setexCalls);
+        $this->assertSame(0, $this->redisSpy->countCallsFor('incrby'));
+
+        $setexByKey = [];
+        foreach ($setexCalls as $call) {
+            $setexByKey[$call['args'][0]] = [$call['args'][1], $call['args'][2]];
+        }
+
+        $this->assertSame([86400, 100], $setexByKey[RedisKeys::PROJECT_TOT_SEGMENTS . $pid]);
+        $this->assertSame([86400, 0], $setexByKey[RedisKeys::PROJ_EQ_WORD_COUNT . $pid]);
+        $this->assertSame([86400, 0], $setexByKey[RedisKeys::PROJ_ST_WORD_COUNT . $pid]);
+        $this->assertSame([86400, 10], $setexByKey[RedisKeys::PROJECT_NUM_SEGMENTS_DONE . $pid]);
     }
 }

--- a/tests/unit/Core/Workers/TMAnalysisV2/ConcurrencyRegressionTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/ConcurrencyRegressionTest.php
@@ -171,10 +171,24 @@ class ConcurrencyRegressionTest extends AbstractTest
         );
         $this->assertGreaterThanOrEqual(1, $nxCountCompletion, "acquireCompletionLock() must use 'NX' option for atomic Redis lock acquisition.");
 
+        // Completion lock must use a SHORT TTL via the constant, NOT 86400: a long TTL
+        // lets a worker killed while holding the lock (e.g. mid gate-retry in
+        // tryCloseProject) block the project's finalization for that whole duration.
+        $completionBody = substr($source, $completionLockPos, 200);
         $this->assertStringContainsString(
+            "'EX', self::COMPLETION_LOCK_TTL_SECONDS",
+            $completionBody,
+            'acquireCompletionLock() must set its TTL from the short COMPLETION_LOCK_TTL_SECONDS constant.'
+        );
+        $this->assertStringNotContainsString(
             "'EX', 86400",
+            $completionBody,
+            'Completion lock must not use the 86400s TTL — a crashed holder would deadlock finalization for 24h.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/const\s+COMPLETION_LOCK_TTL_SECONDS\s*=\s*300\s*;/',
             $source,
-            "Completion lock must have TTL 86400 to prevent permanent deadlocks on crash."
+            'COMPLETION_LOCK_TTL_SECONDS must be 300s — wide margin over the finalization critical section, still short enough to recover from a crashed lock holder in ~5min.'
         );
     }
 
@@ -369,9 +383,19 @@ class ConcurrencyRegressionTest extends AbstractTest
         $body = substr($source, $methodPos, $methodEnd - $methodPos);
 
         $this->assertStringContainsString(
-            "'EX', 30",
+            "'EX', self::INIT_LOCK_TTL_SECONDS",
             $body,
-            'Init lock TTL must be 30s (not 86400s) — short enough to recover from crashed winners.'
+            'acquireInitLock must set its TTL from the INIT_LOCK_TTL_SECONDS constant.'
+        );
+        $this->assertStringNotContainsString(
+            '86400',
+            $body,
+            'Init lock TTL must be short — never the 86400s completion-lock TTL.'
+        );
+        $this->assertMatchesRegularExpression(
+            '/const\s+INIT_LOCK_TTL_SECONDS\s*=\s*30\s*;/',
+            $source,
+            'INIT_LOCK_TTL_SECONDS must be 30s — short enough to recover from crashed winners.'
         );
     }
 

--- a/tests/unit/Core/Workers/TMAnalysisV2/ProjectCompletionServiceUnitTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/ProjectCompletionServiceUnitTest.php
@@ -90,6 +90,32 @@ class ProjectCompletionServiceUnitTest extends AbstractTest
         $service->tryCloseProject(1, 'pass', 'queue', $this->makeFeatureSet());
     }
 
+    #[Test]
+    public function tryCloseProject_routes_logs_through_injected_logger(): void
+    {
+        // The worker injects _doLog here so completion logs land in the analysis-queue
+        // log rather than the global general_log.txt. Verify the logger is actually used.
+        $captured = [];
+        $logger = function (string $message) use (&$captured): void {
+            $captured[] = $message;
+        };
+
+        $redis = $this->createMock(AnalysisRedisServiceInterface::class);
+        $redis->method('getProjectWordCounts')->willReturn(['project_segments' => 10, 'num_analyzed' => 10]);
+        $redis->method('acquireCompletionLock')->willReturn(true);
+        $redis->expects($this->once())->method('releaseCompletionLock')->with(7);
+
+        $repo = $this->createStub(ProjectCompletionRepositoryInterface::class);
+        // Empty summary → array_pop() yields null → "empty rollup" branch logs + releases.
+        $repo->method('getProjectSegmentsTranslationSummary')->willReturn([]);
+
+        $service = new ProjectCompletionService($redis, $repo, $logger);
+        $service->tryCloseProject(7, 'pass', 'queue', $this->makeFeatureSet());
+
+        $this->assertNotEmpty($captured, 'injected logger must receive completion log output');
+        $this->assertStringContainsString('empty rollup', implode("\n", $captured));
+    }
+
     // ── Happy path ─────────────────────────────────────────────────────
 
     #[Test]
@@ -174,8 +200,87 @@ class ProjectCompletionServiceUnitTest extends AbstractTest
         // transaction must NOT start — updateProjectAnalysisStatus is the real guard.
         $repo->expects($this->never())->method('updateProjectAnalysisStatus');
 
-        $service = new ProjectCompletionService($redis, $repo);
+        // gateRetrySleepMicros:0 → the retry loop exhausts all attempts with no real sleep.
+        $service = new ProjectCompletionService($redis, $repo, null, gateRetrySleepMicros: 0);
         $service->tryCloseProject(42, 'pass', 'queue', $this->makeFeatureSet());
+    }
+
+    #[Test]
+    public function tryCloseProject_finalizes_when_gate_confirms_completion_on_a_later_retry(): void
+    {
+        // Core-fix proof (last-segment race): the first gate read still sees segments
+        // pending (inter-worker commit skew), but a later read confirms completion. The
+        // project must FINALIZE — not release the lock and hang at FAST_OK.
+        $redis = $this->createMock(AnalysisRedisServiceInterface::class);
+        $redis->method('getProjectWordCounts')->willReturn(['project_segments' => 10, 'num_analyzed' => 10]);
+        $redis->method('acquireCompletionLock')->willReturn(true);
+        // It finalized rather than gave up, so the lock is NEVER released here.
+        $redis->expects($this->never())->method('releaseCompletionLock');
+        $redis->expects($this->once())->method('removeProjectFromQueue')->with('queue', 77);
+
+        $repo = $this->createMock(ProjectCompletionRepositoryInterface::class);
+        // Same rollup + per-job-row structure as the happy-path finalize test. First call:
+        // 2 segments still pending. Second call: all analyzed → finalize on this snapshot.
+        $repo->method('getProjectSegmentsTranslationSummary')->willReturnOnConsecutiveCalls(
+            [
+                ['id_job' => 1, 'password' => 'a', 'eq_wc' => 100, 'st_wc' => 200],
+                ['id_job' => null, 'password' => null, 'eq_wc' => 100, 'st_wc' => 200, 'project_segments' => 10, 'num_analyzed' => 8],
+            ],
+            [
+                ['id_job' => 1, 'password' => 'a', 'eq_wc' => 100, 'st_wc' => 200],
+                ['id_job' => null, 'password' => null, 'eq_wc' => 100, 'st_wc' => 200, 'project_segments' => 10, 'num_analyzed' => 10],
+            ],
+        );
+        $repo->method('getProjectJobIds')->willReturn([['id' => 1, 'password' => 'a']]);
+        $repo->expects($this->once())->method('updateProjectAnalysisStatus');
+        // beginTransaction/commit fire once per gate query (master-read wrapper) plus the
+        // completion transaction, so assert the finalize commit ran at all.
+        $repo->expects($this->atLeastOnce())->method('commit');
+
+        // gateRetrySleepMicros:0 → the one retry needed happens with no real sleep.
+        $service = new ProjectCompletionService($redis, $repo, null, gateRetrySleepMicros: 0);
+        $service->tryCloseProject(77, 'pass', 'queue', $this->makeFeatureSet());
+    }
+
+    #[Test]
+    public function tryCloseProject_releases_lock_when_gate_retries_misconfigured_below_one(): void
+    {
+        // maxGateRetries < 1 skips the gate loop entirely, so $rollup stays null. The
+        // defensive post-loop guard must release the lock and bail without finalizing.
+        $redis = $this->createMock(AnalysisRedisServiceInterface::class);
+        $redis->method('getProjectWordCounts')->willReturn(['project_segments' => 10, 'num_analyzed' => 10]);
+        $redis->method('acquireCompletionLock')->willReturn(true);
+        $redis->expects($this->once())->method('releaseCompletionLock')->with(88);
+        $redis->expects($this->never())->method('removeProjectFromQueue');
+
+        $repo = $this->createMock(ProjectCompletionRepositoryInterface::class);
+        // Loop never runs → the gate query is never issued and finalize never starts.
+        $repo->expects($this->never())->method('getProjectSegmentsTranslationSummary');
+        $repo->expects($this->never())->method('updateProjectAnalysisStatus');
+
+        $service = new ProjectCompletionService($redis, $repo, null, maxGateRetries: 0);
+        $service->tryCloseProject(88, 'pass', 'queue', $this->makeFeatureSet());
+    }
+
+    #[Test]
+    public function tryCloseProject_releases_lock_when_rollup_is_empty(): void
+    {
+        // Redis says complete → enters the locked block and acquires the completion lock.
+        // The gate query returns [] (no rows at all), so array_pop yields null → the
+        // "empty rollup" branch must release the lock and bail without finalizing.
+        $redis = $this->createMock(AnalysisRedisServiceInterface::class);
+        $redis->method('getProjectWordCounts')->willReturn(['project_segments' => 10, 'num_analyzed' => 10]);
+        $redis->method('acquireCompletionLock')->willReturn(true);
+        $redis->expects($this->once())->method('releaseCompletionLock')->with(55);
+        $redis->expects($this->never())->method('removeProjectFromQueue');
+
+        $repo = $this->createMock(ProjectCompletionRepositoryInterface::class);
+        $repo->method('getProjectSegmentsTranslationSummary')->willReturn([]);
+        // No finalize: the DONE status update must never run on an empty rollup.
+        $repo->expects($this->never())->method('updateProjectAnalysisStatus');
+
+        $service = new ProjectCompletionService($redis, $repo);
+        $service->tryCloseProject(55, 'pass', 'queue', $this->makeFeatureSet());
     }
 
     // ── Error/rollback path ────────────────────────────────────────────

--- a/tests/unit/Core/Workers/TMAnalysisV2/TMAnalysisWorkerTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/TMAnalysisWorkerTest.php
@@ -279,6 +279,98 @@ class TMAnalysisWorkerTest extends AbstractTest
     }
 
     #[Test]
+    public function process_when_doInit_gets_zero_segment_count_releases_lock_and_skips_counter_init(): void
+    {
+        // Winner branch: we acquire the init lock and run doInit(). The summary query
+        // returns a rollup with project_segments <= 0 (segment rows not visible yet), so
+        // doInit must release the init lock for retry and NEVER persist a zero total.
+        $redis      = $this->createMock(AnalysisRedisServiceInterface::class);
+        $completion = $this->createStub(ProjectCompletionServiceInterface::class);
+        $engine     = $this->createStub(EngineServiceInterface::class);
+        $processor  = $this->createStub(MatchProcessorServiceInterface::class);
+        $updater    = $this->createStub(SegmentUpdaterServiceInterface::class);
+
+        $redis->method('acquireInitLock')->willReturn(true);
+        $completion->method('getProjectSegmentsTranslationSummary')
+            ->willReturn([['project_segments' => 0, 'num_analyzed' => 0]]);
+        $this->stubMatchPipeline($engine, $processor, $redis);
+        $updater->method('setAnalysisValue')->willReturn(1);
+
+        $redis->expects($this->once())->method('releaseInitLock')->with(100);
+        $redis->expects($this->never())->method('initializeProjectCounters');
+
+        $worker = $this->buildWorker(
+            redis: $redis,
+            updater: $updater,
+            completion: $completion,
+            engine: $engine,
+            processor: $processor,
+        );
+        $worker->process($this->makeQueueElement());
+    }
+
+    #[Test]
+    public function process_when_doInit_summary_throws_releases_lock_and_swallows_exception(): void
+    {
+        // Winner branch: doInit() acquires the lock then the summary query throws. The
+        // failure must be swallowed (segment still analyzed on its own) and the lock
+        // released so init can be retried — the exception must NOT escape process().
+        $redis      = $this->createMock(AnalysisRedisServiceInterface::class);
+        $completion = $this->createStub(ProjectCompletionServiceInterface::class);
+        $engine     = $this->createStub(EngineServiceInterface::class);
+        $processor  = $this->createStub(MatchProcessorServiceInterface::class);
+        $updater    = $this->createStub(SegmentUpdaterServiceInterface::class);
+
+        $redis->method('acquireInitLock')->willReturn(true);
+        $completion->method('getProjectSegmentsTranslationSummary')
+            ->willThrowException(new \RuntimeException('summary query failed'));
+        $this->stubMatchPipeline($engine, $processor, $redis);
+        $updater->method('setAnalysisValue')->willReturn(1);
+
+        $redis->expects($this->once())->method('releaseInitLock')->with(100);
+        $redis->expects($this->never())->method('initializeProjectCounters');
+
+        $worker = $this->buildWorker(
+            redis: $redis,
+            updater: $updater,
+            completion: $completion,
+            engine: $engine,
+            processor: $processor,
+        );
+        // Must not throw.
+        $worker->process($this->makeQueueElement());
+    }
+
+    #[Test]
+    public function process_when_reinit_loser_never_acquires_lock_just_logs_and_waits(): void
+    {
+        // Loser branch: the first acquireInitLock fails, waitForInitialization returns
+        // false (winner abandoned init), so we attempt re-init — but the second
+        // acquireInitLock also fails (another loser won it). We log "init not ready" and
+        // wait again without throwing.
+        $redis      = $this->createMock(AnalysisRedisServiceInterface::class);
+        $completion = $this->createStub(ProjectCompletionServiceInterface::class);
+        $engine     = $this->createStub(EngineServiceInterface::class);
+        $processor  = $this->createStub(MatchProcessorServiceInterface::class);
+        $updater    = $this->createStub(SegmentUpdaterServiceInterface::class);
+
+        $redis->expects($this->exactly(2))->method('acquireInitLock')->willReturn(false);
+        $redis->method('waitForInitialization')->willReturn(false);
+        $this->stubMatchPipeline($engine, $processor, $redis);
+        $updater->method('setAnalysisValue')->willReturn(1);
+
+        $worker = $this->buildWorker(
+            redis: $redis,
+            updater: $updater,
+            completion: $completion,
+            engine: $engine,
+            processor: $processor,
+        );
+        // Must not throw.
+        $worker->process($this->makeQueueElement());
+    }
+
+    #[Test]
     public function process_with_empty_raw_word_count_throws_EmptyElementException(): void
     {
         $redis   = $this->createStub(AnalysisRedisServiceInterface::class);


### PR DESCRIPTION
## Summary

TM-analysis projects could stay at `status_analysis = FAST_OK` forever even though every
segment had reached `tm_analysis_status = DONE`. Root cause is a last-segment concurrency
race in `ProjectCompletionService::tryCloseProject`, which is the only path that finalizes
a project and is invoked purely as a per-segment side-effect. With concurrent workers, the
worker holding the completion lock reads the DB-authoritative gate a moment before another
worker commits the truly-final segment (sees "segments remain", releases the lock), while
that other worker — whose commit actually completed the project — is denied the lock and
drops its close attempt with no retry. No segment is set DONE afterwards, so no later
trigger ever fires and the project is stranded.

Confirmed in production from `general_log.txt` (22,841 "MySQL says N remain" with 6 projects
frozen at FAST_OK though all segments DONE) and Redis (`p_num_done` over `p_tot_seg`,
`p_end_lock` free). Fixed without a cron/reconciliation sweep.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `TMAnalysis/Service/ProjectCompletionService.php` | Bounded DB-gate retry (6×1s, injectable) while holding the completion lock so a concurrent final commit lands and the project finalizes instead of stranding; completion logs routed via an injected logger (no more global `general_log.txt`); defensive null-rollup guard |
| `TMAnalysis/Service/AnalysisRedisService.php` | Completion-lock TTL `86400s → 300s` (crash-safety); idempotent analyzed-counter via atomic Lua `SADD`-gate (retry loop can no longer over-count `num_done`); Lua TTL parity for counter keys; absolute `setex` reset in `initializeProjectCounters`; `releaseInitLock`; `waitForInitialization` fast-recovery; TTL constants |
| `TMAnalysisWorker.php` | `doInit` hardening (never persist a zero total, release init lock on failure, swallow init hiccup so a segment is not nacked); thread `id_segment` into `applyPostCommitSideEffects`; inject `_doLog` logger into `ProjectCompletionService`; default `mt_qe` to `0` (was `null`) on a pure-TM match so the analysis `UPDATE` never binds `null` into the `NOT NULL` column (see Notes); self-contained comments |
| `TMAnalysis/Interface/AnalysisRedisServiceInterface.php` | `releaseInitLock` decl; `incrementAnalyzedCount` signature |
| `RedisKeys.php` | New `PROJECT_ANALYZED_SEGMENTS_SET` key |
| `tests/.../TMAnalysisV2/*` (4 files) | New + updated unit tests (retry-recovery behavioral test, idempotent-counter shape, doInit branches, TTL constants) |

## Testing

- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes
- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)

Ran locally (CI will run the full repo suite + baseline PHPStan):

- `phpunit tests/unit/Core/Workers/TMAnalysisV2/` → **OK (232 tests, 731 assertions)**, 0.6s
- `phpunit tests/unit/Core/Workers/` (broader) → **OK (308 tests, 889 assertions)** — no regressions
- `phpstan --configuration=phpstan-no-baseline.neon` on the 5 changed lib files → **0 errors**
- Diff-coverage of changed production lines → **100% (76/76)** — satisfies the ≥80% test-guard gate
- Reviewed by a 5-agent parallel review (goal, QA, code-quality, security, context) — all findings resolved before this PR

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-4-8)

## Notes

- No database migrations.
- Secondary bug fixed in the same worker: `mt_qe` (a `float(19,14) NOT NULL DEFAULT 0`
  column) was bound as `null` whenever the best match carried no MT `score` (a pure TM
  match), so MySQL/ProxySQL raised `1048 Column 'mt_qe' cannot be null`. That failed
  `UPDATE` threw `PDOException → ReQueueException`, so the segment never reached `DONE` and
  was requeued — a second driver of the analysis-never-completes symptom, and a flood in the
  ProxySQL error log. Defaulted to `0`, matching the column default, the `int $mt_qe = 0`
  struct field, and the worker's existing `$bestMatch['score'] ?? 0` convention.
- Behavioral change worth noting: the completion lock is now released ~300s after a
  successful finalization (was 24h). A stray in-flight segment message arriving >300s later
  could re-enter finalization; re-finalization is idempotent (status re-set to DONE, word
  counts recomputed from the same rollup, queue entry already removed).
- Follow-up (not in scope): `KNOWN_CONCURRENCY_ISSUES.md`, referenced by code comments, was
  deleted from the tree in an earlier unrelated commit and should be restored or relocated.

