### PR TITLE
🐛 fix(segments): bust getAllInRange cache on segment disable/enable

### DIFF
--- a/lib/Model/Segments/SegmentDisabledService.php
+++ b/lib/Model/Segments/SegmentDisabledService.php
@@ -68,6 +68,7 @@ class SegmentDisabledService
         $this->segmentMetadataDao->destroyGetCache($id_segment, $metadata->meta_key);
         $this->segmentMetadataDao->destroyGetAllCache($id_segment);
         $this->segmentMetadataDao->destroyGetBySegmentIdsCache($metadata->meta_key);
+        $this->segmentMetadataDao->destroyGetAllInRangeCache();
     }
 
     /**
@@ -90,5 +91,6 @@ class SegmentDisabledService
         $this->segmentMetadataDao->destroyGetCache($id_segment, $key);
         $this->segmentMetadataDao->destroyGetAllCache($id_segment);
         $this->segmentMetadataDao->destroyGetBySegmentIdsCache($key);
+        $this->segmentMetadataDao->destroyGetAllInRangeCache();
     }
 }

--- a/lib/Model/Segments/SegmentMetadataDao.php
+++ b/lib/Model/Segments/SegmentMetadataDao.php
@@ -13,6 +13,7 @@ class SegmentMetadataDao extends AbstractDao
     const string _query_get_all = "SELECT * FROM " . self::TABLE . " WHERE id_segment = ? ";
     const string _query_get = "SELECT * FROM " . self::TABLE . " WHERE id_segment = ? and meta_key = ? ";
     const string _keymap_get_by_segment_ids = "Model\\Segments\\SegmentMetadataDao::getBySegmentIds-";
+    const string _keymap_get_all_in_range = "Model\\Segments\\SegmentMetadataDao::getAllInRange";
 
 /**
      * @throws ReflectionException
@@ -102,6 +103,7 @@ class SegmentMetadataDao extends AbstractDao
         $this->destroyGetAllCache($metadataStruct->id_segment);
         $this->destroyGetCache($metadataStruct->id_segment, $metadataStruct->meta_key);
         $this->destroyGetBySegmentIdsCache($metadataStruct->meta_key);
+        $this->destroyGetAllInRangeCache();
     }
 
     /**
@@ -127,6 +129,7 @@ class SegmentMetadataDao extends AbstractDao
         $this->destroyGetAllCache($id_segment);
         $this->destroyGetCache($id_segment, $key);
         $this->destroyGetBySegmentIdsCache($key);
+        $this->destroyGetAllInRangeCache();
     }
 
     /**
@@ -163,6 +166,15 @@ class SegmentMetadataDao extends AbstractDao
     }
 
     /**
+     * @throws ReflectionException
+     * @throws Exception
+     */
+    public function destroyGetAllInRangeCache(): bool
+    {
+        return $this->_deleteCacheByKey(self::_keymap_get_all_in_range, false);
+    }
+
+    /**
      * @return array<int, SegmentMetadataCollection>
      * @throws ReflectionException
      * @throws Exception
@@ -178,7 +190,8 @@ class SegmentMetadataDao extends AbstractDao
         $results = $this->setCacheTTL($ttl)->_fetchObjectMap(
             $stmt,
             SegmentMetadataStruct::class,
-            [$startSid, $stopSid]
+            [$startSid, $stopSid],
+            self::_keymap_get_all_in_range
         );
 
         $grouped = [];

--- a/tests/unit/Core/Model/Segments/SegmentDisabledServiceTest.php
+++ b/tests/unit/Core/Model/Segments/SegmentDisabledServiceTest.php
@@ -6,6 +6,7 @@ use Matecat\TestHelpers\AbstractTest;
 use Model\DataAccess\Database;
 use Model\Segments\SegmentDisabledService;
 use Model\Segments\SegmentMetadataDao;
+use Model\Segments\SegmentMetadataMarshaller;
 use PDO;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -186,5 +187,52 @@ class SegmentDisabledServiceTest extends AbstractTest
 
         $this->assertFalse($this->service->isDisabled(self::TEST_SEGMENT_ID));
         $this->assertTrue($this->service->isDisabled(self::TEST_SEGMENT_ID_2));
+    }
+
+    // --- getAllInRange cache invalidation (regression) ---
+
+    #[Test]
+    public function disableBustsStaleGetAllInRangeCacheSoFreshCallReflectsDisabledState(): void
+    {
+        $dao = new SegmentMetadataDao($this->database);
+        $ttl = 60;
+
+        // Warm getAllInRange's cache for the range while the segment is not yet disabled,
+        // simulating an earlier get-segments page load / editor scroll.
+        $before = $dao->getAllInRange(self::TEST_SEGMENT_ID, self::TEST_SEGMENT_ID, $ttl);
+        $this->assertArrayNotHasKey(self::TEST_SEGMENT_ID, $before);
+
+        $this->service->disable(self::TEST_SEGMENT_ID);
+
+        // A fresh getAllInRange call, as get-segments would make on refresh, must see the
+        // disabled flag instead of the stale pre-disable cached (empty) result.
+        $after = $dao->getAllInRange(self::TEST_SEGMENT_ID, self::TEST_SEGMENT_ID, $ttl);
+
+        $this->assertArrayHasKey(self::TEST_SEGMENT_ID, $after);
+        $this->assertSame(
+            '1',
+            $after[self::TEST_SEGMENT_ID]->find(SegmentMetadataMarshaller::TRANSLATION_DISABLED)
+        );
+    }
+
+    #[Test]
+    public function enableBustsStaleGetAllInRangeCacheSoFreshCallNoLongerShowsDisabled(): void
+    {
+        $dao = new SegmentMetadataDao($this->database);
+        $ttl = 60;
+
+        $this->insertDisabledFlag(self::TEST_SEGMENT_ID);
+
+        // Warm getAllInRange's cache while the segment IS disabled.
+        $before = $dao->getAllInRange(self::TEST_SEGMENT_ID, self::TEST_SEGMENT_ID, $ttl);
+        $this->assertSame(
+            '1',
+            $before[self::TEST_SEGMENT_ID]->find(SegmentMetadataMarshaller::TRANSLATION_DISABLED)
+        );
+
+        $this->service->enable(self::TEST_SEGMENT_ID);
+
+        $after = $dao->getAllInRange(self::TEST_SEGMENT_ID, self::TEST_SEGMENT_ID, $ttl);
+        $this->assertArrayNotHasKey(self::TEST_SEGMENT_ID, $after);
     }
 }

--- a/tests/unit/Core/Model/Segments/SegmentMetadataDaoInstanceTest.php
+++ b/tests/unit/Core/Model/Segments/SegmentMetadataDaoInstanceTest.php
@@ -242,6 +242,42 @@ class SegmentMetadataDaoInstanceTest extends AbstractTest
         $this->assertIsBool($result);
     }
 
+    // ── destroyGetAllInRangeCache ───────────────────────────────────────────────
+
+    #[Test]
+    public function testDestroyGetAllInRangeCacheReturnsBool(): void
+    {
+        $result = $this->dao->destroyGetAllInRangeCache();
+
+        $this->assertIsBool($result);
+    }
+
+    #[Test]
+    public function testDestroyGetAllInRangeCacheBustsStaleCachedResult(): void
+    {
+        $ttl = 60;
+
+        // Warm the cache for a range where SEGMENT_ID_1 has no metadata yet.
+        $before = $this->dao->getAllInRange(self::SEGMENT_ID_1, self::SEGMENT_ID_1, $ttl);
+        $this->assertArrayNotHasKey(self::SEGMENT_ID_1, $before);
+
+        // Insert directly, bypassing save()/upsert() (which already bust this cache), to
+        // simulate any writer unaware of getAllInRange's cache.
+        $this->database->getConnection()->prepare(
+            "INSERT INTO segment_metadata (id_segment, meta_key, meta_value) VALUES (?, ?, ?)"
+        )->execute([self::SEGMENT_ID_1, 'direct_key', 'direct_value']);
+
+        // Without busting, the stale (empty) result is still served from cache.
+        $stillStale = $this->dao->getAllInRange(self::SEGMENT_ID_1, self::SEGMENT_ID_1, $ttl);
+        $this->assertArrayNotHasKey(self::SEGMENT_ID_1, $stillStale);
+
+        $this->dao->destroyGetAllInRangeCache();
+
+        $fresh = $this->dao->getAllInRange(self::SEGMENT_ID_1, self::SEGMENT_ID_1, $ttl);
+        $this->assertArrayHasKey(self::SEGMENT_ID_1, $fresh);
+        $this->assertCount(1, $fresh[self::SEGMENT_ID_1]);
+    }
+
     // ── getAllInRange (renamed from staticGetAllInRange) ───────────────────────
 
     #[Test]


### PR DESCRIPTION
## Summary

Fixes a bug where disabling/enabling a segment did not update the CAT editor UI: the
`get-segments` endpoint loads segment metadata via `SegmentMetadataDao::getAllInRange()`,
cached for 24h, but `SegmentDisabledService::disable()`/`enable()` never invalidated that
cache — only three other, unrelated caches. This left stale `translation_disabled` state
served for up to 24 hours, including on a plain browser refresh.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Model/Segments/SegmentMetadataDao.php` | add `_keymap_get_all_in_range` constant + `destroyGetAllInRangeCache()`; pass the shared key explicitly to `getAllInRange()`; call the new destroy method from `save()`/`upsert()` |
| `lib/Model/Segments/SegmentDisabledService.php` | call `destroyGetAllInRangeCache()` from `disable()` and `enable()` |
| `tests/unit/Core/Model/Segments/SegmentMetadataDaoInstanceTest.php` | add tests proving `destroyGetAllInRangeCache()` busts a stale cached range |
| `tests/unit/Core/Model/Segments/SegmentDisabledServiceTest.php` | add end-to-end regression tests: `disable()`/`enable()` now bust `getAllInRange`'s cache |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Ran inside the `matecat` docker container (real MySQL + Redis):
- `SegmentMetadataDaoInstanceTest` + `SegmentDisabledServiceTest`: 33/33 pass.
- Confirmed the two new regression tests actually catch the bug: reverted just the two
  source files (`git stash push` on those paths only) and reran — both failed as expected;
  restored the fix and reran — green again.
- `phpstan` (level 8, no baseline) clean on both modified source files.
- Full suite (`--exclude-group=ExternalServices`, 9154 tests) passes with no regressions;
  the only failures/errors present are pre-existing and unrelated to this change
  (`GDriveControllerTest` fixture pollution, `CommentControllerTest` broker-unavailable
  assertions).

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5) — investigated the bug (root-caused via static analysis of
the backend cache layer and frontend SSE/render pipeline), implemented the fix, and wrote
the regression tests. All findings and changes were reviewed before landing.

## Notes

The fix mirrors the existing `getBySegmentIds` cache-busting pattern: all cached
`getAllInRange` variants (one per distinct start/stop range) now share a single group key,
so one `destroyGetAllInRangeCache()` call busts every cached range at once. This trades
some over-invalidation (clearing ranges unrelated to the segment that changed) for
tractable invalidation, since a single `id_segment` cannot otherwise be mapped back to
the specific ranges that might have it cached.

Separately, the same-tab "toast fires but segment still shows editable until navigating
away and back" symptom reported alongside this bug was investigated via static tracing of
the SSE listener → Flux store → memoization → render pipeline; no code defect was found
there (metadata changes are correctly included in every cache/memo equality check). That
part is out of scope for this PR — worth a manual re-check once this fix is live, since it
may resolve as a side effect or need separate follow-up.
