### PR TITLE
✅ test(api): cover aiFeedback.js (job credentials, error paths)

### DIFF
--- a/public/js/api/aiFeedback/aiFeedback.test.js
+++ b/public/js/api/aiFeedback/aiFeedback.test.js
@@ -1,0 +1,79 @@
+import {http, HttpResponse} from 'msw'
+import {mswServer} from '../../../mocks/mswServer'
+import {aiFeedback} from './aiFeedback'
+
+global.config = {
+  basepath: 'http://localhost/',
+  enableMultiDomainApi: false,
+  id_job: '77',
+  password: 'jobpwd',
+  source_code: 'en-US',
+  target_code: 'it-IT',
+  id_client: 'client-1',
+}
+
+const url = config.basepath + 'api/app/ai-assistant/feedback'
+
+test('posts feedback with job credentials from config and returns data', async () => {
+  let received
+  mswServer.use(
+    http.post(url, async ({request}) => {
+      received = await request.json()
+      return HttpResponse.json({channel: 'ok'})
+    }),
+  )
+
+  const response = await aiFeedback({
+    idSegment: '5',
+    source: 'hello',
+    target: 'ciao',
+    style: 'faithful',
+  })
+
+  expect(response).toEqual({channel: 'ok'})
+  expect(received.id_job).toBe('77')
+  expect(received.password).toBe('jobpwd')
+  expect(received.source_language).toBe('en-US')
+  expect(received.target_language).toBe('it-IT')
+  expect(received.id_client).toBe('client-1')
+  expect(received.id_segment).toBe('5')
+  expect(received.text).toBe('hello')
+  expect(received.translation).toBe('ciao')
+  expect(received.style).toBe('faithful')
+})
+
+test('prefers explicit arguments over config defaults', async () => {
+  let received
+  mswServer.use(
+    http.post(url, async ({request}) => {
+      received = await request.json()
+      return HttpResponse.json({channel: 'ok'})
+    }),
+  )
+
+  await aiFeedback({
+    idJob: '999',
+    password: 'other',
+    idSegment: '5',
+  })
+
+  expect(received.id_job).toBe('999')
+  expect(received.password).toBe('other')
+})
+
+test('rejects with the response on a non-ok status', async () => {
+  mswServer.use(http.post(url, () => new HttpResponse(null, {status: 500})))
+
+  const result = await aiFeedback({idSegment: '5'}).catch((error) => error)
+
+  expect(result.ok).toBe(false)
+})
+
+test('rejects with the errors array when the payload carries errors', async () => {
+  const errors = [{code: 1, message: 'nope'}]
+  mswServer.use(http.post(url, () => HttpResponse.json({errors})))
+
+  const result = await aiFeedback({idSegment: '5'}).catch((error) => error)
+
+  expect(result).toEqual(errors)
+})


### PR DESCRIPTION
## Summary

Adds the Jest coverage for `public/js/api/aiFeedback/aiFeedback.js` that `test-guard` flagged
as uncovered on #4681. That PR made `aiFeedback` send `id_job` + `password` (so all three
AI-assistant endpoints carry job credentials); this test locks in that contract.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [x] `test` — test coverage

## Changes

| Area | Change |
|------|--------|
| `public/js/api/aiFeedback/aiFeedback.test.js` | New colocated Jest/MSW suite: POST body carries `id_job`+`password` from config defaults and from explicit args; returns parsed data; rejects the response on non-ok status; rejects the `errors` array when present |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, no baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

Frontend-only change. The suite mirrors the existing `getProjectByToken` MSW idiom. Note: the
local jest harness could not run in my environment (config validation fails on `setupFiles`
for every test, including pre-existing ones); the test is relied upon to run under CI jest.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-4-8)
