### PR TITLE
🌐 i18n(icu-intl): update matecat/icu-intl to v1.1.30

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1748,16 +1748,16 @@
         },
         {
             "name": "matecat/icu-intl",
-            "version": "v1.1.29",
+            "version": "v1.1.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/icu-intl.git",
-                "reference": "74366ceae6b32dc906d3f18d80cc1e5a376ab4cd"
+                "reference": "4185beb0a71278a8448f02b27877eb3848a76b01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/icu-intl/zipball/74366ceae6b32dc906d3f18d80cc1e5a376ab4cd",
-                "reference": "74366ceae6b32dc906d3f18d80cc1e5a376ab4cd",
+                "url": "https://api.github.com/repos/matecat/icu-intl/zipball/4185beb0a71278a8448f02b27877eb3848a76b01",
+                "reference": "4185beb0a71278a8448f02b27877eb3848a76b01",
                 "shasum": ""
             },
             "require": {
@@ -1794,9 +1794,9 @@
             "description": "A PHP port of ICU4J's MessagePattern parser with locale utilities. Parses ICU MessageFormat patterns into an inspectable AST and provides locale data support for internationalization in PHP.",
             "support": {
                 "issues": "https://github.com/matecat/icu-intl/issues",
-                "source": "https://github.com/matecat/icu-intl/tree/v1.1.29"
+                "source": "https://github.com/matecat/icu-intl/tree/v1.1.30"
             },
-            "time": "2026-04-28T09:58:27+00:00"
+            "time": "2026-07-16T11:02:16+00:00"
         },
         {
             "name": "matecat/klein",


### PR DESCRIPTION
## Summary

Update `matecat/icu-intl` from v1.1.29 to v1.1.30, pulling in a Hausa language
update and a batch of new regional language variants.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `composer.lock` | Bump `matecat/icu-intl` from `v1.1.29` (74366ce) to `v1.1.30`, pinning `4185beb0a71278a8448f02b27877eb3848a76b01` (matecat/icu-intl#15 — updated Hausa language) and including `d68fb8cf9e2a87502c338e7bd52522ce386186ae` (matecat/icu-intl#18 — added fr-GP, fr-HT, fr-MQ, fr-TN, pt-AO, pt-CV, pt-MZ, ro-MD, ru-MD, ru-UA, es-BO, es-CL, es-CR, es-EC, es-SV, es-GT, es-NI, es-PY) |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

Dependency-only lock file update (no Matecat source code changed); verified via
this PR's CI run, which executes both commands above.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

None.
