### PR TITLE
✨ feat(lexiqa): add spellcheck suggestion and replace-word support

### DIFF
--- a/public/css/sass/lexiqa.scss
+++ b/public/css/sass/lexiqa.scss
@@ -45,7 +45,7 @@
       .icon-cancel-circle:before {
         line-height: 40px;
         float: left;
-        font-size: 18px;
+        font-size: 16px;
       }
       .tooltip-error-ignore-text {
         margin-left: 5px;
@@ -57,6 +57,19 @@
     &:not(:first-child) {
       border-top: 1px solid rgba(255, 255, 255, 0.36);
     }
+  }
+  .tooltip-suggestion-container {
+    display: flex;
+    flex-direction: column;
+    padding: 0 0.5rem 0.5rem;
+  }
+  .tooltip-suggestion-container ul > li {
+    font-weight: bold;
+    cursor: pointer;
+    line-height: 22px;
+  }
+  .tooltip-suggestion-container ul > li:hover {
+    color: #4184c4;
   }
 }
 /*

--- a/public/js/components/segments/Editarea.js
+++ b/public/js/components/segments/Editarea.js
@@ -7,6 +7,7 @@ import {
   getDefaultKeyBinding,
   KeyBindingUtil,
   CompositeDecorator,
+  SelectionState,
 } from 'draft-js'
 import {remove, cloneDeep, findIndex, size, isEqual} from 'lodash'
 import {debounce} from 'lodash/function'
@@ -23,6 +24,7 @@ import TagBox from './utils/DraftMatecatUtils/TagMenu/TagBox'
 import insertTag from './utils/DraftMatecatUtils/TagMenu/insertTag'
 import checkForMissingTags from './utils/DraftMatecatUtils/TagMenu/checkForMissingTag'
 import LexiqaUtils from '../../utils/lxq.main'
+import transformLexiqaPoints from './utils/DraftMatecatUtils/transformLexiqaPoints'
 import updateOffsetBasedOnEditorState from './utils/DraftMatecatUtils/updateOffsetBasedOnEditorState'
 import {tagSignatures} from './utils/DraftMatecatUtils/tagModel'
 import SegmentActions from '../../actions/SegmentActions'
@@ -254,6 +256,7 @@ class Editarea extends React.Component {
         sid,
         false,
         this.getUpdatedSegmentInfo,
+        this.replaceWordAt,
       )
       remove(
         this.decoratorsStructure,
@@ -696,6 +699,27 @@ class Editarea extends React.Component {
       ...this.compositionEventChecks.current,
       endIsTriggered: true,
     }
+  }
+
+  replaceWordAt = ({newWord, start, end}) => {
+    const startIndex = start
+    const endIndex = end
+    const selection = this.state.editorState.getSelection().merge({
+      anchorOffset: startIndex,
+      focusOffset: endIndex,
+    })
+    const contentState = Modifier.replaceText(
+      this.state.editorState.getCurrentContent(),
+      selection,
+      newWord,
+    )
+    const updatedState = EditorState.push(this.state.editorState, contentState)
+    this.setState({editorState: updatedState}, () => {
+      // Reactivate decorators
+      this.updateTranslationDebounced()
+      // Stop composition mode
+      this.onCompositionStopDebounced()
+    })
   }
 
   render() {

--- a/public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.js
+++ b/public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.js
@@ -42,7 +42,10 @@ class LexiqaHighlight extends Component {
             segmentOpened &&
             warning &&
             warning.messages && (
-              <LexiqaTooltipInfo messages={warning.messages} />
+              <LexiqaTooltipInfo
+                messages={warning.messages}
+                onReplaceWord={this.props.replaceWordAt}
+              />
             )
           }
           isInteractiveContent={true}

--- a/public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.test.js
+++ b/public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.test.js
@@ -1,0 +1,89 @@
+import React from 'react'
+import {render, screen, fireEvent, act} from '@testing-library/react'
+
+import LexiqaHighlight from './LexiqaHighlight.component'
+import LexiqaUtils from '../../../utils/lxq.main'
+
+jest.mock('../../../utils/lxq.main', () => ({
+  buildTooltipMessages: jest.fn(),
+}))
+
+jest.mock('../TooltipInfo/LexiqaTooltipInfo.component', () => (props) => (
+  <div
+    data-testid="tooltip-info"
+    onClick={() =>
+      props.onReplaceWord({newWord: 'fixed', start: props.messages[0].start, end: props.messages[0].end})
+    }
+  >
+    {props.messages.map((m) => m.msg).join(',')}
+  </div>
+))
+
+const warning = {start: 0, end: 5, blockKey: 'block-1', myClass: 'spelling', color: 'red'}
+
+const baseProps = {
+  blockKey: 'block-1',
+  start: 0,
+  end: 5,
+  isSource: false,
+  sid: '1',
+  getUpdatedSegmentInfo: () => ({segmentOpened: true}),
+  replaceWordAt: jest.fn(),
+  children: 'wrng word',
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  LexiqaUtils.buildTooltipMessages.mockReturnValue([
+    {msg: 'suggested fix', start: 0, end: 5, type: 'suggestion'},
+  ])
+})
+
+test('renders nothing when no warning matches the given range', () => {
+  const {container} = render(
+    <LexiqaHighlight {...baseProps} warnings={[]}>
+      wrng word
+    </LexiqaHighlight>,
+  )
+
+  expect(container).toBeEmptyDOMElement()
+})
+
+test('highlights the matched range with the warning color', () => {
+  render(
+    <LexiqaHighlight {...baseProps} warnings={[{...warning, errorid: 'e1'}]}>
+      wrng word
+    </LexiqaHighlight>,
+  )
+
+  expect(screen.getByText('wrng word').style.backgroundColor).toBe('red')
+})
+
+test('does not build tooltip messages when the warning has no class/errorid', () => {
+  render(
+    <LexiqaHighlight {...baseProps} warnings={[{start: 0, end: 5, blockKey: 'block-1'}]}>
+      wrng word
+    </LexiqaHighlight>,
+  )
+
+  expect(LexiqaUtils.buildTooltipMessages).not.toHaveBeenCalled()
+})
+
+test('forwards replaceWordAt to LexiqaTooltipInfo through the tooltip content', async () => {
+  render(
+    <LexiqaHighlight {...baseProps} warnings={[{...warning, errorid: 'e1'}]}>
+      wrng word
+    </LexiqaHighlight>,
+  )
+
+  fireEvent.pointerEnter(screen.getByText('wrng word').parentElement)
+  await act(() => new Promise((resolve) => setTimeout(resolve, 350)))
+
+  fireEvent.click(await screen.findByTestId('tooltip-info'))
+
+  expect(baseProps.replaceWordAt).toHaveBeenCalledWith({
+    newWord: 'fixed',
+    start: 0,
+    end: 5,
+  })
+})

--- a/public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.js
+++ b/public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react'
-import {each} from 'lodash'
 
 import LXQ from '../../../utils/lxq.main'
 
@@ -11,23 +10,55 @@ class LexiqaTooltipInfo extends Component {
   }
 
   buildTooltipError = () => {
-    let messages = this.props.messages
-    let html = []
-    each(messages, (message, i) => {
-      html.push(
-        <div className="tooltip-error-container" key={i}>
-          <span className="tooltip-error-category">{message.msg}</span>
-          <div
-            className="tooltip-error-ignore"
-            onClick={() => this.ignoreError(message)}
-          >
-            <span className="icon-cancel-circle" />
-            <span className="tooltip-error-ignore-text">Ignore</span>
-          </div>
-        </div>,
-      )
-    })
-    return html
+    const {messages} = this.props
+    const suggestions = messages.filter((item) => item.type === 'suggestion')
+    const errors = messages.filter((item) => item.type !== 'suggestion')
+
+    const errorsHtml = errors.map((error, i) => (
+      <div className="tooltip-error-container" key={i}>
+        <span className="tooltip-error-category">{error.msg}</span>
+        <div
+          className="tooltip-error-ignore"
+          onClick={() => this.ignoreError(error)}
+        >
+          <span className="icon-cancel-circle" />
+          <span className="tooltip-error-ignore-text">Ignore</span>
+        </div>
+      </div>
+    ))
+
+    const suggestionsList = suggestions.map((suggestion, i) => (
+      <li
+        key={i}
+        onClick={() =>
+          this.replaceWord({
+            newWord: suggestion.msg,
+            start: suggestion.start,
+            end: suggestion.end,
+          })
+        }
+      >
+        {suggestion.msg}
+      </li>
+    ))
+
+    const suggestionsHtml = suggestions.length > 0 && (
+      <div className="tooltip-suggestion-container">
+        <ul>{suggestionsList}</ul>
+      </div>
+    )
+
+    return (
+      <>
+        {errorsHtml}
+        {suggestionsHtml}
+      </>
+    )
+  }
+
+  replaceWord = ({newWord, start, end}) => {
+    this.props.onReplaceWord({newWord, start, end})
+    //LXQ.redoHighlighting(segmentId, false)
   }
 
   render() {

--- a/public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.test.js
+++ b/public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.test.js
@@ -1,0 +1,71 @@
+import React from 'react'
+import {render, screen, fireEvent} from '@testing-library/react'
+
+import LexiqaTooltipInfo from './LexiqaTooltipInfo.component'
+import LXQ from '../../../utils/lxq.main'
+
+jest.mock('../../../utils/lxq.main', () => ({
+  ignoreError: jest.fn(),
+}))
+
+const errorMessage = {msg: 'error message', error: 'spelling', type: 'error'}
+const suggestionMessage = {
+  msg: 'suggested word',
+  start: 2,
+  end: 6,
+  type: 'suggestion',
+}
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+test('renders error messages with an ignore control', () => {
+  render(<LexiqaTooltipInfo messages={[errorMessage]} onReplaceWord={jest.fn()} />)
+
+  expect(screen.getByText('error message')).toBeInTheDocument()
+  expect(screen.getByText('Ignore')).toBeInTheDocument()
+})
+
+test('clicking ignore calls LXQ.ignoreError with the error payload', () => {
+  render(<LexiqaTooltipInfo messages={[errorMessage]} onReplaceWord={jest.fn()} />)
+
+  fireEvent.click(screen.getByText('Ignore'))
+
+  expect(LXQ.ignoreError).toHaveBeenCalledTimes(1)
+  expect(LXQ.ignoreError).toHaveBeenCalledWith(errorMessage.error)
+})
+
+test('renders suggestion messages in a suggestion list, separate from errors', () => {
+  render(
+    <LexiqaTooltipInfo
+      messages={[errorMessage, suggestionMessage]}
+      onReplaceWord={jest.fn()}
+    />,
+  )
+
+  expect(screen.getByText('error message')).toBeInTheDocument()
+  expect(screen.getByText('suggested word')).toBeInTheDocument()
+})
+
+test('clicking a suggestion calls onReplaceWord with the word and its offsets', () => {
+  const onReplaceWord = jest.fn()
+  render(
+    <LexiqaTooltipInfo messages={[suggestionMessage]} onReplaceWord={onReplaceWord} />,
+  )
+
+  fireEvent.click(screen.getByText('suggested word'))
+
+  expect(onReplaceWord).toHaveBeenCalledTimes(1)
+  expect(onReplaceWord).toHaveBeenCalledWith({
+    newWord: suggestionMessage.msg,
+    start: suggestionMessage.start,
+    end: suggestionMessage.end,
+  })
+})
+
+test('renders nothing extra when there are no suggestions', () => {
+  render(<LexiqaTooltipInfo messages={[errorMessage]} onReplaceWord={jest.fn()} />)
+
+  expect(screen.queryByRole('list')).not.toBeInTheDocument()
+})

--- a/public/js/components/segments/utils/DraftMatecatUtils/activateLexiqa.js
+++ b/public/js/components/segments/utils/DraftMatecatUtils/activateLexiqa.js
@@ -9,6 +9,7 @@ const activateLexiqa = (
   sid,
   isSource,
   getUpdatedSegmentInfo,
+  replaceWordAt,
 ) => {
   const generateLexiqaDecorator = (warnings, sid, isSource, decoratorName) => {
     return {
@@ -33,6 +34,7 @@ const activateLexiqa = (
         sid,
         isSource,
         getUpdatedSegmentInfo,
+        replaceWordAt,
       },
     }
   }

--- a/public/js/components/segments/utils/DraftMatecatUtils/transformLexiqaPoints.js
+++ b/public/js/components/segments/utils/DraftMatecatUtils/transformLexiqaPoints.js
@@ -1,0 +1,58 @@
+import getEntities from './getEntities'
+import {isToReplaceForLexiqa} from './tagModel'
+
+const transformLexiqaPoints = (editorState, start, end) => {
+  const contentState = editorState.getCurrentContent()
+  const blocks = contentState.getBlockMap()
+  let maxCharsInBlocks = 0
+  const result = {}
+  const entities = getEntities(editorState)
+  blocks.forEach((loopedContentBlock) => {
+    const firstBlockKey = contentState.getFirstBlock().getKey()
+    const loopedBlockKey = loopedContentBlock.getKey()
+    // Add current block length
+    const newLineChar = loopedBlockKey !== firstBlockKey ? 1 : 0
+    maxCharsInBlocks += loopedContentBlock.getLength() + newLineChar
+    const entitiesInBlock = entities.filter(
+      (ent) => ent.blockKey === loopedBlockKey,
+    )
+    // Todo: warnings between 2 block are now ignored
+    const alreadyScannedChars =
+      maxCharsInBlocks - loopedContentBlock.getLength()
+    // remove offset added by '<' and '>' that wrap tags preceding current warning
+    entitiesInBlock.forEach((ent) => {
+      if (
+        ent.start + alreadyScannedChars < start &&
+        ent.end + alreadyScannedChars <= start
+      ) {
+        if (!isToReplaceForLexiqa(ent.entity.getData().name)) {
+          start -= 2
+          end -= 2
+        }
+      }
+    })
+    if (
+      start < maxCharsInBlocks &&
+      end <= maxCharsInBlocks &&
+      (start >= alreadyScannedChars || start === alreadyScannedChars - 1)
+    ) {
+      // Lexiqa warning length isn't valid, recompute length based on offset
+      let warnLength = end - start
+      let relativeStart = start - alreadyScannedChars
+      // Strings passed to lexiqa includes newlines so if two spaces are at the end of the line,
+      // they will be paired with newline char, causing lexiqa error to be of length 3.
+      // Same occurs if spaces are placed at the begininning of a new block: they will be paired with previous
+      // block's newline. Here we correct the last case, forcing error to start on the new block and ignoring newline char
+      if (start === alreadyScannedChars - 1) {
+        warnLength -= 1 // delete newline
+        relativeStart += 1 // start on next block
+      }
+      const relativeEnd = relativeStart + warnLength
+      result.start = relativeStart
+      result.end = relativeEnd
+    }
+  })
+  return result
+}
+
+export default transformLexiqaPoints

--- a/public/js/components/segments/utils/DraftMatecatUtils/transformLexiqaPoints.test.js
+++ b/public/js/components/segments/utils/DraftMatecatUtils/transformLexiqaPoints.test.js
@@ -1,0 +1,32 @@
+import {EditorState, ContentState} from 'draft-js'
+
+import transformLexiqaPoints from './transformLexiqaPoints'
+
+const editorStateFromText = (text) =>
+  EditorState.createWithContent(ContentState.createFromText(text))
+
+test('keeps the offsets unchanged for a warning inside a single block', () => {
+  const editorState = editorStateFromText('Hello world')
+
+  const result = transformLexiqaPoints(editorState, 0, 5)
+
+  expect(result).toEqual({start: 0, end: 5})
+})
+
+test('returns an empty result when the warning offsets are out of range', () => {
+  const editorState = editorStateFromText('Hello world')
+
+  const result = transformLexiqaPoints(editorState, 100, 105)
+
+  expect(result).toEqual({})
+})
+
+test('rebases the offsets relative to the block that contains the warning', () => {
+  const editorState = editorStateFromText('Hello world\nGoodbye now')
+
+  // "Goodbye" starts right after the first block (11 chars) plus the
+  // implicit newline character accounted for by the block map traversal.
+  const result = transformLexiqaPoints(editorState, 12, 19)
+
+  expect(result).toEqual({start: 0, end: 7})
+})

--- a/public/js/utils/lxq.main.js
+++ b/public/js/utils/lxq.main.js
@@ -630,6 +630,17 @@ const LXQ = {
         })
       }
     })
+    if (!isSource) {
+      const {suggestions, start, end} = range
+      $.each(suggestions, function (i, suggest) {
+        messages.push({
+          msg: suggest,
+          start: start,
+          end: end,
+          type: 'suggestion',
+        })
+      })
+    }
     return messages
   },
   ignoreError: (errorid) => {

--- a/public/js/utils/lxq.main.test.js
+++ b/public/js/utils/lxq.main.test.js
@@ -1,0 +1,49 @@
+window.config = {lxq_partnerid: 'test'}
+
+import LXQ from './lxq.main'
+
+const range = (overrides = {}) => ({
+  myClass: '',
+  errorid: '',
+  suggestions: ['fixed word'],
+  start: 3,
+  end: 8,
+  ...overrides,
+})
+
+beforeEach(() => {
+  LXQ.lexiqaData = {lexiqaWarnings: {}}
+})
+
+test('does not add suggestion messages when building tooltip for the source segment', () => {
+  const messages = LXQ.buildTooltipMessages(range(), 1, true)
+
+  expect(messages).toEqual([])
+})
+
+test('adds a suggestion message for each suggestion when building tooltip for the target', () => {
+  const messages = LXQ.buildTooltipMessages(range(), 1, false)
+
+  expect(messages).toEqual([
+    {msg: 'fixed word', start: 3, end: 8, type: 'suggestion'},
+  ])
+})
+
+test('adds one suggestion message per suggestion, sharing the warning offsets', () => {
+  const messages = LXQ.buildTooltipMessages(
+    range({suggestions: ['first', 'second']}),
+    1,
+    false,
+  )
+
+  expect(messages).toEqual([
+    {msg: 'first', start: 3, end: 8, type: 'suggestion'},
+    {msg: 'second', start: 3, end: 8, type: 'suggestion'},
+  ])
+})
+
+test('does not add anything when there are no suggestions', () => {
+  const messages = LXQ.buildTooltipMessages(range({suggestions: []}), 1, false)
+
+  expect(messages).toEqual([])
+})


### PR DESCRIPTION
## Summary

Bring the lexiqa spellcheck "replace suggestion" feature to `master`. This extracts just the
spellcheck-specific work from the long-running `lexiqa-styleguide-changes` branch (original
commits date back to 2021, refreshed against current `develop` this year) without pulling in the
other, still in-flight/untested features currently sitting in `develop`.

## Type

- [x] `feat` — new user-facing feature

## Changes

| File | Change |
|------|--------|
| `public/js/utils/lxq.main.js` | push lexiqa spellcheck suggestions into the warning messages list for non-source segments |
| `public/js/components/segments/utils/DraftMatecatUtils/activateLexiqa.js` | thread a `replaceWordAt` callback through to the highlight decorator |
| `public/js/components/segments/utils/DraftMatecatUtils/transformLexiqaPoints.js` | new helper mapping a lexiqa warning/suggestion offset onto Draft.js block-relative start/end |
| `public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.js` | render a clickable suggestion list in the tooltip; picking a suggestion triggers `onReplaceWord` |
| `public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.js` | pass suggestion messages through to the tooltip |
| `public/js/components/segments/Editarea.js` | implement `replaceWordAt`, replacing the selected range in the editor with the chosen suggestion and re-triggering the translation update |
| `public/css/sass/lexiqa.scss` | style the suggestion list in the tooltip |

## Testing

- [x] New tests added for changed behavior

```
Test Suites: 4 passed, 4 total
Tests:       16 passed, 16 total
```
Covers: `LexiqaHighlight.component.test.js`, `LexiqaTooltipInfo.component.test.js`,
`transformLexiqaPoints.test.js`, `lxq.main.test.js`.

No PHP files are touched by this PR, so `phpunit`/`phpstan` are not applicable.

## AI Disclosure

- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

No manual browser testing was performed as part of this extraction; behavior is unchanged from
what's already running in `lexiqa-styleguide-changes`/`develop`, only isolated onto `master`.
