### PR TITLE
♻️ refactor(htaccess): fix static-asset exclusion regex to prevent router bypass

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -27,7 +27,7 @@ RewriteRule ^ - [E=CONTEXT_PREVIEW:1]
 
 # Route all through the router
 RewriteRule ^$ router.php [QSA,L]
-RewriteRule !.(css|fonts|gif|jpe?g?|png|ico|js|svg|woff|ttf|map|json)$ router.php [QSA,L]
+RewriteRule !\.(css|fonts|gif|jpe?g|png|ico|js|svg|woff|ttf|map|json)$ router.php [QSA,L]
 
 RedirectMatch 404 ^/\.git
 RedirectMatch 404 ^/vendor


### PR DESCRIPTION
## Summary

Fixes a regex flaw in the root `.htaccess` static-asset exclusion rule that let some
request URLs bypass `router.php` and fall through to an Apache static-file `404`.

Two problems in the old pattern `!.(css|fonts|gif|jpe?g?|png|ico|js|svg|woff|ttf|map|json)$`:

- **Unescaped dot** — `.` matched any character, not a literal `.`, so the extension
  boundary was not actually anchored to a dot.
- **`jpe?g?` made the `g` optional** — the trailing `g?` matched URLs ending in `jp`
  or `jpe` (not just `jpg`/`jpeg`). Randomly generated job passwords ending in those
  substrings were treated as static assets, skipped the router, and returned a static
  `404` in production.

New pattern `!\.(css|fonts|gif|jpe?g|png|ico|js|svg|woff|ttf|map|json)$` escapes the dot
and requires the full `jpg`/`jpeg` extension.

## Type

- [x] `refactor` — restructure without behavior change

## Changes

| File | Change |
|------|--------|
| `.htaccess` | escape the extension-boundary dot (`.` → `\.`) and drop the optional `g?` so `jpe?g` only matches `jpg`/`jpeg` |

## Testing

- [x] Manual testing performed (describe below)

Rewrite rules in `.htaccess` are Apache-server config and are not covered by the PHPUnit
suite. Verified by inspecting the regex against affected URL shapes: job passwords/URLs
ending in `jp`, `jpe`, `js`, `map`, etc. no longer match the exclusion and are correctly
routed through `router.php`; genuine static assets (`.css`, `.jpg`, `.jpeg`, `.js`, …)
still bypass the router as before.

## AI Disclosure

- [x] No AI tools were used in this PR

## Notes

Affects production routing. The optional-`g` bug specifically surfaced for job URLs whose
random password ended in `jp`/`jpe`.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216727961799111
  - https://app.asana.com/0/0/1216658470089243