### PR TITLE
🐛 fix(project-template): persist empty mandatory_issues as json array

### DIFF
--- a/inc/validation/schema/job_metadata.json
+++ b/inc/validation/schema/job_metadata.json
@@ -49,6 +49,21 @@
         "additionalProperties": false,
         "properties": {
           "key": {
+            "const": "mandatory_issues"
+          },
+          "value": {
+            "type": "array",
+            "items": {
+              "enum": ["r1", "r2"]
+            }
+          }
+        }
+      },
+      {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "key": {
             "const": "tm_prioritization"
           },
           "value": {

--- a/lib/Model/Projects/ProjectTemplateStruct.php
+++ b/lib/Model/Projects/ProjectTemplateStruct.php
@@ -111,7 +111,7 @@ class ProjectTemplateStruct extends AbstractDaoSilentStruct implements IDaoStruc
         $this->target_language = (!empty($decodedObject->target_language)) ? serialize($decodedObject->target_language) : null;
         $this->mt_quality_value_in_editor = (!empty($decodedObject->mt_quality_value_in_editor)) ? (int)$decodedObject->mt_quality_value_in_editor : null;
         $this->icu_enabled = $decodedObject->icu_enabled ?? true;
-        $this->mandatory_issues = (!empty($decodedObject->mandatory_issues)) ? (json_encode($decodedObject->mandatory_issues) ?: null) : null;
+        $this->mandatory_issues = (($decodedObject->mandatory_issues ?? null) !== null) ? (json_encode($decodedObject->mandatory_issues) ?: null) : null;
 
         return $this;
     }

--- a/nodejs/yarn.lock
+++ b/nodejs/yarn.lock
@@ -270,24 +270,29 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@colors/colors@^1.6.0", "@colors/colors@1.6.0":
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
+"@colors/colors@1.6.0":
   version "1.6.0"
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz"
   integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
 
-"@dabh/diagnostics@^2.0.8":
-  version "2.0.8"
-  resolved "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz"
-  integrity sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz"
+  integrity sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==
   dependencies:
-    "@so-ric/colorspace" "^1.1.6"
+    colorspace "1.1.x"
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@ioredis/commands@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz"
-  integrity sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -581,9 +586,9 @@
   integrity sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==
 
 "@sinclair/typebox@^0.34.0":
-  version "0.34.49"
-  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz"
-  integrity sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==
+  version "0.34.52"
+  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz"
+  integrity sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==
 
 "@sinonjs/commons@^3.0.1":
   version "3.0.1"
@@ -598,14 +603,6 @@
   integrity sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
-
-"@so-ric/colorspace@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz"
-  integrity sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==
-  dependencies:
-    color "^5.0.2"
-    text-hex "1.0.x"
 
 "@socket.io/cluster-adapter@^0.3.0":
   version "0.3.0"
@@ -671,10 +668,15 @@
   dependencies:
     "@babel/types" "^7.28.2"
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
 "@types/cors@^2.8.12":
-  version "2.8.19"
-  resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz"
-  integrity sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==
+  version "2.8.17"
+  resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz"
+  integrity sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==
   dependencies:
     "@types/node" "*"
 
@@ -698,11 +700,11 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/node@*", "@types/node@>=10.0.0":
-  version "25.9.1"
-  resolved "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz"
-  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
+  version "22.10.7"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz"
+  integrity sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==
   dependencies:
-    undici-types ">=7.24.0 <7.24.7"
+    undici-types "~6.20.0"
 
 "@types/stack-utils@^2.0.3":
   version "2.0.3"
@@ -713,13 +715,6 @@
   version "1.3.5"
   resolved "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz"
   integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
-
-"@types/ws@^8.5.12":
-  version "8.18.1"
-  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
-  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
-  dependencies:
-    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -734,14 +729,14 @@
     "@types/yargs-parser" "*"
 
 "@ungap/structured-clone@^1.3.0":
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz"
-  integrity sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
+  version "1.3.3"
+  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz"
+  integrity sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==
 
-"@unrs/resolver-binding-linux-arm64-gnu@1.12.2":
+"@unrs/resolver-binding-linux-x64-gnu@1.12.2":
   version "1.12.2"
-  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz"
-  integrity sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz"
+  integrity sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==
 
 accepts@~1.3.4:
   version "1.3.8"
@@ -801,9 +796,9 @@ argparse@^1.0.7:
     sprintf-js "~1.0.2"
 
 async@^3.2.3:
-  version "3.2.6"
-  resolved "https://registry.npmjs.org/async/-/async-3.2.6.tgz"
-  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
+  version "3.2.4"
+  resolved "https://registry.npmjs.org/async/-/async-3.2.4.tgz"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 babel-jest@30.4.1:
   version "30.4.1"
@@ -875,35 +870,35 @@ base64id@~2.0.0, base64id@2.0.0:
   resolved "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
-baseline-browser-mapping@^2.10.12:
-  version "2.10.33"
-  resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz"
-  integrity sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==
+baseline-browser-mapping@^2.10.42:
+  version "2.10.44"
+  resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz"
+  integrity sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.16"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
   dependencies:
     balanced-match "^1.0.0"
 
 browserslist@^4.24.0, "browserslist@>= 4.21.0":
-  version "4.28.2"
-  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz"
-  integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
+  version "4.28.6"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz"
+  integrity sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==
   dependencies:
-    baseline-browser-mapping "^2.10.12"
-    caniuse-lite "^1.0.30001782"
-    electron-to-chromium "^1.5.328"
-    node-releases "^2.0.36"
+    baseline-browser-mapping "^2.10.42"
+    caniuse-lite "^1.0.30001803"
+    electron-to-chromium "^1.5.389"
+    node-releases "^2.0.51"
     update-browserslist-db "^1.2.3"
 
 bser@2.1.1:
@@ -913,7 +908,7 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-equal-constant-time@^1.0.1:
+buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
@@ -938,10 +933,10 @@ camelcase@^6.3.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001782:
-  version "1.0.30001793"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz"
-  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
+caniuse-lite@^1.0.30001803:
+  version "1.0.30001806"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz"
+  integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
 
 chalk@^4.1.2:
   version "4.1.2"
@@ -975,10 +970,10 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-cluster-key-slot@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz"
-  integrity sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==
+cluster-key-slot@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
 
 co@^4.6.0:
   version "4.6.0"
@@ -990,6 +985,13 @@ collect-v8-coverage@^1.0.2:
   resolved "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz"
   integrity sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==
 
+color-convert@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
@@ -997,37 +999,39 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-convert@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz"
-  integrity sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==
-  dependencies:
-    color-name "^2.0.0"
-
-color-name@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz"
-  integrity sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==
+color-name@^1.0.0, color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^2.1.3:
-  version "2.1.4"
-  resolved "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz"
-  integrity sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
   dependencies:
-    color-name "^2.0.0"
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
 
-color@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.npmjs.org/color/-/color-5.0.3.tgz"
-  integrity sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/color/-/color-3.2.1.tgz"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
   dependencies:
-    color-convert "^3.1.3"
-    color-string "^2.1.3"
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1061,17 +1065,17 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.4.1, debug@4.4.3:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
-
-debug@~4.3.1:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2, debug@~4.3.4:
   version "4.3.7"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
+  dependencies:
+    ms "^2.1.3"
+
+debug@~4.4.1:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
@@ -1085,7 +1089,7 @@ deepmerge@^4.3.1:
   resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
-denque@2.1.0:
+denque@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz"
   integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
@@ -1107,10 +1111,10 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
-electron-to-chromium@^1.5.328:
-  version "1.5.367"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.367.tgz"
-  integrity sha512-4Mk/mrynCNQ+atY40D3UpmhLWB6AHMbYMlIrPhHcMF6x0L7O0b052FCAsxw1LlaR++UFuNg3D/A6XCuGDa0guQ==
+electron-to-chromium@^1.5.389:
+  version "1.5.394"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.394.tgz"
+  integrity sha512-Wmt2Gm0o8JWBuGgmc4XZ0u9s1RaCRqhxP47phplmfg04+qypTUurpeJGP45A7Fhv7jdrrVH44PLlR9qXo37cVQ==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -1138,20 +1142,20 @@ engine.io-parser@~5.2.1:
   integrity sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==
 
 engine.io@~6.6.0:
-  version "6.6.8"
-  resolved "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz"
-  integrity sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==
+  version "6.6.2"
+  resolved "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz"
+  integrity sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==
   dependencies:
+    "@types/cookie" "^0.4.1"
     "@types/cors" "^2.8.12"
     "@types/node" ">=10.0.0"
-    "@types/ws" "^8.5.12"
     accepts "~1.3.4"
     base64id "2.0.0"
     cookie "~0.7.2"
     cors "~2.8.5"
-    debug "~4.4.1"
+    debug "~4.3.1"
     engine.io-parser "~5.2.1"
-    ws "~8.20.1"
+    ws "~8.17.1"
 
 error-ex@^1.3.1:
   version "1.3.4"
@@ -1348,17 +1352,19 @@ inherits@^2.0.3, inherits@2:
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ioredis@^5.4.2:
-  version "5.11.0"
-  resolved "https://registry.npmjs.org/ioredis/-/ioredis-5.11.0.tgz"
-  integrity sha512-EZBErytyVovD8f6pDfG3Kb37N6Y3lmDA9NNj+4+IP13CzzHGeX+OyeRM2Um13khRzoBSzzL+5lVnCX8V2RLeMg==
+  version "5.4.2"
+  resolved "https://registry.npmjs.org/ioredis/-/ioredis-5.4.2.tgz"
+  integrity sha512-0SZXGNGZ+WzISQ67QDyZ2x0+wVxjjUndtD8oSeik/4ajifeiRufed8fCb8QW8VMyi4MXcS+UO1k/0NGhvq1PAg==
   dependencies:
-    "@ioredis/commands" "1.10.0"
-    cluster-key-slot "1.1.1"
-    debug "4.4.3"
-    denque "2.1.0"
-    redis-errors "1.2.0"
-    redis-parser "3.0.0"
-    standard-as-callback "2.1.0"
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.1.0"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
 
 ip-regex@^4.3.0:
   version "4.3.0"
@@ -1369,6 +1375,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -1803,9 +1814,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1826,11 +1837,11 @@ json5@^2.2.3:
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonwebtoken@^9.0.2:
-  version "9.0.3"
-  resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz"
-  integrity sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==
+  version "9.0.2"
+  resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz"
+  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
   dependencies:
-    jws "^4.0.1"
+    jws "^3.2.2"
     lodash.includes "^4.3.0"
     lodash.isboolean "^3.0.3"
     lodash.isinteger "^4.0.4"
@@ -1841,21 +1852,21 @@ jsonwebtoken@^9.0.2:
     ms "^2.1.1"
     semver "^7.5.4"
 
-jwa@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz"
-  integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
   dependencies:
-    buffer-equal-constant-time "^1.0.1"
+    buffer-equal-constant-time "1.0.1"
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz"
-  integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
   dependencies:
-    jwa "^2.0.1"
+    jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
 kuler@^2.0.0:
@@ -1880,10 +1891,20 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"
   integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
@@ -1915,7 +1936,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-logform@^2.7.0:
+logform@^2.4.0, logform@^2.7.0:
   version "2.7.0"
   resolved "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz"
   integrity sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==
@@ -2029,10 +2050,10 @@ node-int64@^0.4.0:
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-releases@^2.0.36:
-  version "2.0.47"
-  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz"
-  integrity sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==
+node-releases@^2.0.51:
+  version "2.0.51"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz"
+  integrity sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==
 
 normalize-path@^3.0.0:
   version "3.0.0"
@@ -2157,9 +2178,9 @@ picomatch@^2.0.4:
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
-  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
 pirates@^4.0.7:
   version "4.0.7"
@@ -2207,12 +2228,12 @@ readable-stream@^3.4.0, readable-stream@^3.6.2:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-redis-errors@^1.0.0, redis-errors@1.2.0:
+redis-errors@^1.0.0, redis-errors@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz"
   integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
 
-redis-parser@3.0.0:
+redis-parser@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz"
   integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
@@ -2242,9 +2263,9 @@ safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-stable-stringify@^2.3.1:
-  version "2.5.0"
-  resolved "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz"
-  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
+  version "2.4.1"
+  resolved "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz"
+  integrity sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==
 
 semver@^6.3.1:
   version "6.3.1"
@@ -2252,9 +2273,9 @@ semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.5.3, semver@^7.5.4, semver@^7.7.2:
-  version "7.8.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz"
-  integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
+  version "7.8.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz"
+  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -2278,36 +2299,43 @@ signal-exit@^4.0.1:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 socket.io-adapter@^2.5.4, socket.io-adapter@~2.5.2, socket.io-adapter@~2.5.5:
-  version "2.5.7"
-  resolved "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz"
-  integrity sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==
+  version "2.5.5"
+  resolved "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz"
+  integrity sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==
   dependencies:
-    debug "~4.4.1"
-    ws "~8.20.1"
+    debug "~4.3.4"
+    ws "~8.17.1"
 
 socket.io-parser@~4.2.4:
-  version "4.2.6"
-  resolved "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz"
-  integrity sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==
+  version "4.2.4"
+  resolved "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz"
+  integrity sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
-    debug "~4.4.1"
+    debug "~4.3.1"
 
 socket.io@^4.8.1:
-  version "4.8.3"
-  resolved "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz"
-  integrity sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==
+  version "4.8.1"
+  resolved "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz"
+  integrity sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==
   dependencies:
     accepts "~1.3.4"
     base64id "~2.0.0"
     cors "~2.8.5"
-    debug "~4.4.1"
+    debug "~4.3.2"
     engine.io "~6.6.0"
     socket.io-adapter "~2.5.2"
     socket.io-parser "~4.2.4"
@@ -2342,7 +2370,7 @@ stack-utils@^2.0.6:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-standard-as-callback@2.1.0:
+standard-as-callback@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz"
   integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
@@ -2494,10 +2522,10 @@ uid2@1.0.0:
   resolved "https://registry.npmjs.org/uid2/-/uid2-1.0.0.tgz"
   integrity sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==
 
-"undici-types@>=7.24.0 <7.24.7":
-  version "7.24.6"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz"
-  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
+undici-types@~6.20.0:
+  version "6.20.0"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz"
+  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
 unrs-resolver@^1.7.11:
   version "1.12.2"
@@ -2580,7 +2608,7 @@ winston-daily-rotate-file@^5.0.0:
     triple-beam "^1.4.1"
     winston-transport "^4.7.0"
 
-winston-transport@^4.7.0, winston-transport@^4.9.0:
+winston-transport@^4.5.0, winston-transport@^4.7.0:
   version "4.9.0"
   resolved "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz"
   integrity sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==
@@ -2590,21 +2618,21 @@ winston-transport@^4.7.0, winston-transport@^4.9.0:
     triple-beam "^1.3.0"
 
 winston@^3:
-  version "3.19.0"
-  resolved "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz"
-  integrity sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==
+  version "3.8.2"
+  resolved "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz"
+  integrity sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==
   dependencies:
-    "@colors/colors" "^1.6.0"
-    "@dabh/diagnostics" "^2.0.8"
+    "@colors/colors" "1.5.0"
+    "@dabh/diagnostics" "^2.0.2"
     async "^3.2.3"
     is-stream "^2.0.0"
-    logform "^2.7.0"
+    logform "^2.4.0"
     one-time "^1.0.0"
     readable-stream "^3.4.0"
     safe-stable-stringify "^2.3.1"
     stack-trace "0.0.x"
     triple-beam "^1.3.0"
-    winston-transport "^4.9.0"
+    winston-transport "^4.5.0"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
@@ -2646,10 +2674,10 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@~8.20.1:
-  version "8.20.1"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+ws@~8.17.1:
+  version "8.17.1"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 y18n@^5.0.5:
   version "5.0.8"
@@ -2667,9 +2695,9 @@ yargs-parser@^21.1.1:
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^17.7.2:
-  version "17.7.2"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  version "17.7.3"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"

--- a/public/js/api/updateJobMetadata/updateJobMetadata.js
+++ b/public/js/api/updateJobMetadata/updateJobMetadata.js
@@ -18,6 +18,7 @@ export const updateJobMetadata = async ({
   characterCounterCountTags,
   characterCounterMode,
   subfilteringHandlers,
+  mandatoryIssues,
 }) => {
   const paramsData = Object.entries({
     tm_prioritization:
@@ -28,6 +29,7 @@ export const updateJobMetadata = async ({
         : undefined,
     character_counter_mode: characterCounterMode,
     subfiltering_handlers: subfilteringHandlers,
+    mandatory_issues: mandatoryIssues,
   })
     .filter(([, value]) => typeof value !== 'undefined')
     .map(([key, value]) => ({key, value}))

--- a/public/js/api/updateJobMetadata/updateJobMetadata.test.js
+++ b/public/js/api/updateJobMetadata/updateJobMetadata.test.js
@@ -1,0 +1,222 @@
+import {http, HttpResponse} from 'msw'
+import {mswServer} from '../../../mocks/mswServer'
+import {updateJobMetadata} from './updateJobMetadata'
+
+global.config = {
+  basepath: 'http://localhost/',
+  enableMultiDomainApi: false,
+  id_job: '42',
+  password: 'testpwd',
+}
+
+const url = `${config.basepath}api/app/jobs/${config.id_job}/${config.password}/metadata`
+
+describe('updateJobMetadata', () => {
+  describe('request URL', () => {
+    test('uses idJob and password from config by default', async () => {
+      let requestUrl
+      mswServer.use(
+        http.post('*', ({request}) => {
+          requestUrl = request.url
+          return HttpResponse.json({})
+        }),
+      )
+
+      await updateJobMetadata({})
+
+      expect(requestUrl).toBe(url)
+    })
+
+    test('prefers explicit idJob and password over config', async () => {
+      let requestUrl
+      mswServer.use(
+        http.post('*', ({request}) => {
+          requestUrl = request.url
+          return HttpResponse.json({})
+        }),
+      )
+
+      await updateJobMetadata({idJob: '99', password: 'other'})
+
+      expect(requestUrl).toBe(
+        `${config.basepath}api/app/jobs/99/other/metadata`,
+      )
+    })
+  })
+
+  describe('request body serialization', () => {
+    const captureBody = () => {
+      let received
+      mswServer.use(
+        http.post(url, async ({request}) => {
+          received = await request.json()
+          return HttpResponse.json({})
+        }),
+      )
+      return () => received
+    }
+
+    test('sends body as an array of {key, value} pairs', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({characterCounterMode: 'chars'})
+      expect(Array.isArray(getBody())).toBe(true)
+      expect(getBody()[0]).toMatchObject({key: expect.any(String), value: expect.anything()})
+    })
+
+    test('includes tmPrioritization when boolean true', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({tmPrioritization: true})
+      expect(getBody()).toContainEqual({key: 'tm_prioritization', value: true})
+    })
+
+    test('includes tmPrioritization when boolean false', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({tmPrioritization: false})
+      expect(getBody()).toContainEqual({key: 'tm_prioritization', value: false})
+    })
+
+    test('excludes tmPrioritization when undefined', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({})
+      expect(getBody().map(({key}) => key)).not.toContain('tm_prioritization')
+    })
+
+    test('excludes tmPrioritization when a non-boolean value is passed', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({tmPrioritization: 'yes'})
+      expect(getBody().map(({key}) => key)).not.toContain('tm_prioritization')
+    })
+
+    test('includes characterCounterCountTags when boolean true', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({characterCounterCountTags: true})
+      expect(getBody()).toContainEqual({
+        key: 'character_counter_count_tags',
+        value: true,
+      })
+    })
+
+    test('includes characterCounterCountTags when boolean false', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({characterCounterCountTags: false})
+      expect(getBody()).toContainEqual({
+        key: 'character_counter_count_tags',
+        value: false,
+      })
+    })
+
+    test('excludes characterCounterCountTags when a non-boolean value is passed', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({characterCounterCountTags: 1})
+      expect(getBody().map(({key}) => key)).not.toContain(
+        'character_counter_count_tags',
+      )
+    })
+
+    test('includes characterCounterMode', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({characterCounterMode: 'words'})
+      expect(getBody()).toContainEqual({
+        key: 'character_counter_mode',
+        value: 'words',
+      })
+    })
+
+    test('includes subfilteringHandlers', async () => {
+      const getBody = captureBody()
+      const handlers = {handler: 'test'}
+      await updateJobMetadata({subfilteringHandlers: handlers})
+      expect(getBody()).toContainEqual({
+        key: 'subfiltering_handlers',
+        value: handlers,
+      })
+    })
+
+    test('includes mandatoryIssues', async () => {
+      const getBody = captureBody()
+      const issues = ['r1', 'r2']
+      await updateJobMetadata({mandatoryIssues: issues})
+      expect(getBody()).toContainEqual({key: 'mandatory_issues', value: issues})
+    })
+
+    test('includes mandatoryIssues when empty array', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({mandatoryIssues: []})
+      expect(getBody()).toContainEqual({key: 'mandatory_issues', value: []})
+    })
+
+    test('omits undefined fields from the payload', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({characterCounterMode: 'chars'})
+      const keys = getBody().map(({key}) => key)
+      expect(keys).not.toContain('tm_prioritization')
+      expect(keys).not.toContain('character_counter_count_tags')
+      expect(keys).not.toContain('subfiltering_handlers')
+      expect(keys).not.toContain('mandatory_issues')
+    })
+
+    test('sends an empty array when all fields are undefined', async () => {
+      const getBody = captureBody()
+      await updateJobMetadata({})
+      expect(getBody()).toEqual([])
+    })
+  })
+
+  describe('request headers and credentials', () => {
+    test('sends Content-Type: application/json', async () => {
+      let contentType
+      mswServer.use(
+        http.post(url, ({request}) => {
+          contentType = request.headers.get('Content-Type')
+          return HttpResponse.json({})
+        }),
+      )
+
+      await updateJobMetadata({})
+
+      expect(contentType).toBe('application/json')
+    })
+  })
+
+  describe('response handling', () => {
+    test('returns data from a successful response', async () => {
+      mswServer.use(
+        http.post(url, () =>
+          HttpResponse.json({status: 'OK', updated: true}),
+        ),
+      )
+
+      const result = await updateJobMetadata({})
+
+      expect(result).toEqual({status: 'OK', updated: true})
+    })
+
+    test('strips the errors field from the returned data', async () => {
+      mswServer.use(
+        http.post(url, () => HttpResponse.json({status: 'OK', errors: []})),
+      )
+
+      const result = await updateJobMetadata({})
+
+      expect(result).not.toHaveProperty('errors')
+    })
+
+    test('rejects with the response on a non-ok HTTP status', async () => {
+      mswServer.use(http.post(url, () => new HttpResponse(null, {status: 500})))
+
+      const result = await updateJobMetadata({}).catch((e) => e)
+
+      expect(result.ok).toBe(false)
+      expect(result.status).toBe(500)
+    })
+
+    test('rejects with the errors array when the payload contains errors', async () => {
+      const errors = [{code: 10, message: 'invalid'}]
+      mswServer.use(http.post(url, () => HttpResponse.json({errors})))
+
+      const result = await updateJobMetadata({}).catch((e) => e)
+
+      expect(result).toEqual(errors)
+    })
+  })
+})

--- a/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.js
+++ b/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.js
@@ -3,6 +3,7 @@ import {CharacterCounterRules} from '../OtherTab/CharacterCounterRules'
 import {SettingsPanelContext} from '../../SettingsPanelContext'
 import {updateJobMetadata} from '../../../../api/updateJobMetadata'
 import {Tagging} from '../OtherTab/Tagging'
+import {MandatoryIssues} from '../OtherTab/MandatoryIssues'
 
 export const EditorOtherTab = () => {
   const {currentProjectTemplate, tmKeys} = useContext(SettingsPanelContext)
@@ -18,13 +19,16 @@ export const EditorOtherTab = () => {
         previousCurrentProjectTemplate.current.characterCounterMode !==
           currentProjectTemplate?.characterCounterMode ||
         previousCurrentProjectTemplate.current.subfilteringHandlers !==
-          currentProjectTemplate?.subfilteringHandlers)
+          currentProjectTemplate?.subfilteringHandlers ||
+        previousCurrentProjectTemplate.current.mandatoryIssues !==
+          currentProjectTemplate?.mandatoryIssues)
     ) {
       updateJobMetadata({
         characterCounterCountTags:
           currentProjectTemplate.characterCounterCountTags,
         characterCounterMode: currentProjectTemplate.characterCounterMode,
         subfilteringHandlers: currentProjectTemplate.subfilteringHandlers,
+        mandatoryIssues: currentProjectTemplate.mandatoryIssues,
       })
     }
 
@@ -33,11 +37,13 @@ export const EditorOtherTab = () => {
         currentProjectTemplate?.characterCounterCountTags,
       characterCounterMode: currentProjectTemplate?.characterCounterMode,
       subfilteringHandlers: currentProjectTemplate?.subfilteringHandlers,
+      mandatoryIssues: currentProjectTemplate?.mandatoryIssues,
     }
   }, [
     currentProjectTemplate?.characterCounterCountTags,
     currentProjectTemplate?.characterCounterMode,
     currentProjectTemplate?.subfilteringHandlers,
+    currentProjectTemplate?.mandatoryIssues,
     tmKeys,
   ])
 
@@ -46,6 +52,7 @@ export const EditorOtherTab = () => {
       <div className="settings-panel-contentwrapper-tab-subcategories">
         <h2>General settings</h2>
         <Tagging />
+        <MandatoryIssues />
       </div>
       <div className="settings-panel-contentwrapper-tab-subcategories">
         <h2>Character counter settings</h2>

--- a/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.test.js
+++ b/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.test.js
@@ -1,0 +1,224 @@
+import React from 'react'
+import {render, screen, within} from '@testing-library/react'
+import {EditorOtherTab} from './EditorOtherTab'
+import {SettingsPanelContext} from '../../SettingsPanelContext'
+import {updateJobMetadata} from '../../../../api/updateJobMetadata'
+
+jest.mock('../../../../api/updateJobMetadata', () => ({
+  updateJobMetadata: jest.fn(),
+}))
+
+jest.mock('../OtherTab/Tagging', () => ({
+  Tagging: () => <div data-testid="tagging" />,
+}))
+
+jest.mock('../OtherTab/MandatoryIssues', () => ({
+  MandatoryIssues: () => <div data-testid="mandatory-issues" />,
+}))
+
+jest.mock('../OtherTab/CharacterCounterRules', () => ({
+  CharacterCounterRules: () => <div data-testid="character-counter-rules" />,
+}))
+
+const baseTemplate = {
+  characterCounterCountTags: false,
+  characterCounterMode: 'chars',
+  subfilteringHandlers: null,
+  mandatoryIssues: [],
+}
+
+const renderComponent = (template = baseTemplate, tmKeys = []) =>
+  render(
+    <SettingsPanelContext.Provider
+      value={{currentProjectTemplate: template, tmKeys}}
+    >
+      <EditorOtherTab />
+    </SettingsPanelContext.Provider>,
+  )
+
+const reRenderComponent = (rerender, template, tmKeys = []) =>
+  rerender(
+    <SettingsPanelContext.Provider
+      value={{currentProjectTemplate: template, tmKeys}}
+    >
+      <EditorOtherTab />
+    </SettingsPanelContext.Provider>,
+  )
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  global.config = {is_cattool: true}
+})
+
+describe('EditorOtherTab', () => {
+  describe('rendering', () => {
+    test('renders outer wrapper with correct classes', () => {
+      const {container} = renderComponent()
+      expect(
+        container.querySelector(
+          '.editor-settings-options-box.settings-panel-contentwrapper-tab-background',
+        ),
+      ).toBeInTheDocument()
+    })
+
+    test('renders two subcategory sections', () => {
+      const {container} = renderComponent()
+      expect(
+        container.querySelectorAll(
+          '.settings-panel-contentwrapper-tab-subcategories',
+        ),
+      ).toHaveLength(2)
+    })
+
+    describe('General settings section', () => {
+      let generalSection
+
+      beforeEach(() => {
+        const {container} = renderComponent()
+        generalSection = container.querySelectorAll(
+          '.settings-panel-contentwrapper-tab-subcategories',
+        )[0]
+      })
+
+      test('has "General settings" heading', () => {
+        expect(
+          within(generalSection).getByText('General settings'),
+        ).toBeInTheDocument()
+      })
+
+      test('renders Tagging', () => {
+        expect(within(generalSection).getByTestId('tagging')).toBeInTheDocument()
+      })
+
+      test('renders MandatoryIssues', () => {
+        expect(
+          within(generalSection).getByTestId('mandatory-issues'),
+        ).toBeInTheDocument()
+      })
+
+      test('does not render CharacterCounterRules', () => {
+        expect(
+          within(generalSection).queryByTestId('character-counter-rules'),
+        ).not.toBeInTheDocument()
+      })
+    })
+
+    describe('Character counter settings section', () => {
+      let counterSection
+
+      beforeEach(() => {
+        const {container} = renderComponent()
+        counterSection = container.querySelectorAll(
+          '.settings-panel-contentwrapper-tab-subcategories',
+        )[1]
+      })
+
+      test('has "Character counter settings" heading', () => {
+        expect(
+          within(counterSection).getByText('Character counter settings'),
+        ).toBeInTheDocument()
+      })
+
+      test('renders CharacterCounterRules', () => {
+        expect(
+          within(counterSection).getByTestId('character-counter-rules'),
+        ).toBeInTheDocument()
+      })
+
+      test('does not render general settings children', () => {
+        expect(
+          within(counterSection).queryByTestId('tagging'),
+        ).not.toBeInTheDocument()
+        expect(
+          within(counterSection).queryByTestId('mandatory-issues'),
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('updateJobMetadata side effects', () => {
+    test('does not call updateJobMetadata on first render', () => {
+      renderComponent()
+      expect(updateJobMetadata).not.toHaveBeenCalled()
+    })
+
+    test('does not call updateJobMetadata when is_cattool is false', () => {
+      global.config.is_cattool = false
+      const {rerender} = renderComponent()
+      reRenderComponent(rerender, {
+        ...baseTemplate,
+        characterCounterMode: 'words',
+      })
+      expect(updateJobMetadata).not.toHaveBeenCalled()
+    })
+
+    test('does not call updateJobMetadata when only tmKeys changes', () => {
+      const {rerender} = renderComponent(baseTemplate, [])
+      reRenderComponent(rerender, baseTemplate, [{id: 1}])
+      expect(updateJobMetadata).not.toHaveBeenCalled()
+    })
+
+    test('calls updateJobMetadata when characterCounterMode changes', () => {
+      const {rerender} = renderComponent()
+      reRenderComponent(rerender, {...baseTemplate, characterCounterMode: 'words'})
+      expect(updateJobMetadata).toHaveBeenCalledTimes(1)
+      expect(updateJobMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({characterCounterMode: 'words'}),
+      )
+    })
+
+    test('calls updateJobMetadata when characterCounterCountTags changes', () => {
+      const {rerender} = renderComponent()
+      reRenderComponent(rerender, {...baseTemplate, characterCounterCountTags: true})
+      expect(updateJobMetadata).toHaveBeenCalledTimes(1)
+      expect(updateJobMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({characterCounterCountTags: true}),
+      )
+    })
+
+    test('calls updateJobMetadata when subfilteringHandlers changes', () => {
+      const {rerender} = renderComponent()
+      const handlers = {handler: 'test'}
+      reRenderComponent(rerender, {...baseTemplate, subfilteringHandlers: handlers})
+      expect(updateJobMetadata).toHaveBeenCalledTimes(1)
+      expect(updateJobMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({subfilteringHandlers: handlers}),
+      )
+    })
+
+    test('calls updateJobMetadata when mandatoryIssues changes', () => {
+      const {rerender} = renderComponent()
+      const issues = [{id: 1, name: 'issue'}]
+      reRenderComponent(rerender, {...baseTemplate, mandatoryIssues: issues})
+      expect(updateJobMetadata).toHaveBeenCalledTimes(1)
+      expect(updateJobMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({mandatoryIssues: issues}),
+      )
+    })
+
+    test('passes all template fields to updateJobMetadata', () => {
+      const {rerender} = renderComponent()
+      const newTemplate = {
+        characterCounterCountTags: true,
+        characterCounterMode: 'words',
+        subfilteringHandlers: {handler: 'test'},
+        mandatoryIssues: [{id: 1}],
+      }
+      reRenderComponent(rerender, newTemplate)
+      expect(updateJobMetadata).toHaveBeenCalledWith({
+        characterCounterCountTags: true,
+        characterCounterMode: 'words',
+        subfilteringHandlers: {handler: 'test'},
+        mandatoryIssues: [{id: 1}],
+      })
+    })
+
+    test('calls updateJobMetadata only once per change, not on unchanged re-renders', () => {
+      const {rerender} = renderComponent()
+      const changedTemplate = {...baseTemplate, characterCounterMode: 'words'}
+      reRenderComponent(rerender, changedTemplate)
+      reRenderComponent(rerender, changedTemplate)
+      expect(updateJobMetadata).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/public/js/pages/CatTool.js
+++ b/public/js/pages/CatTool.js
@@ -650,7 +650,7 @@ function CatTool() {
         },
         icuEnabled: !!jobMetadata.project.icu_enabled ?? false,
         ...(Array.isArray(jobMetadata.project.mandatory_issues) && {
-          mandatoryIssues: jobMetadata.project.mandatory_issues,
+          mandatoryIssues: jobMetadata.job.mandatory_issues,
         }),
       }))
     }

--- a/public/js/pages/CatTool.test.js
+++ b/public/js/pages/CatTool.test.js
@@ -422,6 +422,7 @@ describe('CatTool', () => {
         character_counter_count_tags: false,
         character_counter_mode: null,
         subfiltering_handlers: [],
+        mandatory_issues,
       },
       project: {
         mandatory_issues,

--- a/tests/unit/Core/Controllers/JobMetadataControllerTest.php
+++ b/tests/unit/Core/Controllers/JobMetadataControllerTest.php
@@ -300,6 +300,104 @@ class JobMetadataControllerTest extends AbstractTest
         $this->controller->save();
     }
 
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function save_persists_full_payload_including_mandatory_issues(): void
+    {
+        $body = (string)json_encode([
+            ['key' => 'character_counter_count_tags', 'value' => false],
+            ['key' => 'character_counter_mode', 'value' => 'google_ads'],
+            ['key' => 'subfiltering_handlers', 'value' => []],
+            ['key' => 'mandatory_issues', 'value' => ['r1', 'r2']],
+        ]);
+
+        $this->setRequest([
+            'id_job' => (string)$this->jobId(self::BASE),
+            'password' => self::JOB_PASSWORD,
+        ], $body, true);
+
+        $this->responseMock->expects($this->once())
+            ->method('json')
+            ->with($this->callback(function (array $data): bool {
+                $this->assertCount(4, $data);
+                return true;
+            }));
+
+        $this->controller->save();
+
+        $stored = (new MetadataDao(obtainTestDatabase()))
+            ->get($this->jobId(self::BASE), self::JOB_PASSWORD, 'mandatory_issues');
+        $this->assertNotNull($stored);
+        $this->assertSame('["r1","r2"]', $stored->value);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function save_persists_empty_mandatory_issues_as_json_array(): void
+    {
+        $body = (string)json_encode([
+            ['key' => 'mandatory_issues', 'value' => []],
+        ]);
+
+        $this->setRequest([
+            'id_job' => (string)$this->jobId(self::BASE),
+            'password' => self::JOB_PASSWORD,
+        ], $body, true);
+
+        $this->responseMock->expects($this->once())->method('json');
+
+        $this->controller->save();
+
+        $stored = (new MetadataDao(obtainTestDatabase()))
+            ->get($this->jobId(self::BASE), self::JOB_PASSWORD, 'mandatory_issues');
+        $this->assertNotNull($stored);
+        $this->assertSame('[]', $stored->value);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function save_throws_validation_exception_for_mandatory_issues_with_unknown_value(): void
+    {
+        $body = (string)json_encode([
+            ['key' => 'mandatory_issues', 'value' => ['not_a_valid_issue']],
+        ]);
+
+        $this->setRequest([
+            'id_job' => (string)$this->jobId(self::BASE),
+            'password' => self::JOB_PASSWORD,
+        ], $body, true);
+
+        $this->expectException(JSONValidatorException::class);
+
+        $this->controller->save();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function save_throws_validation_exception_for_mandatory_issues_with_additional_property(): void
+    {
+        $body = (string)json_encode([
+            ['key' => 'mandatory_issues', 'value' => ['r1'], 'unexpected' => 'x'],
+        ]);
+
+        $this->setRequest([
+            'id_job' => (string)$this->jobId(self::BASE),
+            'password' => self::JOB_PASSWORD,
+        ], $body, true);
+
+        $this->expectException(JSONValidatorException::class);
+
+        $this->controller->save();
+    }
+
     // ─── sanitizeRequestParams() ───
 
     /**

--- a/tests/unit/Core/Model/Projects/ProjectTemplateStructTest.php
+++ b/tests/unit/Core/Model/Projects/ProjectTemplateStructTest.php
@@ -56,6 +56,7 @@ class ProjectTemplateStructTest extends AbstractTest
         $this->assertSame(serialize(['it-IT', 'fr-FR']), $struct->target_language);
         $this->assertSame(42, $struct->mt_quality_value_in_editor);
         $this->assertTrue($struct->icu_enabled);
+        $this->assertSame('["r1","r2"]', $struct->mandatory_issues);
     }
 
     #[Test]
@@ -69,6 +70,7 @@ class ProjectTemplateStructTest extends AbstractTest
         $input->mt = NAN;
         $input->subfiltering_handlers = NAN;
         $input->mt_quality_value_in_editor = 0;
+        $input->mandatory_issues = null;
 
         $struct = new ProjectTemplateStruct();
         $struct->hydrateFromJSON($input, 123, 456);
@@ -84,6 +86,24 @@ class ProjectTemplateStructTest extends AbstractTest
         $this->assertNull($struct->subfiltering_handlers);
         $this->assertNull($struct->mt_quality_value_in_editor);
         $this->assertTrue($struct->icu_enabled);
+        $this->assertNull($struct->mandatory_issues);
+    }
+
+    #[Test]
+    public function hydrateFromJSONEncodesEmptyArrayMandatoryIssuesAsEmptyJsonArrayNotNull(): void
+    {
+        $input = $this->makeHydrationInput();
+        $input->mandatory_issues = [];
+
+        $struct = new ProjectTemplateStruct();
+        $struct->hydrateFromJSON($input, 1, 2);
+
+        $this->assertSame(
+            '[]',
+            $struct->mandatory_issues,
+            'an empty mandatory_issues array must be persisted as "[]", not null'
+        );
+        $this->assertSame([], $struct->getMandatoryIssues());
     }
 
     #[Test]
@@ -234,6 +254,7 @@ class ProjectTemplateStructTest extends AbstractTest
         $struct->created_at = '2026-05-01 10:20:30';
         $struct->modified_at = '2026-05-03 11:22:33';
         $struct->icu_enabled = true;
+        $struct->mandatory_issues = '["r1","r2"]';
 
         $payload = $struct->jsonSerialize();
 
@@ -257,6 +278,7 @@ class ProjectTemplateStructTest extends AbstractTest
         $this->assertSame((new DateTime('2026-05-01 10:20:30'))->format(DATE_RFC822), $payload['created_at']);
         $this->assertSame((new DateTime('2026-05-03 11:22:33'))->format(DATE_RFC822), $payload['modified_at']);
         $this->assertTrue($payload['icu_enabled']);
+        $this->assertSame(['r1', 'r2'], $payload['mandatory_issues']);
     }
 
     #[Test]
@@ -295,6 +317,7 @@ class ProjectTemplateStructTest extends AbstractTest
             'source_language' => 'en-US',
             'target_language' => ['it-IT'],
             'mt_quality_value_in_editor' => null,
+            'mandatory_issues' => ['r1', 'r2'],
         ];
     }
 }

--- a/tests/unit/Core/Structs/ProjectTemplateStructTest.php
+++ b/tests/unit/Core/Structs/ProjectTemplateStructTest.php
@@ -40,6 +40,7 @@ class ProjectTemplateStructTest extends AbstractTest
         $obj->target_language            = ['it-IT', 'de-DE'];
         $obj->mt_quality_value_in_editor = 80;
         $obj->icu_enabled                = true;
+        $obj->mandatory_issues           = ['issue1', 'issue2'];
 
         return $obj;
     }
@@ -91,6 +92,7 @@ class ProjectTemplateStructTest extends AbstractTest
         self::assertIsString($struct->tm);
         self::assertIsString($struct->subfiltering_handlers);
         self::assertIsString($struct->target_language);
+        self::assertIsString($struct->mandatory_issues);
     }
 
     #[Test]
@@ -143,6 +145,54 @@ class ProjectTemplateStructTest extends AbstractTest
             $struct->subfiltering_handlers,
             'subfiltering_handlers should be null when json_encode fails, not empty string'
         );
+    }
+
+    // ── Phase 2b — mandatory_issues null vs empty array ──────────
+
+    #[Test]
+    public function hydrateFromJsonEncodesEmptyArrayMandatoryIssuesAsEmptyJsonArray(): void
+    {
+        $struct = new ProjectTemplateStruct();
+        $obj    = $this->createFullInputObject();
+
+        $obj->mandatory_issues = [];
+
+        $struct->hydrateFromJSON($obj, 1);
+
+        self::assertSame(
+            '[]',
+            $struct->mandatory_issues,
+            'an empty array must be persisted as "[]", not null'
+        );
+        self::assertSame([], $struct->getMandatoryIssues());
+    }
+
+    #[Test]
+    public function hydrateFromJsonSetsMandatoryIssuesToNullWhenInputIsNull(): void
+    {
+        $struct = new ProjectTemplateStruct();
+        $obj    = $this->createFullInputObject();
+
+        $obj->mandatory_issues = null;
+
+        $struct->hydrateFromJSON($obj, 1);
+
+        self::assertNull($struct->mandatory_issues);
+        self::assertNull($struct->getMandatoryIssues());
+    }
+
+    #[Test]
+    public function hydrateFromJsonEncodesNonEmptyMandatoryIssues(): void
+    {
+        $struct = new ProjectTemplateStruct();
+        $obj    = $this->createFullInputObject();
+
+        $obj->mandatory_issues = ['tag_mismatch', 'empty_target'];
+
+        $struct->hydrateFromJSON($obj, 1);
+
+        self::assertSame('["tag_mismatch","empty_target"]', $struct->mandatory_issues);
+        self::assertSame(['tag_mismatch', 'empty_target'], $struct->getMandatoryIssues());
     }
 
     // ── Phase 3 — DateTime safety in jsonSerialize ───────────────
@@ -272,7 +322,7 @@ class ProjectTemplateStructTest extends AbstractTest
             'mt_quality_value_in_editor',
             'character_counter_count_tags', 'character_counter_mode',
             'subject', 'source_language', 'target_language',
-            'created_at', 'modified_at', 'icu_enabled',
+            'created_at', 'modified_at', 'icu_enabled', 'mandatory_issues',
         ];
 
         foreach ($expectedKeys as $key) {
@@ -283,5 +333,6 @@ class ProjectTemplateStructTest extends AbstractTest
         self::assertIsObject($result['mt']);
         self::assertIsArray($result['tm']);
         self::assertIsArray($result['target_language']);
+        self::assertSame(['issue1', 'issue2'], $result['mandatory_issues']);
     }
 }


### PR DESCRIPTION
## Summary

Fix `ProjectTemplateStruct::hydrateFromJSON()` persisting `mandatory_issues` as `NULL`
instead of `"[]"` when an empty array is sent.

## Type

<!-- Check one. -->

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

<!-- Key changes — what was modified and how.
     One line per file or logical group. -->

| File | Change |
|------|--------|
| `lib/Model/Projects/ProjectTemplateStruct.php` | Check `mandatory_issues` against `!== null` (via `??`) instead of `!empty()`, so an empty array is encoded as `"[]"` rather than collapsed to `null` |
| `tests/unit/Core/Structs/ProjectTemplateStructTest.php` | Add `mandatory_issues` to the full input fixture and add regression tests for empty array / null / non-empty array hydration |
| `tests/unit/Core/Model/Projects/ProjectTemplateStructTest.php` | Add `mandatory_issues` to the hydration fixture and add a regression test for the empty-array case |

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Ran the affected suites directly:

```
vendor/bin/phpunit tests/unit/Core/Structs/ProjectTemplateStructTest.php \
  tests/unit/Core/Model/Projects/ProjectTemplateStructTest.php --no-coverage
OK (32 tests, 170 assertions)

vendor/bin/phpstan analyse lib/Model/Projects/ProjectTemplateStruct.php \
  tests/unit/Core/Structs/ProjectTemplateStructTest.php \
  tests/unit/Core/Model/Projects/ProjectTemplateStructTest.php \
  --configuration=phpstan.neon --no-progress --error-format=table
[OK] No errors
```

Confirmed the new tests are meaningful by reverting the fix locally and re-running: both new
`mandatory_issues` empty-array tests fail against the old `!empty()` check, then pass again
once the fix is restored.

## AI Disclosure

<!-- If AI tools were used to write or review code in this PR, disclose it.
     AI-assisted code is welcome, but you must understand everything you ship.
     Unreviewed AI output will not be merged. -->

- [x] No AI tools were used in this PR
- [ ] AI tools were used — name the agent/tool below

## Notes

<!-- Anything reviewers should know — breaking changes, follow-up work,
     deployment steps, or open questions. Leave blank if none. -->

Before this fix, `mandatory_issues` had no test coverage at all in either
`ProjectTemplateStructTest` suite — hydrating without it set even triggered an "Undefined
property" PHP warning. That gap is why the empty-array bug shipped unnoticed.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206476339305494