### PR TITLE
🐛 fix(api): default icu_enabled to true when param is omitted

### DIFF
--- a/lib/Controller/API/App/ConvertFileController.php
+++ b/lib/Controller/API/App/ConvertFileController.php
@@ -93,7 +93,10 @@ class ConvertFileController extends KleinController
         $source_lang = filter_var($this->request->param('source_lang'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
         $target_lang = filter_var($this->request->param('target_lang'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
         $segmentation_rule = filter_var($this->request->param('segmentation_rule'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
-        $icu_enabled = filter_var($this->request->param('icu_enabled'), FILTER_VALIDATE_BOOLEAN);
+        $icu_enabled = ($this->request->param('icu_enabled') !== null) ? filter_var(
+            $this->request->param('icu_enabled'),
+            FILTER_VALIDATE_BOOLEAN
+        ) : true; // icu_enabled true by default
         $filters_extraction_parameters_template = filter_var(
             $this->request->param('filters_extraction_parameters_template'),
             FILTER_SANITIZE_SPECIAL_CHARS,

--- a/lib/Controller/API/V1/NewController.php
+++ b/lib/Controller/API/V1/NewController.php
@@ -396,7 +396,10 @@ class NewController extends KleinController
         $deepl_id_glossary = filter_var($this->request->param('deepl_id_glossary'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
         $deepl_formality = filter_var($this->request->param('deepl_formality'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
         $deepl_engine_type = filter_var($this->request->param('deepl_engine_type'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
-        $icu_enabled = filter_var($this->request->param('icu_enabled'), FILTER_VALIDATE_BOOLEAN);
+        $icu_enabled = ($this->request->param('icu_enabled') !== null) ? filter_var(
+            $this->request->param('icu_enabled'),
+            FILTER_VALIDATE_BOOLEAN
+        ) : true; // icu_enabled true by default
         $mandatory_issues = filter_var(
             $this->request->param('mandatory_issues'),
             FILTER_SANITIZE_FULL_SPECIAL_CHARS,

--- a/tests/unit/Core/Controllers/ConvertFileControllerTest.php
+++ b/tests/unit/Core/Controllers/ConvertFileControllerTest.php
@@ -253,6 +253,30 @@ class ConvertFileControllerTest extends AbstractTest
     }
 
     #[Test]
+    public function validateTheRequest_icu_enabled_defaults_to_true_when_missing(): void
+    {
+        $params = $this->validParams();
+        unset($params['icu_enabled']);
+        $this->setRequestParams($params);
+
+        $result = $this->invokePrivate('validateTheRequest');
+
+        $this->assertTrue($result['icu_enabled']);
+    }
+
+    #[Test]
+    public function validateTheRequest_icu_enabled_stays_false_when_explicitly_disabled(): void
+    {
+        $params                = $this->validParams();
+        $params['icu_enabled'] = '0';
+        $this->setRequestParams($params);
+
+        $result = $this->invokePrivate('validateTheRequest');
+
+        $this->assertFalse($result['icu_enabled']);
+    }
+
+    #[Test]
     public function validateTheRequest_segmentation_rule_paragraph_is_preserved(): void
     {
         $params                      = $this->validParams();

--- a/tests/unit/Core/Controllers/NewControllerTest.php
+++ b/tests/unit/Core/Controllers/NewControllerTest.php
@@ -362,6 +362,149 @@ class NewControllerTest extends AbstractTest
     }
 
     /**
+     * icu_enabled must default to `true` when the request omits the parameter entirely.
+     *
+     * @throws ReflectionException
+     * @throws Exception
+     */
+    #[Test]
+    public function testValidateTheRequestDefaultsIcuEnabledToTrueWhenMissing(): void
+    {
+        $user = $this->createMock(UserStruct::class);
+        $user->expects($this->once())->method('getPersonalTeam')->willReturn(new TeamStruct());
+        $user->expects($this->once())->method('getEmail')->willReturn("test-email@translated.com");
+
+        $this->requestMock = new Request(
+            [],
+            [
+                JobsMetadataMarshaller::CHARACTER_COUNTER_COUNT_TAGS->value => '1',
+                JobsMetadataMarshaller::CHARACTER_COUNTER_MODE->value => 'google_ads',
+                'due_date' => '20251231',
+                'source_lang' => 'en',
+                'target_lang' => 'fr,de',
+                'mt_engine' => 1,
+                'tms_engine' => 1,
+                'segmentation_rule' => 'patent',
+            ],
+            [],
+            [],
+            [
+                'file[]' => [
+                    'name' => 'foo.docx',
+                    'tmp_name' => '/tmp/xdwlky',
+                ]
+            ]
+        );
+
+        $this->createMocks();
+
+        $reflector = new ReflectionProperty($this->controller, 'user');
+        $reflector->setValue($this->controller, $user);
+
+        $validateParameters = $this->method->invoke($this->controller);
+
+        $this->assertArrayHasKey('icu_enabled', $validateParameters);
+        $this->assertTrue($validateParameters['icu_enabled']);
+        $this->assertTrue($validateParameters['metadata'][\Model\Projects\ProjectsMetadataMarshaller::ICU_ENABLED->value]);
+    }
+
+    /**
+     * icu_enabled must stay `false` when the request explicitly disables it.
+     *
+     * @throws ReflectionException
+     * @throws Exception
+     */
+    #[Test]
+    public function testValidateTheRequestKeepsIcuEnabledFalseWhenExplicitlyDisabled(): void
+    {
+        $user = $this->createMock(UserStruct::class);
+        $user->expects($this->once())->method('getPersonalTeam')->willReturn(new TeamStruct());
+        $user->expects($this->once())->method('getEmail')->willReturn("test-email@translated.com");
+
+        $this->requestMock = new Request(
+            [],
+            [
+                JobsMetadataMarshaller::CHARACTER_COUNTER_COUNT_TAGS->value => '1',
+                JobsMetadataMarshaller::CHARACTER_COUNTER_MODE->value => 'google_ads',
+                'due_date' => '20251231',
+                'source_lang' => 'en',
+                'target_lang' => 'fr,de',
+                'mt_engine' => 1,
+                'tms_engine' => 1,
+                'segmentation_rule' => 'patent',
+                'icu_enabled' => 'false',
+            ],
+            [],
+            [],
+            [
+                'file[]' => [
+                    'name' => 'foo.docx',
+                    'tmp_name' => '/tmp/xdwlky',
+                ]
+            ]
+        );
+
+        $this->createMocks();
+
+        $reflector = new ReflectionProperty($this->controller, 'user');
+        $reflector->setValue($this->controller, $user);
+
+        $validateParameters = $this->method->invoke($this->controller);
+
+        $this->assertArrayHasKey('icu_enabled', $validateParameters);
+        $this->assertFalse($validateParameters['icu_enabled']);
+        $this->assertFalse($validateParameters['metadata'][\Model\Projects\ProjectsMetadataMarshaller::ICU_ENABLED->value]);
+    }
+
+    /**
+     * icu_enabled must be `true` when the request explicitly enables it.
+     *
+     * @throws ReflectionException
+     * @throws Exception
+     */
+    #[Test]
+    public function testValidateTheRequestKeepsIcuEnabledTrueWhenExplicitlyEnabled(): void
+    {
+        $user = $this->createMock(UserStruct::class);
+        $user->expects($this->once())->method('getPersonalTeam')->willReturn(new TeamStruct());
+        $user->expects($this->once())->method('getEmail')->willReturn("test-email@translated.com");
+
+        $this->requestMock = new Request(
+            [],
+            [
+                JobsMetadataMarshaller::CHARACTER_COUNTER_COUNT_TAGS->value => '1',
+                JobsMetadataMarshaller::CHARACTER_COUNTER_MODE->value => 'google_ads',
+                'due_date' => '20251231',
+                'source_lang' => 'en',
+                'target_lang' => 'fr,de',
+                'mt_engine' => 1,
+                'tms_engine' => 1,
+                'segmentation_rule' => 'patent',
+                'icu_enabled' => 'true',
+            ],
+            [],
+            [],
+            [
+                'file[]' => [
+                    'name' => 'foo.docx',
+                    'tmp_name' => '/tmp/xdwlky',
+                ]
+            ]
+        );
+
+        $this->createMocks();
+
+        $reflector = new ReflectionProperty($this->controller, 'user');
+        $reflector->setValue($this->controller, $user);
+
+        $validateParameters = $this->method->invoke($this->controller);
+
+        $this->assertArrayHasKey('icu_enabled', $validateParameters);
+        $this->assertTrue($validateParameters['icu_enabled']);
+        $this->assertTrue($validateParameters['metadata'][\Model\Projects\ProjectsMetadataMarshaller::ICU_ENABLED->value]);
+    }
+
+    /**
      * @throws ReflectionException
      * @throws Exception
      */


### PR DESCRIPTION
## Summary

`icu_enabled` was meant to default to `true` for API-created projects, but the existing
`=== null` check could never trigger: `filter_var(..., FILTER_VALIDATE_BOOLEAN)` never returns
`null`, so an omitted `icu_enabled` param silently resolved to `false`. This checks the raw
request param for `null` *before* running it through `filter_var`, matching the pattern already
used for `get_public_matches` in `NewController`.

## Type

<!-- Check one. -->

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

<!-- Key changes — what was modified and how.
     One line per file or logical group. -->

| File | Change |
|------|--------|
| `lib/Controller/API/V1/NewController.php` | Check raw param for `null` before `filter_var` so `icu_enabled` defaults to `true` when omitted |
| `lib/Controller/API/App/ConvertFileController.php` | Same fix as above, for the file-conversion endpoint |
| `tests/unit/Core/Controllers/NewControllerTest.php` | Add tests for `icu_enabled` missing / explicit `false` / explicit `true` |
| `tests/unit/Core/Controllers/ConvertFileControllerTest.php` | Add tests for `icu_enabled` missing / explicit `false` |

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Ran the full `NewController*` and `ConvertFileControllerTest` suites plus PHPStan level 8 on all
four touched files — all green. Before applying the fix, added a temporary probe test that
reproduced the bug (`icu_enabled` resolving to `false` when omitted from the request), confirming
the fix is effective.

## AI Disclosure

<!-- If AI tools were used to write or review code in this PR, disclose it.
     AI-assisted code is welcome, but you must understand everything you ship.
     Unreviewed AI output will not be merged. -->

- [x] No AI tools were used in this PR
- [ ] AI tools were used — name the agent/tool below

## Notes

<!-- Anything reviewers should know — breaking changes, follow-up work,
     deployment steps, or open questions. Leave blank if none. -->

None.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216524205374318