### PR TITLE
🐛 fix(qa-warnings): categorize and surface unedited-fuzzy-match warnings

### DIFF
--- a/lib/Controller/API/App/GetWarningController.php
+++ b/lib/Controller/API/App/GetWarningController.php
@@ -21,6 +21,7 @@ use Model\Segments\SegmentDao;
 use Model\Segments\SegmentMetadataDao;
 use Model\Segments\SegmentMetadataMarshaller;
 use Model\Segments\SegmentOriginalDataDao;
+use Model\Translations\SegmentTranslationDao;
 use Model\Translations\WarningDao;
 use Utils\LQA\ICUSourceSegmentChecker;
 use Utils\LQA\QA;
@@ -115,6 +116,7 @@ class GetWarningController extends KleinController
         $trg_content = $request['trg_content'];
         $password = $request['password'];
         $characters_counter = $request['characters_counter'];
+        $segment_status = $request['segment_status'];
 
         $chunk = $this->getChunkAndLoadProjectFeatures($id_job, $password);
         $featureSet = $this->getFeatureSet();
@@ -166,6 +168,21 @@ class GetWarningController extends KleinController
         }
 
         $QA->performConsistencyCheck();
+
+        // Surface the same fuzzy-unchanged warning here as set-translation persists, based on
+        // the currently persisted suggestion for this segment (covers live typing checks and
+        // segments reopened after being confirmed).
+        $oldTranslation = (new SegmentTranslationDao($this->getDatabase()))->findBySegmentAndJob($id, (int) $id_job);
+
+        if ($oldTranslation !== null && QA::isUnmodifiedFuzzyMatchConfirmation(
+            $segment_status,
+            $oldTranslation->suggestion_source,
+            $oldTranslation->suggestion_match,
+            $oldTranslation->suggestion,
+            $Filter->fromLayer1ToLayer0($trg_content)
+        )) {
+            $QA->addError(QA::ERR_FUZZY_UNCHANGED);
+        }
 
         $result = array_merge(
             [

--- a/lib/Controller/API/App/SetTranslationController.php
+++ b/lib/Controller/API/App/SetTranslationController.php
@@ -301,7 +301,13 @@ class SetTranslationController extends AbstractStatefulKleinController
 
         // Warn (and persist a QA warning, like a tag order mismatch) when a fuzzy TM match
         // is confirmed verbatim, i.e. without any modification by the translator.
-        if ($this->isUnmodifiedFuzzyMatchConfirmation($new_translation)) {
+        if (QA::isUnmodifiedFuzzyMatchConfirmation(
+            $new_translation->status,
+            $new_translation->suggestion_source,
+            $new_translation->suggestion_match,
+            $new_translation->suggestion,
+            $new_translation->translation
+        )) {
             $check->addError(QA::ERR_FUZZY_UNCHANGED);
             $new_translation->serialized_errors_list = $check->getWarningsJSON();
             $new_translation->warning = $check->thereAreWarnings();
@@ -311,47 +317,6 @@ class SetTranslationController extends AbstractStatefulKleinController
             'new' => $new_translation,
             'old' => $old_translation,
         ];
-    }
-
-    /**
-     * Detects whether the confirmation is a fuzzy TM match accepted without any edit.
-     *
-     * The check is intentionally based on the persisted suggestion so that it also works
-     * when a segment is opened, left untouched, and confirmed later (even after being
-     * navigated away from and reopened already populated).
-     *
-     * @param SegmentTranslationStruct $newTranslation The translation being persisted
-     *
-     * @return bool True when a fuzzy TM match is being confirmed verbatim
-     */
-    private function isUnmodifiedFuzzyMatchConfirmation(SegmentTranslationStruct $newTranslation): bool
-    {
-        // Only when confirming, never for draft/new auto-saves.
-        if (!in_array($newTranslation->status, [
-            TranslationStatus::STATUS_TRANSLATED,
-            TranslationStatus::STATUS_APPROVED,
-            TranslationStatus::STATUS_APPROVED2,
-        ], true)) {
-            return false;
-        }
-
-        // Only TM suggestions are relevant (excludes MT and "no match").
-        if ($newTranslation->suggestion_source !== EngineConstants::TM) {
-            return false;
-        }
-
-        // Only fuzzy bands: exclude 100% exact and ICE (>= 100) matches and unknown values.
-        $match = (int)$newTranslation->suggestion_match;
-        if ($match <= 0 || $match >= 100) {
-            return false;
-        }
-
-        if (empty($newTranslation->suggestion)) {
-            return false;
-        }
-
-        // The translation was confirmed exactly as the suggestion (no edit performed).
-        return trim((string)$newTranslation->translation) === trim((string)$newTranslation->suggestion);
     }
 
     /**

--- a/lib/Utils/LQA/QA.php
+++ b/lib/Utils/LQA/QA.php
@@ -9,6 +9,8 @@ use Matecat\ICU\MessagePatternComparator;
 use Model\FeaturesBase\FeatureSet;
 use Model\Jobs\JobStruct;
 use Model\Segments\SegmentMetadataStruct;
+use Utils\Constants\EngineConstants;
+use Utils\Constants\TranslationStatus;
 use Utils\LQA\BxExG\Validator;
 use Utils\LQA\QA\ContentPreprocessor;
 use Utils\LQA\QA\DomHandler;
@@ -532,6 +534,54 @@ class QA
             self::WARNING => $exceptionList[self::WARNING] ?? [],
             self::INFO => $exceptionList[self::INFO] ?? [],
         ];
+    }
+
+    /**
+     * Detects whether a fuzzy TM match is being confirmed verbatim, i.e. without any edit.
+     *
+     * Shared by the set-translation persistence path and the live get-local-warning check,
+     * so both surface {@see self::ERR_FUZZY_UNCHANGED} consistently from the same rule.
+     *
+     * @param string|null $status The segment status being confirmed (e.g. TranslationStatus::STATUS_TRANSLATED)
+     * @param string|null $suggestionSource The suggestion source (e.g. EngineConstants::TM)
+     * @param string|int|null $suggestionMatch The suggestion match percentage
+     * @param string|null $suggestion The suggested TM translation text
+     * @param string $translation The translation text being confirmed
+     * @return bool True when a fuzzy TM match is being confirmed verbatim
+     */
+    public static function isUnmodifiedFuzzyMatchConfirmation(
+        ?string $status,
+        ?string $suggestionSource,
+        string|int|null $suggestionMatch,
+        ?string $suggestion,
+        string $translation
+    ): bool {
+        // Only when confirming, never for draft/new auto-saves.
+        if (!in_array($status, [
+            TranslationStatus::STATUS_TRANSLATED,
+            TranslationStatus::STATUS_APPROVED,
+            TranslationStatus::STATUS_APPROVED2,
+        ], true)) {
+            return false;
+        }
+
+        // Only TM suggestions are relevant (excludes MT and "no match").
+        if ($suggestionSource !== EngineConstants::TM) {
+            return false;
+        }
+
+        // Only fuzzy bands: exclude 100% exact and ICE (>= 100) matches and unknown values.
+        $match = (int)$suggestionMatch;
+        if ($match <= 0 || $match >= 100) {
+            return false;
+        }
+
+        if (empty($suggestion)) {
+            return false;
+        }
+
+        // The translation was confirmed exactly as the suggestion (no edit performed).
+        return trim($translation) === trim($suggestion);
     }
 
     // ========== Main Check Methods ==========

--- a/lib/View/API/V2/Json/QAWarning.php
+++ b/lib/View/API/V2/Json/QAWarning.php
@@ -22,6 +22,8 @@ class QAWarning
     const string MISMATCH_CATEGORY = "MISMATCH";
     const string ICU_CATEGORY = "ICU";
 
+    const string FUZZY_CATEGORY = "FUZZY";
+
     protected function pushErrorSegment(string $error_type, ?int $error_category, mixed $content): void
     {
         $category = match ($error_category) {
@@ -36,6 +38,7 @@ class QAWarning
             QA::ERR_SYMBOL_MISMATCH,
             QA::ERR_NEWLINE_MISMATCH => self::MISMATCH_CATEGORY,
             QA::ERR_ICU_VALIDATION => self::ICU_CATEGORY,
+            QA::ERR_FUZZY_UNCHANGED => self::FUZZY_CATEGORY,
             default => self::TAGS_CATEGORY,
         };
 

--- a/tests/unit/Core/Controllers/GetWarningControllerTest.php
+++ b/tests/unit/Core/Controllers/GetWarningControllerTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 use ReflectionException;
 use Utils\Logger\MatecatLogger;
+use Utils\LQA\QA;
 
 class TestableGetWarningController extends GetWarningController
 {
@@ -441,6 +442,68 @@ class GetWarningControllerTest extends AbstractTest
             ->with($this->callback(function (array $data): bool {
                 $this->assertArrayHasKey('data', $data);
                 $this->assertArrayHasKey('errors', $data);
+                return true;
+            }));
+
+        $this->controller->local();
+    }
+
+    #[Test]
+    public function local_includes_fuzzy_category_when_unmodified_fuzzy_match_confirmed(): void
+    {
+        $conn = obtainTestDatabase()->getConnection();
+        $conn->exec(
+            "UPDATE segment_translations SET suggestion = 'Ciao mondo', suggestion_source = 'TM', suggestion_match = 75 " .
+            "WHERE id_segment = " . self::TEST_SEGMENT_ID . " AND id_job = " . self::TEST_JOB_ID
+        );
+
+        $this->setRequestParams([
+            'id' => (string) self::TEST_SEGMENT_ID,
+            'id_job' => (string) self::TEST_JOB_ID,
+            'src_content' => 'Hello world',
+            'trg_content' => 'Ciao mondo',
+            'password' => self::TEST_JOB_PASSWORD,
+            'segment_status' => 'TRANSLATED',
+        ]);
+
+        $this->responseMock->expects($this->once())
+            ->method('json')
+            ->with($this->callback(function (array $data): bool {
+                $categories = $data['details']['issues_info']['WARNING']['Categories']->getArrayCopy();
+
+                $this->assertArrayHasKey('FUZZY', $categories);
+                $this->assertCount(1, $categories['FUZZY']);
+                $this->assertSame(QA::ERR_FUZZY_UNCHANGED, $categories['FUZZY'][0]->outcome);
+
+                return true;
+            }));
+
+        $this->controller->local();
+    }
+
+    #[Test]
+    public function local_does_not_include_fuzzy_category_for_non_tm_suggestion(): void
+    {
+        $conn = obtainTestDatabase()->getConnection();
+        $conn->exec(
+            "UPDATE segment_translations SET suggestion = 'Ciao mondo', suggestion_source = 'MT', suggestion_match = 75 " .
+            "WHERE id_segment = " . self::TEST_SEGMENT_ID . " AND id_job = " . self::TEST_JOB_ID
+        );
+
+        $this->setRequestParams([
+            'id' => (string) self::TEST_SEGMENT_ID,
+            'id_job' => (string) self::TEST_JOB_ID,
+            'src_content' => 'Hello world',
+            'trg_content' => 'Ciao mondo',
+            'password' => self::TEST_JOB_PASSWORD,
+            'segment_status' => 'TRANSLATED',
+        ]);
+
+        $this->responseMock->expects($this->once())
+            ->method('json')
+            ->with($this->callback(function (array $data): bool {
+                $this->assertNull($data['details']);
+
                 return true;
             }));
 

--- a/tests/unit/Core/Controllers/SetTranslationControllerTest.php
+++ b/tests/unit/Core/Controllers/SetTranslationControllerTest.php
@@ -1015,6 +1015,146 @@ class SetTranslationControllerTest extends AbstractTest
         $method->invoke($controller, 'Should fail', '', $this->makeQAStub());
     }
 
+    /**
+     * thereAreWarnings() is called twice by buildNewTranslation(): once before the fuzzy-unchanged
+     * check runs, once after (only if the fuzzy branch fires and calls addError()). Consecutive
+     * return values simulate that state transition without needing a real QA instance.
+     */
+    private function makeFuzzyAwareQAStub(bool $warningsBeforeFuzzyCheck, bool $warningsAfterFuzzyCheck, string $warningsJson): QA
+    {
+        $qa = $this->createStub(QA::class);
+        $qa->method('thereAreWarnings')->willReturnOnConsecutiveCalls($warningsBeforeFuzzyCheck, $warningsAfterFuzzyCheck);
+        $qa->method('getWarningsJSON')->willReturn($warningsJson);
+
+        return $qa;
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    #[Test]
+    public function buildNewTranslationSetsFuzzyWarningWhenUnmodifiedFuzzyMatchConfirmed(): void
+    {
+        // makeDefaultOldTranslation() already yields a fuzzy-band TM suggestion (75%, 'Old suggestion').
+        $old = $this->makeDefaultOldTranslation();
+        $controller = $this->createTestableController($old);
+
+        $this->setProperty($controller, [
+            'suggestion_array' => null,
+            'chosen_suggestion_index' => null,
+            'id_segment' => '42',
+            'id_job' => '100',
+            'status' => TranslationStatus::STATUS_TRANSLATED,
+            'segment' => $this->makeDefaultSegment(),
+            'time_to_edit' => 1000,
+        ]);
+
+        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]);
+        $qa = $this->makeFuzzyAwareQAStub(false, true, $fuzzyWarningJson);
+
+        $method = (new ReflectionClass(SetTranslationController::class))->getMethod('buildNewTranslation');
+        $result = $method->invoke($controller, 'Old suggestion', '[]', $qa);
+
+        $new = $result['new'];
+        self::assertTrue($new->warning, 'Unmodified fuzzy match confirmation must set warning to true');
+        self::assertSame($fuzzyWarningJson, $new->serialized_errors_list, 'serialized_errors_list must be refreshed with the fuzzy warning');
+
+        $decoded = json_decode($new->serialized_errors_list, true);
+        self::assertSame(QA::ERR_FUZZY_UNCHANGED, $decoded[0]['outcome']);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    #[Test]
+    public function buildNewTranslationSkipsFuzzyWarningWhenTranslationEdited(): void
+    {
+        $old = $this->makeDefaultOldTranslation();
+        $controller = $this->createTestableController($old);
+
+        $this->setProperty($controller, [
+            'suggestion_array' => null,
+            'chosen_suggestion_index' => null,
+            'id_segment' => '42',
+            'id_job' => '100',
+            'status' => TranslationStatus::STATUS_TRANSLATED,
+            'segment' => $this->makeDefaultSegment(),
+            'time_to_edit' => 1000,
+        ]);
+
+        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]);
+        $qa = $this->makeFuzzyAwareQAStub(false, true, $fuzzyWarningJson);
+
+        $method = (new ReflectionClass(SetTranslationController::class))->getMethod('buildNewTranslation');
+        $result = $method->invoke($controller, 'An edited translation', '[]', $qa);
+
+        $new = $result['new'];
+        self::assertFalse($new->warning, 'Edited translation must not trigger the fuzzy-unchanged warning');
+        self::assertSame('[]', $new->serialized_errors_list, 'serialized_errors_list must be left untouched');
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    #[Test]
+    public function buildNewTranslationSkipsFuzzyWarningForExactMatch(): void
+    {
+        $old = $this->makeDefaultOldTranslation();
+        $old->suggestion_match = '100';
+        $controller = $this->createTestableController($old);
+
+        $this->setProperty($controller, [
+            'suggestion_array' => null,
+            'chosen_suggestion_index' => null,
+            'id_segment' => '42',
+            'id_job' => '100',
+            'status' => TranslationStatus::STATUS_TRANSLATED,
+            'segment' => $this->makeDefaultSegment(),
+            'time_to_edit' => 1000,
+        ]);
+
+        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]);
+        $qa = $this->makeFuzzyAwareQAStub(false, true, $fuzzyWarningJson);
+
+        $method = (new ReflectionClass(SetTranslationController::class))->getMethod('buildNewTranslation');
+        $result = $method->invoke($controller, 'Old suggestion', '[]', $qa);
+
+        $new = $result['new'];
+        self::assertFalse($new->warning, 'Exact/ICE match confirmation must not trigger the fuzzy-unchanged warning');
+        self::assertSame('[]', $new->serialized_errors_list, 'serialized_errors_list must be left untouched');
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    #[Test]
+    public function buildNewTranslationSkipsFuzzyWarningForNonTMSource(): void
+    {
+        $old = $this->makeDefaultOldTranslation();
+        $old->suggestion_source = EngineConstants::MT;
+        $controller = $this->createTestableController($old);
+
+        $this->setProperty($controller, [
+            'suggestion_array' => null,
+            'chosen_suggestion_index' => null,
+            'id_segment' => '42',
+            'id_job' => '100',
+            'status' => TranslationStatus::STATUS_TRANSLATED,
+            'segment' => $this->makeDefaultSegment(),
+            'time_to_edit' => 1000,
+        ]);
+
+        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]);
+        $qa = $this->makeFuzzyAwareQAStub(false, true, $fuzzyWarningJson);
+
+        $method = (new ReflectionClass(SetTranslationController::class))->getMethod('buildNewTranslation');
+        $result = $method->invoke($controller, 'Old suggestion', '[]', $qa);
+
+        $new = $result['new'];
+        self::assertFalse($new->warning, 'Non-TM suggestion source must not trigger the fuzzy-unchanged warning');
+        self::assertSame('[]', $new->serialized_errors_list, 'serialized_errors_list must be left untouched');
+    }
+
     // ──────────────────────────────────────────────────────────────
     // SECTION 6: Additional private/protected methods coverage
     // ──────────────────────────────────────────────────────────────

--- a/tests/unit/Core/LQA/QATest.php
+++ b/tests/unit/Core/LQA/QATest.php
@@ -8,6 +8,8 @@ use Matecat\TestHelpers\AbstractTest;
 use Model\Segments\SegmentMetadataMarshaller;
 use Model\Segments\SegmentMetadataStruct;
 use PHPUnit\Framework\Attributes\Test;
+use Utils\Constants\EngineConstants;
+use Utils\Constants\TranslationStatus;
 use Utils\LQA\QA;
 use Utils\LQA\QA\ErrorManager;
 
@@ -990,6 +992,120 @@ class QATest extends AbstractTest
         $this->assertEquals(ErrorManager::ERROR, QA::ERROR);
         $this->assertEquals(ErrorManager::WARNING, QA::WARNING);
         $this->assertEquals(ErrorManager::INFO, QA::INFO);
+    }
+
+    // ========== isUnmodifiedFuzzyMatchConfirmation Tests ==========
+
+    #[Test]
+    public function isUnmodifiedFuzzyMatchConfirmationReturnsTrueForVerbatimFuzzyConfirmation(): void
+    {
+        $result = QA::isUnmodifiedFuzzyMatchConfirmation(
+            TranslationStatus::STATUS_TRANSLATED,
+            EngineConstants::TM,
+            '75',
+            'Old suggestion',
+            'Old suggestion'
+        );
+
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function isUnmodifiedFuzzyMatchConfirmationReturnsFalseWhenTranslationEdited(): void
+    {
+        $result = QA::isUnmodifiedFuzzyMatchConfirmation(
+            TranslationStatus::STATUS_TRANSLATED,
+            EngineConstants::TM,
+            '75',
+            'Old suggestion',
+            'An edited translation'
+        );
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function isUnmodifiedFuzzyMatchConfirmationReturnsFalseForExactMatch(): void
+    {
+        $result = QA::isUnmodifiedFuzzyMatchConfirmation(
+            TranslationStatus::STATUS_TRANSLATED,
+            EngineConstants::TM,
+            '100',
+            'Old suggestion',
+            'Old suggestion'
+        );
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function isUnmodifiedFuzzyMatchConfirmationReturnsFalseForZeroMatch(): void
+    {
+        $result = QA::isUnmodifiedFuzzyMatchConfirmation(
+            TranslationStatus::STATUS_TRANSLATED,
+            EngineConstants::TM,
+            '0',
+            'Old suggestion',
+            'Old suggestion'
+        );
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function isUnmodifiedFuzzyMatchConfirmationReturnsFalseForNonTMSource(): void
+    {
+        $result = QA::isUnmodifiedFuzzyMatchConfirmation(
+            TranslationStatus::STATUS_TRANSLATED,
+            EngineConstants::MT,
+            '75',
+            'Old suggestion',
+            'Old suggestion'
+        );
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function isUnmodifiedFuzzyMatchConfirmationReturnsFalseForDraftStatus(): void
+    {
+        $result = QA::isUnmodifiedFuzzyMatchConfirmation(
+            TranslationStatus::STATUS_DRAFT,
+            EngineConstants::TM,
+            '75',
+            'Old suggestion',
+            'Old suggestion'
+        );
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function isUnmodifiedFuzzyMatchConfirmationReturnsFalseForEmptySuggestion(): void
+    {
+        $result = QA::isUnmodifiedFuzzyMatchConfirmation(
+            TranslationStatus::STATUS_TRANSLATED,
+            EngineConstants::TM,
+            '75',
+            null,
+            'Old suggestion'
+        );
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function isUnmodifiedFuzzyMatchConfirmationIgnoresLeadingAndTrailingWhitespace(): void
+    {
+        $result = QA::isUnmodifiedFuzzyMatchConfirmation(
+            TranslationStatus::STATUS_APPROVED,
+            EngineConstants::TM,
+            '75',
+            'Old suggestion',
+            '  Old suggestion  '
+        );
+
+        $this->assertTrue($result);
     }
 
     // ========== Segment Language Edge Cases ==========

--- a/tests/unit/Core/View/API/V2/Json/QAGlobalWarningTest.php
+++ b/tests/unit/Core/View/API/V2/Json/QAGlobalWarningTest.php
@@ -59,6 +59,21 @@ class QAGlobalWarningTest extends AbstractTest
         $this->assertEmpty($result['details'][QA::WARNING]['Categories']);
     }
 
+    public function testRenderFuzzyUnchangedWarningBucketedUnderFuzzyCategory(): void
+    {
+        $struct = $this->makeGlobalWarningStruct(
+            json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]),
+            '42'
+        );
+
+        $qa     = new QAGlobalWarning([$struct], []);
+        $result = $qa->render();
+
+        $this->assertArrayHasKey('FUZZY', $result['details'][QA::WARNING]['Categories']);
+        $this->assertContains('42', $result['details'][QA::WARNING]['Categories']['FUZZY']);
+        $this->assertArrayNotHasKey('TAGS', $result['details'][QA::WARNING]['Categories']);
+    }
+
     public function testRenderTranslationMismatchesAppendedToWarning(): void
     {
         $qa     = new QAGlobalWarning([], [['first_of_my_job' => 'mismatch_seg_10']]);

--- a/tests/unit/Core/View/API/V2/Json/QAWarningTest.php
+++ b/tests/unit/Core/View/API/V2/Json/QAWarningTest.php
@@ -67,6 +67,17 @@ class QAWarningTest extends AbstractTest
         $this->assertArrayHasKey(QAWarning::ICU_CATEGORY, $structure[QA::INFO]['Categories']);
     }
 
+    public function testPushErrorSegmentFuzzyCategory(): void
+    {
+        $warning = $this->makeConcreteWarning();
+        $warning->init();
+        $warning->callPushErrorSegment(QA::WARNING, QA::ERR_FUZZY_UNCHANGED, 'seg6');
+
+        $structure = $warning->getStructure();
+        $this->assertArrayHasKey(QAWarning::FUZZY_CATEGORY, $structure[QA::WARNING]['Categories']);
+        $this->assertContains('seg6', $structure[QA::WARNING]['Categories'][QAWarning::FUZZY_CATEGORY]);
+    }
+
     public function testPushErrorSegmentDefaultsToTagsCategory(): void
     {
         $warning = $this->makeConcreteWarning();


### PR DESCRIPTION
## Summary

Wires the `FUZZY` QA warning category all the way through: an unedited-fuzzy-match confirmation
is now correctly categorized as `FUZZY` instead of falling back to `TAGS`, and it's surfaced from
the live `get-local-warning` endpoint too, not just after saving via `set-translation`.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `lib/View/API/V2/Json/QAWarning.php` | Map `QA::ERR_FUZZY_UNCHANGED` to `FUZZY_CATEGORY` in `pushErrorSegment()` instead of the `TAGS_CATEGORY` default |
| `lib/Utils/LQA/QA.php` | Extract a shared static `isUnmodifiedFuzzyMatchConfirmation()` check |
| `lib/Controller/API/App/SetTranslationController.php` | Use the shared static check instead of a private duplicate |
| `lib/Controller/API/App/GetWarningController.php` | `local()` now fetches the segment's persisted suggestion metadata and adds the fuzzy warning to the live QA check, so it's returned in `Warnings -> Categories` too |
| `tests/unit/Core/View/API/V2/Json/QAWarningTest.php` | Test for the `FUZZY` category mapping |
| `tests/unit/Core/View/API/V2/Json/QAGlobalWarningTest.php` | Test for the `FUZZY` bucket rendered from a persisted `serialized_errors_list` |
| `tests/unit/Core/LQA/QATest.php` | 8 cases for the new shared static check |
| `tests/unit/Core/Controllers/SetTranslationControllerTest.php` | 4 cases for the fuzzy-unchanged branch in `buildNewTranslation()` |
| `tests/unit/Core/Controllers/GetWarningControllerTest.php` | 2 cases confirming `local()` surfaces/omits the `FUZZY` category correctly |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite: 9221 tests, 4 pre-existing failures in `CommentControllerTest` (`*_broker_is_unavailable`
cases), unrelated to this change and reproducing identically on `develop` without this branch's
commit. `phpstan` reports 0 errors on all four changed production files.

## AI Disclosure

- [x] No AI tools were used in this PR

## Notes

None.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203325585598454