### PR TITLE
🐛 fix(tm-key): align name sanitization between save and job-assignment endpoints

### DIFF
--- a/lib/Controller/API/App/TMXFileController.php
+++ b/lib/Controller/API/App/TMXFileController.php
@@ -12,6 +12,7 @@ use Model\TmKeyManagement\MemoryKeyDao;
 use Model\TmKeyManagement\MemoryKeyStruct;
 use TypeError;
 use Utils\Registry\AppConfig;
+use Utils\TmKeyManagement\TmKeyManager;
 use Utils\TmKeyManagement\TmKeyStruct;
 use Utils\TMS\TMSFile;
 use Utils\TMS\TMSService;
@@ -69,7 +70,7 @@ class TMXFileController extends KleinController
                 $userMemoryKey = $mkDao->read($searchMemoryKey);
 
                 if (!empty($userMemoryKey) && isset($userMemoryKey[0]->tm_key) && empty($userMemoryKey[0]->tm_key->name)) {
-                    $userMemoryKey[0]->tm_key->name = $fileInfo->name;
+                    $userMemoryKey[0]->tm_key->name = TmKeyManager::sanitizeName($fileInfo->name);
                     $mkDao->atomicUpdate($userMemoryKey[0]);
                 }
             }

--- a/lib/Controller/API/App/UserKeysController.php
+++ b/lib/Controller/API/App/UserKeysController.php
@@ -166,7 +166,7 @@ class UserKeysController extends KleinController
     {
         $key = filter_var($this->request->param('key'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
         $emails = filter_var($this->request->param('emails'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
-        $description = filter_var($this->request->param('description'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
+        $description = TmKeyManager::sanitizeName($this->request->param('description'));
         $remove_from = filter_var($this->request->param('remove_from'), FILTER_SANITIZE_FULL_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
 
         // check for eventual errors on the input passed
@@ -181,17 +181,21 @@ class UserKeysController extends KleinController
         // in this case, an error MUST be thrown
         if ($this->request->param('description') and $this->request->param('description') !== $description) {
             throw new InvalidArgumentException(
-                "<span>Resource names cannot contain the following characters:</span>"
+                "<span>Resource names can only contain letters, numbers, spaces and these special characters:</span>"
+                . "<ul>"
+                . "<li>. (period)</li>"
+                . "<li>- (hyphen)</li>"
+                . "<li>_ (underscore)</li>"
+                . "<li>{ } (braces)</li>"
+                . "</ul>"
+                . "<span>The following characters are not allowed:</span>"
                 . "<ul>"
                 . "<li>&lt; (less than)</li>"
                 . "<li>&gt; (greater than)</li>"
                 . "<li>&amp; (ampersand)</li>"
                 . "<li>&quot; (double quote)</li>"
                 . "<li>&#39; (single quote)</li>"
-                . "</ul>"
-                . "<span>Non-printable control characters are not allowed either. See the "
-                . "<a href=\"https://gist.github.com/mauretto78/83db58b7023a2f7bb26b252360d3692a\" "
-                . "target=\"_blank\" rel=\"noopener noreferrer\">full list of unsupported characters</a>.</span>",
+                . "</ul>",
                 -3
             );
         }

--- a/lib/Utils/TmKeyManagement/TmKeyManager.php
+++ b/lib/Utils/TmKeyManagement/TmKeyManager.php
@@ -197,6 +197,29 @@ class TmKeyManager
     }
 
     /**
+     * Sanitizes a TM key/resource name, allow-listing letters, numbers,
+     * whitespace, `. - _` and `{}` (the latter needed for the `{{pid}}`
+     * placeholder). This is the single canonical rule for TM/glossary resource
+     * names and MUST be applied at every point a name is persisted, not only
+     * when a key is assigned to a job.
+     *
+     * @param string|null $name
+     *
+     * @return string|null
+     */
+    public static function sanitizeName(?string $name): ?string
+    {
+        if (is_null($name)) {
+            return null;
+        }
+
+        $name      = preg_replace('/[^.\-_\p{L}\p{N}\s{}]+/u', '', $name);
+        $sanitized = filter_var($name, FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
+
+        return $sanitized !== false ? $sanitized : null;
+    }
+
+    /**
      * This method sanitize fields received with struct
      *
      * @param TmKeyStruct $obj
@@ -231,9 +254,7 @@ class TmKeyManager
         }
 
         if (!is_null($obj->name)) {
-            $obj->name = preg_replace('/[^.\-_\p{L}\p{N}\s{}]+/u', '', $obj->name);
-            $sanitized = filter_var($obj->name, FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
-            $obj->name = $sanitized !== false ? $sanitized : null;
+            $obj->name = self::sanitizeName($obj->name);
         }
 
         if (!is_null($obj->key)) {

--- a/lib/View/Emails/ShareKey/message_content.html
+++ b/lib/View/Emails/ShareKey/message_content.html
@@ -1,21 +1,21 @@
 <p class="p_line_height_1_5">
     Hello,
     <br>
-    <?=$senderFullName?><? if( !empty( $senderEmail ) ): ?> (<?=$senderEmail?>)<? endif; ?> shared the following language resource with you.
+    <?=htmlspecialchars($senderFullName, ENT_QUOTES, 'UTF-8')?><? if( !empty( $senderEmail ) ): ?> (<?=htmlspecialchars($senderEmail, ENT_QUOTES, 'UTF-8')?>)<? endif; ?> shared the following language resource with you.
 </p>
 <p class="p_line_height_1_5">
-    <span class="align-center" style="font-weight: bold;">Description:</span> <span><?=$tm_key_name?></span>
+    <span class="align-center" style="font-weight: bold;">Description:</span> <span><?=htmlspecialchars($tm_key_name, ENT_QUOTES, 'UTF-8')?></span>
     <br>
-    <span class="align-center" style="font-weight: bold;">Private key:</span> <span> <?=$tm_key_value?></span>
+    <span class="align-center" style="font-weight: bold;">Private key:</span> <span> <?=htmlspecialchars($tm_key_value, ENT_QUOTES, 'UTF-8')?></span>
 </p>
 <p class="p_line_height_1_5">
-    If you have an account on Matecat registered to <?=$addressMail?>, you will find the language resource in the 'Translation Memory and Glossary' tab of the settings panel.
+    If you have an account on Matecat registered to <?=htmlspecialchars($addressMail, ENT_QUOTES, 'UTF-8')?>, you will find the language resource in the 'Translation Memory and Glossary' tab of the settings panel.
 </p>
 <p class="p_bottom_5">Otherwise:</p>
 <ol>
     <li>Open the <span style="font-weight: bold;">'Translation Memory and Glossary'</span> tab from the Settings panel.</li>
     <li>Click <span style="font-weight: bold;">'Add shared resource'</span>.</li>
     <li>Enter a name for the resource in the dedicated field.</li>
-    <li>Paste the key (<span class="align-center" style="font-weight: bold;"><?=$tm_key_value?></span>) into the dedicated field.</li>
+    <li>Paste the key (<span class="align-center" style="font-weight: bold;"><?=htmlspecialchars($tm_key_value, ENT_QUOTES, 'UTF-8')?></span>) into the dedicated field.</li>
     <li>Click <span style="font-weight: bold;">'Confirm'</span>.</li>
 </ol>

--- a/tests/unit/Core/Controllers/TMXFileControllerTest.php
+++ b/tests/unit/Core/Controllers/TMXFileControllerTest.php
@@ -467,6 +467,46 @@ class TMXFileControllerTest extends AbstractTest
         $this->assertSame('Default.tmx', $body['data']['uuids'][0]['name']);
     }
 
+    /**
+     * Regression: import() used to write the raw uploaded filename straight into
+     * memory_keys.key_name with zero sanitization. A filename containing symbols
+     * that TmKeyManager::sanitizeName() would strip elsewhere (e.g. on job
+     * assignment) must now be sanitized the same way here too, closing the one
+     * path that persisted fully unsanitized client input.
+     *
+     * @throws ReflectionException
+     */
+    #[Test]
+    public function import_success_sanitizes_uploaded_filename_before_storing_as_key_name(): void
+    {
+        AppConfig::$DEFAULT_TM_KEY = 'the-default-key';
+        $this->seedMemoryKey('non-default-key-symbols');
+
+        $this->setRequestWithUploadedFile('èòà£££$$$.tmx', '<tmx version="1.4"/>', [
+            'tm_key' => 'non-default-key-symbols',
+        ]);
+        $this->reflector->getProperty('response')->setValue($this->controller, new Response());
+
+        $tmsServiceStub = $this->createStub(TMSService::class);
+        $tmsServiceStub->method('addTmxInMyMemory')->willReturn([]);
+        $this->controller->tmsServiceStub = $tmsServiceStub;
+
+        ob_start();
+        try {
+            $this->controller->import();
+        } finally {
+            ob_end_clean();
+        }
+
+        $stmt = $this->seedConnection()->prepare(
+            "SELECT key_name FROM memory_keys WHERE uid = :uid AND key_value = :key_value"
+        );
+        $stmt->execute(['uid' => $this->userId(self::BASE), 'key_value' => 'non-default-key-symbols']);
+        $keyName = $stmt->fetchColumn();
+
+        $this->assertSame('èòà.tmx', $keyName);
+    }
+
     // ─── importStatus() ───
 
     /**

--- a/tests/unit/Core/Controllers/UserKeysControllerTest.php
+++ b/tests/unit/Core/Controllers/UserKeysControllerTest.php
@@ -374,9 +374,10 @@ class UserKeysControllerTest extends AbstractTest
             $this->assertStringContainsString('&amp;', $e->getMessage());
             $this->assertStringContainsString('&quot;', $e->getMessage());
             $this->assertStringContainsString('&#39;', $e->getMessage());
-            $this->assertStringContainsString(
-                'https://gist.github.com/mauretto78/83db58b7023a2f7bb26b252360d3692a',
-                $e->getMessage()
+            $this->assertStringNotContainsString(
+                'gist.github.com',
+                $e->getMessage(),
+                'the gist link was intentionally dropped from the message'
             );
         }
     }
@@ -398,7 +399,7 @@ class UserKeysControllerTest extends AbstractTest
             $this->fail('Expected InvalidArgumentException was not thrown');
         } catch (InvalidArgumentException $e) {
             $this->assertSame(-3, $e->getCode());
-            $this->assertStringContainsString('Resource names cannot contain', $e->getMessage());
+            $this->assertStringContainsString('Resource names can only contain', $e->getMessage());
         }
     }
 
@@ -408,12 +409,57 @@ class UserKeysControllerTest extends AbstractTest
     public static function forbiddenDescriptionCharacterProvider(): array
     {
         return [
-            'less-than'    => ['<'],
-            'greater-than' => ['>'],
-            'ampersand'    => ['&'],
-            'double-quote' => ['"'],
-            'single-quote' => ["'"],
+            'less-than'      => ['<'],
+            'greater-than'   => ['>'],
+            'ampersand'      => ['&'],
+            'double-quote'   => ['"'],
+            'single-quote'   => ["'"],
+            'pound-sign'     => ['£'],
+            'dollar-sign'    => ['$'],
         ];
+    }
+
+    /**
+     * Regression: the job-assignment sanitizer (TmKeyManager::sanitize()) strips symbols
+     * like £/$ that this endpoint used to let through untouched, producing a name that
+     * silently changed once the key was assigned to a job. Saving must now be rejected
+     * up front instead, using the same allow-list as job assignment.
+     *
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_throws_minus_three_for_symbols_stripped_by_job_assignment(): void
+    {
+        $this->setRequestParams([
+            'key'         => 'abcdef1234567890',
+            'description' => 'èòà£££$$$',
+        ]);
+
+        try {
+            $this->invokePrivate('validateTheRequest');
+            $this->fail('Expected InvalidArgumentException was not thrown');
+        } catch (InvalidArgumentException $e) {
+            $this->assertSame(-3, $e->getCode());
+        }
+    }
+
+    /**
+     * Accented letters are allowed by TmKeyManager::sanitizeName()'s \p{L} class, so a
+     * description made only of accented letters must be accepted unchanged.
+     *
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_accepts_accented_only_description(): void
+    {
+        $this->setRequestParams([
+            'key'         => 'abcdef1234567890',
+            'description' => 'èòà',
+        ]);
+
+        $result = $this->invokePrivate('validateTheRequest');
+
+        $this->assertSame('èòà', $result['description']);
     }
 
     // ─── getMkDao ───
@@ -702,6 +748,27 @@ class UserKeysControllerTest extends AbstractTest
         $keyValue = $stmt->fetchColumn();
 
         $this->assertSame($newKeyValue, $keyValue);
+    }
+
+    /**
+     * Regression: previously this name was saved verbatim here and only trimmed down to
+     * "èòà" later when assigned to a job, so the two components disagreed on the name.
+     * newKey() must now reject it up front instead of persisting a value that would
+     * later mismatch.
+     *
+     * @throws Throwable
+     */
+    #[Test]
+    public function newKey_rejects_name_containing_symbols_job_assignment_would_strip(): void
+    {
+        $newKeyValue = 'ctrltestsymbolkey' . self::BASE;
+
+        $this->setRequestParams(['key' => $newKeyValue, 'description' => 'èòà£££$$$']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(-3);
+
+        $this->controller->newKey();
     }
 
     /**

--- a/tests/unit/Core/TmKeyManagement/ShareKeyEmailTest.php
+++ b/tests/unit/Core/TmKeyManagement/ShareKeyEmailTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Matecat\Core\TmKeyManagement;
+
+use Matecat\TestHelpers\AbstractTest;
+use Model\TmKeyManagement\MemoryKeyStruct;
+use Model\Users\UserStruct;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
+use Utils\TmKeyManagement\ShareKeyEmail;
+use Utils\TmKeyManagement\TmKeyStruct;
+
+class ShareKeyEmailTest extends AbstractTest
+{
+    private function makeSender(): UserStruct
+    {
+        $user = new UserStruct();
+        $user->uid = 1;
+        $user->email = 'sender@example.com';
+        $user->first_name = 'Ann';
+        $user->last_name = 'Sender';
+
+        return $user;
+    }
+
+    private function makeKeyStruct(?string $name): MemoryKeyStruct
+    {
+        $tmKey = new TmKeyStruct();
+        $tmKey->key = 'somekeyvalue';
+        $tmKey->name = $name;
+
+        $keyStruct = new MemoryKeyStruct();
+        $keyStruct->uid = 1;
+        $keyStruct->tm_key = $tmKey;
+
+        return $keyStruct;
+    }
+
+    #[Test]
+    public function getTemplateVariablesReturnsExpectedKeys(): void
+    {
+        $email = new ShareKeyEmail($this->makeSender(), ['recipient@example.com', 'Recipient'], $this->makeKeyStruct('My Glossary'));
+        $method = new ReflectionMethod(ShareKeyEmail::class, '_getTemplateVariables');
+        $vars = $method->invoke($email);
+
+        $this->assertSame('My Glossary', $vars['tm_key_name']);
+        $this->assertSame('somekeyvalue', $vars['tm_key_value']);
+        $this->assertSame('recipient@example.com', $vars['addressMail']);
+    }
+
+    /**
+     * Regression: message_content.html used to echo tm_key_name (and the other
+     * template variables) with no HTML escaping, so a key name containing raw
+     * markup would be injected verbatim into the outgoing email. Every variable
+     * must now be escaped by the template.
+     */
+    #[Test]
+    public function buildMessageContentEscapesKeyNameContainingMarkup(): void
+    {
+        $email = new ShareKeyEmail($this->makeSender(), ['recipient@example.com', 'Recipient'], $this->makeKeyStruct('<script>alert(1)</script>'));
+        $method = new ReflectionMethod(ShareKeyEmail::class, '_buildMessageContent');
+        $html = $method->invoke($email);
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+}

--- a/tests/unit/Core/TmKeyManagement/TmKeyManagerTest.php
+++ b/tests/unit/Core/TmKeyManagement/TmKeyManagerTest.php
@@ -25,15 +25,44 @@ class TmKeyManagerTest extends AbstractTest
     {
         $obj = new TmKeyStruct();
         $obj->name = 'Resource with <script>alert(1)</script> and {{pid}}';
-        
+
         TmKeyManager::sanitize($obj);
-        
-        // < and > are removed or encoded by filter_var depending on implementation, 
+
+        // < and > are removed or encoded by filter_var depending on implementation,
         // but preg_replace should strip them if they are not in the allowed list.
         // In the updated code: [^.\-_\p{L}\p{N}\s{}]+
         // <, >, (, ) are NOT in the allowed list.
-        
+
         $this->assertStringContainsString('{{pid}}', $obj->name);
         $this->assertStringNotContainsString('<script>', $obj->name);
+    }
+
+    /**
+     * sanitizeName() is the shared, canonical name filter that must now also gate the
+     * "save a new TM key" endpoint, so that both save and job-assignment agree on the
+     * stored value. \p{L} preserves Unicode letters like accented characters, while
+     * currency/other symbols are stripped.
+     */
+    #[Test]
+    public function testSanitizeNamePreservesAccentedLettersAndStripsSymbols()
+    {
+        $this->assertSame('èòà', TmKeyManager::sanitizeName('èòà£££$$$'));
+    }
+
+    #[Test]
+    public function testSanitizeNameReturnsNullForNull()
+    {
+        $this->assertNull(TmKeyManager::sanitizeName(null));
+    }
+
+    #[Test]
+    public function testSanitizeUsesSanitizeNameForNameField()
+    {
+        $obj = new TmKeyStruct();
+        $obj->name = 'èòà£££$$$';
+
+        TmKeyManager::sanitize($obj);
+
+        $this->assertSame('èòà', $obj->name);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a silent mismatch: a TM/glossary resource name saved via the settings panel was accepted verbatim by `UserKeysController`, but stripped of symbols like `£` and `$` later when the key was assigned to a job via `TmKeyManager::sanitize()`. The persisted name silently changed on job assignment, causing the two components to disagree on the stored value.

Root fix: extract the name allow-list from `TmKeyManager::sanitize()` into a public static `sanitizeName()` method and apply it at every point a name is persisted — saving a key, uploading a TMX, and job assignment (which already had it).

Two secondary fixes in the same area:
- **Share-key email XSS** — `message_content.html` echoed `$senderFullName`, `$tm_key_name`, `$tm_key_value`, and `$addressMail` without `htmlspecialchars()`, allowing raw HTML injection into the outgoing email body.
- **Error message UX** — replaced the single "characters not allowed" list with two lists (allowed special chars / not allowed chars) and removed the gist link.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Utils/TmKeyManagement/TmKeyManager.php` | Extract `sanitizeName()` static method from `sanitize()`; `sanitize()` now delegates to it |
| `lib/Controller/API/App/UserKeysController.php` | Use `TmKeyManager::sanitizeName()` for the description param; update XSS error message to two `<ul>` lists (allowed / not allowed), drop gist link |
| `lib/Controller/API/App/TMXFileController.php` | Apply `TmKeyManager::sanitizeName()` when writing the TMX filename as the key name |
| `lib/View/Emails/ShareKey/message_content.html` | Add `htmlspecialchars(…, ENT_QUOTES, 'UTF-8')` to all echoed variables |
| `tests/unit/Core/TmKeyManagement/TmKeyManagerTest.php` | Tests for `sanitizeName()`: null passthrough, accented-letters preserved, symbols stripped; test that `sanitize()` delegates correctly |
| `tests/unit/Core/Controllers/UserKeysControllerTest.php` | Extend `forbiddenDescriptionCharacterProvider` with `£`/`$`; add regression tests for symbols-stripped-by-job-assignment and accented-only name; align assertions to new message text |
| `tests/unit/Core/Controllers/TMXFileControllerTest.php` | Regression test: TMX import sanitizes the uploaded filename before storing it as key name |
| `tests/unit/Core/TmKeyManagement/ShareKeyEmailTest.php` | **New** — tests for `_getTemplateVariables()` keys and `_buildMessageContent()` HTML-escaping |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

PHPStan (no-baseline, level 8): 0 errors on all touched production files.

`PersistenceNeeded` tests (`TMXFileControllerTest::import_success_sanitizes_uploaded_filename_before_storing_as_key_name`) require `pdo_mysql` on PHP 8.3 (not installed locally — pre-existing environment limitation shared by the entire `PersistenceNeeded` suite).

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-4-6)

## Notes

`sanitizeName()` applies the same regex allow-list (`\p{L}\p{N}\s.\-_{}`) as the old inline code in `sanitize()`, so job-assignment behaviour is unchanged. The only visible side effect is that the save endpoint now rejects names that previously slipped through (symbols like `£`, `$`, non-BMP characters), which is the intended fix.

No schema migration needed.