### PR TITLE
♻️ refactor(project-bar): remove fixed header height and obsolete search bar padding logic

### DIFF
--- a/public/css/sass/commons/_nav-bar.scss
+++ b/public/css/sass/commons/_nav-bar.scss
@@ -6,7 +6,6 @@ header {
   z-index: 6;
   margin: 0;
   background: #002b5c;
-  height: 60px;
   @media only screen and (max-width: 992px) {
     min-width: 992px;
     position: relative;

--- a/public/css/sass/components/SegmentsContainer.scss
+++ b/public/css/sass/components/SegmentsContainer.scss
@@ -135,13 +135,15 @@
 }
 
 .project-bar-blink {
-  animation: blinkBackground 1s;
+  animation: blinkBackground 1.2s;
+  animation-iteration-count: 3;
   border-top-left-radius: 8px;
   border-bottom-left-radius: 8px;
 }
 
 .project-bar-blink-wordcounter {
-  animation: blinkBackground 1s;
+  animation: blinkBackground 1.2s;
+  animation-iteration-count: 3;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-top-right-radius: 8px;
@@ -154,7 +156,7 @@
   }
 
   50% {
-    background-color: rgba(42, 140, 252, 0.25);
+    background-color: rgba(42, 140, 252, 0.4);
   }
 
   100% {

--- a/public/css/sass/components/SegmentsContainer.scss
+++ b/public/css/sass/components/SegmentsContainer.scss
@@ -112,20 +112,6 @@
     animation-direction: reverse;
   }
 
-  .sticky-project-bar-blink {
-    animation: blinkBackground 1s;
-    border-top-left-radius: 8px;
-    border-bottom-left-radius: 8px;
-  }
-
-  .sticky-project-bar-blink-wordcounter {
-    animation: blinkBackground 1s;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-    border-top-right-radius: 8px;
-    border-bottom-right-radius: 8px;
-  }
-
   @keyframes changeFileAnimation {
     0% {
       transform: translateY(0);
@@ -146,18 +132,32 @@
       opacity: 1;
     }
   }
+}
 
-  @keyframes blinkBackground {
-    0% {
-      background-color: transparent;
-    }
+.project-bar-blink {
+  animation: blinkBackground 1s;
+  border-top-left-radius: 8px;
+  border-bottom-left-radius: 8px;
+}
 
-    50% {
-      background-color: rgba(42, 140, 252, 0.25);
-    }
+.project-bar-blink-wordcounter {
+  animation: blinkBackground 1s;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
 
-    100% {
-      background-color: transparent;
-    }
+@keyframes blinkBackground {
+  0% {
+    background-color: transparent;
+  }
+
+  50% {
+    background-color: rgba(42, 140, 252, 0.25);
+  }
+
+  100% {
+    background-color: transparent;
   }
 }

--- a/public/css/sass/style.scss
+++ b/public/css/sass/style.scss
@@ -300,7 +300,7 @@ section.opened .warnings {
   color: #788190;
   display: flex;
   justify-content: flex-start;
-  padding: 40px 115px 10px 4.5%;
+  padding: 18px 115px 10px 4.5%;
   align-items: center;
   span.fileFormat {
     padding: 10px 15px 9px 47px;

--- a/public/css/sass/style.scss
+++ b/public/css/sass/style.scss
@@ -300,7 +300,7 @@ section.opened .warnings {
   color: #788190;
   display: flex;
   justify-content: flex-start;
-  padding: 18px 115px 10px 4.5%;
+  padding: 10px 115px 10px 4.5%;
   align-items: center;
   span.fileFormat {
     padding: 10px 15px 9px 47px;

--- a/public/js/components/common/VirtualList/Rows/RowSegment.js
+++ b/public/js/components/common/VirtualList/Rows/RowSegment.js
@@ -93,11 +93,20 @@ RowSegment.propTypes = {
 
 export default RowSegment
 
-export const ProjectBar = ({segment, files, sideOpen, isSticky, listRef}) => {
+export const ProjectBar = ({
+  segment,
+  files,
+  sideOpen,
+  listRef,
+  isSticky,
+  isBlinking,
+}) => {
   const [isFileChange, setIsFileChange] = useState(false)
+  const [isBlinkingState, setIsBlinkingState] = useState(false)
 
   const ref = useRef()
   const previousFileIdRef = useRef()
+  const isBlikingRef = useRef()
 
   const openInstructionsModal = (id_file) => {
     const props = {
@@ -138,7 +147,8 @@ export const ProjectBar = ({segment, files, sideOpen, isSticky, listRef}) => {
 
   useEffect(() => {
     let tmOutReset
-    const stopFileChangeAnim = () => setIsFileChange(false)
+
+    const container = ref.current
     const filenameElement = ref.current.firstChild
     const wordcounterElement = ref.current.children[1]
 
@@ -147,17 +157,16 @@ export const ProjectBar = ({segment, files, sideOpen, isSticky, listRef}) => {
       idFileSegment !== previousFileIdRef.current &&
       typeof previousFileIdRef.current === 'number'
     ) {
-      ref.current.style.animation = 'none'
+      container.style.animation = 'none'
       if (filenameElement) filenameElement.style.animation = 'none'
       if (wordcounterElement) wordcounterElement.style.animation = 'none'
 
       tmOutReset = setTimeout(() => {
-        ref.current.style.animation = ''
+        container.style.animation = ''
         if (filenameElement) filenameElement.style.animation = ''
         if (wordcounterElement) wordcounterElement.style.animation = ''
       }, 0)
 
-      filenameElement?.addEventListener('animationend', stopFileChangeAnim)
       setIsFileChange(true)
     }
 
@@ -165,8 +174,7 @@ export const ProjectBar = ({segment, files, sideOpen, isSticky, listRef}) => {
 
     return () => {
       clearTimeout(tmOutReset)
-      filenameElement?.removeEventListener('animationend', stopFileChangeAnim)
-      stopFileChangeAnim()
+      setIsBlinkingState(false)
     }
   }, [isSticky, idFileSegment])
 
@@ -179,7 +187,7 @@ export const ProjectBar = ({segment, files, sideOpen, isSticky, listRef}) => {
         if (newPaddingTop > 10)
           ref.current.style.paddingTop = `${newPaddingTop}px`
       } else {
-        ref.current.style.paddingTop = '14px'
+        ref.current.style.paddingTop = '10px'
       }
     }
 
@@ -193,6 +201,16 @@ export const ProjectBar = ({segment, files, sideOpen, isSticky, listRef}) => {
     return () => listRef?.removeEventListener('scroll', onScroll)
   }, [isSticky, listRef])
 
+  useEffect(() => {
+    if (isSticky) {
+      if (isBlinking) isBlikingRef.current = true
+      if (isFileChange && isBlikingRef.current) {
+        setIsBlinkingState(true)
+        isBlikingRef.current = false
+      }
+    }
+  }, [isSticky, isBlinking, isFileChange])
+
   const previousScrollTopRef = useRef(0)
   const isScrollingReverseRef = useRef(false)
   if (isSticky && listRef?.scrollTop !== previousScrollTopRef.current) {
@@ -205,10 +223,12 @@ export const ProjectBar = ({segment, files, sideOpen, isSticky, listRef}) => {
     <div
       ref={ref}
       className={`projectbar ${isFileChange ? `sticky-project-bar-change-file-animation ${isScrollingReverseRef.current ? 'sticky-project-bar-change-file-animation-reverse' : ''}` : ''} ${classes}`}
+      onAnimationEnd={() => setIsFileChange(false)}
     >
-      {file ? (
+      {file && (
         <div
-          className={`projectbar-filename ${isFileChange ? 'sticky-project-bar-blink' : ''}`}
+          className={`projectbar-filename ${isBlinkingState ? 'project-bar-blink' : ''}`}
+          onAnimationEnd={() => setIsBlinkingState(false)}
         >
           <span
             title={currentSegment.filename}
@@ -217,10 +237,10 @@ export const ProjectBar = ({segment, files, sideOpen, isSticky, listRef}) => {
             {file.file_name}
           </span>
         </div>
-      ) : null}
+      )}
       {file && file.weighted_words > 0 ? (
         <div
-          className={`projectbar-wordcounter ${isFileChange ? 'sticky-project-bar-blink sticky-project-bar-blink-wordcounter' : ''}`}
+          className={`projectbar-wordcounter ${isBlinkingState ? 'project-bar-blink project-bar-blink-wordcounter' : ''}`}
         >
           <span>
             Payable Words: <strong>{file.weighted_words}</strong>

--- a/public/js/components/common/VirtualList/Rows/RowSegment.js
+++ b/public/js/components/common/VirtualList/Rows/RowSegment.js
@@ -202,13 +202,17 @@ export const ProjectBar = ({
   }, [isSticky, listRef])
 
   useEffect(() => {
+    let tmOut
+
     if (isSticky) {
-      if (isBlinking) isBlikingRef.current = true
-      if (isFileChange && isBlikingRef.current) {
-        setIsBlinkingState(true)
-        isBlikingRef.current = false
+      if (isBlinking) {
+        isBlikingRef.current = true
+        setTimeout(() => (isBlikingRef.current = false), 300)
       }
+      if (isFileChange && isBlikingRef.current) setIsBlinkingState(true)
     }
+
+    return () => clearTimeout(tmOut)
   }, [isSticky, isBlinking, isFileChange])
 
   const previousScrollTopRef = useRef(0)

--- a/public/js/components/segments/SegmentsContainer.js
+++ b/public/js/components/segments/SegmentsContainer.js
@@ -203,7 +203,6 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
   const [files, setFiles] = useState(CatToolStore.getJobFilesInfo())
   const [addedComment, setAddedComment] = useState(undefined)
   const [scrollTopVisible, setScrollTopVisible] = useState(undefined)
-  const [isSearchBarOpen, setIsSearchBarOpen] = useState(false)
   const [clientConnected, setClientConnected] = useState()
   const [clientId, setClientId] = useState()
   const [firstRowIdVisible, setFirstRowIdVisible] = useState()
@@ -515,9 +514,6 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
     const closeSide = () => setIsSideOpen(false)
     const storeJobInfo = (files) => setFiles(files)
     const onAddComment = (sid) => setAddedComment({sid})
-    const toggleSearchBar = (container) =>
-      container === 'search' && setIsSearchBarOpen((prevState) => !prevState)
-    const closeSubHeader = () => setIsSearchBarOpen(false)
 
     const sseConnection = (clientId) => {
       setClientConnected(!!clientId)
@@ -546,8 +542,6 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
     SegmentStore.addListener(SegmentConstants.CLOSE_SIDE, closeSide)
     CatToolStore.addListener(CatToolConstants.STORE_FILES_INFO, storeJobInfo)
     CommentsStore.addListener(CommentsConstants.ADD_COMMENT, onAddComment)
-    CatToolStore.addListener(CatToolConstants.TOGGLE_CONTAINER, toggleSearchBar)
-    CatToolStore.addListener(CatToolConstants.CLOSE_SUBHEADER, closeSubHeader)
     CatToolStore.addListener(CatToolConstants.CLIENT_CONNECT, sseConnection)
 
     document.addEventListener('mousedown', mousedownHandler)
@@ -576,14 +570,6 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
         storeJobInfo,
       )
       CommentsStore.removeListener(CommentsConstants.ADD_COMMENT, onAddComment)
-      CatToolStore.removeListener(
-        CatToolConstants.TOGGLE_CONTAINER,
-        toggleSearchBar,
-      )
-      CatToolStore.removeListener(
-        CatToolConstants.CLOSE_SUBHEADER,
-        closeSubHeader,
-      )
       CatToolStore.removeListener(
         CatToolConstants.CLIENT_CONNECT,
         sseConnection,
@@ -841,15 +827,7 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
       }
       return 0
     }
-    // padding top when search bar is open
-    const paddingTopSearchBarOpened = isSearchBarOpen
-      ? SEARCH_BAR_OPENED_PADDING_TOP
-      : 0
-    // set inline style
-    listRef.current.firstChild.style.marginTop = `${
-      getPadding() + paddingTopSearchBarOpened
-    }px`
-  }, [isSideOpen, segments, addedComment, isSearchBarOpen])
+  }, [isSideOpen, segments, addedComment])
 
   // reset scrollTo
   useEffect(() => {

--- a/public/js/components/segments/SegmentsContainer.js
+++ b/public/js/components/segments/SegmentsContainer.js
@@ -882,14 +882,38 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
     if (typeof firstRowIdVisible !== 'undefined') {
       const props = getSegmentPropsBySid(firstRowIdVisible)
 
-      return props && (
-        <div
-          className={`sticky-project-bar ${props.sideOpen ? 'sticky-project-bar-slide-right' : ''}`}
-        >
-          <ProjectBar
-            {...{...props, listRef: listRef.current, isSticky: true}}
-          />
-        </div>
+      const index = rows.findIndex(({id}) =>
+        scrollToSid?.toString().indexOf('-') === -1
+          ? parseInt(id) === parseInt(scrollToSid)
+          : id === scrollToSid,
+      )
+
+      let isOnScreen = false
+      if (index !== -1 && listRef.current) {
+        const rowTop = rows
+          .slice(0, index)
+          .reduce((sum, row) => sum + row.height, 0)
+        const rowBottom = rowTop + rows[index].height
+        const scrollTop = listRef.current.scrollTop
+        const viewportBottom = scrollTop + listRef.current.clientHeight
+        isOnScreen = rowBottom > scrollTop && rowTop < viewportBottom
+      }
+
+      return (
+        props && (
+          <div
+            className={`sticky-project-bar ${props.sideOpen ? 'sticky-project-bar-slide-right' : ''}`}
+          >
+            <ProjectBar
+              {...{
+                ...props,
+                listRef: listRef.current,
+                isSticky: true,
+                isBlinking: scrollToSid && !isOnScreen,
+              }}
+            />
+          </div>
+        )
       )
     }
   }

--- a/public/js/components/segments/SegmentsContainer.test.js
+++ b/public/js/components/segments/SegmentsContainer.test.js
@@ -77,8 +77,6 @@ jest.mock('../../constants/SegmentConstants', () => ({
 
 jest.mock('../../constants/CatToolConstants', () => ({
   STORE_FILES_INFO: 'STORE_FILES_INFO',
-  TOGGLE_CONTAINER: 'TOGGLE_CONTAINER',
-  CLOSE_SUBHEADER: 'CLOSE_SUBHEADER',
   CLIENT_CONNECT: 'CLIENT_CONNECT',
 }))
 
@@ -333,14 +331,6 @@ describe('SegmentsContainer', () => {
         expect.any(Function),
       )
       expect(CatToolStore.addListener).toHaveBeenCalledWith(
-        CatToolConstants.TOGGLE_CONTAINER,
-        expect.any(Function),
-      )
-      expect(CatToolStore.addListener).toHaveBeenCalledWith(
-        CatToolConstants.CLOSE_SUBHEADER,
-        expect.any(Function),
-      )
-      expect(CatToolStore.addListener).toHaveBeenCalledWith(
         CatToolConstants.CLIENT_CONNECT,
         expect.any(Function),
       )
@@ -405,40 +395,6 @@ describe('SegmentsContainer', () => {
       act(() => {
         mockCatToolStoreListeners[CatToolConstants.CLIENT_CONNECT](null)
       })
-    })
-  })
-
-  describe('TOGGLE_CONTAINER event', () => {
-    test('toggles search bar open when container is "search"', () => {
-      renderComponent()
-      act(() => {
-        mockCatToolStoreListeners[CatToolConstants.TOGGLE_CONTAINER]('search')
-      })
-      act(() => {
-        mockCatToolStoreListeners[CatToolConstants.TOGGLE_CONTAINER]('search')
-      })
-      // No crash
-    })
-
-    test('does not toggle search bar when container is not "search"', () => {
-      renderComponent()
-      act(() => {
-        mockCatToolStoreListeners[CatToolConstants.TOGGLE_CONTAINER]('other')
-      })
-      // No crash, state unchanged
-    })
-  })
-
-  describe('CLOSE_SUBHEADER event', () => {
-    test('closes search bar', () => {
-      renderComponent()
-      act(() => {
-        mockCatToolStoreListeners[CatToolConstants.TOGGLE_CONTAINER]('search')
-      })
-      act(() => {
-        mockCatToolStoreListeners[CatToolConstants.CLOSE_SUBHEADER]()
-      })
-      // No crash
     })
   })
 


### PR DESCRIPTION
## Summary

Removes the fixed 60px header height and the now-obsolete search-bar padding
compensation logic, adjusting the warnings section padding accordingly.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| public/css/sass/commons/_nav-bar.scss | remove fixed `height: 60px` from header |
| public/css/sass/style.scss | adjust warnings top padding from 40px to 18px |
| public/js/components/segments/SegmentsContainer.js | remove `isSearchBarOpen` state, its store listeners, and the dynamic `marginTop` calculation |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

<!-- describe your manual testing steps here -->

## AI Disclosure

- [x] No AI tools were used in this PR
- [ ] AI tools were used — name the agent/tool below

## Notes