### PR TITLE
🐛 fix(replace-all): restore version history, fix undo and demote status by actor level

### DIFF
--- a/lib/Controller/API/App/GetSearchController.php
+++ b/lib/Controller/API/App/GetSearchController.php
@@ -489,19 +489,35 @@ class GetSearchController extends AbstractStatefulKleinController
      */
     private function getNewStatus(SegmentTranslationStruct $translationStruct, ?int $revisionNumber = null): string
     {
-        if (!isset($revisionNumber)) {
-            return TranslationStatus::STATUS_DRAFT;
-        }
+        // A replace-all is an automated, unseen change, so the current editor must re-review it: the
+        // touched segment is demoted to one tier BELOW the actor's review level, and never higher than
+        // the segment's own current tier (a replace can only demote, never promote). The actor is
+        // identified by $revisionNumber: null = translator, 1 = R1, 2 = R2.
+        //
+        //   ceiling (one tier below the actor):
+        //     translator -> DRAFT, R1 -> TRANSLATED, R2 -> APPROVED
+        //   result = min(currentTier, ceilingTier), mapped back to a status:
+        //     translator:  APPROVED2/APPROVED/TRANSLATED -> DRAFT
+        //     R1:          APPROVED2/APPROVED/TRANSLATED -> TRANSLATED
+        //     R2:          APPROVED2 -> APPROVED, APPROVED stays APPROVED, TRANSLATED stays TRANSLATED
+        $tierOfStatus = [
+            TranslationStatus::STATUS_NEW        => 0,
+            TranslationStatus::STATUS_DRAFT      => 0,
+            TranslationStatus::STATUS_REJECTED   => 0,
+            TranslationStatus::STATUS_TRANSLATED => 1,
+            TranslationStatus::STATUS_APPROVED   => 2,
+            TranslationStatus::STATUS_APPROVED2  => 3,
+        ];
+        $statusOfTier = [
+            0 => TranslationStatus::STATUS_DRAFT,
+            1 => TranslationStatus::STATUS_TRANSLATED,
+            2 => TranslationStatus::STATUS_APPROVED,
+        ];
 
-        // A replace-all is an automated, unseen change, so the current editor must re-review it:
-        // demote the segment one quality tier so each touched segment re-enters that level's to-do
-        // queue. APPROVED2 (R2) -> APPROVED, APPROVED (R1) -> TRANSLATED, anything else -> DRAFT;
-        // on the translate page ($revisionNumber === null, handled above) everything drops to DRAFT.
-        return match ($translationStruct->status) {
-            TranslationStatus::STATUS_APPROVED => TranslationStatus::STATUS_TRANSLATED,
-            TranslationStatus::STATUS_APPROVED2 => TranslationStatus::STATUS_APPROVED,
-            default => TranslationStatus::STATUS_DRAFT
-        };
+        $ceilingTier = max(0, min(2, $revisionNumber ?? 0));
+        $currentTier = $tierOfStatus[$translationStruct->status] ?? 0;
+
+        return $statusOfTier[min($currentTier, $ceilingTier)];
     }
 
     /**

--- a/tests/unit/Core/Controllers/GetSearchControllerTest.php
+++ b/tests/unit/Core/Controllers/GetSearchControllerTest.php
@@ -329,63 +329,52 @@ class GetSearchControllerTest extends AbstractTest
     }
 
     // ─── getNewStatus ───
-    // A replace-all is an automated, unseen change, so the editor must re-review it: the status is
-    // demoted one quality tier. On the translate page (revisionNumber === null) everything drops to
-    // DRAFT; on a revision page APPROVED2 -> APPROVED, APPROVED -> TRANSLATED, anything else -> DRAFT.
+    // A replace-all is an automated, unseen change, so the editor must re-review it. The touched
+    // segment is demoted to one tier below the actor's review level, and the result is never higher
+    // than that ceiling nor higher than the segment's current tier (a replace never promotes):
+    //   - Translator (revisionNumber null): ceiling DRAFT   -> APPROVED2/APPROVED/TRANSLATED all -> DRAFT
+    //   - R1 (revisionNumber 1):            ceiling TRANSLATED -> APPROVED2/APPROVED/TRANSLATED all -> TRANSLATED
+    //   - R2 (revisionNumber 2):            ceiling APPROVED   -> APPROVED2 -> APPROVED, APPROVED stays,
+    //                                                            TRANSLATED stays TRANSLATED
 
-    #[Test]
-    public function getNewStatus_returns_draft_when_no_revision_number(): void
+    /**
+     * @return array<string, array{string, ?int, string}>
+     */
+    public static function newStatusMatrixProvider(): array
     {
-        $translation = new \Model\Translations\SegmentTranslationStruct();
-        $translation->status = 'APPROVED';
-
-        $result = $this->invokePrivate('getNewStatus', [$translation, null]);
-
-        $this->assertSame('DRAFT', $result);
+        return [
+            // translator: everything collapses to DRAFT
+            'translator on approved2'  => ['APPROVED2', null, 'DRAFT'],
+            'translator on approved'   => ['APPROVED', null, 'DRAFT'],
+            'translator on translated' => ['TRANSLATED', null, 'DRAFT'],
+            'translator on rejected'   => ['REJECTED', null, 'DRAFT'],
+            'translator on draft'      => ['DRAFT', null, 'DRAFT'],
+            // R1: ceiling is TRANSLATED, never promotes below it
+            'r1 on approved2'  => ['APPROVED2', 1, 'TRANSLATED'],
+            'r1 on approved'   => ['APPROVED', 1, 'TRANSLATED'],
+            'r1 on translated' => ['TRANSLATED', 1, 'TRANSLATED'],
+            'r1 on draft'      => ['DRAFT', 1, 'DRAFT'],
+            // R2: ceiling is APPROVED, never promotes below it
+            'r2 on approved2'  => ['APPROVED2', 2, 'APPROVED'],
+            'r2 on approved'   => ['APPROVED', 2, 'APPROVED'],
+            'r2 on translated' => ['TRANSLATED', 2, 'TRANSLATED'],
+            'r2 on draft'      => ['DRAFT', 2, 'DRAFT'],
+        ];
     }
 
     #[Test]
-    public function getNewStatus_demotes_translated_to_draft_on_revision(): void
-    {
+    #[\PHPUnit\Framework\Attributes\DataProvider('newStatusMatrixProvider')]
+    public function getNewStatus_demotes_by_actor_revision_level(
+        string $currentStatus,
+        ?int $revisionNumber,
+        string $expected
+    ): void {
         $translation = new \Model\Translations\SegmentTranslationStruct();
-        $translation->status = 'TRANSLATED';
+        $translation->status = $currentStatus;
 
-        $result = $this->invokePrivate('getNewStatus', [$translation, 1]);
+        $result = $this->invokePrivate('getNewStatus', [$translation, $revisionNumber]);
 
-        $this->assertSame('DRAFT', $result);
-    }
-
-    #[Test]
-    public function getNewStatus_demotes_approved_to_translated_on_revision(): void
-    {
-        $translation = new \Model\Translations\SegmentTranslationStruct();
-        $translation->status = 'APPROVED';
-
-        $result = $this->invokePrivate('getNewStatus', [$translation, 1]);
-
-        $this->assertSame('TRANSLATED', $result);
-    }
-
-    #[Test]
-    public function getNewStatus_demotes_approved2_to_approved_on_revision(): void
-    {
-        $translation = new \Model\Translations\SegmentTranslationStruct();
-        $translation->status = 'APPROVED2';
-
-        $result = $this->invokePrivate('getNewStatus', [$translation, 2]);
-
-        $this->assertSame('APPROVED', $result);
-    }
-
-    #[Test]
-    public function getNewStatus_demotes_rejected_to_draft_on_revision(): void
-    {
-        $translation = new \Model\Translations\SegmentTranslationStruct();
-        $translation->status = 'REJECTED';
-
-        $result = $this->invokePrivate('getNewStatus', [$translation, 2]);
-
-        $this->assertSame('DRAFT', $result);
+        $this->assertSame($expected, $result);
     }
 
     // ─── getReplacedSegmentTranslation ───


### PR DESCRIPTION
## Summary

Fixes several correctness bugs in the search "replace all" / "undo replace all" pipeline and its
downstream side effects. The primary bug: on a project with the Translation Versions feature, a
replace-all produced **no** version history, translation events, or completion refresh because a
single version handler was built once (with no `id_segment`), so the factory always returned the
no-op `DummyTranslationVersionHandler`. This PR builds a real per-segment handler inside the loop,
restores the version/event/cache-flush side effects, corrects the undo cursor, and makes the
status-demotion rule depend on the acting user's review level.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

- **Per-segment version handler** — `GetSearchController::updateSegments` now builds the version
  handler per segment (real `TranslationVersionsHandler` when the feature is on), so version rows,
  translation events and the segment-translation cache flush actually happen on replace-all.
- **Status demotion by actor level** — `getNewStatus` demotes a touched segment to one tier *below*
  the acting user's review level and never promotes: translator → `DRAFT`; R1 → `TRANSLATED` (cap);
  R2 → `APPROVED` (cap), with `TRANSLATED` left untouched. The result is the lower of the segment's
  own tier and that ceiling.
- **Undo cursor** — `MySQLReplaceEventIndexDao::getActualIndex` fixed to read the scalar index from
  the fetched row (`(int)($row['v'] ?? 0)`) instead of dereferencing a nested array.
- **PostAddSegmentTranslationEvent** — dispatched after a non-empty replace-all batch so
  `ProjectCompletion` refreshes `chunk_completion`.
- **Dead redo path removed** — `redoReplaceAll` / `getSegmentForRedoReplaceAll` and the now-unused
  `SegmentTranslationDao` dependency dropped from `ReplaceHistory`; constructor shape guarded by test.
- **TranslationEventsHandler** — the removed "translated-from-revision" guard (CWE-863 remediation)
  is now covered by a positive test asserting it no longer throws.
- **Frontend** — MSW tests added for the `replaceAllIntoSegments` and `copyAllSourceToTarget` API
  modules (posted FormData fields, resolved value, both error paths).

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite green (9208 tests). PHPStan level 8, 0 errors. A real-SQL end-to-end integration test
(`GetSearchControllerReplaceUndoIntegrationTest`) drives replace-all → undo against MySQL and asserts
the restored state plus written version history. Changed-line coverage on the latest commit is 100%
(16/16 executable lines).

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (Claude Opus) assisted with implementation, test authoring and verification.

## Notes

No database migration is required. The status-demotion change alters replace-all behavior for
revisors: a replace on the revision pages now caps at one tier below the actor's level instead of
always dropping to `DRAFT`, matching the intended review workflow.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216846602229534