### PR TITLE
🐛 fix(mymemory): hydrate source and target language codes on TM matches

### DIFF
--- a/lib/Utils/Engines/MyMemory.php
+++ b/lib/Utils/Engines/MyMemory.php
@@ -176,9 +176,11 @@ class MyMemory extends AbstractEngine
 
                 if (!empty($decoded['matches'])) {
                     foreach ($decoded['matches'] as $pos => $match) {
-                        $decoded['matches'][$pos]['segment'] = $match['segment'];
-                        $decoded['matches'][$pos]['translation'] = $match['translation'];
+                        $decoded['matches'][$pos]['segment']     = $match['segment'] ?? '';
+                        $decoded['matches'][$pos]['translation'] = $match['translation'] ?? '';
                         $decoded['matches'][$pos]['target_note'] = $match['target_note'] ?? '';
+                        $decoded['matches'][$pos]['source']      = $this->_config['source'] ?? $match['source'] ?? '';
+                        $decoded['matches'][$pos]['target']      = $this->_config['target'] ?? $match['target'] ?? '';
                     }
                 }
 

--- a/lib/Utils/Engines/MyMemory.php
+++ b/lib/Utils/Engines/MyMemory.php
@@ -179,8 +179,8 @@ class MyMemory extends AbstractEngine
                         $decoded['matches'][$pos]['segment']     = $match['segment'] ?? '';
                         $decoded['matches'][$pos]['translation'] = $match['translation'] ?? '';
                         $decoded['matches'][$pos]['target_note'] = $match['target_note'] ?? '';
-                        $decoded['matches'][$pos]['source']      = $this->_config['source'] ?? $match['source'] ?? '';
-                        $decoded['matches'][$pos]['target']      = $this->_config['target'] ?? $match['target'] ?? '';
+                        $decoded['matches'][$pos]['source']      = $match['source'] ?? $this->_config['source'] ?? '';
+                        $decoded['matches'][$pos]['target']      = $match['target'] ?? $this->_config['target'] ?? '';
                     }
                 }
 

--- a/lib/Utils/Engines/Results/MyMemory/GetMemoryResponse.php
+++ b/lib/Utils/Engines/Results/MyMemory/GetMemoryResponse.php
@@ -83,12 +83,14 @@ class GetMemoryResponse extends TMSAbstractResponse
             'reference' => $match['reference'] ?? '',
             'last-updated-by' => $match['last-updated-by'] ?? '',
             'last-update-date' => $match['last-update-date'] ?? '1970-01-01 00:00:00',
-            'tm_properties' => $match['tm_properties'],
+            'tm_properties' => $match['tm_properties'] ?? null,
             'key' => $match['key'] ?? '',
             'ICE' => $match['ICE'] ?? false,
             'source_note' => $match['source_note'] ?? null,
             'target_note' => $match['target_note'] ?? '',
             'penalty' => $match['penalty'] ?? null,
+            'source' => $match['source'] ?? null,
+            'target' => $match['target'] ?? null,
         ]);
     }
 

--- a/nodejs/yarn.lock
+++ b/nodejs/yarn.lock
@@ -270,29 +270,24 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@colors/colors@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
-  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
-
-"@colors/colors@1.6.0":
+"@colors/colors@^1.6.0", "@colors/colors@1.6.0":
   version "1.6.0"
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz"
   integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
 
-"@dabh/diagnostics@^2.0.2":
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz"
-  integrity sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==
+"@dabh/diagnostics@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz"
+  integrity sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==
   dependencies:
-    colorspace "1.1.x"
+    "@so-ric/colorspace" "^1.1.6"
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@ioredis/commands@^1.1.1":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz"
-  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+"@ioredis/commands@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz"
+  integrity sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==
 
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
@@ -586,9 +581,9 @@
   integrity sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==
 
 "@sinclair/typebox@^0.34.0":
-  version "0.34.52"
-  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz"
-  integrity sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==
+  version "0.34.49"
+  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz"
+  integrity sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==
 
 "@sinonjs/commons@^3.0.1":
   version "3.0.1"
@@ -603,6 +598,14 @@
   integrity sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
+
+"@so-ric/colorspace@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz"
+  integrity sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==
+  dependencies:
+    color "^5.0.2"
+    text-hex "1.0.x"
 
 "@socket.io/cluster-adapter@^0.3.0":
   version "0.3.0"
@@ -668,15 +671,10 @@
   dependencies:
     "@babel/types" "^7.28.2"
 
-"@types/cookie@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz"
-  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
-
 "@types/cors@^2.8.12":
-  version "2.8.17"
-  resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz"
-  integrity sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==
+  version "2.8.19"
+  resolved "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz"
+  integrity sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==
   dependencies:
     "@types/node" "*"
 
@@ -700,11 +698,11 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/node@*", "@types/node@>=10.0.0":
-  version "22.10.7"
-  resolved "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz"
-  integrity sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==
+  version "25.9.1"
+  resolved "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz"
+  integrity sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==
   dependencies:
-    undici-types "~6.20.0"
+    undici-types ">=7.24.0 <7.24.7"
 
 "@types/stack-utils@^2.0.3":
   version "2.0.3"
@@ -715,6 +713,13 @@
   version "1.3.5"
   resolved "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz"
   integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
+
+"@types/ws@^8.5.12":
+  version "8.18.1"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -729,9 +734,9 @@
     "@types/yargs-parser" "*"
 
 "@ungap/structured-clone@^1.3.0":
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz"
-  integrity sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz"
+  integrity sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
 
 "@unrs/resolver-binding-linux-x64-gnu@1.12.2":
   version "1.12.2"
@@ -796,9 +801,9 @@ argparse@^1.0.7:
     sprintf-js "~1.0.2"
 
 async@^3.2.3:
-  version "3.2.4"
-  resolved "https://registry.npmjs.org/async/-/async-3.2.4.tgz"
-  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
+  version "3.2.6"
+  resolved "https://registry.npmjs.org/async/-/async-3.2.6.tgz"
+  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
 babel-jest@30.4.1:
   version "30.4.1"
@@ -870,35 +875,35 @@ base64id@~2.0.0, base64id@2.0.0:
   resolved "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
-baseline-browser-mapping@^2.10.42:
-  version "2.10.44"
-  resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz"
-  integrity sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==
+baseline-browser-mapping@^2.10.12:
+  version "2.10.33"
+  resolved "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz"
+  integrity sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.15"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz"
+  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz"
+  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
   dependencies:
     balanced-match "^1.0.0"
 
 browserslist@^4.24.0, "browserslist@>= 4.21.0":
-  version "4.28.6"
-  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz"
-  integrity sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==
+  version "4.28.2"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz"
+  integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
   dependencies:
-    baseline-browser-mapping "^2.10.42"
-    caniuse-lite "^1.0.30001803"
-    electron-to-chromium "^1.5.389"
-    node-releases "^2.0.51"
+    baseline-browser-mapping "^2.10.12"
+    caniuse-lite "^1.0.30001782"
+    electron-to-chromium "^1.5.328"
+    node-releases "^2.0.36"
     update-browserslist-db "^1.2.3"
 
 bser@2.1.1:
@@ -908,7 +913,7 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-equal-constant-time@1.0.1:
+buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
@@ -933,10 +938,10 @@ camelcase@^6.3.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001803:
-  version "1.0.30001806"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz"
-  integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
+caniuse-lite@^1.0.30001782:
+  version "1.0.30001793"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz"
+  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
 
 chalk@^4.1.2:
   version "4.1.2"
@@ -970,10 +975,10 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-cluster-key-slot@^1.1.0:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz"
-  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+cluster-key-slot@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz"
+  integrity sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==
 
 co@^4.6.0:
   version "4.6.0"
@@ -985,13 +990,6 @@ collect-v8-coverage@^1.0.2:
   resolved "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz"
   integrity sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==
 
-color-convert@^1.9.3:
-  version "1.9.3"
-  resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
-
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
@@ -999,39 +997,37 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@^1.0.0, color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+color-convert@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz"
+  integrity sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==
+  dependencies:
+    color-name "^2.0.0"
+
+color-name@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz"
+  integrity sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==
 
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.6.0:
-  version "1.9.1"
-  resolved "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz"
-  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+color-string@^2.1.3:
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz"
+  integrity sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==
   dependencies:
-    color-name "^1.0.0"
-    simple-swizzle "^0.2.2"
+    color-name "^2.0.0"
 
-color@^3.1.3:
-  version "3.2.1"
-  resolved "https://registry.npmjs.org/color/-/color-3.2.1.tgz"
-  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+color@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/color/-/color-5.0.3.tgz"
+  integrity sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==
   dependencies:
-    color-convert "^1.9.3"
-    color-string "^1.6.0"
-
-colorspace@1.1.x:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz"
-  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
-  dependencies:
-    color "^3.1.3"
-    text-hex "1.0.x"
+    color-convert "^3.1.3"
+    color-string "^2.1.3"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1065,17 +1061,17 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2, debug@~4.3.4:
-  version "4.3.7"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
-  integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
-  dependencies:
-    ms "^2.1.3"
-
-debug@~4.4.1:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@~4.4.1, debug@4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
+debug@~4.3.1:
+  version "4.3.7"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz"
+  integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
   dependencies:
     ms "^2.1.3"
 
@@ -1089,7 +1085,7 @@ deepmerge@^4.3.1:
   resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
-denque@^2.1.0:
+denque@2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz"
   integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
@@ -1111,10 +1107,10 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
-electron-to-chromium@^1.5.389:
-  version "1.5.394"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.394.tgz"
-  integrity sha512-Wmt2Gm0o8JWBuGgmc4XZ0u9s1RaCRqhxP47phplmfg04+qypTUurpeJGP45A7Fhv7jdrrVH44PLlR9qXo37cVQ==
+electron-to-chromium@^1.5.328:
+  version "1.5.367"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.367.tgz"
+  integrity sha512-4Mk/mrynCNQ+atY40D3UpmhLWB6AHMbYMlIrPhHcMF6x0L7O0b052FCAsxw1LlaR++UFuNg3D/A6XCuGDa0guQ==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -1142,20 +1138,20 @@ engine.io-parser@~5.2.1:
   integrity sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==
 
 engine.io@~6.6.0:
-  version "6.6.2"
-  resolved "https://registry.npmjs.org/engine.io/-/engine.io-6.6.2.tgz"
-  integrity sha512-gmNvsYi9C8iErnZdVcJnvCpSKbWTt1E8+JZo8b+daLninywUWi5NQ5STSHZ9rFjFO7imNcvb8Pc5pe/wMR5xEw==
+  version "6.6.8"
+  resolved "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz"
+  integrity sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==
   dependencies:
-    "@types/cookie" "^0.4.1"
     "@types/cors" "^2.8.12"
     "@types/node" ">=10.0.0"
+    "@types/ws" "^8.5.12"
     accepts "~1.3.4"
     base64id "2.0.0"
     cookie "~0.7.2"
     cors "~2.8.5"
-    debug "~4.3.1"
+    debug "~4.4.1"
     engine.io-parser "~5.2.1"
-    ws "~8.17.1"
+    ws "~8.20.1"
 
 error-ex@^1.3.1:
   version "1.3.4"
@@ -1352,19 +1348,17 @@ inherits@^2.0.3, inherits@2:
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ioredis@^5.4.2:
-  version "5.4.2"
-  resolved "https://registry.npmjs.org/ioredis/-/ioredis-5.4.2.tgz"
-  integrity sha512-0SZXGNGZ+WzISQ67QDyZ2x0+wVxjjUndtD8oSeik/4ajifeiRufed8fCb8QW8VMyi4MXcS+UO1k/0NGhvq1PAg==
+  version "5.11.1"
+  resolved "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz"
+  integrity sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==
   dependencies:
-    "@ioredis/commands" "^1.1.1"
-    cluster-key-slot "^1.1.0"
-    debug "^4.3.4"
-    denque "^2.1.0"
-    lodash.defaults "^4.2.0"
-    lodash.isarguments "^3.1.0"
-    redis-errors "^1.2.0"
-    redis-parser "^3.0.0"
-    standard-as-callback "^2.1.0"
+    "@ioredis/commands" "1.10.0"
+    cluster-key-slot "1.1.1"
+    debug "4.4.3"
+    denque "2.1.0"
+    redis-errors "1.2.0"
+    redis-parser "3.0.0"
+    standard-as-callback "2.1.0"
 
 ip-regex@^4.3.0:
   version "4.3.0"
@@ -1375,11 +1369,6 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
-
-is-arrayish@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz"
-  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -1814,9 +1803,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.15.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz"
-  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
+  version "3.14.2"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz"
+  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1837,11 +1826,11 @@ json5@^2.2.3:
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonwebtoken@^9.0.2:
-  version "9.0.2"
-  resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz"
-  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
+  version "9.0.3"
+  resolved "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz"
+  integrity sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==
   dependencies:
-    jws "^3.2.2"
+    jws "^4.0.1"
     lodash.includes "^4.3.0"
     lodash.isboolean "^3.0.3"
     lodash.isinteger "^4.0.4"
@@ -1852,21 +1841,21 @@ jsonwebtoken@^9.0.2:
     ms "^2.1.1"
     semver "^7.5.4"
 
-jwa@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz"
-  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+jwa@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz"
+  integrity sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==
   dependencies:
-    buffer-equal-constant-time "1.0.1"
+    buffer-equal-constant-time "^1.0.1"
     ecdsa-sig-formatter "1.0.11"
     safe-buffer "^5.0.1"
 
-jws@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz"
-  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+jws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz"
+  integrity sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==
   dependencies:
-    jwa "^1.4.1"
+    jwa "^2.0.1"
     safe-buffer "^5.0.1"
 
 kuler@^2.0.0:
@@ -1891,20 +1880,10 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.defaults@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
-  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
-
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz"
   integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
-
-lodash.isarguments@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
-  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
@@ -1936,7 +1915,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-logform@^2.4.0, logform@^2.7.0:
+logform@^2.7.0:
   version "2.7.0"
   resolved "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz"
   integrity sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==
@@ -2050,10 +2029,10 @@ node-int64@^0.4.0:
   resolved "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-releases@^2.0.51:
-  version "2.0.51"
-  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz"
-  integrity sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==
+node-releases@^2.0.36:
+  version "2.0.47"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz"
+  integrity sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==
 
 normalize-path@^3.0.0:
   version "3.0.0"
@@ -2178,9 +2157,9 @@ picomatch@^2.0.4:
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3:
-  version "4.0.5"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz"
-  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pirates@^4.0.7:
   version "4.0.7"
@@ -2228,12 +2207,12 @@ readable-stream@^3.4.0, readable-stream@^3.6.2:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-redis-errors@^1.0.0, redis-errors@^1.2.0:
+redis-errors@^1.0.0, redis-errors@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz"
   integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
 
-redis-parser@^3.0.0:
+redis-parser@3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz"
   integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
@@ -2263,9 +2242,9 @@ safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-stable-stringify@^2.3.1:
-  version "2.4.1"
-  resolved "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz"
-  integrity sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
 semver@^6.3.1:
   version "6.3.1"
@@ -2273,9 +2252,9 @@ semver@^6.3.1:
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 semver@^7.5.3, semver@^7.5.4, semver@^7.7.2:
-  version "7.8.4"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz"
-  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
+  version "7.8.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz"
+  integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -2299,43 +2278,36 @@ signal-exit@^4.0.1:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-simple-swizzle@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz"
-  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
-  dependencies:
-    is-arrayish "^0.3.1"
-
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 socket.io-adapter@^2.5.4, socket.io-adapter@~2.5.2, socket.io-adapter@~2.5.5:
-  version "2.5.5"
-  resolved "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz"
-  integrity sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==
+  version "2.5.7"
+  resolved "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz"
+  integrity sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==
   dependencies:
-    debug "~4.3.4"
-    ws "~8.17.1"
+    debug "~4.4.1"
+    ws "~8.20.1"
 
 socket.io-parser@~4.2.4:
-  version "4.2.4"
-  resolved "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz"
-  integrity sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==
+  version "4.2.6"
+  resolved "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz"
+  integrity sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
-    debug "~4.3.1"
+    debug "~4.4.1"
 
 socket.io@^4.8.1:
-  version "4.8.1"
-  resolved "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz"
-  integrity sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==
+  version "4.8.3"
+  resolved "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz"
+  integrity sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==
   dependencies:
     accepts "~1.3.4"
     base64id "~2.0.0"
     cors "~2.8.5"
-    debug "~4.3.2"
+    debug "~4.4.1"
     engine.io "~6.6.0"
     socket.io-adapter "~2.5.2"
     socket.io-parser "~4.2.4"
@@ -2370,7 +2342,7 @@ stack-utils@^2.0.6:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-standard-as-callback@^2.1.0:
+standard-as-callback@2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz"
   integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
@@ -2522,10 +2494,10 @@ uid2@1.0.0:
   resolved "https://registry.npmjs.org/uid2/-/uid2-1.0.0.tgz"
   integrity sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==
 
-undici-types@~6.20.0:
-  version "6.20.0"
-  resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz"
-  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+"undici-types@>=7.24.0 <7.24.7":
+  version "7.24.6"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz"
+  integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
 unrs-resolver@^1.7.11:
   version "1.12.2"
@@ -2608,7 +2580,7 @@ winston-daily-rotate-file@^5.0.0:
     triple-beam "^1.4.1"
     winston-transport "^4.7.0"
 
-winston-transport@^4.5.0, winston-transport@^4.7.0:
+winston-transport@^4.7.0, winston-transport@^4.9.0:
   version "4.9.0"
   resolved "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz"
   integrity sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==
@@ -2618,21 +2590,21 @@ winston-transport@^4.5.0, winston-transport@^4.7.0:
     triple-beam "^1.3.0"
 
 winston@^3:
-  version "3.8.2"
-  resolved "https://registry.npmjs.org/winston/-/winston-3.8.2.tgz"
-  integrity sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==
+  version "3.19.0"
+  resolved "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz"
+  integrity sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==
   dependencies:
-    "@colors/colors" "1.5.0"
-    "@dabh/diagnostics" "^2.0.2"
+    "@colors/colors" "^1.6.0"
+    "@dabh/diagnostics" "^2.0.8"
     async "^3.2.3"
     is-stream "^2.0.0"
-    logform "^2.4.0"
+    logform "^2.7.0"
     one-time "^1.0.0"
     readable-stream "^3.4.0"
     safe-stable-stringify "^2.3.1"
     stack-trace "0.0.x"
     triple-beam "^1.3.0"
-    winston-transport "^4.5.0"
+    winston-transport "^4.9.0"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
@@ -2674,10 +2646,10 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@~8.17.1:
-  version "8.17.1"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz"
-  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+ws@~8.20.1:
+  version "8.20.1"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
 
 y18n@^5.0.5:
   version "5.0.8"
@@ -2695,9 +2667,9 @@ yargs-parser@^21.1.1:
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^17.7.2:
-  version "17.7.3"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz"
-  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
+  version "17.7.2"
+  resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"

--- a/public/css/sass/style.scss
+++ b/public/css/sass/style.scss
@@ -1730,7 +1730,8 @@ body.archived section .status-container a.status:hover {
   }
 }
 .graysmall .graysmall-details {
-  display: block;
+  display: flex;
+  justify-content: flex-end;
   width: 100%; /*To be tested*/
   position: absolute;
   bottom: 0;
@@ -1738,15 +1739,18 @@ body.archived section .status-container a.status:hover {
   margin-top: 10px;
   margin-right: 15px;
   z-index: 0;
+  gap: 4px;
 }
 
 .graysmall-details li {
   float: right;
   width: auto !important;
-  font-size: 11px;
+  font-size: 10px;
+  line-height: 10px;
   margin: 0 0px;
-  padding: 2px 5px 0px 5px;
+  padding: 2px 4px;
   border-bottom: none;
+  border-radius: 1px;
 }
 
 .graysmall:hover {
@@ -1925,7 +1929,14 @@ section.opened.editor .status {
   background: colors.$orangeDefault !important;
   color: #333 !important;
 }
-
+.per-yellow-variant {
+  background: colors.$orange600 !important;
+  color: colors.$white !important;
+}
+.per-grey {
+  background: #B6B8BB !important;
+  color: colors.$white !important;
+}
 .per-red {
   background: colors.$redDefault !important;
   color: #fff !important;
@@ -1949,7 +1960,7 @@ section.opened.editor .status {
 .graysmall-details .per-blue,
 .graysmall-details .per-orange,
 .graysmall-details .per-green {
-  width: 35px !important;
+  min-width: 35px !important;
   text-align: center;
   display: block !important;
 }

--- a/public/js/components/segments/SegmentFooterMultiMatches.js
+++ b/public/js/components/segments/SegmentFooterMultiMatches.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {createRef} from 'react'
 import {fromJS} from 'immutable'
 import {isUndefined} from 'lodash'
 import $ from 'jquery'
@@ -109,22 +109,30 @@ class SegmentFooterMultiMatches extends React.Component {
   getMatchInfo(match) {
     return (
       <ul className="graysmall-details">
-        <li className={'percent ' + match.percentClass}>{match.percentText}</li>
-        <li>{match.suggestion_info}</li>
         <li className="graydesc">
           Source:
-          <span className="bold" style={{fontSize: '14px'}}>
-            {' '}
-            {match.cb}
-          </span>
+          <span className="bold"> {match.cb}</span>
         </li>
-        <li className="graydesc">
+        <li>{match.suggestion_info}</li>
+        <li
+          ref={createRef()}
+          className={`percent  ${
+            match.source !== config.source_rfc
+              ? 'per-yellow-variant'
+              : 'per-green'
+          }`}
+        >
+          {match.source} {'>'} {match.target}{' '}
+          {match.source !== config.source_rfc ? '(-1%)' : ''}
+        </li>
+        <li className={'percent ' + match.percentClass}>{match.percentText}</li>
+        {/*<li className="graydesc">
           Target:
           <span className="bold" style={{fontSize: '14px'}}>
             {' '}
             {match.target}
           </span>
-        </li>
+        </li>*/}
       </ul>
     )
   }

--- a/public/js/components/segments/SegmentFooterTabMatches.js
+++ b/public/js/components/segments/SegmentFooterTabMatches.js
@@ -50,6 +50,7 @@ class SegmentFooterTabMatches extends React.Component {
       item.segment = this.segment
       item.translation = this.translation
       item.target = this.target
+      item.source = this.source
       if (
         'sentence_confidence' in this &&
         this.sentence_confidence !== '' &&
@@ -169,9 +170,44 @@ class SegmentFooterTabMatches extends React.Component {
 
   getMatchInfo(match) {
     const penaltyPercRef = createRef()
-
+    console.log(
+      match,
+      match.source,
+      match.target,
+      config.target_rfc,
+      config.source_rfc,
+    )
     return (
       <ul className="graysmall-details">
+        <li className="graydesc graydesc-sourcekey">
+          Source:
+          <span className="bold" title={match.cb}>
+            {' '}
+            {match.cb}
+          </span>
+        </li>
+        <li>{match.suggestion_info}</li>
+        {(match.target !== config.target_rfc ||
+          match.source !== config.source_rfc) && (
+          <Tooltip
+            content={
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <span>Language variations results will have a penalty</span>
+              </div>
+            }
+          >
+            <li ref={createRef()} className={`percent per-yellow-variant`}>
+              {match.source} {'>'} {match.target} (-1%)
+            </li>
+          </Tooltip>
+        )}
+        <li className={'percent ' + match.percentClass}>{match.percentText}</li>
+
         {match.penalty > 0 && (
           <Tooltip
             content={
@@ -197,20 +233,12 @@ class SegmentFooterTabMatches extends React.Component {
             </li>
           </Tooltip>
         )}
-        <li className={'percent ' + match.percentClass}>{match.percentText}</li>
-        <li>{match.suggestion_info}</li>
-        <li className={'graydesc'}>
+
+        {/*<li className={'graydesc'}>
           <span className={'bold'} style={{fontSize: '14px'}}>
             {ApplicationStore.getLanguageNameFromLocale(match.target)}
           </span>
-        </li>
-        <li className="graydesc graydesc-sourcekey">
-          Source:
-          <span className="bold" style={{fontSize: '14px'}} title={match.cb}>
-            {' '}
-            {match.cb}
-          </span>
-        </li>
+        </li>*/}
 
         {this.getMatchInfoMetadata(match)}
       </ul>

--- a/public/js/components/segments/TabConcordanceResults.js
+++ b/public/js/components/segments/TabConcordanceResults.js
@@ -4,6 +4,7 @@ import React, {
   useImperativeHandle,
   useState,
   forwardRef,
+  createRef,
 } from 'react'
 import PropTypes from 'prop-types'
 import SegmentStore from '../../stores/SegmentStore'
@@ -143,15 +144,26 @@ export const TabConcordanceResults = forwardRef(({segment, isActive}, ref) => {
           </span>
         </li>
         <ul className="graysmall-details">
-          <li>{item.last_update_date}</li>
-          <li className="graydesc">
-            <span className="bold">
-              {ApplicationStore.getLanguageNameFromLocale(item.target)}
-            </span>
-          </li>
           <li className="graydesc">
             Source: <span className={'bold'}>{item.created_by}</span>
           </li>
+          <li>{item.last_update_date}</li>
+          <li
+            ref={createRef()}
+            className={`percent ${
+              item.target !== config.target_rfc ||
+              item.source !== config.source_rfc
+                ? 'per-yellow-variant'
+                : 'per-green'
+            } `}
+          >
+            {item.source} {'>'} {item.target}
+          </li>
+          {/*<li className="graydesc">
+            <span className="bold">
+              {ApplicationStore.getLanguageNameFromLocale(item.target)}
+            </span>
+          </li>*/}
         </ul>
       </ul>
     )

--- a/tests/unit/Core/Engines/Results/MyMemory/GetMemoryResponseTest.php
+++ b/tests/unit/Core/Engines/Results/MyMemory/GetMemoryResponseTest.php
@@ -68,4 +68,115 @@ class GetMemoryResponseTest extends AbstractTest
         self::assertCount(1, $array);
         self::assertSame('Ciao mondo', $array[0]['raw_translation']);
     }
+
+    /**
+     * Proves Bug 1 fix: when the MyMemory API returns a match entry where the
+     * `segment` or `translation` key is absent entirely (e.g. MT-only entries,
+     * degraded API responses), buildMyMemoryMatch must produce empty strings —
+     * not null — so downstream callers are never handed a null content field.
+     */
+    #[Test]
+    public function matchWithMissingSegmentAndTranslationKeysProducesEmptyStrings(): void
+    {
+        $db         = $this->createStub(IDatabase::class);
+        $featureSet = new FeatureSet($db);
+
+        $decoded = [
+            'responseStatus' => 200,
+            'responseData'   => '',
+            'matches'        => [
+                [
+                    'id'               => '42',
+                    // 'segment' and 'translation' intentionally absent to simulate API omitting them
+                    'match'            => 0.80,
+                    'last-update-date' => '2024-01-01 00:00:00',
+                    'create-date'      => '2024-01-01 00:00:00',
+                    'tm_properties'    => '',
+                ],
+            ],
+        ];
+
+        $response = GetMemoryResponse::getInstance($decoded, $featureSet);
+        $array    = $response->get_matches_as_array(1);
+
+        self::assertCount(1, $array);
+        self::assertSame('', $array[0]['raw_segment'],    'missing segment key must produce empty string, not null');
+        self::assertSame('', $array[0]['raw_translation'], 'missing translation key must produce empty string, not null');
+        self::assertNotNull($array[0]['raw_segment'],    'raw_segment must never be null');
+        self::assertNotNull($array[0]['raw_translation'], 'raw_translation must never be null');
+    }
+
+    /**
+     * Proves Bug 2 fix: source and target language codes injected into decoded
+     * match data (as _decode() now does from $this->_config) must be hydrated
+     * on the Matches object and appear in get_matches_as_array() output.
+     * Before the fix buildMyMemoryMatch() never passed these keys, leaving
+     * source and target permanently null on every MyMemory TM match.
+     */
+    #[Test]
+    public function matchWithSourceAndTargetLanguageCodesHydratesthem(): void
+    {
+        $db         = $this->createStub(IDatabase::class);
+        $featureSet = new FeatureSet($db);
+
+        $decoded = [
+            'responseStatus' => 200,
+            'responseData'   => '',
+            'matches'        => [
+                [
+                    'id'               => '1',
+                    'segment'          => 'Hello world',
+                    'translation'      => 'Ciao mondo',
+                    'match'            => 0.95,
+                    'last-update-date' => '2024-01-01 00:00:00',
+                    'create-date'      => '2024-01-01 00:00:00',
+                    'tm_properties'    => '',
+                    'source'           => 'en-US',
+                    'target'           => 'it-IT',
+                ],
+            ],
+        ];
+
+        $response = GetMemoryResponse::getInstance($decoded, $featureSet);
+        $array    = $response->get_matches_as_array(1);
+
+        self::assertCount(1, $array);
+        self::assertSame('en-US', $array[0]['source'], 'source language code must be hydrated on the match');
+        self::assertSame('it-IT', $array[0]['target'], 'target language code must be hydrated on the match');
+    }
+
+    /**
+     * Proves Bug 3 fix: when the tm_properties key is absent from the raw match
+     * data, buildMyMemoryMatch must not raise a PHP notice and Matches must
+     * default tm_properties to an empty array.
+     */
+    #[Test]
+    public function matchWithMissingTmPropertiesDefaultsToEmptyArray(): void
+    {
+        $db         = $this->createStub(IDatabase::class);
+        $featureSet = new FeatureSet($db);
+
+        $decoded = [
+            'responseStatus' => 200,
+            'responseData'   => '',
+            'matches'        => [
+                [
+                    'id'               => '1',
+                    'segment'          => 'Hello world',
+                    'translation'      => 'Ciao mondo',
+                    'match'            => 0.95,
+                    'last-update-date' => '2024-01-01 00:00:00',
+                    'create-date'      => '2024-01-01 00:00:00',
+                    // 'tm_properties' intentionally absent
+                ],
+            ],
+        ];
+
+        $response = GetMemoryResponse::getInstance($decoded, $featureSet);
+        $array    = $response->get_matches_as_array(1);
+
+        self::assertCount(1, $array);
+        self::assertIsArray($array[0]['tm_properties'], 'missing tm_properties must default to an array');
+        self::assertEmpty($array[0]['tm_properties']);
+    }
 }

--- a/tests/unit/Core/TestMyMemory/DecodeMyMemoryTest.php
+++ b/tests/unit/Core/TestMyMemory/DecodeMyMemoryTest.php
@@ -301,5 +301,83 @@ LAB;
         $this->assertEquals("", $property->getValue($actual_result));
     }
 
+    /**
+     * Proves that the source/target language codes returned by MyMemory on the match
+     * itself take precedence over the ones held in $this->_config: the config values
+     * are only a fallback for when MyMemory omits them from the match.
+     * @group   regression
+     * @covers  MyMemory::_decode
+     * @throws ReflectionException
+     */
+    #[Test]
+    public function test__decode_prefers_match_source_and_target_over_config_values()
+    {
+        $reflector = new ReflectionClass($this->myMemory);
+        $configProperty = $reflector->getProperty('_config');
+        $configProperty->setValue($this->myMemory, array_merge(
+            $configProperty->getValue($this->myMemory),
+            ['source' => 'fr-FR', 'target' => 'de-DE']
+        ));
+
+        $json_input = <<<LAB
+{"responseData":{"translatedText":null,"match":null},"responseDetails":"","responseStatus":200,"matches":[{"id":"1","segment":"Hello world","translation":"Ciao mondo","quality":"70","reference":"","usage-count":1,"subject":"All","created-by":"MyMemory","last-updated-by":"MyMemory","create-date":"2016-05-02 17:15:11","last-update-date":"2016-05-02 17:15:11","tm_properties":"","match":0.95,"source":"en-US","target":"it-IT"}]}
+LAB;
+
+        $array_params = [
+            'q' => 'Hello world',
+            'langpair' => 'en-US|it-IT',
+            'de' => 'demo@matecat.com',
+            'mt' => null,
+            'numres' => 100,
+        ];
+
+        /**
+         * @var $actual_result GetMemoryResponse
+         */
+        $actual_result = $this->method->invoke($this->myMemory, $json_input, $array_params, 'gloss_get_relative_url');
+        $array = $actual_result->get_matches_as_array(1);
+
+        $this->assertSame('en-US', $array[0]['source'], 'match source must win over config source');
+        $this->assertSame('it-IT', $array[0]['target'], 'match target must win over config target');
+    }
+
+    /**
+     * Proves that when MyMemory omits source/target from the match, the values
+     * configured on the engine ($this->_config) are used as a fallback.
+     * @group   regression
+     * @covers  MyMemory::_decode
+     * @throws ReflectionException
+     */
+    #[Test]
+    public function test__decode_falls_back_to_config_source_and_target_when_match_omits_them()
+    {
+        $reflector = new ReflectionClass($this->myMemory);
+        $configProperty = $reflector->getProperty('_config');
+        $configProperty->setValue($this->myMemory, array_merge(
+            $configProperty->getValue($this->myMemory),
+            ['source' => 'fr-FR', 'target' => 'de-DE']
+        ));
+
+        $json_input = <<<LAB
+{"responseData":{"translatedText":null,"match":null},"responseDetails":"","responseStatus":200,"matches":[{"id":"1","segment":"Hello world","translation":"Ciao mondo","quality":"70","reference":"","usage-count":1,"subject":"All","created-by":"MyMemory","last-updated-by":"MyMemory","create-date":"2016-05-02 17:15:11","last-update-date":"2016-05-02 17:15:11","tm_properties":"","match":0.95}]}
+LAB;
+
+        $array_params = [
+            'q' => 'Hello world',
+            'langpair' => 'fr-FR|de-DE',
+            'de' => 'demo@matecat.com',
+            'mt' => null,
+            'numres' => 100,
+        ];
+
+        /**
+         * @var $actual_result GetMemoryResponse
+         */
+        $actual_result = $this->method->invoke($this->myMemory, $json_input, $array_params, 'gloss_get_relative_url');
+        $array = $actual_result->get_matches_as_array(1);
+
+        $this->assertSame('fr-FR', $array[0]['source'], 'config source must be used as fallback');
+        $this->assertSame('de-DE', $array[0]['target'], 'config target must be used as fallback');
+    }
 
 }


### PR DESCRIPTION
## Summary

MyMemory TM matches were losing their source/target language codes, and `segment`/
`translation` could end up `null` when the API response omitted those keys. This fixes
`MyMemory::_decode()` and `GetMemoryResponse::buildMyMemoryMatch()` to hydrate `source`/
`target` from the engine config and to always default `segment`/`translation` to an empty
string.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Utils/Engines/MyMemory.php` | inject `source`/`target` from `$this->_config` into decoded matches; default `segment`/`translation` to `''` when absent |
| `lib/Utils/Engines/Results/MyMemory/GetMemoryResponse.php` | hydrate `source`/`target` (and null-safe `tm_properties`) onto `Matches` in `buildMyMemoryMatch()` |
| `tests/unit/Core/Engines/Results/MyMemory/GetMemoryResponseTest.php` | new regression tests for missing `segment`/`translation`, missing `tm_properties`, and `source`/`target` hydration |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Ran the full suite in Docker: 9222 tests, 30003 assertions. 4 pre-existing failures in
`CommentControllerTest` (broker-unavailable scenarios) are environment-dependent and
unrelated to this change — they also fail on `develop` in this environment since the
ActiveMQ broker container is reachable rather than down.

`phpstan` run clean (0 errors) on all three changed files.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

None.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216294000966428