### PR TITLE
🐛 fix(api): send id_job and currentPassword in searchTermIntoSegments

### DIFF
--- a/public/js/api/searchTermIntoSegments/searchTermIntoSegments.js
+++ b/public/js/api/searchTermIntoSegments/searchTermIntoSegments.js
@@ -1,4 +1,4 @@
-import {getMatecatApiDomain} from '../../utils/getMatecatApiDomain'
+import {getMatecatApiDomain} from '../../utils/getMatecatApiDomain';
 
 /**
  * Search term into segments
@@ -18,7 +18,7 @@ import {getMatecatApiDomain} from '../../utils/getMatecatApiDomain'
  */
 export const searchTermIntoSegments = async ({
   idJob = config.id_job,
-  password = config.password,
+  password = config.currentPassword,
   token,
   source,
   target,
@@ -30,7 +30,7 @@ export const searchTermIntoSegments = async ({
   revisionNumber,
 }) => {
   const paramsData = {
-    job: idJob,
+    id_job: idJob,
     password,
     token,
     source,

--- a/public/js/api/searchTermIntoSegments/searchTermIntoSegments.test.js
+++ b/public/js/api/searchTermIntoSegments/searchTermIntoSegments.test.js
@@ -1,0 +1,81 @@
+import {http, HttpResponse} from 'msw'
+import {mswServer} from '../../../mocks/mswServer'
+import {searchTermIntoSegments} from './searchTermIntoSegments'
+
+global.config = {
+  basepath: 'http://localhost/',
+  enableMultiDomainApi: false,
+  id_job: '77',
+  currentPassword: 'jobpwd',
+  revisionNumber: undefined,
+}
+
+const url = config.basepath + 'api/app/search'
+
+test('posts search with job credentials from config and returns data', async () => {
+  let form
+  mswServer.use(
+    http.post(url, async ({request}) => {
+      form = await request.formData()
+      return HttpResponse.json({total: 2})
+    }),
+  )
+
+  const response = await searchTermIntoSegments({
+    token: 'tok',
+    source: 'hello',
+    target: 'ciao',
+    status: 'all',
+    matchcase: false,
+    exactmatch: false,
+    inCurrentChunkOnly: true,
+    replace: 'world',
+    revisionNumber: 2,
+  })
+
+  expect(response).toEqual({total: 2})
+  expect(form.get('id_job')).toBe('77')
+  expect(form.get('password')).toBe('jobpwd')
+  expect(form.get('source')).toBe('hello')
+  expect(form.get('target')).toBe('ciao')
+  expect(form.get('replace')).toBe('world')
+  expect(form.get('status')).toBe('all')
+  expect(form.get('inCurrentChunkOnly')).toBe('true')
+  expect(form.get('revision_number')).toBe('2')
+})
+
+test('prefers explicit idJob and password over config defaults', async () => {
+  let form
+  mswServer.use(
+    http.post(url, async ({request}) => {
+      form = await request.formData()
+      return HttpResponse.json({total: 0})
+    }),
+  )
+
+  await searchTermIntoSegments({idJob: '999', password: 'other', source: 'x'})
+
+  expect(form.get('id_job')).toBe('999')
+  expect(form.get('password')).toBe('other')
+})
+
+test('rejects with the response on a non-ok status', async () => {
+  mswServer.use(http.post(url, () => new HttpResponse(null, {status: 500})))
+
+  const result = await searchTermIntoSegments({source: 'x'}).catch(
+    (error) => error,
+  )
+
+  expect(result.ok).toBe(false)
+})
+
+test('rejects with the errors array when the payload carries errors', async () => {
+  const errors = [{code: 1, message: 'nope'}]
+  mswServer.use(http.post(url, () => HttpResponse.json({errors})))
+
+  const result = await searchTermIntoSegments({source: 'x'}).catch(
+    (error) => error,
+  )
+
+  expect(result).toEqual(errors)
+})


### PR DESCRIPTION
## Summary

Aligns the `searchTermIntoSegments` frontend API module with the backend parameter contract used by
the other search endpoints: the job id is sent as `id_job` (was `job`) and the password defaults to
`config.currentPassword` (was `config.password`). Without this, the simple-search request posted the
wrong field names and an undefined password.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

- **`public/js/api/searchTermIntoSegments/searchTermIntoSegments.js`** — post `id_job` instead of
  `job`; default `password` from `config.currentPassword` instead of `config.password`.
- **`public/js/api/searchTermIntoSegments/searchTermIntoSegments.test.js`** — new MSW tests covering
  the posted FormData fields (`id_job`, `password`, `source`, `status`, `inCurrentChunkOnly`,
  `revision_number`), the config-default vs explicit override precedence, and both rejection paths
  (non-ok status, `errors` payload).

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Frontend-only change. `yarn test` covers the module via the new MSW suite; PHP suites and PHPStan do
not apply.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (Claude Opus) authored the MSW regression test. The source fix was written by the author.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216846602229546