### PR TITLE
🐛 fix(cattool): read job-scoped mandatory issues instead of project snapshot

### DIFF
--- a/public/js/actions/SegmentActions.js
+++ b/public/js/actions/SegmentActions.js
@@ -266,8 +266,7 @@ const SegmentActions = {
        If is an ICE we allow to change the translation because is not possible to add an issue
      */
 
-    const mandatoryIssues =
-      CatToolStore.getJobMetadata().project.mandatory_issues
+    const mandatoryIssues = CatToolStore.getJobMetadata().job.mandatory_issues
 
     const currentRevisionKey = `r${config.revisionNumber}`
 

--- a/public/js/actions/SegmentActions.test.js
+++ b/public/js/actions/SegmentActions.test.js
@@ -275,7 +275,7 @@ describe('SegmentActions.clickOnApprovedButton — mandatory issues gate', () =>
 
   test('opens issues panel when mandatory_issues is undefined (non-array defaults to required)', () => {
     CatToolStore.getJobMetadata.mockReturnValue({
-      project: {mandatory_issues: undefined},
+      job: {mandatory_issues: undefined},
     })
     SegmentActions.clickOnApprovedButton(makeSegment(), false)
     expect(openIssuesSpy).toHaveBeenCalledWith({sid: '1-1'}, true)
@@ -283,7 +283,7 @@ describe('SegmentActions.clickOnApprovedButton — mandatory issues gate', () =>
 
   test('opens issues panel when current revision is in mandatory_issues array', () => {
     CatToolStore.getJobMetadata.mockReturnValue({
-      project: {mandatory_issues: ['r1', 'r2']},
+      job: {mandatory_issues: ['r1', 'r2']},
     })
     SegmentActions.clickOnApprovedButton(makeSegment(), false)
     expect(openIssuesSpy).toHaveBeenCalledWith({sid: '1-1'}, true)
@@ -291,7 +291,7 @@ describe('SegmentActions.clickOnApprovedButton — mandatory issues gate', () =>
 
   test('skips issues panel when current revision is absent from mandatory_issues', () => {
     CatToolStore.getJobMetadata.mockReturnValue({
-      project: {mandatory_issues: ['r2']},
+      job: {mandatory_issues: ['r2']},
     })
     SegmentActions.clickOnApprovedButton(makeSegment(), false)
     expect(openIssuesSpy).not.toHaveBeenCalled()
@@ -299,7 +299,7 @@ describe('SegmentActions.clickOnApprovedButton — mandatory issues gate', () =>
 
   test('skips issues panel when mandatory_issues is empty (none required)', () => {
     CatToolStore.getJobMetadata.mockReturnValue({
-      project: {mandatory_issues: []},
+      job: {mandatory_issues: []},
     })
     SegmentActions.clickOnApprovedButton(makeSegment(), false)
     expect(openIssuesSpy).not.toHaveBeenCalled()
@@ -308,7 +308,7 @@ describe('SegmentActions.clickOnApprovedButton — mandatory issues gate', () =>
   test('opens issues panel for revision 2 when r2 is in mandatory_issues', () => {
     global.config.revisionNumber = 2
     CatToolStore.getJobMetadata.mockReturnValue({
-      project: {mandatory_issues: ['r1', 'r2']},
+      job: {mandatory_issues: ['r1', 'r2']},
     })
     SegmentActions.clickOnApprovedButton(makeSegment(), false)
     expect(openIssuesSpy).toHaveBeenCalledWith({sid: '1-1'}, true)
@@ -317,7 +317,16 @@ describe('SegmentActions.clickOnApprovedButton — mandatory issues gate', () =>
   test('skips issues panel for revision 2 when only r1 is in mandatory_issues', () => {
     global.config.revisionNumber = 2
     CatToolStore.getJobMetadata.mockReturnValue({
-      project: {mandatory_issues: ['r1']},
+      job: {mandatory_issues: ['r1']},
+    })
+    SegmentActions.clickOnApprovedButton(makeSegment(), false)
+    expect(openIssuesSpy).not.toHaveBeenCalled()
+  })
+
+  test('skips a per-job "only r2" override even if project-level default still lists r1 (regression)', () => {
+    CatToolStore.getJobMetadata.mockReturnValue({
+      project: {mandatory_issues: ['r1', 'r2']},
+      job: {mandatory_issues: ['r2']},
     })
     SegmentActions.clickOnApprovedButton(makeSegment(), false)
     expect(openIssuesSpy).not.toHaveBeenCalled()

--- a/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.js
+++ b/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.js
@@ -4,6 +4,8 @@ import {SettingsPanelContext} from '../../SettingsPanelContext'
 import {updateJobMetadata} from '../../../../api/updateJobMetadata'
 import {Tagging} from '../OtherTab/Tagging'
 import {MandatoryIssues} from '../OtherTab/MandatoryIssues'
+import CatToolStore from '../../../../stores/CatToolStore'
+import CatToolConstants from '../../../../constants/CatToolConstants'
 
 export const EditorOtherTab = () => {
   const {currentProjectTemplate, tmKeys} = useContext(SettingsPanelContext)
@@ -29,6 +31,25 @@ export const EditorOtherTab = () => {
         characterCounterMode: currentProjectTemplate.characterCounterMode,
         subfilteringHandlers: currentProjectTemplate.subfilteringHandlers,
         mandatoryIssues: currentProjectTemplate.mandatoryIssues,
+      }).then(() => {
+        const jobMetadata = CatToolStore.getJobMetadata()
+        if (!jobMetadata) return
+
+        const updatedJobMetadata = {
+          ...jobMetadata,
+          job: {
+            ...jobMetadata.job,
+            character_counter_count_tags:
+              currentProjectTemplate.characterCounterCountTags,
+            character_counter_mode: currentProjectTemplate.characterCounterMode,
+            subfiltering_handlers: currentProjectTemplate.subfilteringHandlers,
+            mandatory_issues: currentProjectTemplate.mandatoryIssues,
+          },
+        }
+        CatToolStore.setJobMetadata(updatedJobMetadata)
+        CatToolStore.emitChange(CatToolConstants.GET_JOB_METADATA, {
+          jobMetadata: updatedJobMetadata,
+        })
       })
     }
 

--- a/public/js/pages/CatTool.js
+++ b/public/js/pages/CatTool.js
@@ -649,7 +649,7 @@ function CatTool() {
           },
         },
         icuEnabled: !!jobMetadata.project.icu_enabled ?? false,
-        ...(Array.isArray(jobMetadata.project.mandatory_issues) && {
+        ...(Array.isArray(jobMetadata.job.mandatory_issues) && {
           mandatoryIssues: jobMetadata.job.mandatory_issues,
         }),
       }))


### PR DESCRIPTION
## Summary

Selecting a per-job mandatory-issues override (e.g. "only R2") had no effect on segment
approval: the enforcement check and the settings-panel gate condition both read the
project-level metadata snapshot taken once at project creation, instead of the job-level
value that the settings panel actually updates. This fixes both to read the job-scoped
value, and refreshes the cached job metadata immediately after saving so an already-open
editor session picks up the change without a page reload.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/actions/SegmentActions.js` | Read `job.mandatory_issues` instead of the stale `project.mandatory_issues` snapshot when gating mandatory-issue enforcement on approval |
| `public/js/pages/CatTool.js` | Fix the same project/job scope mismatch in the gate condition that populates the settings-panel template state |
| `public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.js` | Refresh `CatToolStore`'s cached job metadata right after `updateJobMetadata` succeeds, so an open editor session applies the new setting without reload |
| `public/js/actions/SegmentActions.test.js` | Update mocks to job-scoped metadata; add a regression test for a per-job override coexisting with a wider project-level default |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Manually verified in the editor: set mandatory issues to "Only R2" on a job, confirmed
approving a modified segment with no issues no longer forces the issues panel open in R1,
while it still does in R2.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

None.
