### PR TITLE
🐛 fix(fuzzy-alert): scope unedited-fuzzy-match preference to job and user

### DIFF
--- a/lib/Utils/LQA/QA/ErrorManager.php
+++ b/lib/Utils/LQA/QA/ErrorManager.php
@@ -131,7 +131,7 @@ class ErrorManager
         2000 => 'Smart count plural forms mismatch',
         2001 => '%smartcount tag count mismatch',
         3000 => 'Characters limit exceeded',
-        4000 => 'Fuzzy match confirmed without changes',
+        4000 => 'Unedited fuzzy match confirmed',
     ];
 
     /** @var array<int, string|null> */
@@ -139,7 +139,7 @@ class ErrorManager
         29 => "Should be < g ... > ... < /g >",
         1000 => "Press 'alt + t' shortcut to add tags or delete extra tags.",
         3000 => 'Maximum characters limit exceeded.',
-        4000 => 'A fuzzy TM match was confirmed without any edit. Please review it before confirming.',
+        4000 => 'This segment was confirmed without making any changes, despite being a fuzzy match.',
     ];
 
     /** @var array{ERROR: list<ErrObject>, WARNING: list<ErrObject>, INFO: list<ErrObject>} */

--- a/public/js/components/modals/UnmodifiedFuzzyMatchModal.js
+++ b/public/js/components/modals/UnmodifiedFuzzyMatchModal.js
@@ -2,12 +2,13 @@ import React, {useRef} from 'react'
 import ModalsActions from '../../actions/ModalsActions'
 
 export const HIDE_UNMODIFIED_FUZZY_MATCH_MODAL_STORAGE =
-  'unmodified-fuzzy-match-modal' + config.id_job
+  'unmodified-fuzzy-match-modal' + config.id_job + '-' + config.userMail
 
 /**
  * Warns the translator when a fuzzy TM match is about to be confirmed without
  * any modification. A "don't show again" checkbox persists the choice for the
- * current job (same pattern used for the ICE unlock and copy-source modals).
+ * current job and user (same pattern used for the ICE unlock and copy-source
+ * modals, scoped per user like JobMetadata's instructions popup).
  */
 export const UnmodifiedFuzzyMatchModal = ({
   successCallback,
@@ -38,9 +39,9 @@ export const UnmodifiedFuzzyMatchModal = ({
       <div className="matecat-modal-middle">
         <div className={'ui one column grid'}>
           <div className="column left aligned" style={{fontSize: '18px'}}>
-            You are about to confirm a fuzzy match without making any changes.
-            Fuzzy matches are not exact and usually need to be reviewed and
-            edited. Are you sure you want to confirm it as is?
+            You are confirming a fuzzy match without making any changes.
+            Fuzzy matches usually need to be edited due to differences in the
+            source text. Are you sure you want to proceed?
           </div>
           <div className="column right aligned">
             <div className="ui button cancel-button" onClick={onCancel}>
@@ -50,7 +51,7 @@ export const UnmodifiedFuzzyMatchModal = ({
               className="ui primary button right floated"
               onClick={onConfirm}
             >
-              Confirm
+              Confirm anyway
             </div>
           </div>
           <div className="column left aligned">
@@ -60,7 +61,7 @@ export const UnmodifiedFuzzyMatchModal = ({
               ref={checkbox}
             />
             <label htmlFor="checkbox_unmodified_fuzzy">
-              {` Don't show this dialog again for the current job`}
+              {` Don't show this again for this job`}
             </label>
           </div>
         </div>

--- a/public/js/components/modals/UnmodifiedFuzzyMatchModal.test.js
+++ b/public/js/components/modals/UnmodifiedFuzzyMatchModal.test.js
@@ -1,0 +1,53 @@
+import {render, screen} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import {
+  UnmodifiedFuzzyMatchModal,
+  HIDE_UNMODIFIED_FUZZY_MATCH_MODAL_STORAGE,
+} from './UnmodifiedFuzzyMatchModal'
+
+jest.mock('../../actions/ModalsActions', () => ({
+  onCloseModal: jest.fn(),
+}))
+
+describe('UnmodifiedFuzzyMatchModal', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  test('storage key is scoped to both job and user', () => {
+    expect(HIDE_UNMODIFIED_FUZZY_MATCH_MODAL_STORAGE).toBe(
+      'unmodified-fuzzy-match-modal' + config.id_job + '-' + config.userMail,
+    )
+    expect(HIDE_UNMODIFIED_FUZZY_MATCH_MODAL_STORAGE).toContain(
+      config.userMail,
+    )
+  })
+
+  test('persists the "don\'t show again" choice under the job+user key on confirm', async () => {
+    const successCallback = jest.fn()
+    render(<UnmodifiedFuzzyMatchModal successCallback={successCallback} />)
+
+    await userEvent.click(
+      screen.getByLabelText(/don't show this again for this job/i),
+    )
+    await userEvent.click(screen.getByText('Confirm anyway'))
+
+    expect(
+      localStorage.getItem(HIDE_UNMODIFIED_FUZZY_MATCH_MODAL_STORAGE),
+    ).toBe('1')
+    expect(successCallback).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not persist the preference when the checkbox is left unchecked', async () => {
+    const successCallback = jest.fn()
+    render(<UnmodifiedFuzzyMatchModal successCallback={successCallback} />)
+
+    await userEvent.click(screen.getByText('Confirm anyway'))
+
+    expect(
+      localStorage.getItem(HIDE_UNMODIFIED_FUZZY_MATCH_MODAL_STORAGE),
+    ).toBeNull()
+  })
+})

--- a/public/js/setTranslationUtil.js
+++ b/public/js/setTranslationUtil.js
@@ -87,7 +87,7 @@ export const segmentTranslation = (
       {
         successCallback: proceedWithTranslation,
       },
-      'Confirm fuzzy match',
+      'Confirm unedited fuzzy match?',
     )
     return
   }

--- a/setupFiles.jest.js
+++ b/setupFiles.jest.js
@@ -4,4 +4,5 @@ import 'whatwg-fetch'
 // global.jQuery = $
 global.config = {
   id_job: 2,
+  userMail: 'jest-user@example.com',
 }

--- a/tests/unit/Core/Controllers/SetTranslationControllerTest.php
+++ b/tests/unit/Core/Controllers/SetTranslationControllerTest.php
@@ -1049,7 +1049,7 @@ class SetTranslationControllerTest extends AbstractTest
             'time_to_edit' => 1000,
         ]);
 
-        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]);
+        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Unedited fuzzy match confirmed']]);
         $qa = $this->makeFuzzyAwareQAStub(false, true, $fuzzyWarningJson);
 
         $method = (new ReflectionClass(SetTranslationController::class))->getMethod('buildNewTranslation');
@@ -1082,7 +1082,7 @@ class SetTranslationControllerTest extends AbstractTest
             'time_to_edit' => 1000,
         ]);
 
-        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]);
+        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Unedited fuzzy match confirmed']]);
         $qa = $this->makeFuzzyAwareQAStub(false, true, $fuzzyWarningJson);
 
         $method = (new ReflectionClass(SetTranslationController::class))->getMethod('buildNewTranslation');
@@ -1113,7 +1113,7 @@ class SetTranslationControllerTest extends AbstractTest
             'time_to_edit' => 1000,
         ]);
 
-        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]);
+        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Unedited fuzzy match confirmed']]);
         $qa = $this->makeFuzzyAwareQAStub(false, true, $fuzzyWarningJson);
 
         $method = (new ReflectionClass(SetTranslationController::class))->getMethod('buildNewTranslation');
@@ -1144,7 +1144,7 @@ class SetTranslationControllerTest extends AbstractTest
             'time_to_edit' => 1000,
         ]);
 
-        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]);
+        $fuzzyWarningJson = json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Unedited fuzzy match confirmed']]);
         $qa = $this->makeFuzzyAwareQAStub(false, true, $fuzzyWarningJson);
 
         $method = (new ReflectionClass(SetTranslationController::class))->getMethod('buildNewTranslation');

--- a/tests/unit/Core/LQA/ErrorManagerTest.php
+++ b/tests/unit/Core/LQA/ErrorManagerTest.php
@@ -284,7 +284,7 @@ class ErrorManagerTest extends AbstractTest
 
         $warnings = $this->errorManager->getWarnings();
         $this->assertEquals(ErrorManager::ERR_FUZZY_UNCHANGED, $warnings[0]->outcome);
-        $this->assertEquals('Fuzzy match confirmed without changes', $warnings[0]->debug);
+        $this->assertEquals('Unedited fuzzy match confirmed', $warnings[0]->debug);
     }
 
     #[Test]

--- a/tests/unit/Core/View/API/V2/Json/QAGlobalWarningTest.php
+++ b/tests/unit/Core/View/API/V2/Json/QAGlobalWarningTest.php
@@ -62,7 +62,7 @@ class QAGlobalWarningTest extends AbstractTest
     public function testRenderFuzzyUnchangedWarningBucketedUnderFuzzyCategory(): void
     {
         $struct = $this->makeGlobalWarningStruct(
-            json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Fuzzy match confirmed without changes']]),
+            json_encode([['outcome' => QA::ERR_FUZZY_UNCHANGED, 'debug' => 'Unedited fuzzy match confirmed']]),
             '42'
         );
 


### PR DESCRIPTION
## Summary

Scope the "don't show this again for this job" preference on the unedited fuzzy-match
confirmation modal to job **and** user (it was job-only, so the preference leaked across
different translators working the same job). Also updates the modal and warning banner
copy per the requested wording.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/modals/UnmodifiedFuzzyMatchModal.js` | Storage key now includes `config.userMail` alongside `config.id_job`; updated body text, primary button and checkbox copy |
| `public/js/setTranslationUtil.js` | Updated modal title |
| `lib/Utils/LQA/QA/ErrorManager.php` | Updated warning banner title (`errorMap[4000]`) and sub-text (`tipMap[4000]`) |
| `tests/unit/Core/Controllers/SetTranslationControllerTest.php` | Updated fixtures to match new banner copy |
| `tests/unit/Core/LQA/ErrorManagerTest.php` | Updated assertion to match new banner copy |
| `tests/unit/Core/View/API/V2/Json/QAGlobalWarningTest.php` | Updated fixture to match new banner copy |
| `public/js/components/modals/UnmodifiedFuzzyMatchModal.test.js` | New regression test covering the job+user storage key |
| `setupFiles.jest.js` | Added `config.userMail` to the jest global config used by tests |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

`vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` (9227 tests) passes except
for 4 pre-existing failures in `CommentControllerTest` (`*_throws_when_broker_is_unavailable`),
unrelated to this change — they assert an exception when the ActiveMQ broker is unreachable and
are environment-dependent. `npx jest` (full frontend suite, 76 suites / 760 tests) passes clean,
including the 3 new tests in `UnmodifiedFuzzyMatchModal.test.js`.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

No behavior change beyond the storage key scoping and copy text — no migrations involved.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203325585598454