### PR TITLE
🔒 security(tm-keys): store names raw, validate input and encode at output sinks

### DIFF
--- a/lib/Controller/API/App/CreateProjectController.php
+++ b/lib/Controller/API/App/CreateProjectController.php
@@ -457,6 +457,7 @@ class CreateProjectController extends AbstractStatefulKleinController
      * @return array<string, mixed>
      * @throws \DomainException
      * @throws \TypeError
+     * @throws InvalidArgumentException
      */
     private static function sanitizeTmKeyArr(array $elem): array
     {

--- a/lib/Controller/API/App/TMXFileController.php
+++ b/lib/Controller/API/App/TMXFileController.php
@@ -12,6 +12,7 @@ use Model\TmKeyManagement\MemoryKeyDao;
 use Model\TmKeyManagement\MemoryKeyStruct;
 use TypeError;
 use Utils\Registry\AppConfig;
+use Utils\TmKeyManagement\TmKeyManager;
 use Utils\TmKeyManagement\TmKeyStruct;
 use Utils\TMS\TMSFile;
 use Utils\TMS\TMSService;
@@ -69,8 +70,12 @@ class TMXFileController extends KleinController
                 $userMemoryKey = $mkDao->read($searchMemoryKey);
 
                 if (!empty($userMemoryKey) && isset($userMemoryKey[0]->tm_key) && empty($userMemoryKey[0]->tm_key->name)) {
-                    $userMemoryKey[0]->tm_key->name = $fileInfo->name;
-                    $mkDao->atomicUpdate($userMemoryKey[0]);
+                    try {
+                        $userMemoryKey[0]->tm_key->name = TmKeyManager::validateName($fileInfo->name);
+                        $mkDao->atomicUpdate($userMemoryKey[0]);
+                    } catch (InvalidArgumentException) {
+                        // the TMX filename is not a usable resource name: skip the optional rename
+                    }
                 }
             }
         }

--- a/lib/Controller/API/App/TmKeyManagementController.php
+++ b/lib/Controller/API/App/TmKeyManagementController.php
@@ -122,16 +122,6 @@ class TmKeyManagementController extends AbstractStatefulKleinController
 
         }
 
-        if (!empty($sortedKeys)) {
-            $sortedKeys = array_map(function (ClientTmKeyStruct $jobKey) {
-                if ($jobKey->name !== null) {
-                    $jobKey->name = html_entity_decode($jobKey->name);
-                }
-
-                return $jobKey;
-            }, $sortedKeys);
-        }
-
         return $sortedKeys;
     }
 

--- a/lib/Controller/API/App/UserKeysController.php
+++ b/lib/Controller/API/App/UserKeysController.php
@@ -166,7 +166,7 @@ class UserKeysController extends KleinController
     {
         $key = filter_var($this->request->param('key'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
         $emails = filter_var($this->request->param('emails'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
-        $description = filter_var($this->request->param('description'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
+        $description = $this->request->param('description');
         $remove_from = filter_var($this->request->param('remove_from'), FILTER_SANITIZE_FULL_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
 
         // check for eventual errors on the input passed
@@ -174,23 +174,9 @@ class UserKeysController extends KleinController
             throw new InvalidArgumentException("Key missing", -2);
         }
 
-        // Prevent XSS attack
-        // ===========================
-        // POC. Try to add this string in the input:
-        // <details x=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:2 open ontoggle="prompt(document.cookie);">
-        // in this case, an error MUST be thrown
-        if ($this->request->param('description') and $this->request->param('description') !== $description) {
-            throw new InvalidArgumentException(
-                "<span>Resource names cannot contain the following characters:</span>"
-                . "<ul>"
-                . "<li>&lt; (less than)</li>"
-                . "<li>&gt; (greater than)</li>"
-                . "<li>&amp; (ampersand)</li>"
-                . "<li>&quot; (double quote)</li>"
-                . "<li>&#39; (single quote)</li>"
-                . "</ul>",
-                -3
-            );
+        // Prevent XSS attack by escaping HTML-relevant characters instead of rejecting the request
+        if (!empty($description)) {
+            $description = htmlspecialchars((string)$description, ENT_QUOTES, 'UTF-8');
         }
 
         return [

--- a/lib/Controller/API/App/UserKeysController.php
+++ b/lib/Controller/API/App/UserKeysController.php
@@ -174,10 +174,10 @@ class UserKeysController extends KleinController
             throw new InvalidArgumentException("Key missing", -2);
         }
 
-        // Prevent XSS attack by escaping HTML-relevant characters instead of rejecting the request
-        if (!empty($description)) {
-            $description = htmlspecialchars((string)$description, ENT_QUOTES, 'UTF-8');
-        }
+        // Names are stored raw: TmKeyManager::validateName() enforces semantics
+        // (string type, valid UTF-8, no invisible characters) and rejects bad
+        // input with code -3; HTML/XML escaping happens at each output sink.
+        $description = TmKeyManager::validateName($description);
 
         return [
             'key' => $key,

--- a/lib/Controller/API/V1/NewController.php
+++ b/lib/Controller/API/V1/NewController.php
@@ -971,6 +971,7 @@ class NewController extends KleinController
      * @return array<string, mixed>
      * @throws \DomainException
      * @throws \TypeError
+     * @throws InvalidArgumentException
      */
     private static function sanitizeTmKeyArr(array $elem): array
     {

--- a/lib/Controller/API/V3/DownloadQRController.php
+++ b/lib/Controller/API/V3/DownloadQRController.php
@@ -396,7 +396,7 @@ class DownloadQRController extends KleinController
             $xml .= '<id_file>' . $datum[10] . '</id_file>';
             $xml .= '<warning>' . $datum[11] . '</warning>';
             $xml .= '<suggestion_match>' . $datum[12] . '</suggestion_match>';
-            $xml .= '<suggestion_source>' . $datum[13] . '</suggestion_source>';
+            $xml .= '<suggestion_source>' . htmlspecialchars($datum[13] ?? '', ENT_QUOTES | ENT_XML1, 'UTF-8') . '</suggestion_source>';
             $xml .= '<suggestion>' . $datum[14] . '</suggestion>';
             $xml .= '<edit_distance>' . $datum[15] . '</edit_distance>';
             $xml .= '<locked>' . $datum[16] . '</locked>';

--- a/lib/Utils/TMS/TMSService.php
+++ b/lib/Utils/TMS/TMSService.php
@@ -574,7 +574,7 @@ class TMSService
 
         $suggestionsArray = json_decode($row['suggestions_array'], true);
         $suggestionOrigin = Utils::changeMemorySuggestionSource($suggestionsArray[0], $row['tm_keys'], $this->database, $uid);
-        $tmOrigin = '<prop type="x-MateCAT-suggestion-origin">' . $suggestionOrigin . "</prop>";
+        $tmOrigin = '<prop type="x-MateCAT-suggestion-origin">' . htmlspecialchars($suggestionOrigin, ENT_QUOTES | ENT_XML1, 'UTF-8') . "</prop>";
         if (preg_match("/[a-f0-9]{8,}/", $suggestionsArray[0]['memory_key'])) {
             $tmOrigin .= "\n        <prop type=\"x-MateCAT-suggestion-private-key\">" . $suggestionsArray[0]['memory_key'] . "</prop>";
         }

--- a/lib/Utils/TmKeyManagement/TmKeyManager.php
+++ b/lib/Utils/TmKeyManagement/TmKeyManager.php
@@ -231,9 +231,7 @@ class TmKeyManager
         }
 
         if (!is_null($obj->name)) {
-            $obj->name = preg_replace('/[^.\-_\p{L}\p{N}\s{}]+/u', '', $obj->name);
-            $sanitized = filter_var($obj->name, FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
-            $obj->name = $sanitized !== false ? $sanitized : null;
+            $obj->name = htmlspecialchars($obj->name, ENT_QUOTES, 'UTF-8');
         }
 
         if (!is_null($obj->key)) {

--- a/lib/Utils/TmKeyManagement/TmKeyManager.php
+++ b/lib/Utils/TmKeyManagement/TmKeyManager.php
@@ -4,7 +4,9 @@ namespace Utils\TmKeyManagement;
 
 use DomainException;
 use Exception;
+use InvalidArgumentException;
 use Model\DataAccess\Database;
+use Normalizer;
 use Model\DataAccess\IDatabase;
 use Model\TmKeyManagement\MemoryKeyDao;
 use Model\TmKeyManagement\MemoryKeyStruct;
@@ -197,6 +199,47 @@ class TmKeyManager
     }
 
     /**
+     * Validates and normalizes a user-provided resource name.
+     *
+     * Names are stored raw: no HTML escaping happens here, encoding for a
+     * specific destination (HTML, XML, email template) is the output layer's
+     * job. This method only enforces semantics: a name must be a UTF-8 string
+     * without invisible characters.
+     *
+     * @param mixed $name
+     *
+     * @return string|null
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function validateName(mixed $name): ?string
+    {
+        if (is_null($name)) {
+            return null;
+        }
+
+        if (!is_string($name)) {
+            throw new InvalidArgumentException("Resource name must be a string", -3);
+        }
+
+        if (!mb_check_encoding($name, 'UTF-8')) {
+            throw new InvalidArgumentException("Resource name is not valid UTF-8", -3);
+        }
+
+        // Cc covers NUL/ESC/newlines, Cf covers zero-width and bidi overrides
+        // used to spoof how a name reads. U+200D (ZWJ) is excluded so emoji
+        // sequences survive.
+        $name = preg_replace('/(?![\x{200D}])[\p{Cc}\p{Cf}]/u', '', $name) ?? '';
+        $name = Normalizer::normalize(trim($name), Normalizer::FORM_C);
+
+        if ($name === false) {
+            throw new InvalidArgumentException("Resource name is not valid UTF-8", -3);
+        }
+
+        return mb_substr($name, 0, 255);
+    }
+
+    /**
      * This method sanitize fields received with struct
      *
      * @param TmKeyStruct $obj
@@ -205,6 +248,7 @@ class TmKeyManager
      *
      * @throws \TypeError
      * @throws DomainException
+     * @throws InvalidArgumentException
      */
     public static function sanitize(TmKeyStruct $obj): TmKeyStruct
     {
@@ -230,9 +274,7 @@ class TmKeyManager
             $obj->uid_rev = $sanitized !== false ? (int)$sanitized : null;
         }
 
-        if (!is_null($obj->name)) {
-            $obj->name = htmlspecialchars($obj->name, ENT_QUOTES, 'UTF-8');
-        }
+        $obj->name = self::validateName($obj->name);
 
         if (!is_null($obj->key)) {
             $sanitized = filter_var($obj->key, FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);

--- a/lib/View/Emails/ShareKey/message_content.html
+++ b/lib/View/Emails/ShareKey/message_content.html
@@ -1,15 +1,15 @@
 <p class="p_line_height_1_5">
     Hello,
     <br>
-    <?=$senderFullName?><? if( !empty( $senderEmail ) ): ?> (<?=$senderEmail?>)<? endif; ?> shared the following language resource with you.
+    <?=htmlspecialchars($senderFullName, ENT_QUOTES, 'UTF-8')?><? if( !empty( $senderEmail ) ): ?> (<?=htmlspecialchars($senderEmail, ENT_QUOTES, 'UTF-8')?>)<? endif; ?> shared the following language resource with you.
 </p>
 <p class="p_line_height_1_5">
-    <span class="align-center" style="font-weight: bold;">Description:</span> <span><?=$tm_key_name?></span>
+    <span class="align-center" style="font-weight: bold;">Description:</span> <span><?=htmlspecialchars($tm_key_name, ENT_QUOTES, 'UTF-8')?></span>
     <br>
     <span class="align-center" style="font-weight: bold;">Private key:</span> <span> <?=$tm_key_value?></span>
 </p>
 <p class="p_line_height_1_5">
-    If you have an account on Matecat registered to <?=$addressMail?>, you will find the language resource in the 'Translation Memory and Glossary' tab of the settings panel.
+    If you have an account on Matecat registered to <?=htmlspecialchars($addressMail, ENT_QUOTES, 'UTF-8')?>, you will find the language resource in the 'Translation Memory and Glossary' tab of the settings panel.
 </p>
 <p class="p_bottom_5">Otherwise:</p>
 <ol>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "classnames": "^2.2.6",
     "crypto-js": "^4.1.1",
     "diff-match-patch": "^1.0.5",
+    "dompurify": "^3.4.12",
     "draft-js": "^0.11.4",
     "events": "^3.3.0",
     "file-saver": "^2.0.5",

--- a/public/js/actions/CatToolActions.js
+++ b/public/js/actions/CatToolActions.js
@@ -20,6 +20,7 @@ import {
   removeAllNotifications,
 } from './notificationActions'
 import OfflineUtils from '../utils/offlineUtils'
+import TEXT_UTILS from '../utils/textUtils'
 
 let CatToolActions = {
   popupInfoUserMenu: () => 'infoUserMenu-' + config.userMail,
@@ -160,7 +161,11 @@ let CatToolActions = {
           getDomainsList({
             keys: filteredKeys.map(({key}) => key),
           })
-          const keys = filteredKeys.map((item) => ({...item, id: item.key}))
+          const keys = filteredKeys.map((item) => ({
+            ...item,
+            id: item.key,
+            name: TEXT_UTILS.decodeHtml(item.name),
+          }))
           AppDispatcher.dispatch({
             actionType: CatToolConstants.UPDATE_TM_KEYS,
             keys,

--- a/public/js/actions/CatToolActions.js
+++ b/public/js/actions/CatToolActions.js
@@ -20,7 +20,6 @@ import {
   removeAllNotifications,
 } from './notificationActions'
 import OfflineUtils from '../utils/offlineUtils'
-import TEXT_UTILS from '../utils/textUtils'
 
 let CatToolActions = {
   popupInfoUserMenu: () => 'infoUserMenu-' + config.userMail,
@@ -161,11 +160,7 @@ let CatToolActions = {
           getDomainsList({
             keys: filteredKeys.map(({key}) => key),
           })
-          const keys = filteredKeys.map((item) => ({
-            ...item,
-            id: item.key,
-            name: TEXT_UTILS.decodeHtml(item.name),
-          }))
+          const keys = filteredKeys.map((item) => ({...item, id: item.key}))
           AppDispatcher.dispatch({
             actionType: CatToolConstants.UPDATE_TM_KEYS,
             keys,
@@ -214,7 +209,9 @@ let CatToolActions = {
    *                      tc (top center), br (bottom right), bl (bottom left), bc (bottom center)
    * closeCallback    (Function) A callback function that will be called when the notification is about to be removed.
    * openCallback     (Function) A callback function that will be called when the notification is successfully added.
-   * allowHtml:       (Boolean, Default false) Set to true if the text contains HTML, like buttons
+   * allowHtml:       (Boolean, Default false) Reserved for operator-authored broadcasts (SSE global messages).
+   *                      The HTML is sanitized before rendering. For anything interpolating user data,
+   *                      pass a ReactNode as text instead.
    * autoDismiss:     (Boolean, Default true) Set if notification is dismissible by the user.
    *
    */

--- a/public/js/actions/ManageActions.js
+++ b/public/js/actions/ManageActions.js
@@ -197,7 +197,6 @@ let ManageActions = {
       text: 'Something went wrong, the project has been assigned to another member or moved to another team.',
       type: 'warning',
       position: 'bl',
-      allowHtml: true,
       autoDismiss: false,
     }
     CatToolActions.addNotification(notification)
@@ -234,7 +233,6 @@ let ManageActions = {
             name,
           type: 'success',
           position: 'bl',
-          allowHtml: true,
           timer: 3000,
         }
         CatToolActions.addNotification(notification)
@@ -283,7 +281,6 @@ let ManageActions = {
             text: `The selected projects have been successfully assigned to ${user.first_name} ${user.last_name}.`,
             type: 'warning',
             position: 'bl',
-            allowHtml: true,
             timer: 10000,
           }
           CatToolActions.addNotification(notification)
@@ -293,7 +290,6 @@ let ManageActions = {
             text: 'Some projects failed',
             type: 'error',
             position: 'bl',
-            allowHtml: true,
             timer: 10000,
           }
           CatToolActions.addNotification(errorNotification)
@@ -366,7 +362,6 @@ let ManageActions = {
               ' Team',
             type: 'success',
             position: 'bl',
-            allowHtml: true,
             timer: 3000,
           }
           CatToolActions.addNotification(notification)
@@ -457,7 +452,6 @@ let ManageActions = {
             text: `The selected projects have been successfully moved to the ${team.name} team.`,
             type: 'warning',
             position: 'bl',
-            allowHtml: true,
             timer: 10000,
           }
           CatToolActions.addNotification(notification)
@@ -467,7 +461,6 @@ let ManageActions = {
             text: 'Some projects failed',
             type: 'error',
             position: 'bl',
-            allowHtml: true,
             timer: 10000,
           }
           CatToolActions.addNotification(errorNotification)

--- a/public/js/actions/SegmentActions.js
+++ b/public/js/actions/SegmentActions.js
@@ -603,13 +603,24 @@ const SegmentActions = {
       !config.isReview &&
       config.job_completion_current_phase == 'revise'
     if (projectCompletionCheck) {
-      let message =
-        'All segments are in <b>read-only mode</b> because this job is under review.'
+      let message = (
+        <>
+          All segments are in <b>read-only mode</b> because this job is under
+          review.
+        </>
+      )
 
       if (config.chunk_completion_undoable && config.last_completion_event_id) {
-        message =
-          message +
-          '<p class=\'warning-call-to\'><a href="javascript:void(0);" id="showTranslateWarningMessageUndoLink" >Re-Open Job</a></p>'
+        message = (
+          <>
+            {message}
+            <p className="warning-call-to">
+              <a href="#" id="showTranslateWarningMessageUndoLink">
+                Re-Open Job
+              </a>
+            </p>
+          </>
+        )
       }
 
       addNotification({
@@ -620,7 +631,6 @@ const SegmentActions = {
         text: message,
         title: 'Warning',
         type: 'warning',
-        allowHtml: true,
       })
     }
     if (TextUtils.justSelecting('readonly')) return

--- a/public/js/components/header/cattol/MarkAsCompleteButton.js
+++ b/public/js/components/header/cattol/MarkAsCompleteButton.js
@@ -61,13 +61,24 @@ export const MarkAsCompleteButton = ({featureEnabled, isReview}) => {
 
   const showTranslateWarningMessage = () => {
     // if (!lastCompletionEventId) return
-    let message =
-      'All segments are in <b>read-only mode</b> because this job is under review.'
+    let message = (
+      <>
+        All segments are in <b>read-only mode</b> because this job is under
+        review.
+      </>
+    )
 
     if (config.chunk_completion_undoable && config.last_completion_event_id) {
-      message =
-        message +
-        '<p class=\'warning-call-to\'><a href="javascript:void(0);" id="showTranslateWarningMessageUndoLink" >Re-Open Job</a></p>'
+      message = (
+        <>
+          {message}
+          <p className="warning-call-to">
+            <a href="#" id="showTranslateWarningMessageUndoLink">
+              Re-Open Job
+            </a>
+          </p>
+        </>
+      )
     }
 
     CatToolActions.addNotification({
@@ -78,7 +89,6 @@ export const MarkAsCompleteButton = ({featureEnabled, isReview}) => {
       text: message,
       title: 'Warning',
       type: 'warning',
-      allowHtml: true,
     })
   }
 

--- a/public/js/components/header/cattol/segment_filter/segment_filter.js
+++ b/public/js/components/header/cattol/segment_filter/segment_filter.js
@@ -39,7 +39,6 @@ let SegmentFilterUtils = {
         text: text,
         title: title,
         type: 'warning',
-        allowHtml: true,
       })
     })()
   },

--- a/public/js/components/modals/ShareTmModal.js
+++ b/public/js/components/modals/ShareTmModal.js
@@ -52,7 +52,6 @@ class ShareTmModal extends React.Component {
             type: 'success',
             text: `The resource has been shared.`,
             position: 'br',
-            allowHtml: true,
             timer: 5000,
           })
           callback.call()

--- a/public/js/components/notificationsComponent/NotificationBox.js
+++ b/public/js/components/notificationsComponent/NotificationBox.js
@@ -10,7 +10,9 @@
  * position:        (String, Default "bl") Position of the notification. Available: tr (top right), tl (top left),
  *                      tc (top center), br (bottom right), bl (bottom left), bc (bottom center)
  * autoDismiss:     (Boolean, Default true) Set if notification is dismissible by the user.
- * allowHtml:       (Boolean, Default false) Set to true if the text contains HTML, like buttons
+ * allowHtml:       (Boolean, Default false) Reserved for operator-authored broadcasts (SSE global messages).
+ *                      The HTML is sanitized before rendering. For anything interpolating user data,
+ *                      pass a ReactNode as text instead.
  * closeCallback    (Function) A callback function that will be called when the notification is about to be removed.
  * openCallback     (Function) A callback function that will be called when the notification is successfully added.
  * dismissable      (Boolean, Default true) If show or not the button to close the notification

--- a/public/js/components/notificationsComponent/NotificationItem.js
+++ b/public/js/components/notificationsComponent/NotificationItem.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React, {useState, useRef, useEffect} from 'react'
+import TEXT_UTILS from '../../utils/textUtils'
 
 const NotificationItem = ({
   uid,
@@ -66,9 +67,10 @@ const NotificationItem = ({
     }
   }, [remove])
 
-  const allowHTML = (string) => {
-    return {__html: string}
-  }
+  // allowHtml is reserved for operator-authored broadcasts (SSE global
+  // messages): the markup is sanitized before injection. Any notification
+  // interpolating user data must pass a ReactNode as text instead.
+  const allowHTML = (string) => TEXT_UTILS.sanitizedHTML(string)
 
   const getCssPropertyByPosition = () => {
     let css = {}
@@ -154,7 +156,7 @@ const NotificationItem = ({
 
 NotificationItem.propTypes = {
   position: PropTypes.string,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   text: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   type: PropTypes.string,
   autoDismiss: PropTypes.bool,

--- a/public/js/components/notificationsComponent/NotificationItem.test.js
+++ b/public/js/components/notificationsComponent/NotificationItem.test.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import NotificationItem from './NotificationItem'
+
+const baseProps = {
+  uid: 'test-notification',
+  type: 'success',
+  position: 'br',
+  autoDismiss: false,
+  onRemove: () => {},
+}
+
+test('renders a ReactNode text with user data as plain text', () => {
+  const name = '<img src=x onerror="window.__xss=1"> R&D'
+  render(
+    <NotificationItem
+      {...baseProps}
+      title="Resource shared"
+      text={
+        <>
+          The resource <b>{name}</b> has been shared.
+        </>
+      }
+    />,
+  )
+
+  expect(screen.queryByRole('img')).toBeNull()
+  expect(screen.getByText(name)).toBeInTheDocument()
+  expect(document.querySelector('.notification-message b')).not.toBeNull()
+  expect(window.__xss).toBeUndefined()
+})
+
+test('sanitizes markup rendered through allowHtml', () => {
+  render(
+    <NotificationItem
+      {...baseProps}
+      title="Notice"
+      text='<b>hello</b><img src="x" onerror="window.__xss=1">'
+      allowHtml
+    />,
+  )
+
+  const message = document.querySelector('.notification-message')
+  expect(message.querySelector('b')).not.toBeNull()
+  const img = message.querySelector('img')
+  if (img) {
+    expect(img.getAttribute('onerror')).toBeNull()
+  }
+  expect(window.__xss).toBeUndefined()
+})
+
+test('renders a plain string text as text', () => {
+  render(
+    <NotificationItem
+      {...baseProps}
+      title="Notice"
+      text="<script>alert(1)</script>"
+    />,
+  )
+
+  expect(screen.getByText('<script>alert(1)</script>')).toBeInTheDocument()
+})

--- a/public/js/components/outsource/AssignToTranslator.js
+++ b/public/js/components/outsource/AssignToTranslator.js
@@ -82,7 +82,6 @@ class AssignToTranslator extends React.Component {
       text: message.text,
       type: 'success',
       position: 'bl',
-      allowHtml: true,
       timer: 10000,
     }
     CatToolActions.addNotification(notification)
@@ -101,49 +100,97 @@ class AssignToTranslator extends React.Component {
   }
   shareToTranslatorMailChangeNotification(mail, job) {
     return {
-      title:
-        'Job sent with <div class="green-label" style="display: inline; background-color: #5ea400; color: white; padding: 2px 5px;">new password </div>',
-      text:
-        '<div style="margin-top: 16px;">To: <a href="mailto:' +
-        mail +
-        '">' +
-        mail +
-        '</a> ' +
-        '<div class="job-reference" style="display: inline-block; width: 100%; margin-top: 10px;"> ' +
-        '<div class style="display: inline-block; font-size: 14px; color: grey;">(' +
-        job.id +
-        ')</div> ' +
-        '<div class="source-target languages-tooltip" style="display: inline-block; font-weight: 700;"> ' +
-        '<div class="source-box" style="display: inherit;">' +
-        job.sourceTxt +
-        '</div> ' +
-        '<div class="in-to" style="top: 3px; display: inherit; position: relative;"> <i class="icon-chevron-right icon"></i> </div> ' +
-        '<div class="target-box" style="display: inherit;">' +
-        job.targetTxt +
-        '</div> </div> </div></div>',
+      title: (
+        <>
+          Job sent with{' '}
+          <div
+            className="green-label"
+            style={{
+              display: 'inline',
+              backgroundColor: '#5ea400',
+              color: 'white',
+              padding: '2px 5px',
+            }}
+          >
+            new password{' '}
+          </div>
+        </>
+      ),
+      text: (
+        <div style={{marginTop: '16px'}}>
+          To: <a href={`mailto:${mail}`}>{mail}</a>{' '}
+          <div
+            className="job-reference"
+            style={{display: 'inline-block', width: '100%', marginTop: '10px'}}
+          >
+            {' '}
+            <div
+              style={{display: 'inline-block', fontSize: '14px', color: 'grey'}}
+            >
+              ({job.id})
+            </div>{' '}
+            <div
+              className="source-target languages-tooltip"
+              style={{display: 'inline-block', fontWeight: 700}}
+            >
+              {' '}
+              <div className="source-box" style={{display: 'inherit'}}>
+                {job.sourceTxt}
+              </div>{' '}
+              <div
+                className="in-to"
+                style={{top: '3px', display: 'inherit', position: 'relative'}}
+              >
+                {' '}
+                <i className="icon-chevron-right icon"></i>{' '}
+              </div>{' '}
+              <div className="target-box" style={{display: 'inherit'}}>
+                {job.targetTxt}
+              </div>{' '}
+            </div>{' '}
+          </div>
+        </div>
+      ),
     }
   }
   shareToTranslatorNotification(mail, job) {
     return {
       title: 'Job sent',
-      text:
-        '<div style="margin-top: 16px;">To: <a href="mailto:' +
-        mail +
-        '">' +
-        mail +
-        '</a> ' +
-        '<div class="job-reference" style="display: inline-block; width: 100%; margin-top: 10px;"> ' +
-        '<div class style="display: inline-block; font-size: 14px; color: grey;">' +
-        job.id +
-        ' </div> ' +
-        '<div class="source-target languages-tooltip" style="display: inline-block; font-weight: 700;"> ' +
-        '<div class="source-box" style="display: inherit;">' +
-        job.sourceTxt +
-        '</div> ' +
-        '<div class="in-to" style="top: 3px; display: inherit; position: relative;"> <i class="icon-chevron-right icon"></i> </div> ' +
-        '<div class="target-box" style="display: inherit;">' +
-        job.targetTxt +
-        '</div> </div> </div></div>',
+      text: (
+        <div style={{marginTop: '16px'}}>
+          To: <a href={`mailto:${mail}`}>{mail}</a>{' '}
+          <div
+            className="job-reference"
+            style={{display: 'inline-block', width: '100%', marginTop: '10px'}}
+          >
+            {' '}
+            <div
+              style={{display: 'inline-block', fontSize: '14px', color: 'grey'}}
+            >
+              {job.id}{' '}
+            </div>{' '}
+            <div
+              className="source-target languages-tooltip"
+              style={{display: 'inline-block', fontWeight: 700}}
+            >
+              {' '}
+              <div className="source-box" style={{display: 'inherit'}}>
+                {job.sourceTxt}
+              </div>{' '}
+              <div
+                className="in-to"
+                style={{top: '3px', display: 'inherit', position: 'relative'}}
+              >
+                {' '}
+                <i className="icon-chevron-right icon"></i>{' '}
+              </div>{' '}
+              <div className="target-box" style={{display: 'inherit'}}>
+                {job.targetTxt}
+              </div>{' '}
+            </div>{' '}
+          </div>
+        </div>
+      ),
     }
   }
   shareToTranslatorDateChangeNotification(email, oldDate, newDate) {
@@ -151,52 +198,83 @@ class AssignToTranslator extends React.Component {
     oldDate = CommonUtils.getGMTDate(oldDate)
     newDate = CommonUtils.formatDate(newDate, 'yyyy-MM-d hh:mm a')
     newDate = CommonUtils.getGMTDate(newDate)
+    const dateBlock = (date, notUsed) => (
+      <div
+        className={`job-delivery${notUsed ? ' not-used' : ''}`}
+        title="Delivery date"
+        style={{
+          display: 'inline-block',
+          marginBottom: '10px',
+          fontWeight: 700,
+          ...(notUsed
+            ? {textDecoration: 'line-through', position: 'relative'}
+            : {marginRight: '10px'}),
+        }}
+      >
+        {' '}
+        <div
+          className="outsource-day-text"
+          style={{display: 'inline-block', marginRight: '3px'}}
+        >
+          {date.day}
+        </div>{' '}
+        <div
+          className="outsource-month-text"
+          style={{display: 'inline-block', marginRight: '5px'}}
+        >
+          {date.month}
+        </div>{' '}
+        <div className="outsource-time-text" style={{display: 'inline-block'}}>
+          {date.time}
+        </div>{' '}
+        <div
+          className="outsource-gmt-text"
+          style={{display: 'inline-block', fontWeight: 100, color: 'grey'}}
+        >
+          ({date.gmt})
+        </div>{' '}
+        {notUsed && (
+          <div
+            className="old"
+            style={{
+              width: '100%',
+              height: '1px',
+              borderTop: '1px solid black',
+              top: '-10px',
+              position: 'relative',
+            }}
+          ></div>
+        )}
+      </div>
+    )
     return {
       title: 'Job delivery update',
-      text:
-        '<div style="margin-top: 16px;"><div class="job-reference" style="display: inline-block; width: 100%;"> To: ' +
-        '<div class="job-delivery" title="Delivery date" style="display: inline-block; margin-bottom: 10px; font-weight: 700; margin-right: 10px;"> ' +
-        '<div class="outsource-day-text" style="display: inline-block; margin-right: 3px;">' +
-        newDate.day +
-        '</div> ' +
-        '<div class="outsource-month-text" style="display: inline-block; margin-right: 5px;">' +
-        newDate.month +
-        '</div> ' +
-        '<div class="outsource-time-text" style="display: inline-block;">' +
-        newDate.time +
-        '</div> ' +
-        '<div class="outsource-gmt-text" style="display: inline-block; font-weight: 100;color: grey;">(' +
-        newDate.gmt +
-        ')</div> ' +
-        '</div> <div class="job-delivery not-used" title="Delivery date" style="display: inline-block; margin-bottom: 10px; font-weight: 700; text-decoration: line-through; position: relative;"> ' +
-        '<div class="outsource-day-text" style="display: inline-block; margin-right: 3px;">' +
-        oldDate.day +
-        '</div> ' +
-        '<div class="outsource-month-text" style="display: inline-block; margin-right: 5px;">' +
-        oldDate.month +
-        '</div> ' +
-        '<div class="outsource-time-text" style="display: inline-block;">' +
-        oldDate.time +
-        '</div> ' +
-        '<div class="outsource-gmt-text" style="display: inline-block; font-weight: 100; color: grey;">(' +
-        oldDate.gmt +
-        ')</div> ' +
-        '<div class="old" style="width: 100%; height: 1px; border-top: 1px solid black; top: -10px; position: relative;"></div> </div> ' +
-        '</div>Translator: <a href="mailto:' +
-        email +
-        '">' +
-        email +
-        '</a> </div></div>',
+      text: (
+        <div style={{marginTop: '16px'}}>
+          <div
+            className="job-reference"
+            style={{display: 'inline-block', width: '100%'}}
+          >
+            {' '}
+            To: {dateBlock(newDate, false)} {dateBlock(oldDate, true)}
+            Translator: <a href={`mailto:${email}`}>{email}</a>{' '}
+          </div>
+        </div>
+      ),
     }
   }
   showShareTranslatorError() {
     ModalsActions.onCloseModal()
     const notification = {
       title: 'Problems sending the job',
-      text: 'Please try later or contact <a href="mailto:support@matecat.com">support@matecat.com</a>',
+      text: (
+        <>
+          Please try later or contact{' '}
+          <a href="mailto:support@matecat.com">support@matecat.com</a>
+        </>
+      ),
       type: 'error',
       position: 'bl',
-      allowHtml: true,
       timer: 10000,
     }
     CatToolActions.addNotification(notification)

--- a/public/js/components/projects/JobContainer.js
+++ b/public/js/components/projects/JobContainer.js
@@ -151,21 +151,58 @@ class JobContainer extends React.Component {
       this.oldPassword,
       revision_number,
     ).then(function (data) {
+      let translator = self.props.job.get('translator')
+      const undoChangePassword = function () {
+        CatToolActions.removeNotification(notification)
+        changeJobPassword(
+          self.props.job.toJS(),
+          data.new_pwd,
+          revision_number,
+          1,
+          self.oldPassword,
+        ).then(function (data) {
+          const restoreNotification = {
+            title: 'Change job password',
+            text: 'The previous password has been restored.',
+            type: 'warning',
+            position: 'bl',
+            timer: 7000,
+          }
+          CatToolActions.addNotification(restoreNotification)
+          ManageActions.changeJobPassword(
+            self.props.project,
+            self.props.job,
+            data.new_pwd,
+            data.old_pwd,
+            revision_number,
+            translator,
+          )
+        })
+      }
       const notification = {
         uid: 'change-password',
         title: revision_number
           ? `${revision_number === 1 ? 'Revise' : 'Revise 2'} password changed`
           : 'Translate password changed',
-        text: revision_number
-          ? `The ${revision_number === 1 ? 'Revise' : 'Revise 2'} password has been changed. <a class="undo-password">Undo</a>`
-          : 'The Translate password has been changed. <a class="undo-password">Undo</a>',
+        text: (
+          <>
+            The{' '}
+            {revision_number
+              ? revision_number === 1
+                ? 'Revise'
+                : 'Revise 2'
+              : 'Translate'}{' '}
+            password has been changed.{' '}
+            <a className="undo-password" onClick={undoChangePassword}>
+              Undo
+            </a>
+          </>
+        ),
         type: 'warning',
         position: 'bl',
-        allowHtml: true,
         timer: 10000,
       }
       CatToolActions.addNotification(notification)
-      let translator = self.props.job.get('translator')
       ManageActions.changeJobPassword(
         self.props.project,
         self.props.job,
@@ -173,36 +210,6 @@ class JobContainer extends React.Component {
         data.old_pwd,
         revision_number,
       )
-      setTimeout(function () {
-        $('.undo-password').off('click')
-        $('.undo-password').on('click', function () {
-          CatToolActions.removeNotification(notification)
-          changeJobPassword(
-            self.props.job.toJS(),
-            data.new_pwd,
-            revision_number,
-            1,
-            self.oldPassword,
-          ).then(function (data) {
-            const restoreNotification = {
-              title: 'Change job password',
-              text: 'The previous password has been restored.',
-              type: 'warning',
-              position: 'bl',
-              timer: 7000,
-            }
-            CatToolActions.addNotification(restoreNotification)
-            ManageActions.changeJobPassword(
-              self.props.project,
-              self.props.job,
-              data.new_pwd,
-              data.old_pwd,
-              revision_number,
-              translator,
-            )
-          })
-        })
-      }, 500)
     })
   }
 
@@ -211,17 +218,51 @@ class JobContainer extends React.Component {
     this.oldPassword = this.props.job.get('password')
     changeJobPassword(this.props.job.toJS(), this.oldPassword).then(
       function (data) {
+        let translator = self.props.job.get('translator')
+        const undoRemoveTranslator = function () {
+          CatToolActions.removeNotification(notification)
+          changeJobPassword(
+            self.props.job.toJS(),
+            data.new_pwd,
+            null,
+            1,
+            self.oldPassword,
+          ).then(function (data) {
+            const passwordNotification = {
+              uid: 'change-password',
+              title: 'Change job password',
+              text: 'The previous password has been restored.',
+              type: 'warning',
+              position: 'bl',
+              timer: 7000,
+            }
+            CatToolActions.addNotification(passwordNotification)
+            ManageActions.changeJobPassword(
+              self.props.project,
+              self.props.job,
+              data.new_pwd,
+              data.old_pwd,
+              null,
+              translator,
+            )
+          })
+        }
         const notification = {
           uid: 'remove-translator',
           title: 'Job unassigned',
-          text: 'The translator has been removed and the password changed. <a class="undo-password">Undo</a>',
+          text: (
+            <>
+              The translator has been removed and the password changed.{' '}
+              <a className="undo-password" onClick={undoRemoveTranslator}>
+                Undo
+              </a>
+            </>
+          ),
           type: 'warning',
           position: 'bl',
-          allowHtml: true,
           timer: 10000,
         }
         CatToolActions.addNotification(notification)
-        let translator = self.props.job.get('translator')
         ManageActions.changeJobPassword(
           self.props.project,
           self.props.job,
@@ -230,37 +271,6 @@ class JobContainer extends React.Component {
           null,
           null,
         )
-        setTimeout(function () {
-          $('.undo-password').off('click')
-          $('.undo-password').on('click', function () {
-            CatToolActions.removeNotification(notification)
-            changeJobPassword(
-              self.props.job.toJS(),
-              data.new_pwd,
-              null,
-              1,
-              self.oldPassword,
-            ).then(function (data) {
-              const passwordNotification = {
-                uid: 'change-password',
-                title: 'Change job password',
-                text: 'The previous password has been restored.',
-                type: 'warning',
-                position: 'bl',
-                timer: 7000,
-              }
-              CatToolActions.addNotification(passwordNotification)
-              ManageActions.changeJobPassword(
-                self.props.project,
-                self.props.job,
-                data.new_pwd,
-                data.old_pwd,
-                null,
-                translator,
-              )
-            })
-          })
-        }, 500)
       },
     )
   }
@@ -273,7 +283,6 @@ class JobContainer extends React.Component {
         text: `The selected jobs has been successfully archived.`,
         type: 'warning',
         position: 'bl',
-        allowHtml: true,
         timer: 10000,
       })
     }
@@ -287,7 +296,6 @@ class JobContainer extends React.Component {
         text: `The selected jobs has been successfully canceled.`,
         type: 'warning',
         position: 'bl',
-        allowHtml: true,
         timer: 10000,
       })
     }
@@ -301,7 +309,6 @@ class JobContainer extends React.Component {
         text: `The selected jobs has been successfully unarchived.`,
         type: 'warning',
         position: 'bl',
-        allowHtml: true,
         timer: 10000,
       })
     }
@@ -325,7 +332,6 @@ class JobContainer extends React.Component {
             text: `The selected jobs has been successfully deleted permanently.`,
             type: 'warning',
             position: 'bl',
-            allowHtml: true,
             timer: 10000,
           })
         }

--- a/public/js/components/projects/ProjectsBulkActions/ProjectsBulkActions.js
+++ b/public/js/components/projects/ProjectsBulkActions/ProjectsBulkActions.js
@@ -384,7 +384,6 @@ export const ProjectsBulkActions = ({
           text: `The selected jobs have been successfully ${id === JOBS_ACTIONS.ARCHIVE.id ? 'archived' : id === JOBS_ACTIONS.UNARCHIVE.id ? 'unarchived' : id === JOBS_ACTIONS.CANCEL.id ? 'canceled' : id === JOBS_ACTIONS.RESUME.id ? 'resumed' : 'deleted permanently'}.`,
           type: 'warning',
           position: 'bl',
-          allowHtml: true,
           timer: 10000,
         })
         break
@@ -410,7 +409,6 @@ export const ProjectsBulkActions = ({
           text: 'The Revise 2 links for the selected jobs have been generated successfully.',
           type: 'warning',
           position: 'bl',
-          allowHtml: true,
           timer: 10000,
         })
         break
@@ -449,7 +447,6 @@ export const ProjectsBulkActions = ({
                 : 'The Translate passwords for the selected jobs have been changed successfully',
               type: 'warning',
               position: 'bl',
-              allowHtml: true,
               timer: 10000,
             }
             CatToolActions.addNotification(notification)
@@ -459,7 +456,6 @@ export const ProjectsBulkActions = ({
               text: 'Some jobs failed',
               type: 'error',
               position: 'bl',
-              allowHtml: true,
               timer: 10000,
             }
             CatToolActions.addNotification(errorNotification)

--- a/public/js/components/quality_report/SegmentQR.js
+++ b/public/js/components/quality_report/SegmentQR.js
@@ -327,7 +327,7 @@ class SegmentQR extends React.Component {
     return text
   }
   allowHTML(string) {
-    return {__html: string}
+    return TextUtils.sanitizedHTML(string)
   }
   componentDidUpdate(prevProps) {
     if (prevProps.revisionToShow !== this.props.revisionToShow) {

--- a/public/js/components/quality_report/SegmentQRLine.js
+++ b/public/js/components/quality_report/SegmentQRLine.js
@@ -1,4 +1,5 @@
 import React, {useRef} from 'react'
+import TEXT_UTILS from '../../utils/textUtils'
 const SegmentQRLine = ({
   showSuggestionSource = false,
   segment,
@@ -16,9 +17,7 @@ const SegmentQRLine = ({
   rev,
 }) => {
   const textRef = useRef()
-  const allowHTML = (string) => {
-    return {__html: string}
-  }
+  const allowHTML = (string) => TEXT_UTILS.sanitizedHTML(string)
   const getTimeToEdit = (tte) => {
     let str_pad_left = function (string, pad, length) {
       return (new Array(length + 1).join(pad) + string).slice(-length)

--- a/public/js/components/review_extended/ReviewExtendedIssue.js
+++ b/public/js/components/review_extended/ReviewExtendedIssue.js
@@ -75,15 +75,32 @@ export const ReviewExtendedIssue = ({
     if (issue.id === issueEditing?.id) setIssueEditing(undefined)
 
     CatToolActions.removeAllNotifications()
+    const undoDeleteIssue = function () {
+      setVisible(true)
+      changeVisibility(issue.id, true)
+      CatToolActions.removeAllNotifications()
+      const restoreNotification = {
+        title: 'Issue deleted',
+        text: 'The issue has been restored.',
+        type: 'warning',
+        position: 'bl',
+        timer: 5000,
+      }
+      CatToolActions.addNotification(restoreNotification)
+      window.onbeforeunload = null
+    }
     const notification = {
       title: 'Issue deleted',
-      text:
-        'The selected issue has been deleted. <a class="undo-issue-deleted undo-issue-deleted-' +
-        issue.id +
-        '">Undo</a>',
+      text: (
+        <>
+          The selected issue has been deleted.{' '}
+          <a className="undo-issue-deleted" onClick={undoDeleteIssue}>
+            Undo
+          </a>
+        </>
+      ),
       type: 'warning',
       position: 'bl',
-      allowHtml: true,
       timer: 10000,
       closeCallback: function () {
         SegmentActions.deleteIssue(issue, sid)
@@ -93,24 +110,6 @@ export const ReviewExtendedIssue = ({
     window.onbeforeunload = function () {
       SegmentActions.deleteIssue(issue, sid)
     }
-    setTimeout(function () {
-      const $button = $('.undo-issue-deleted-' + issue.id)
-      $button.off('click')
-      $button.on('click', function () {
-        setVisible(true)
-        changeVisibility(issue.id, true)
-        CatToolActions.removeAllNotifications()
-        const notification = {
-          title: 'Issue deleted',
-          text: 'The issue has been restored.',
-          type: 'warning',
-          position: 'bl',
-          timer: 5000,
-        }
-        CatToolActions.addNotification(notification)
-        window.onbeforeunload = null
-      })
-    }, 500)
   }
 
   const setCommentViewCallback = (event) => {

--- a/public/js/components/segments/SegmentFooterTabAiAlternatives.js
+++ b/public/js/components/segments/SegmentFooterTabAiAlternatives.js
@@ -1,6 +1,7 @@
 import React, {createRef, useEffect, useRef, useState} from 'react'
 import PropTypes from 'prop-types'
 import SegmentStore from '../../stores/SegmentStore'
+import TEXT_UTILS from '../../utils/textUtils'
 import SegmentConstants from '../../constants/SegmentConstants'
 import {Button, BUTTON_MODE, BUTTON_TYPE} from '../common/Button/Button'
 import DraftMatecatUtils from './utils/DraftMatecatUtils'
@@ -338,9 +339,7 @@ export const SegmentFooterTabAiAlternatives = ({
     }
   }, [segment])
 
-  const allowHTML = (string) => {
-    return {__html: string}
-  }
+  const allowHTML = (string) => TEXT_UTILS.sanitizedHTML(string)
 
   return (
     <div

--- a/public/js/components/segments/SegmentFooterTabLaraStyles.js
+++ b/public/js/components/segments/SegmentFooterTabLaraStyles.js
@@ -1,6 +1,7 @@
 import React, {useContext, useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import SegmentStore from '../../stores/SegmentStore'
+import TEXT_UTILS from '../../utils/textUtils'
 import SegmentConstants from '../../constants/SegmentConstants'
 import {
   decodePlaceholdersToPlainText,
@@ -171,9 +172,7 @@ export const SegmentFooterTabLaraStyles = ({
       })
   }
 
-  const allowHTML = (string) => {
-    return {__html: string}
-  }
+  const allowHTML = (string) => TEXT_UTILS.sanitizedHTML(string)
 
   return (
     <div

--- a/public/js/components/settingsPanel/Contents/MachineTranslationTab/DeepLGlossary/DeepLGlossary.js
+++ b/public/js/components/settingsPanel/Contents/MachineTranslationTab/DeepLGlossary/DeepLGlossary.js
@@ -26,7 +26,6 @@ const COLUMNS_TABLE = [
   {name: ''},
 ]
 
-
 export const DEEPL_GLOSSARY_ROW_NONE = ''
 
 export const DeepLGlossary = ({id, setGlossaries, isCattoolPage = false}) => {
@@ -73,9 +72,13 @@ export const DeepLGlossary = ({id, setGlossaries, isCattoolPage = false}) => {
           CatToolActions.addNotification({
             title: 'Glossary deleted',
             type: 'success',
-            text: `The glossary (<b>${glossary.name}</b>) has been successfully deleted`,
+            text: (
+              <>
+                The glossary (<b>{glossary.name}</b>) has been successfully
+                deleted
+              </>
+            ),
             position: 'br',
-            allowHtml: true,
             timer: 5000,
           })
           CreateProjectActions.updateProjectTemplates({
@@ -92,7 +95,6 @@ export const DeepLGlossary = ({id, setGlossaries, isCattoolPage = false}) => {
           type: 'error',
           text: 'Error deleting glossary',
           position: 'br',
-          allowHtml: true,
           timer: 5000,
         })
       })

--- a/public/js/components/settingsPanel/Contents/MachineTranslationTab/DeepLGlossary/DeepLGlossaryCreateRow.js
+++ b/public/js/components/settingsPanel/Contents/MachineTranslationTab/DeepLGlossary/DeepLGlossaryCreateRow.js
@@ -68,7 +68,6 @@ export const DeepLGlossaryCreateRow = ({engineId, row, setRows}) => {
         type: 'error',
         text: !name ? 'Name mandatory' : 'File mandatory',
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       })
       return false
@@ -89,7 +88,6 @@ export const DeepLGlossaryCreateRow = ({engineId, row, setRows}) => {
       type: 'success',
       text: 'Glossary created successfully',
       position: 'br',
-      allowHtml: true,
       timer: 5000,
     })
     setIsWaitingResult(false)
@@ -100,7 +98,6 @@ export const DeepLGlossaryCreateRow = ({engineId, row, setRows}) => {
       type: 'error',
       text: 'Error creating glossary',
       position: 'br',
-      allowHtml: true,
       timer: 5000,
     })
     setIsWaitingResult(false)

--- a/public/js/components/settingsPanel/Contents/MachineTranslationTab/MTGlossary/MTGlossary.js
+++ b/public/js/components/settingsPanel/Contents/MachineTranslationTab/MTGlossary/MTGlossary.js
@@ -111,9 +111,13 @@ export const MTGlossary = ({id, setGlossaries, isCattoolPage = false}) => {
           CatToolActions.addNotification({
             title: 'Glossary deleted',
             type: 'success',
-            text: `The glossary (<b>${glossary.name}</b>) has been successfully deleted`,
+            text: (
+              <>
+                The glossary (<b>{glossary.name}</b>) has been successfully
+                deleted
+              </>
+            ),
             position: 'br',
-            allowHtml: true,
             timer: 5000,
           })
           CreateProjectActions.updateProjectTemplates({
@@ -130,7 +134,6 @@ export const MTGlossary = ({id, setGlossaries, isCattoolPage = false}) => {
           type: 'error',
           text: 'Error deleting glossary',
           position: 'br',
-          allowHtml: true,
           timer: 5000,
         })
       })

--- a/public/js/components/settingsPanel/Contents/MachineTranslationTab/MTGlossary/MTGlossaryCreateRow.js
+++ b/public/js/components/settingsPanel/Contents/MachineTranslationTab/MTGlossary/MTGlossaryCreateRow.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types'
 import Upload from '../../../../../../img/icons/Upload'
 import Checkmark from '../../../../../../img/icons/Checkmark'
 import Close from '../../../../../../img/icons/Close'
-import {MTGlossaryStatus, MT_GLOSSARY_CREATE_ROW_ID} from './MTGlossaryConstants'
+import {
+  MTGlossaryStatus,
+  MT_GLOSSARY_CREATE_ROW_ID,
+} from './MTGlossaryConstants'
 import {createMemoryAndImportGlossary} from '../../../../../api/createMemoryAndImportGlossary/createMemoryAndImportGlossary'
 import LabelWithTooltip from '../../../../common/LabelWithTooltip'
 import CatToolActions from '../../../../../actions/CatToolActions'
@@ -87,7 +90,6 @@ export const MTGlossaryCreateRow = ({engineId, row, setRows}) => {
         type: 'error',
         text: !name ? 'Name mandatory' : 'File mandatory',
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       })
       return false
@@ -108,7 +110,6 @@ export const MTGlossaryCreateRow = ({engineId, row, setRows}) => {
       type: 'success',
       text: 'Glossary created successfully',
       position: 'br',
-      allowHtml: true,
       timer: 5000,
     })
     setIsWaitingResult(false)
@@ -119,7 +120,6 @@ export const MTGlossaryCreateRow = ({engineId, row, setRows}) => {
       type: 'error',
       text: 'Error creating glossary',
       position: 'br',
-      allowHtml: true,
       timer: 5000,
     })
     setIsWaitingResult(false)

--- a/public/js/components/settingsPanel/Contents/MachineTranslationTab/MTGlossary/MTGlossaryRow.js
+++ b/public/js/components/settingsPanel/Contents/MachineTranslationTab/MTGlossary/MTGlossaryRow.js
@@ -51,7 +51,6 @@ export const MTGlossaryRow = ({
         type: 'success',
         text: `Glossary file ${file.name} imported successfully`,
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       })
       setIsWaitingResult(false)
@@ -62,7 +61,6 @@ export const MTGlossaryRow = ({
         type: 'error',
         text: `Glossary file ${file.name} import error`,
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       })
       setIsWaitingResult(false)

--- a/public/js/components/settingsPanel/Contents/MachineTranslationTab/MachineTranslationTab.js
+++ b/public/js/components/settingsPanel/Contents/MachineTranslationTab/MachineTranslationTab.js
@@ -190,9 +190,12 @@ export const MachineTranslationTab = () => {
         CatToolActions.addNotification({
           title: 'MT deleted',
           type: 'success',
-          text: `The MT (<b>${mtToDelete.name}</b>) has been successfully deleted`,
+          text: (
+            <>
+              The MT (<b>{mtToDelete.name}</b>) has been successfully deleted
+            </>
+          ),
           position: 'br',
-          allowHtml: true,
           timer: 5000,
         })
       })

--- a/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/ExportGlossary.js
+++ b/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/ExportGlossary.js
@@ -25,7 +25,6 @@ export const ExportGlossary = ({row, onClose}) => {
         text: `You will receive the link at ${email}`,
         type: 'success',
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       }
       CatToolActions.addNotification(notification)

--- a/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/ExportTMX.js
+++ b/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/ExportTMX.js
@@ -26,7 +26,6 @@ export const ExportTMX = ({row, onClose}) => {
         text: `You will receive the link at ${email}`,
         type: 'success',
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       }
       CatToolActions.addNotification(notification)

--- a/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/ShareResource.js
+++ b/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/ShareResource.js
@@ -35,7 +35,6 @@ export const ShareResource = ({row, onClose, onShare}) => {
         type: 'error',
         text: errorsObject.message,
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       })
       setStatus({errors: errorsObject})
@@ -50,9 +49,12 @@ export const ShareResource = ({row, onClose, onShare}) => {
           CatToolActions.addNotification({
             title: 'Resource shared',
             type: 'success',
-            text: `The resource <b>${row.name}</b> has been shared.`,
+            text: (
+              <>
+                The resource <b>{row.name}</b> has been shared.
+              </>
+            ),
             position: 'br',
-            allowHtml: true,
             timer: 5000,
           })
           setStatus({successfull: true})

--- a/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/TMCreateResourceRow.js
+++ b/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/TMCreateResourceRow.js
@@ -95,7 +95,6 @@ export const TMCreateResourceRow = ({row}) => {
       CatToolActions.addNotification({
         ...message,
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       })
       return
@@ -169,9 +168,12 @@ export const TMCreateResourceRow = ({row}) => {
           CatToolActions.addNotification({
             title: 'Resource created ',
             type: 'success',
-            text: `Resource <b>${name}</b> created successfully`,
+            text: (
+              <>
+                Resource <b>{name}</b> created successfully
+              </>
+            ),
             position: 'br',
-            allowHtml: true,
             timer: 5000,
           })
         })
@@ -186,7 +188,6 @@ export const TMCreateResourceRow = ({row}) => {
             type: 'error',
             text: errMessage,
             position: 'br',
-            allowHtml: true,
             timer: 5000,
           })
         })
@@ -218,7 +219,6 @@ export const TMCreateResourceRow = ({row}) => {
             type: 'error',
             text: errMessage,
             position: 'br',
-            allowHtml: true,
             timer: 5000,
           })
         })
@@ -254,7 +254,6 @@ export const TMCreateResourceRow = ({row}) => {
           title: 'Invalid key',
           type: 'error',
           text: errMessage,
-          allowHtml: true,
           position: 'br',
           timer: 5000,
         })
@@ -295,7 +294,6 @@ export const TMCreateResourceRow = ({row}) => {
           title: 'Invalid key',
           type: 'error',
           text: message,
-          allowHtml: true,
           position: 'br',
           timer: 5000,
         })

--- a/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/TMKeyRow.js
+++ b/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/TMKeyRow.js
@@ -87,7 +87,6 @@ export const TMKeyRow = ({row, onExpandRow}) => {
         type: 'error',
         text: 'You can activate up to 10 resources per project.',
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       })
       setIsLookup(false)
@@ -179,7 +178,6 @@ export const TMKeyRow = ({row, onExpandRow}) => {
         type: 'error',
         text: 'This name is already in use, please choose a different one',
         position: 'br',
-        allowHtml: true,
         timer: 5000,
       })
 
@@ -214,7 +212,6 @@ export const TMKeyRow = ({row, onExpandRow}) => {
               type: 'error',
               text: errMessage,
               position: 'br',
-              allowHtml: true,
               timer: 5000,
             })
             setTmKeys((prevState) =>
@@ -238,7 +235,6 @@ export const TMKeyRow = ({row, onExpandRow}) => {
           type: 'error',
           text: 'Resource name cannot be empty. Please provide a valid name.',
           position: 'br',
-          allowHtml: true,
           timer: 5000,
         })
         setTmKeys((prevState) =>
@@ -324,10 +320,13 @@ export const TMKeyRow = ({row, onExpandRow}) => {
         }
         const notification = {
           title: 'Resource deleted',
-          text: `The resource (<b>${row.name}</b>) has been successfully deleted`,
+          text: (
+            <>
+              The resource (<b>{row.name}</b>) has been successfully deleted
+            </>
+          ),
           type: 'success',
           position: 'br',
-          allowHtml: true,
           timer: 5000,
         }
         CatToolActions.addNotification(notification)
@@ -338,7 +337,6 @@ export const TMKeyRow = ({row, onExpandRow}) => {
           type: 'error',
           text: 'There was an error saving your data. Please retry!',
           position: 'br',
-          allowHtml: true,
           timer: 5000,
         })
         onExpandRow({row, shouldExpand: false})

--- a/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/TranslationMemoryGlossaryTab.test.js
+++ b/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/TranslationMemoryGlossaryTab.test.js
@@ -571,3 +571,23 @@ test('Modal delete tmkeys used in other templates', async () => {
     'The memory key you are about to delete is used in the following project creation template(s):',
   )
 })
+
+test('Key names containing markup render as plain text', async () => {
+  const xssName = '<img src=x onerror="window.__xss=1"> R&D'
+  const {projectTemplates, ...rest} = contextMockValues({
+    tmKeysMockArray: tmKeysMock.tm_keys
+      .filter(({key}) => key === '74b6c82408a028b6f020')
+      .map((key) => ({...key, name: xssName})),
+  })
+  const contextValues = {
+    ...rest,
+    projectTemplates,
+    currentProjectTemplate: projectTemplates[0],
+  }
+
+  render(<WrapperComponent {...contextValues} />)
+
+  expect(screen.queryByRole('img')).toBeNull()
+  expect(screen.getByDisplayValue(xssName)).toBeInTheDocument()
+  expect(window.__xss).toBeUndefined()
+})

--- a/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/hooks/useExport.js
+++ b/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/hooks/useExport.js
@@ -40,7 +40,6 @@ function useExport({type, row, onClose}) {
           type: 'error',
           text: errorsObject.message,
           position: 'br',
-          allowHtml: true,
           timer: 5000,
         })
         setStatus({errors: errorsObject})

--- a/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/hooks/useImport.js
+++ b/public/js/components/settingsPanel/Contents/TranslationMemoryGlossaryTab/hooks/useImport.js
@@ -73,7 +73,6 @@ function useImport({type, row, onClose}) {
               type: 'error',
               text: message,
               position: 'br',
-              allowHtml: true,
               timer: 5000,
             })
           })
@@ -176,7 +175,6 @@ function useImport({type, row, onClose}) {
       type: 'error',
       text: error?.errors?.[0]?.message ?? 'Error',
       position: 'br',
-      allowHtml: true,
       timer: 5000,
     })
     setStatus([{errors: error.errors}])

--- a/public/js/pages/CatTool.js
+++ b/public/js/pages/CatTool.js
@@ -56,7 +56,6 @@ import {
   BUTTON_MODE,
   BUTTON_SIZE,
 } from '../components/common/Button/Button'
-import TEXT_UTILS from '../utils/textUtils'
 
 const urlParams = new URLSearchParams(window.location.search)
 const initialStateIsOpenSettings = Boolean(urlParams.get('openTab'))
@@ -241,7 +240,6 @@ function CatTool() {
           return {
             ...key,
             id: key.key,
-            name: TEXT_UTILS.decodeHtml(key.name),
             isActive: Boolean(key.r || key.w),
             isLocked: !key.owner,
           }

--- a/public/js/pages/CatTool.js
+++ b/public/js/pages/CatTool.js
@@ -56,6 +56,7 @@ import {
   BUTTON_MODE,
   BUTTON_SIZE,
 } from '../components/common/Button/Button'
+import TEXT_UTILS from '../utils/textUtils'
 
 const urlParams = new URLSearchParams(window.location.search)
 const initialStateIsOpenSettings = Boolean(urlParams.get('openTab'))
@@ -240,6 +241,7 @@ function CatTool() {
           return {
             ...key,
             id: key.key,
+            name: TEXT_UTILS.decodeHtml(key.name),
             isActive: Boolean(key.r || key.w),
             isLocked: !key.owner,
           }

--- a/public/js/pages/NewProject.js
+++ b/public/js/pages/NewProject.js
@@ -64,7 +64,6 @@ import {ANALYSIS_SCHEMA_KEYS} from '../components/settingsPanel/Contents/Analysi
 import {FILTERS_PARAMS_SCHEMA_KEYS} from '../components/settingsPanel/Contents/FileImportTab/FiltersParams/FiltersParams'
 import {XLIFF_SETTINGS_SCHEMA_KEYS} from '../components/settingsPanel/Contents/FileImportTab/XliffSettings/XliffSettings'
 import {DEEPL_GLOSSARY_ROW_NONE} from '../components/settingsPanel/Contents/MachineTranslationTab/DeepLGlossary/DeepLGlossary'
-import TEXT_UTILS from '../utils/textUtils'
 
 const SELECT_HEIGHT = 324
 
@@ -437,7 +436,6 @@ const NewProject = () => {
           ...tm_keys.map((key) => ({
             ...key,
             id: key.key,
-            name: TEXT_UTILS.decodeHtml(key.name),
             ...(isMatchingKeyFromQuery &&
               key.key === tmKeyFromQueryString && {
                 isActive: true,

--- a/public/js/pages/NewProject.js
+++ b/public/js/pages/NewProject.js
@@ -64,6 +64,7 @@ import {ANALYSIS_SCHEMA_KEYS} from '../components/settingsPanel/Contents/Analysi
 import {FILTERS_PARAMS_SCHEMA_KEYS} from '../components/settingsPanel/Contents/FileImportTab/FiltersParams/FiltersParams'
 import {XLIFF_SETTINGS_SCHEMA_KEYS} from '../components/settingsPanel/Contents/FileImportTab/XliffSettings/XliffSettings'
 import {DEEPL_GLOSSARY_ROW_NONE} from '../components/settingsPanel/Contents/MachineTranslationTab/DeepLGlossary/DeepLGlossary'
+import TEXT_UTILS from '../utils/textUtils'
 
 const SELECT_HEIGHT = 324
 
@@ -436,6 +437,7 @@ const NewProject = () => {
           ...tm_keys.map((key) => ({
             ...key,
             id: key.key,
+            name: TEXT_UTILS.decodeHtml(key.name),
             ...(isMatchingKeyFromQuery &&
               key.key === tmKeyFromQueryString && {
                 isActive: true,

--- a/public/js/setTranslationUtil.js
+++ b/public/js/setTranslationUtil.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import SegmentUtils from './utils/segmentUtils'
 import {SEGMENTS_STATUS} from './constants/Constants'
 import {isUndefined} from 'lodash'
@@ -272,25 +273,41 @@ const checkSegmentsPropagation = (item, propagationData) => {
       )
     }
     if (!autoPropagate && propagationData.segments_for_propagation) {
-      let text =
-        'The segment translation has been propagated to the other repetitions.'
+      let text = (
+        <>
+          The segment translation has been propagated to the other repetitions.
+        </>
+      )
       if (
         propagationData.segments_for_propagation.not_propagated &&
         propagationData.segments_for_propagation.not_propagated.ice.id &&
         propagationData.segments_for_propagation.not_propagated.ice.id.length >
           0
       ) {
-        text =
-          'The segment translation has been <b>propagated to the other repetitions</b>.</br> Repetitions in <b>locked segments have been excluded</b> from the propagation.'
+        text = (
+          <>
+            The segment translation has been{' '}
+            <b>propagated to the other repetitions</b>.
+            <br /> Repetitions in <b>locked segments have been excluded</b> from
+            the propagation.
+          </>
+        )
       } else if (
         propagationData.segments_for_propagation.not_propagated &&
         propagationData.segments_for_propagation.not_propagated.not_ice.id &&
         propagationData.segments_for_propagation.not_propagated.not_ice.id
           .length > 0
       ) {
-        text =
-          'The segment translation has been <b>propagated to the other repetitions in locked segments</b>. </br> Repetitions in <b>non-locked segments have been excluded</b> from the' +
-          ' propagation.'
+        text = (
+          <>
+            The segment translation has been{' '}
+            <b>propagated to the other repetitions in locked segments</b>.
+            <br /> Repetitions in <b>
+              non-locked segments have been excluded
+            </b>{' '}
+            from the propagation.
+          </>
+        )
       }
 
       const notification = {
@@ -299,7 +316,6 @@ const checkSegmentsPropagation = (item, propagationData) => {
         type: 'info',
         autoDismiss: true,
         timer: 5000,
-        allowHtml: true,
         position: 'bl',
       }
       CatToolActions.removeAllNotifications()

--- a/public/js/sse/SocketListener.js
+++ b/public/js/sse/SocketListener.js
@@ -1,4 +1,4 @@
-import {useContext, useEffect} from 'react'
+import React, {useContext, useEffect} from 'react'
 import useSocketLayer, {ConnectionStates} from '../hooks/useSocketLayer'
 import CatToolActions from '../actions/CatToolActions'
 import SegmentActions from '../actions/SegmentActions'
@@ -25,13 +25,22 @@ const SocketListener = ({isAuthenticated, userId}) => {
       if (serverVersion !== config.build_number) {
         const notification = {
           title: 'New update available!',
-          text:
-            'We’ve just released an update with improvements and bug fixes.<br/>' +
-            'To ensure all changes are applied correctly, we recommend refreshing the page.<br/><br/>' +
-            'Click Refresh or press <strong>Ctrl+R</strong> (Windows) / <strong>Cmd+R</strong> (Mac).<br/><br/>' +
-            'Thank you for using Matecat!',
+          text: (
+            <>
+              We’ve just released an update with improvements and bug fixes.
+              <br />
+              To ensure all changes are applied correctly, we recommend
+              refreshing the page.
+              <br />
+              <br />
+              Click Refresh or press <strong>Ctrl+R</strong> (Windows) /{' '}
+              <strong>Cmd+R</strong> (Mac).
+              <br />
+              <br />
+              Thank you for using Matecat!
+            </>
+          ),
           type: 'warning',
-          allowHtml: true,
         }
         CatToolActions.addNotification(notification)
       }

--- a/public/js/utils/offlineUtils.js
+++ b/public/js/utils/offlineUtils.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import {
   addClassToSegment,
   removeClassToSegment,
@@ -35,7 +36,6 @@ const OfflineUtils = {
             type: 'warning',
             position: 'bl',
             autoDismiss: false,
-            allowHtml: true,
             timer: 7000,
           }
           addNotification(notification)
@@ -97,16 +97,27 @@ const OfflineUtils = {
     if (this.offline) {
       const notification = {
         uid: 'offline-counter',
-        title:
-          '<div class="message-offline-icons"><span class="icon-power-cord"></span><span class="icon-power-cord2"></span></div>No connection available',
-        text:
-          'You can still translate <span class="remainingSegments">' +
-          --this.offlineCacheRemaining +
-          '</span> segments in offline mode. Do not refresh or you lose the segments!',
+        title: (
+          <>
+            <div className="message-offline-icons">
+              <span className="icon-power-cord"></span>
+              <span className="icon-power-cord2"></span>
+            </div>
+            No connection available
+          </>
+        ),
+        text: (
+          <>
+            You can still translate{' '}
+            <span className="remainingSegments">
+              {--this.offlineCacheRemaining}
+            </span>{' '}
+            segments in offline mode. Do not refresh or you lose the segments!
+          </>
+        ),
         type: 'warning',
         position: 'bl',
         autoDismiss: false,
-        allowHtml: true,
         timer: 7000,
       }
       addNotification(notification)

--- a/public/js/utils/textUtils.js
+++ b/public/js/utils/textUtils.js
@@ -1,4 +1,5 @@
 import {isUndefined} from 'lodash'
+import DOMPurify from 'dompurify'
 import $ from 'jquery'
 import {regexWordDelimiter} from '../components/segments/utils/DraftMatecatUtils/textConstants'
 import CommonUtils from './commonUtils'
@@ -7,6 +8,15 @@ import {tagSignatures} from '../components/segments/utils/DraftMatecatUtils/tagM
 
 const TEXT_UTILS = {
   diffMatchPatch: new diff_match_patch(),
+  /**
+   * The only sanctioned way to feed a string into dangerouslySetInnerHTML:
+   * the markup is sanitized with DOMPurify before being injected.
+   */
+  sanitizedHTML: (html) => ({
+    // contenteditable="false" is part of the tag-pill markup emitted by
+    // transformTagsToHtml and is safe to keep
+    __html: DOMPurify.sanitize(html, {ADD_ATTR: ['contenteditable']}),
+  }),
   getDiffHtml: function (source, target) {
     let dmp = new diff_match_patch()
     /*
@@ -497,11 +507,6 @@ const TEXT_UTILS = {
       ? new RegExp(tagSignatures.space.placeholder, 'g')
       : null
     return text.replace(spaceRegexp, ' ')
-  },
-  decodeHtml: (text) => {
-    const textarea = document.createElement('textarea')
-    textarea.innerHTML = text
-    return textarea.value
   },
 }
 

--- a/public/js/utils/textUtils.js
+++ b/public/js/utils/textUtils.js
@@ -498,6 +498,11 @@ const TEXT_UTILS = {
       : null
     return text.replace(spaceRegexp, ' ')
   },
+  decodeHtml: (text) => {
+    const textarea = document.createElement('textarea')
+    textarea.innerHTML = text
+    return textarea.value
+  },
 }
 
 export default TEXT_UTILS

--- a/public/js/utils/textUtilsSanitizedHTML.test.js
+++ b/public/js/utils/textUtilsSanitizedHTML.test.js
@@ -1,0 +1,26 @@
+import TEXT_UTILS from './textUtils'
+
+describe('sanitizedHTML', () => {
+  test('returns the __html shape for dangerouslySetInnerHTML', () => {
+    expect(TEXT_UTILS.sanitizedHTML('<b>hi</b>')).toEqual({
+      __html: '<b>hi</b>',
+    })
+  })
+
+  test('strips script tags and event handlers', () => {
+    const {__html} = TEXT_UTILS.sanitizedHTML(
+      '<img src=x onerror=alert(1)><script>alert(2)</script><b>ok</b>',
+    )
+    expect(__html).not.toContain('onerror')
+    expect(__html).not.toContain('<script')
+    expect(__html).toContain('<b>ok</b>')
+  })
+
+  test('preserves the tag-pill markup emitted by transformTagsToHtml', () => {
+    const pill =
+      '<span contenteditable="false" class="tag small">&lt;br/&gt;</span>'
+    const {__html} = TEXT_UTILS.sanitizedHTML(pill)
+    expect(__html).toContain('class="tag small"')
+    expect(__html).toContain('contenteditable="false"')
+  })
+})

--- a/tests/unit/Core/Controllers/TmKeyManagementAppControllerTest.php
+++ b/tests/unit/Core/Controllers/TmKeyManagementAppControllerTest.php
@@ -245,15 +245,17 @@ class TmKeyManagementAppControllerTest extends AbstractTest
      * @throws \Throwable
      */
     #[Test]
-    public function sortKeysInTheRightOrder_html_decodes_matched_key_name(): void
+    public function sortKeysInTheRightOrder_keeps_matched_key_name_untouched(): void
     {
+        // names are stored raw, so the read path must not decode (or otherwise
+        // rewrite) them: a literal "&amp;" typed by the user stays "&amp;"
         $key = new ClientTmKeyStruct(['key' => 'ddddddddddd44444', 'name' => 'Foo &amp; Bar']);
         $jobKeyList = [['key' => 'ddddddddddd44444']];
 
         $result = $this->invokePrivate('sortKeysInTheRightOrder', [[$key], $jobKeyList]);
 
         $this->assertCount(1, $result);
-        $this->assertSame('Foo & Bar', $result[0]->name);
+        $this->assertSame('Foo &amp; Bar', $result[0]->name);
     }
 
     // ─── getByJob (public action) ───

--- a/tests/unit/Core/Controllers/UserKeysControllerTest.php
+++ b/tests/unit/Core/Controllers/UserKeysControllerTest.php
@@ -354,50 +354,104 @@ class UserKeysControllerTest extends AbstractTest
     }
 
     /**
+     * Descriptions are stored raw: HTML-escaping happens at each output sink,
+     * never at the input boundary.
+     *
      * @throws Throwable
      */
     #[Test]
-    public function validateTheRequest_escapes_html_special_chars_in_description(): void
+    #[DataProvider('rawDescriptionProvider')]
+    public function validateTheRequest_stores_description_byte_identical(string $description): void
     {
         $this->setRequestParams([
             'key'         => 'abcdef1234567890',
-            'description' => '<script>alert(1)</script>',
+            'description' => $description,
         ]);
 
         $result = $this->invokePrivate('validateTheRequest');
 
-        $this->assertSame('&lt;script&gt;alert(1)&lt;/script&gt;', $result['description']);
+        $this->assertSame($description, $result['description']);
     }
 
     /**
-     * @throws Throwable
+     * @return array<string, array{0: string}>
      */
-    #[Test]
-    #[DataProvider('htmlSpecialDescriptionCharacterProvider')]
-    public function validateTheRequest_escapes_each_html_special_character(string $char, string $escaped): void
-    {
-        $this->setRequestParams([
-            'key'         => 'abcdef1234567890',
-            'description' => "Glossary {$char} name",
-        ]);
-
-        $result = $this->invokePrivate('validateTheRequest');
-
-        $this->assertSame("Glossary {$escaped} name", $result['description']);
-    }
-
-    /**
-     * @return array<string, array{0: string, 1: string}>
-     */
-    public static function htmlSpecialDescriptionCharacterProvider(): array
+    public static function rawDescriptionProvider(): array
     {
         return [
-            'less-than'    => ['<', '&lt;'],
-            'greater-than' => ['>', '&gt;'],
-            'ampersand'    => ['&', '&amp;'],
-            'double-quote' => ['"', '&quot;'],
-            'single-quote' => ["'", '&#039;'],
+            'script tag'   => ['<script>alert(1)</script>'],
+            'ampersand'    => ['R&D — Client (2024)'],
+            'double-quote' => ['The "official" glossary'],
+            'single-quote' => ["L'été"],
+            'accents'      => ['Memoria è rotta'],
+            'emoji'        => ['Fruit glossary 🍎'],
         ];
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_never_stores_html_entities(): void
+    {
+        $this->setRequestParams([
+            'key'         => 'abcdef1234567890',
+            'description' => '<b>R&D</b> "quoted"',
+        ]);
+
+        $result = $this->invokePrivate('validateTheRequest');
+
+        $this->assertDoesNotMatchRegularExpression('/&(lt|gt|amp|quot|#0?39);/', $result['description']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_throws_minus_three_on_invalid_utf8_description(): void
+    {
+        $this->setRequestParams([
+            'key'         => 'abcdef1234567890',
+            'description' => "Memoria \xC3 rotta",
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(-3);
+
+        $this->invokePrivate('validateTheRequest');
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_throws_minus_three_on_array_description(): void
+    {
+        $this->setRequestParams([
+            'key'         => 'abcdef1234567890',
+            'description' => ['x'],
+        ]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(-3);
+
+        $this->invokePrivate('validateTheRequest');
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_strips_control_and_invisible_characters(): void
+    {
+        $this->setRequestParams([
+            'key'         => 'abcdef1234567890',
+            'description' => "a\x00b\x1bc\nd\u{200B}\u{202E}e",
+        ]);
+
+        $result = $this->invokePrivate('validateTheRequest');
+
+        $this->assertSame('abcde', $result['description']);
     }
 
     // ─── getMkDao ───

--- a/tests/unit/Core/Controllers/UserKeysControllerTest.php
+++ b/tests/unit/Core/Controllers/UserKeysControllerTest.php
@@ -357,63 +357,46 @@ class UserKeysControllerTest extends AbstractTest
      * @throws Throwable
      */
     #[Test]
-    public function validateTheRequest_throws_minus_three_on_xss_description(): void
+    public function validateTheRequest_escapes_html_special_chars_in_description(): void
     {
         $this->setRequestParams([
             'key'         => 'abcdef1234567890',
             'description' => '<script>alert(1)</script>',
         ]);
 
-        try {
-            $this->invokePrivate('validateTheRequest');
-            $this->fail('Expected InvalidArgumentException was not thrown');
-        } catch (InvalidArgumentException $e) {
-            $this->assertSame(-3, $e->getCode());
-            $this->assertStringContainsString('&lt;', $e->getMessage());
-            $this->assertStringContainsString('&gt;', $e->getMessage());
-            $this->assertStringContainsString('&amp;', $e->getMessage());
-            $this->assertStringContainsString('&quot;', $e->getMessage());
-            $this->assertStringContainsString('&#39;', $e->getMessage());
-            $this->assertStringNotContainsString(
-                'gist.github.com',
-                $e->getMessage(),
-                'the gist link about non-printable characters was intentionally dropped from the message'
-            );
-        }
+        $result = $this->invokePrivate('validateTheRequest');
+
+        $this->assertSame('&lt;script&gt;alert(1)&lt;/script&gt;', $result['description']);
     }
 
     /**
      * @throws Throwable
      */
     #[Test]
-    #[DataProvider('forbiddenDescriptionCharacterProvider')]
-    public function validateTheRequest_throws_minus_three_for_each_forbidden_character(string $char): void
+    #[DataProvider('htmlSpecialDescriptionCharacterProvider')]
+    public function validateTheRequest_escapes_each_html_special_character(string $char, string $escaped): void
     {
         $this->setRequestParams([
             'key'         => 'abcdef1234567890',
             'description' => "Glossary {$char} name",
         ]);
 
-        try {
-            $this->invokePrivate('validateTheRequest');
-            $this->fail('Expected InvalidArgumentException was not thrown');
-        } catch (InvalidArgumentException $e) {
-            $this->assertSame(-3, $e->getCode());
-            $this->assertStringContainsString('Resource names cannot contain', $e->getMessage());
-        }
+        $result = $this->invokePrivate('validateTheRequest');
+
+        $this->assertSame("Glossary {$escaped} name", $result['description']);
     }
 
     /**
-     * @return array<string, array{0: string}>
+     * @return array<string, array{0: string, 1: string}>
      */
-    public static function forbiddenDescriptionCharacterProvider(): array
+    public static function htmlSpecialDescriptionCharacterProvider(): array
     {
         return [
-            'less-than'    => ['<'],
-            'greater-than' => ['>'],
-            'ampersand'    => ['&'],
-            'double-quote' => ['"'],
-            'single-quote' => ["'"],
+            'less-than'    => ['<', '&lt;'],
+            'greater-than' => ['>', '&gt;'],
+            'ampersand'    => ['&', '&amp;'],
+            'double-quote' => ['"', '&quot;'],
+            'single-quote' => ["'", '&#039;'],
         ];
     }
 

--- a/tests/unit/Core/TmKeyManagement/TmKeyManagerTest.php
+++ b/tests/unit/Core/TmKeyManagement/TmKeyManagerTest.php
@@ -25,15 +25,13 @@ class TmKeyManagerTest extends AbstractTest
     {
         $obj = new TmKeyStruct();
         $obj->name = 'Resource with <script>alert(1)</script> and {{pid}}';
-        
+
         TmKeyManager::sanitize($obj);
-        
-        // < and > are removed or encoded by filter_var depending on implementation, 
-        // but preg_replace should strip them if they are not in the allowed list.
-        // In the updated code: [^.\-_\p{L}\p{N}\s{}]+
-        // <, >, (, ) are NOT in the allowed list.
-        
-        $this->assertStringContainsString('{{pid}}', $obj->name);
-        $this->assertStringNotContainsString('<script>', $obj->name);
+
+        // htmlspecialchars encodes <, >, &, ", ' instead of stripping them,
+        // so the {{pid}} placeholder is left untouched (braces aren't escaped)
+        // while the script tag becomes harmless encoded text.
+
+        $this->assertSame('Resource with &lt;script&gt;alert(1)&lt;/script&gt; and {{pid}}', $obj->name);
     }
 }

--- a/tests/unit/Core/TmKeyManagement/TmKeyManagerTest.php
+++ b/tests/unit/Core/TmKeyManagement/TmKeyManagerTest.php
@@ -2,10 +2,12 @@
 
 namespace Matecat\Core\TmKeyManagement;
 
+use InvalidArgumentException;
 use Matecat\TestHelpers\AbstractTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Utils\TmKeyManagement\TmKeyManager;
 use Utils\TmKeyManagement\TmKeyStruct;
-use PHPUnit\Framework\Attributes\Test;
 
 class TmKeyManagerTest extends AbstractTest
 {
@@ -14,24 +16,132 @@ class TmKeyManagerTest extends AbstractTest
     {
         $obj = new TmKeyStruct();
         $obj->name = 'New resource created for project {{pid}}';
-        
+
         TmKeyManager::sanitize($obj);
-        
+
         $this->assertEquals('New resource created for project {{pid}}', $obj->name);
     }
 
+    /**
+     * Names are stored raw: escaping for HTML/XML/email is the output layer's
+     * job, so sanitize() must keep every printable character byte-identical.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function rawNameProvider(): array
+    {
+        return [
+            'script tag'   => ['Resource with <script>alert(1)</script> and {{pid}}'],
+            'ampersand'    => ['R&D — Client (2024)'],
+            'double quote' => ['The "official" glossary'],
+            'single quote' => ["L'été"],
+            'accents'      => ['Memoria è rotta'],
+            'emoji'        => ['Fruit glossary 🍎'],
+            'emoji zwj'    => ["Family \u{1F469}\u{200D}\u{1F469}\u{200D}\u{1F466} glossary"],
+        ];
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
     #[Test]
-    public function testSanitizeRemovesOtherSpecialChars()
+    #[DataProvider('rawNameProvider')]
+    public function testSanitizeStoresNamesByteIdentical(string $name)
     {
         $obj = new TmKeyStruct();
-        $obj->name = 'Resource with <script>alert(1)</script> and {{pid}}';
+        $obj->name = $name;
 
         TmKeyManager::sanitize($obj);
 
-        // htmlspecialchars encodes <, >, &, ", ' instead of stripping them,
-        // so the {{pid}} placeholder is left untouched (braces aren't escaped)
-        // while the script tag becomes harmless encoded text.
+        $this->assertSame($name, $obj->name);
+    }
 
-        $this->assertSame('Resource with &lt;script&gt;alert(1)&lt;/script&gt; and {{pid}}', $obj->name);
+    /**
+     * Guards the raw-storage invariant: no HTML entity may ever be produced
+     * by the input layer.
+     *
+     * @throws InvalidArgumentException
+     */
+    #[Test]
+    public function testSanitizeNeverProducesHtmlEntities()
+    {
+        $obj = new TmKeyStruct();
+        $obj->name = '<b>R&D</b> "quoted" \'single\'';
+
+        TmKeyManager::sanitize($obj);
+
+        $this->assertDoesNotMatchRegularExpression('/&(lt|gt|amp|quot|#0?39);/', $obj->name);
+    }
+
+    #[Test]
+    public function testValidateNameRejectsInvalidUtf8()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(-3);
+
+        TmKeyManager::validateName("Memoria \xC3 rotta");
+    }
+
+    #[Test]
+    public function testValidateNameRejectsNonStringInput()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(-3);
+
+        TmKeyManager::validateName(['not', 'a', 'string']);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    #[Test]
+    public function testValidateNameAllowsNull()
+    {
+        $this->assertNull(TmKeyManager::validateName(null));
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    #[Test]
+    public function testValidateNameStripsControlCharacters()
+    {
+        $this->assertSame('abcd', TmKeyManager::validateName("a\x00b\x1bc\nd"));
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    #[Test]
+    public function testValidateNameStripsZeroWidthAndBidiCharacters()
+    {
+        $this->assertSame(
+            'evilname',
+            TmKeyManager::validateName("evil\u{200B}\u{202E}name")
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    #[Test]
+    public function testValidateNameNormalizesToNfcAndTrims()
+    {
+        // "è" as combining sequence (U+0065 U+0300) must become the composed U+00E8
+        $this->assertSame(
+            "Memoria \u{00E8} rotta",
+            TmKeyManager::validateName("  Memoria e\u{0300} rotta  ")
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    #[Test]
+    public function testValidateNameCapsLengthAt255Characters()
+    {
+        $result = TmKeyManager::validateName(str_repeat('à', 300));
+
+        $this->assertSame(255, mb_strlen($result));
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3931,7 +3931,7 @@ dom-helpers@^5.0.1:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
 
-dompurify@^3.3.2:
+dompurify@^3.3.2, dompurify@^3.4.12:
   version "3.4.12"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.12.tgz#6fa2265e9bbdce882c4ace4107626051b448ffa8"
   integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==


### PR DESCRIPTION
## Summary

Reworked after review: TM key names/descriptions are now **stored raw** — no escaping at the
input boundary and no decoding on read. Input validation is consolidated in a single choke
point (`TmKeyManager::validateName()`): non-string or invalid-UTF-8 names are rejected with
code `-3`, control/format characters (including zero-width and bidi overrides) are stripped,
the value is NFC-normalized, trimmed and capped at 255 chars. Escaping now happens at each
output sink (TMX XML prop, ShareKey email template, QR XML). On the frontend the decode
helper is gone, every `allowHtml: true` notification interpolating data was converted to
ReactNode text (React escapes it), the jQuery-bound undo links became real `onClick`
handlers, and the remaining `dangerouslySetInnerHTML` paths (tag-pill markup, SSE operator
broadcasts) are sanitized with DOMPurify.

## Type

<!-- Check one. -->

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Utils/TmKeyManagement/TmKeyManager.php` | New `validateName()` (type/UTF-8 checks, Cc/Cf strip with ZWJ kept, NFC, trim, 255 cap); `sanitize()` stores names raw |
| `lib/Controller/API/App/UserKeysController.php` | `description` validated via `validateName()`, stored raw; array/invalid-UTF-8 input rejected with `-3` |
| `lib/Controller/API/App/TMXFileController.php` | TMX-upload rename path routed through `validateName()` (was an unsanitized bypass) |
| `lib/Controller/API/App/TmKeyManagementController.php` | Removed read-side `html_entity_decode` (would corrupt a literal `&amp;` under raw storage) |
| `lib/Utils/TMS/TMSService.php` | XML-escape the key name in the TMX `x-MateCAT-suggestion-origin` prop |
| `lib/View/Emails/ShareKey/message_content.html` | Escape `tm_key_name`, sender name/email, recipient address (template rendered with zero auto-escaping) |
| `lib/Controller/API/V3/DownloadQRController.php` | XML-escape `<suggestion_source>` (hardening) |
| `lib/Controller/API/App/CreateProjectController.php`, `lib/Controller/API/V1/NewController.php` | `@throws` PHPDoc for the new checked exception |
| `public/js/utils/textUtils.js` | `decodeHtml` removed; new `sanitizedHTML()` (DOMPurify) as the only sanctioned `dangerouslySetInnerHTML` feeder |
| `public/js/pages/CatTool.js`, `public/js/pages/NewProject.js`, `public/js/actions/CatToolActions.js` | Decode call sites removed (files back to `develop` state) |
| `public/js/components/notificationsComponent/NotificationItem.js` | `allowHtml` branch sanitized with DOMPurify; `title` accepts ReactNode; `allowHtml` documented as reserved for operator broadcasts |
| 20+ notification call sites (settingsPanel, projects, actions, outsource, review_extended, header, sse, utils) | `allowHtml: true` removed; markup-bearing texts converted to JSX ReactNodes; jQuery undo links → React `onClick` |
| `public/js/components/segments/SegmentFooterTab{AiAlternatives,LaraStyles}.js`, `public/js/components/quality_report/SegmentQR{,Line}.js` | Tag-pill/diff HTML injections sanitized via `sanitizedHTML()` |
| `package.json`, `yarn.lock` | Add `dompurify` |
| `tests/unit/Core/TmKeyManagement/TmKeyManagerTest.php`, `tests/unit/Core/Controllers/UserKeysControllerTest.php` | Raw round-trip provider, invalid-UTF-8/array `-3` rejections, control/zero-width stripping, NFC+trim, length cap, no-entities invariant |
| `tests/unit/Core/Controllers/TmKeyManagementAppControllerTest.php` | Read path asserted to keep names untouched (no decode) |
| `public/js/**` (new tests) | `NotificationItem.test.js`, `textUtilsSanitizedHTML.test.js`, XSS render-as-text test in `TranslationMemoryGlossaryTab.test.js` |

## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full phpunit run: 9245 tests — the only failures are the 4 pre-existing `CommentControllerTest`
broker-unavailable tests, which fail in any environment where ActiveMQ is reachable and are
unrelated to this branch. PHPStan: 0 errors on the full codebase. Jest: 77 suites / 764 tests
green. `yarn build:dev` OK.

## AI Disclosure

<!-- If AI tools were used to write or review code in this PR, disclose it.
     AI-assisted code is welcome, but you must understand everything you ship.
     Unreviewed AI output will not be merged. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code

## Notes

- The same unsanitized rename bypass exists in the **aligner plugin**
  (`plugins/aligner/.../Controller/TmController.php:179`); the fix is staged in the submodule
  working tree but needs its own commit/PR in the plugin repository.
- Declared out of scope (per review discussion): MyMemory-side CSV formula guard, consolidating
  the two pre-existing frontend decode helpers, a `TaggedText` component to replace the ~12
  `transformTagsToHtml` consumers, and `RequestExportTMXController`'s `STRIP_HIGH` mangling of
  non-ASCII zip names (pre-existing correctness quirk).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211436945814180
