### PR TITLE
🐛 fix(word-count): count ph-only segments as one word and read ctype past x-orig

### DIFF
--- a/lib/Utils/Tools/CatUtils.php
+++ b/lib/Utils/Tools/CatUtils.php
@@ -6,12 +6,12 @@ use DivisionByZeroError;
 use Exception;
 use Matecat\SubFiltering\Enum\CTypeEnum;
 use Matecat\SubFiltering\MateCatFilter;
+use Model\DataAccess\IDatabase;
 use Model\FeaturesBase\FeatureSet;
 use Model\FilesStorage\AbstractFilesStorage;
 use Model\Filters\DTO\IDto;
 use Model\Filters\FiltersConfigTemplateDao;
 use Model\Filters\FiltersConfigTemplateStruct;
-use Model\DataAccess\IDatabase;
 use Model\Jobs\JobDao;
 use Model\Jobs\JobStruct;
 use Model\LQA\ChunkReviewDao;
@@ -367,6 +367,12 @@ class CatUtils
         }
 
         //Remove ampersands and entities.
+        // The cleaning below wipes the tags away, so ask now whether the segment carries any <ph>.
+        // Deliberately no entity decoding first: the subfiltering is the one knowing whether a tag is a
+        // tag, so an escaped &lt;ph/&gt; reaching this point is plain text, not a tag.
+        // The character class is what keeps <phrase> and friends out.
+        $hasPhTag = preg_match('#<ph[\s/>]#i', $string) === 1;
+
         //Converters return entities in XML, we want raw strings.
         //
         //Take a look at this string:
@@ -413,7 +419,18 @@ class CatUtils
         //check for a string made of spaces only, after the string was cleaned
         $no_spaces_string = preg_replace('#[\p{Z}\p{C}]+#u', "", $string) ?? "";
         if ($no_spaces_string == "") {
-            return "";
+            /**
+             * Nothing translatable survived the cleaning. A segment carrying <ph> tags and nothing else is
+             * still work to be delivered, so it weighs one word overall, no matter how many <ph> it holds,
+             * while a segment made of any other tag (<x/>, <g>, <bx/>, ...) keeps weighing nothing.
+             *
+             * This is also the only spot able to tell: at the time the <ph> tags were swapped for a space,
+             * the punctuation stripped above was still in place, so a <ph id="1"/>, would have looked like
+             * a segment carrying text.
+             *
+             * The placeholder is trimmed because a CJK count is a character count, see the caller.
+             */
+            return $hasPhTag ? trim($variables_placeholder) : "";
         }
 
         return !array_key_exists($source_lang_two_letter, self::$cjk) ? $string : $no_spaces_string;
@@ -427,24 +444,63 @@ class CatUtils
      */
     private static function replacePlaceholders(string $string, string $variables_placeholder): string
     {
-        $pattern = '|<ph id ?= ?["\'](mtc_[0-9]+)["\'] ?(ctype=["\'].+?["\'] ?) ?(equiv-text=["\'].+?["\'] ?)/>|ui';
 
+        // Matches ONLY Matecat's own placeholder signature:
+        //   <ph id="mtc_N" ctype="..." [x-orig="..."] equiv-text="..."/>
+        // x-orig is emitted for the ctypes that carry the original tag (x-original_ph_content,
+        // x-original_self_close_ph_with_equiv_text, x-original_x) and is skipped without being captured,
+        // so the group indexes below stay stable. Attribute values are quote bounded ([^"']*) on purpose:
+        // a lazy .+? backtracks across x-orig and drags it into the ctype group, and a $cType like
+        // "x-original_ph_content x-orig=PHBoPg==" can never match a CTypeEnum case.
+        $pattern = '|<ph id ?= ?["\'](mtc_[0-9]+)["\'] ?(ctype=["\'][^"\']*["\'] ?) ?(?:x-orig=["\'][^"\']*["\'] ?)? ?(equiv-text=["\'][^"\']*["\'] ?)/>|ui';
+
+        /**
+         * The caller feeds this method a Layer 1 string (it calls fromLayer0ToLayer1() right before),
+         * and Layer 1 is exactly where those <ph id="mtc_N"/> placeholders are born. So this loop is
+         * the regular path, not an edge case: it runs on every segment carrying html or a variable,
+         * project creation included.
+         *
+         * What the Layer 0 to Layer 1 transition turns into a placeholder:
+         *   - html/xml snippets, ctype x-html / x-xml;
+         *   - variables, ctype depending on the filters enabled for the project (x-twig, x-sprintf, ...);
+         *   - a <ph> coming from the source file, ctype x-original_ph_content. Rare, because our
+         *     conversion filters emit <x> tags instead of <ph>.
+         *
+         * How each one weighs on the word count:
+         *   - html/xml: deleted, counts as zero words;
+         *   - a <ph> coming from the source: zero words, see $phCTypes below;
+         *   - everything else: swapped for $variables_placeholder, counts as one word.
+         *
+         * Whatever is not matched here (a plain <x id="N"/> with no equiv-text, <g>, ...) is handled by
+         * the residual-tag cleanup at the end of this method, which turns it into a single space, so it
+         * survives only as a word separator.
+         */
         preg_match_all($pattern, $string, $matches, PREG_SET_ORDER);
 
-        foreach ($matches as $match) {
-            $ctype = trim($match[2]);
-            $ctype = str_replace('"', '', $ctype);
-            $ctype = str_replace('ctype=', '', $ctype);
+        // A <ph> coming from the source file weighs zero words here, whatever flavour it is. The single
+        // word owed to a segment made of <ph> tags only is granted by countSegmentRawWords(), which is
+        // the one able to tell whether anything else survived the cleaning.
+        $phCTypes = [
+            CTypeEnum::ORIGINAL_PH_CONTENT->value,
+            CTypeEnum::ORIGINAL_SELF_CLOSE_PH_WITH_EQUIV_TEXT->value,
+            CTypeEnum::ORIGINAL_PH_OR_NOT_DATA_REF->value,
+            CTypeEnum::PH_DATA_REF->value,
+        ];
 
-            if (in_array($ctype, [CTypeEnum::HTML->value, CTypeEnum::XML->value])) {
+        foreach ($matches as $match) {
+            $cType = str_replace(['"', "'", 'ctype='], '', trim($match[2]));
+
+            if (in_array($cType, [CTypeEnum::HTML->value, CTypeEnum::XML->value])) {
                 $string = str_replace($match[0], '', $string); // count html snippets as zero words
+            } elseif (in_array($cType, $phCTypes)) {
+                $string = str_replace($match[0], ' ', $string); // a <ph> is a separator, zero words
             } else {
-                $string = str_replace($match[0], $variables_placeholder, $string); // count variables as one word
+                $string = str_replace($match[0], $variables_placeholder, $string); // count all the rest as one word
             }
         }
 
         // remove all residual xliff tags
-        if (preg_match_all('#</?(?![0-9]+)[a-z0-9\-._]+?(?:\s[:_a-z]+=.+?)?\s*/?>#i', $string, $matches, PREG_SET_ORDER)) {
+        if (preg_match_all('#</?(?![0-9]+)([a-z0-9\-._]+)+?(?:\s[:_a-z]+=.+?)?\s*/?>#i', $string, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $tag) {
                 $string = str_replace($tag[0], " ", $string);
             }
@@ -830,7 +886,7 @@ class CatUtils
     /**
      * Get a job from a combination of ID and ANY password (t,r1 or r2)
      *
-     * @param int    $jobId
+     * @param int $jobId
      * @param string $jobPassword
      *
      * @return null|JobStruct
@@ -902,13 +958,13 @@ class CatUtils
     {
         $idJobs = [];
 
-        foreach ($this->jobDao->getNotDeletedByProjectId((int) $projectStruct->id) as $job) {
+        foreach ($this->jobDao->getNotDeletedByProjectId((int)$projectStruct->id) as $job) {
             $idJobs[] = $job->id;
         }
 
         $idJobs = array_unique($idJobs);
         /** @var array<int, int> $idJobs */
-        $idJobs = array_values(array_filter($idJobs, fn ($value) => $value !== null));
+        $idJobs = array_values(array_filter($idJobs, fn($value) => $value !== null));
 
         return $this->jobDao->getSegmentTranslationsCount($idJobs);
     }

--- a/tests/resources/files/xliff/word-count-ph-cases.xliff
+++ b/tests/resources/files/xliff/word-count-ph-cases.xliff
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US" trgLang="it-IT">
+<!--
+    Word count fixture for the <ph> weighting rule implemented in CatUtils.
+
+    Xliff 2.0 on purpose: a 1.2 file is handed over to the filters, which rewrite every <ph> into an
+    <x/>, so a 1.2 fixture could never exercise this rule. A 2.0 file keeps its inline codes, and its
+    <ph dataRef="..."/> reaches the word counter exactly as written here.
+
+    Rule under test:
+      - a unit made of <ph> tags and nothing else weighs ONE word overall, however many <ph> it holds;
+      - as soon as the unit carries any other translatable text, every <ph> weighs ZERO;
+      - only <ph> earns that word: <sc/>, <ec/>, <pc> and friends keep weighing zero.
+
+    Flavours of <ph> covered here:
+      - <ph id="N" dataRef="dN"/>            an inline code pointing at the original data
+      - <ph id="N" dataRef="dN" disp="..."/> the same, plus the display text of the code. disp lives
+                                             inside the tag, so it is NOT translatable text of the unit
+                                             and must not stop the <ph> from earning its word, not even
+                                             when it holds more than one word.
+      - <ph id="mtc_N" ctype="..." x-orig="..." equiv-text="base64:..."/>
+                                             Matecat's own placeholder, the shape produced by the Layer 0
+                                             to Layer 1 transition and the one reaching the counter when a
+                                             Matecat export is re-imported. x-orig sits between ctype and
+                                             equiv-text on purpose: that is what makes the ctype
+                                             unreadable to a lazy regex. Mind that ctype, x-orig and
+                                             equiv-text are Matecat attributes, not xliff 2.0 ones, so
+                                             that single unit is well formed but not schema pure.
+
+    Not covered here on purpose: an entity escaped &lt;ph/&gt;. Deciding what is a tag is the
+    subfiltering's job, so the counter checks the string as it arrives and decodes nothing, meaning an
+    escaped ph earns no word. Careful though, the cleaning does decode the entities on its own, so such
+    a unit ends up weighing zero rather than being counted as plain text. See the unit test for it.
+
+    The expected count is written on every unit. Values were produced by
+    CatUtils::countSegmentRawWords() with source language en-US, not by hand.
+-->
+    <file id="f1" original="word-count-ph-cases.txt">
+        <notes>
+            <note id="n1">Fixture for the &lt;ph&gt; word weighting rule. See the comments above each unit.</note>
+        </notes>
+
+        <!-- ============================================================
+             Nothing but <ph>: the unit weighs one word overall
+             ============================================================ -->
+
+        <!-- expected words: 1 - a single inline code pointing at the original data -->
+        <unit id="ph-only-dataref">
+            <originalData>
+                <data id="d1">&lt;br/&gt;</data>
+            </originalData>
+            <segment>
+                <source><ph id="1" dataRef="d1"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - disp carries the display text of the inline code, not translatable
+             text of the unit: it lives inside the tag and must not tip the unit over -->
+        <unit id="ph-only-dataref-and-disp">
+            <originalData>
+                <data id="d1">&lt;item name="itemname"/&gt;</data>
+            </originalData>
+            <segment>
+                <source><ph id="1" dataRef="d1" disp="itemname"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - same with a disp holding two words, still nothing translatable -->
+        <unit id="ph-only-dataref-and-disp-with-space">
+            <originalData>
+                <data id="d1">&lt;item name="item name"/&gt;</data>
+            </originalData>
+            <segment>
+                <source><ph id="1" dataRef="d1" disp="item name"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - the same, closed by a full stop: punctuation is not translatable text -->
+        <unit id="ph-only-dataref-and-disp-and-full-stop">
+            <originalData>
+                <data id="d1">&lt;item name="itemname"/&gt;</data>
+            </originalData>
+            <segment>
+                <source><ph id="1" dataRef="d1" disp="itemname"/>.</source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - two inline codes, still one word overall, not two -->
+        <unit id="ph-only-two">
+            <originalData>
+                <data id="d1">&lt;br/&gt;</data>
+                <data id="d2">&lt;hr/&gt;</data>
+            </originalData>
+            <segment>
+                <source><ph id="1" dataRef="d1"/><ph id="2" dataRef="d2"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - three inline codes, still one word overall -->
+        <unit id="ph-only-three">
+            <originalData>
+                <data id="d1">&lt;br/&gt;</data>
+                <data id="d2">&lt;hr/&gt;</data>
+                <data id="d3">&lt;wbr/&gt;</data>
+            </originalData>
+            <segment>
+                <source><ph id="1" dataRef="d1"/><ph id="2" dataRef="d2"/><ph id="3" dataRef="d3"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - punctuation is not translatable text, so the ph still earns its word -->
+        <unit id="ph-only-and-punctuation">
+            <originalData>
+                <data id="d1">&lt;br/&gt;</data>
+                <data id="d2">&lt;hr/&gt;</data>
+            </originalData>
+            <segment>
+                <source><ph id="1" dataRef="d1"/>,<ph id="2" dataRef="d2"/>.</source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - Matecat's own placeholder, x-orig between ctype and equiv-text -->
+        <unit id="ph-only-mtc-x-orig">
+            <segment>
+                <source><ph id="mtc_1" ctype="x-original_ph_content" x-orig="PHBoIGlkPSIxIj57dXNlcm5hbWV9PC9waD4=" equiv-text="base64:e3VzZXJuYW1lfQ=="/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - two Matecat placeholders with x-orig, one word overall -->
+        <unit id="ph-only-mtc-x-orig-twice">
+            <segment>
+                <source><ph id="mtc_1" ctype="x-original_ph" x-orig="PHBoIGlkPSIxIi8+" equiv-text="base64:W1tbQlJdXV0="/><ph id="mtc_2" ctype="x-original_ph_content" x-orig="PHBoIGlkPSIyIj54PC9waD4=" equiv-text="base64:eA=="/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- ============================================================
+             Translatable text around: every <ph> falls back to zero words
+             ============================================================ -->
+
+        <!-- expected words: 1 - Ciao. The trailing inline code weighs nothing -->
+        <unit id="ph-next-to-one-word">
+            <originalData>
+                <data id="d1">&lt;br/&gt;</data>
+            </originalData>
+            <segment>
+                <source>Ciao <ph id="1" dataRef="d1"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - Ciao. The disp of the inline code is not counted either -->
+        <unit id="ph-dataref-disp-and-one-word">
+            <originalData>
+                <data id="d1">&lt;item name="itemname"/&gt;</data>
+            </originalData>
+            <segment>
+                <source>Ciao <ph id="1" dataRef="d1" disp="itemname"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 2 - hello, world. The inline code in between weighs nothing -->
+        <unit id="ph-among-words">
+            <originalData>
+                <data id="d1">&lt;br/&gt;</data>
+            </originalData>
+            <segment>
+                <source>hello <ph id="1" dataRef="d1"/> world</source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - Ciao again, three inline codes and a comma add nothing -->
+        <unit id="ph-three-and-one-word">
+            <originalData>
+                <data id="d1">&lt;br/&gt;</data>
+                <data id="d2">&lt;hr/&gt;</data>
+                <data id="d3">&lt;wbr/&gt;</data>
+            </originalData>
+            <segment>
+                <source><ph id="1" dataRef="d1"/>Ciao <ph id="2" dataRef="d2"/>,<ph id="3" dataRef="d3"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 2 - a Matecat placeholder with x-orig among words weighs nothing -->
+        <unit id="ph-mtc-x-orig-among-words">
+            <segment>
+                <source>hello <ph id="mtc_1" ctype="x-original_ph_content" x-orig="PHBoIGlkPSIxIj57dXNlcm5hbWV9PC9waD4=" equiv-text="base64:e3VzZXJuYW1lfQ=="/> world</source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- ============================================================
+             Only <ph> earns the word: the other inline codes do not
+             ============================================================ -->
+
+        <!-- expected words: 0 - a lonely sc/ec pair is not a ph -->
+        <unit id="sc-ec-alone">
+            <originalData>
+                <data id="d1">&lt;b&gt;</data>
+                <data id="d2">&lt;/b&gt;</data>
+            </originalData>
+            <segment>
+                <source><sc id="1" dataRef="d1"/><ec startRef="1" dataRef="d2"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 0 - an empty pc holds no text, and a pc is not a ph -->
+        <unit id="empty-pc-alone">
+            <originalData>
+                <data id="d1">&lt;b&gt;</data>
+                <data id="d2">&lt;/b&gt;</data>
+            </originalData>
+            <segment>
+                <source><pc id="1" dataRefStart="d1" dataRefEnd="d2"></pc></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 3 - the pc weighs nothing, the words it wraps are counted -->
+        <unit id="pc-wrapping-words">
+            <originalData>
+                <data id="d1">&lt;b&gt;</data>
+                <data id="d2">&lt;/b&gt;</data>
+            </originalData>
+            <segment>
+                <source><pc id="1" dataRefStart="d1" dataRefEnd="d2">three bold words</pc></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 1 - the word survives, the sc/ec pair around it weighs nothing -->
+        <unit id="sc-ec-and-one-word">
+            <originalData>
+                <data id="d1">&lt;b&gt;</data>
+                <data id="d2">&lt;/b&gt;</data>
+            </originalData>
+            <segment>
+                <source><sc id="1" dataRef="d1"/>Ciao<ec startRef="1" dataRef="d2"/></source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- ============================================================
+             Neighbouring behaviours, kept here to show they are untouched
+             ============================================================ -->
+
+        <!-- expected words: 4 - Click, right, here, now. The html snippet around them weighs zero -->
+        <unit id="html-snippet-and-words">
+            <segment>
+                <source>Click &lt;b&gt;right here&lt;/b&gt; now</source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 4 - Welcome, back, the variable, enjoy. A variable weighs one word, unlike a ph -->
+        <unit id="variable-and-words">
+            <segment>
+                <source>Welcome back {{username}}, enjoy</source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 6 - The, invoice, totals, 1042, euro, today. A number weighs one word -->
+        <unit id="number-and-words">
+            <segment>
+                <source>The invoice totals 1042 euro today</source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 18 - plain prose, no inline code at all, the reference case -->
+        <unit id="real-text-plain">
+            <segment>
+                <source>Matecat splits every document into segments, and each segment is counted so that the translator knows the workload.</source>
+                <target/>
+            </segment>
+        </unit>
+
+        <!-- expected words: 31 - prose wrapping a ph and a pc, both weighing zero -->
+        <unit id="real-text-with-inline-codes">
+            <originalData>
+                <data id="d1">&lt;var&gt;</data>
+                <data id="d2">&lt;b&gt;</data>
+                <data id="d3">&lt;/b&gt;</data>
+            </originalData>
+            <segment>
+                <source>When a unit carries actual prose, such as this sentence about the placeholder <ph id="1" dataRef="d1" disp="{placeholder}"/> right here, the code adds nothing to the count, and the same holds for <pc id="2" dataRefStart="d2" dataRefEnd="d3">these three</pc> as well.</source>
+                <target/>
+            </segment>
+        </unit>
+
+    </file>
+</xliff>

--- a/tests/unit/Core/Utils/Tools/CatUtilsTest.php
+++ b/tests/unit/Core/Utils/Tools/CatUtilsTest.php
@@ -26,6 +26,7 @@ use Model\Translations\SegmentTranslationStruct;
 use Model\WordCount\CounterModel;
 use Model\WordCount\WordCountStruct;
 use PDOException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionException;
 use ReflectionMethod;
@@ -894,6 +895,178 @@ class CatUtilsTest extends AbstractTest
     {
         $result = (new CatUtils($this->dbStub))->clean_raw_string_4_word_count('I have 42 items', 'en-US');
         $this->assertNotEmpty($result);
+    }
+
+    // -------------------------------------------------------------------------
+    // replacePlaceholders: ctype extraction and per ctype weight
+    // -------------------------------------------------------------------------
+
+    /**
+     * @return list<array{string, string, string}>
+     */
+    public static function placeholderCTypeProvider(): array
+    {
+        return [
+            // the ctypes carrying the original tag ship an x-orig attribute between ctype and
+            // equiv-text: it must be skipped instead of being dragged into the ctype group, otherwise
+            // the ctype is unrecognisable and the <ph> family cannot be told apart from a variable
+            'original ph content, with x-orig' => [
+                '<ph id="mtc_1" ctype="x-original_ph_content" x-orig="PHBoIGlkPSIxIj54PC9waD4=" equiv-text="base64:eA=="/>',
+                ' ',
+                'a <ph> is a separator here, the word it may earn is granted by countSegmentRawWords',
+            ],
+            'original self closing ph with equiv-text, with x-orig' => [
+                '<ph id="mtc_2" ctype="x-original_ph" x-orig="PHBoIGlkPSIxIi8+" equiv-text="base64:eA=="/>',
+                ' ',
+                'a <ph> is a separator here, the word it may earn is granted by countSegmentRawWords',
+            ],
+            // <x/> is not part of the <ph> family and keeps weighing one word
+            'original x, with x-orig' => [
+                '<ph id="mtc_3" ctype="x-original_x" x-orig="PHggaWQ9IjEiLz4=" equiv-text="base64:eA=="/>',
+                ' P ',
+                'x-orig must be skipped without turning the ctype unrecognisable',
+            ],
+            // no x-orig here, and html/xml keep weighing zero words
+            'html snippet' => [
+                '<ph id="mtc_4" ctype="x-html" equiv-text="base64:Jmx0O2ImZ3Q7"/>',
+                '',
+                'html snippet must be dropped',
+            ],
+            'xml snippet' => [
+                '<ph id="mtc_5" ctype="x-xml" equiv-text="base64:Jmx0O2ImZ3Q7"/>',
+                '',
+                'xml snippet must be dropped',
+            ],
+            // the subfiltering does not pair x-html with x-orig today, but this is what guarantees the
+            // ctype is read on its own instead of being glued to whatever attribute follows it
+            'html snippet, with x-orig' => [
+                '<ph id="mtc_7" ctype="x-html" x-orig="PGI+" equiv-text="base64:Jmx0O2ImZ3Q7"/>',
+                '',
+                'ctype must still be recognised when x-orig sits between ctype and equiv-text',
+            ],
+            'variable' => [
+                '<ph id="mtc_6" ctype="x-twig" equiv-text="base64:e3tuYW1lfX0="/>',
+                ' P ',
+                'variable must count as one word',
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('placeholderCTypeProvider')]
+    public function testReplacePlaceholdersWeighsEachCTypeL(string $placeholder, string $expected, string $message): void
+    {
+        $method = new ReflectionMethod(CatUtils::class, 'replacePlaceholders');
+        $result = $method->invoke(null, $placeholder, ' P ');
+
+        $this->assertEquals($expected, $result, $message);
+    }
+
+    /**
+     * A segment made of <ph> tags and nothing else weighs one word overall, however many <ph> it holds
+     * and whatever flavour they are: wrapped into a Matecat placeholder by the Layer 0 to Layer 1
+     * transition (<ph> with content, <ph> with equiv-text) or left raw by it (dataRef). As soon as the
+     * segment carries something else, every <ph> is back to weighing zero.
+     *
+     * @return list<array{string, int}>
+     */
+    public static function phWordWeightProvider(): array
+    {
+        return [
+            // nothing but <ph>: one word overall
+            'single ph with content' => ['<ph id="1">{username}</ph>', 1],
+            'single raw dataRef ph' => ['<ph id="source1" dataRef="source1"/>', 1],
+            'two ph with content still weigh one word overall' => ['<ph id="1">a</ph><ph id="2">b</ph>', 1],
+            'three raw dataRef ph still weigh one word overall' => [
+                '<ph id="source1" dataRef="source1"/><ph id="source2" dataRef="source2"/><ph id="source3" dataRef="source3"/>',
+                1,
+            ],
+            'ph tags and punctuation only, punctuation is not translatable text' => [
+                '<ph id="source1" dataRef="source1"/>,<ph id="source2" dataRef="source2"/>',
+                1,
+            ],
+            // disp holds the display text of the inline code: it lives inside the tag, so it is not
+            // translatable text of the segment and must not stop the ph from earning its word
+            'dataRef ph carrying a disp' => ['<ph id="1" dataRef="d2" disp="itemname"/>', 1],
+            'dataRef ph carrying a disp of two words' => ['<ph id="1" dataRef="d2" disp="item name"/>', 1],
+            'dataRef ph carrying a disp, followed by a full stop' => ['<ph id="1" dataRef="d2" disp="itemname"/>.', 1],
+            'uppercase ph' => ['<PH id="1" dataRef="d2"/>', 1],
+            // translatable text around: every <ph> weighs zero
+            'ph with content among words' => ['hello <ph id="1">{username}</ph> world', 2],
+            'raw dataRef ph next to a word' => ['Ciao <ph id="source1" dataRef="source1"/>', 1],
+            'three raw dataRef ph and one word' => [
+                '<ph id="source1" dataRef="source1"/>Ciao <ph id="source2" dataRef="source2"/>,<ph id="source3" dataRef="source3"/>',
+                1,
+            ],
+            'mixed flavours next to a word' => ['Ciao <ph id="1">x</ph><ph id="source1" dataRef="source1"/>', 1],
+            'dataRef ph with a disp next to a word' => ['Ciao <ph id="1" dataRef="d2" disp="itemname"/>', 1],
+            // only <ph> earns the word, the other inline tags do not
+            'x tag alone weighs nothing' => ['<x id="1"/>', 0],
+            'g tag alone weighs nothing' => ['<g id="1"></g>', 0],
+            'x tag with a disp weighs nothing' => ['<x id="1" dataRef="d2" disp="itemname"/>', 0],
+            'a tag whose name only starts with ph weighs nothing' => ['<phrase id="1"/>', 0],
+            // An escaped tag earns no ph word: the subfiltering, not the counter, decides what a tag is,
+            // so the check runs on the string as it arrives, without decoding anything. Mind that the
+            // cleaning does decode the entities on its own, longstanding behaviour left untouched here,
+            // so such a segment ends up weighing zero instead of being counted as plain text.
+            'escaped ph earns no ph word' => ['&lt;ph id="1" dataRef="d2"/&gt;', 0],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('phWordWeightProvider')]
+    public function testCountSegmentRawWordsWeighsPhOnlyWhenAloneInTheSegmentL(string $segment, int $expected): void
+    {
+        $result = (new CatUtils($this->dbStub))->countSegmentRawWords($segment);
+        $this->assertEquals($expected, $result, $segment . ': wrong word count');
+    }
+
+    /**
+     * A CJK count is a character count, so the word granted to a ph only segment must reach the counter
+     * without the spaces padding the placeholder, otherwise it would be worth three.
+     */
+    #[Test]
+    public function testCountSegmentRawWordsWeighsAPhOnlySegmentOneWordInCjkL(): void
+    {
+        $result = (new CatUtils($this->dbStub))->countSegmentRawWords('<ph id="1" dataRef="d2"/>', 'zh-CN');
+        $this->assertEquals(1, $result);
+    }
+
+    /**
+     * Reads tests/resources/files/xliff/word-count-ph-cases.xliff and pairs every unit with the
+     * "expected words" written in the comment above it, so the fixture cannot drift from the code it
+     * documents. The fixture is xliff 2.0 because a 1.2 file is handed over to the filters, which rewrite
+     * every <ph> into an <x/> and would leave this rule untested.
+     *
+     * @return array<string, array{string, int}>
+     */
+    public static function phWordCountXliffFixtureProvider(): array
+    {
+        $xliff = file_get_contents(self::projectRoot() . '/tests/resources/files/xliff/word-count-ph-cases.xliff');
+        self::assertNotFalse($xliff, 'word count fixture not readable');
+
+        preg_match_all(
+            '#<!--\s*expected words:\s*(\d+).*?-->\s*<unit id="([^"]+)">.*?<source>(.*?)</source>#s',
+            $xliff,
+            $matches,
+            PREG_SET_ORDER
+        );
+        self::assertNotEmpty($matches, 'no annotated unit found in the word count fixture');
+
+        $cases = [];
+        foreach ($matches as $match) {
+            $cases[$match[2]] = [$match[3], (int)$match[1]];
+        }
+
+        return $cases;
+    }
+
+    #[Test]
+    #[DataProvider('phWordCountXliffFixtureProvider')]
+    public function testCountSegmentRawWordsMatchesTheXliffFixtureL(string $source, int $expected): void
+    {
+        $result = (new CatUtils($this->dbStub))->countSegmentRawWords($source);
+        $this->assertEquals($expected, $result, $source . ': fixture and word count disagree');
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A segment made of `<ph>` tags and nothing else used to weigh **zero** words, so it was neither billed nor
shown in the CAT tool, even though it is still work to be delivered. It now weighs **one** word overall,
however many `<ph>` it holds. As soon as the segment carries any other translatable text, every `<ph>` is
back to weighing zero, so the existing counts stay untouched.

While fixing it, the placeholder regex in `CatUtils::replacePlaceholders()` turned out to be unable to read
its own `ctype`: the subfiltering emits an `x-orig` attribute between `ctype` and `equiv-text` for the
ctypes carrying the original tag, and the lazy `ctype` group backtracked across it, producing values such as
`x-original_ph_content x-orig=PHBoPg==` that could never match a `CTypeEnum` case.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Utils/Tools/CatUtils.php` | Placeholder regex reads `ctype` on its own: quote bounded attribute values plus a non capturing optional `x-orig`, so the group indexes stay stable. `'` stripped alongside `"` when reading the ctype. |
| `lib/Utils/Tools/CatUtils.php` | The whole `<ph>` family (`x-original_ph`, `x-original_ph_content`, `x-original_ph_no_data_ref`, `x-ph_data_ref`) is swapped for a plain space in `replacePlaceholders()`, so a `<ph>` is a separator worth zero words. |
| `lib/Utils/Tools/CatUtils.php` | `clean_raw_string_4_word_count()` grants the single word at its existing "string made of spaces only" exit, returning the trimmed variables placeholder when the segment carried a `<ph>`. That is the only spot able to decide: when the tags are swapped the punctuation stripped later is still in place, so `<ph id="1"/>.` would look like a segment carrying text. |
| `tests/unit/Core/Utils/Tools/CatUtilsTest.php` | 7 ctype weight cases through reflection, 20 end to end word counts, a CJK guard, and a fixture driven test reading the expectations out of the xliff below. |
| `tests/resources/files/xliff/word-count-ph-cases.xliff` | New xliff 2.0 fixture, 23 self documented units covering every flavour of `<ph>` plus the inline codes that must keep weighing zero. |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite on this branch: `OK (9287 tests, 30079 assertions)`. PHPStan over the whole codebase: `[OK] No
errors`.

`tests/unit/Core/TestCatUtils/SegmentRawWordCountTest.php` passes **unmodified**, which is the important
part: its 67 assertions encode the legacy word counts, the `<ph dataRef>` segment among them, and none of
them moved.

The fixture is xliff **2.0** on purpose. A 1.2 file is handed over to the filters, which rewrite every
`<ph>` into an `<x/>`, so a 1.2 fixture could never exercise this rule at all.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**Behaviour deltas beyond the tag only case.** Two counts move, both of them consequences of the rule:

1. A `<ph>` *carrying content* sitting among words used to add one word, not by design but because the
   `x-orig` swallow made its ctype unrecognisable, so it fell into the "count as one word" branch. Now it
   adds nothing: `hello <ph id="1">x</ph> world` goes 3 → 2. Xliff 1.2 files with content bearing `ph` tags
   will therefore count slightly lower than before.
2. Tag only segments used to count 0, and `SegmentExtractor.php:443` reads
   `if (empty($wordCount)) { $show_in_cattool = 0; }`. Counting 1 makes those segments **visible and
   translatable** in the CAT tool, which follows from the request but is a change beyond the number itself.

**Escaped tags.** An entity escaped `&lt;ph/&gt;` earns no word: deciding what is a tag is the
subfiltering's job, so the check reads the string as it arrives and decodes nothing. Mind that the cleaning
does decode the entities on its own, longstanding behaviour left untouched, so such a segment ends up
weighing zero rather than being counted as plain text. Pinned by a test so it is recorded rather than
assumed.

**Fixture purity.** Two units (`ph-only-mtc-x-orig`, `ph-only-mtc-x-orig-twice`) use `ctype`, `x-orig` and
`equiv-text`, which are Matecat attributes and not xliff 2.0 ones. They are well formed and parse fine, but
a strict 2.0 schema validator will reject those two units. They are there because they reproduce what a
re-imported Matecat export looks like, which is exactly the shape the ctype fix is about. Happy to move them
out if a schema pure fixture is preferred: the unit tests cover that path independently.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216618299686750