### PR TITLE
🐛 fix(mandatory-issues): surface failed saves and clear stale approve warning

### DIFF
--- a/public/js/actions/CatToolActions.js
+++ b/public/js/actions/CatToolActions.js
@@ -260,13 +260,26 @@ let CatToolActions = {
   },
   getJobMetadata: ({idJob, password}) => {
     if (!CatToolStore.jobMetadata) {
-      getJobMetadata(idJob, password).then((jobMetadata) => {
-        AppDispatcher.dispatch({
-          actionType: CatToolConstants.GET_JOB_METADATA,
-          jobMetadata,
+      getJobMetadata(idJob, password)
+        .then((jobMetadata) => {
+          // A settings change may have landed while this request was in flight; that value is
+          // newer than the response, so it must not be overwritten.
+          if (CatToolStore.jobMetadata) return
+
+          AppDispatcher.dispatch({
+            actionType: CatToolConstants.GET_JOB_METADATA,
+            jobMetadata,
+          })
+          CatToolStore.jobMetadata = jobMetadata
         })
-        CatToolStore.jobMetadata = jobMetadata
-      })
+        .catch(() => {
+          addNotification({
+            title: 'Error loading job settings',
+            type: 'error',
+            text: 'Some editor settings could not be loaded. Reload the page to try again.',
+            position: 'br',
+          })
+        })
     } else {
       AppDispatcher.dispatch({
         actionType: CatToolConstants.GET_JOB_METADATA,

--- a/public/js/actions/CatToolActions.test.js
+++ b/public/js/actions/CatToolActions.test.js
@@ -27,21 +27,27 @@ jest.mock('../utils/offlineUtils', () => ({
 }))
 
 // API imports (only those actually imported by CatToolActions.js)
-jest.mock('../api/getJobStatistics', () => ({ getJobStatistics: jest.fn() }))
+jest.mock('../api/getJobStatistics', () => ({getJobStatistics: jest.fn()}))
 jest.mock('../api/sendRevisionFeedback', () => ({
   sendRevisionFeedback: jest.fn(),
 }))
-jest.mock('../api/getTmKeysJob', () => ({ getTmKeysJob: jest.fn() }))
-jest.mock('../api/getDomainsList', () => ({ getDomainsList: jest.fn() }))
+jest.mock('../api/getTmKeysJob', () => ({getTmKeysJob: jest.fn()}))
+jest.mock('../api/getDomainsList', () => ({getDomainsList: jest.fn()}))
 jest.mock('../api/checkJobKeysHaveGlossary', () => ({
   checkJobKeysHaveGlossary: jest.fn(),
 }))
-jest.mock('../api/getJobMetadata', () => ({ getJobMetadata: jest.fn() }))
-jest.mock('../api/getGlobalWarnings', () => ({ getGlobalWarnings: jest.fn() }))
+jest.mock('../api/getJobMetadata', () => ({getJobMetadata: jest.fn()}))
+jest.mock('../api/getGlobalWarnings', () => ({getGlobalWarnings: jest.fn()}))
 
 jest.mock('../components/modals/AlertModal', () => 'AlertModal')
-jest.mock('../components/modals/RevisionFeedbackModal', () => 'RevisionFeedbackModal')
-jest.mock('../components/modals/ConfirmMessageModal', () => 'ConfirmMessageModal')
+jest.mock(
+  '../components/modals/RevisionFeedbackModal',
+  () => 'RevisionFeedbackModal',
+)
+jest.mock(
+  '../components/modals/ConfirmMessageModal',
+  () => 'ConfirmMessageModal',
+)
 
 jest.mock('../constants/ModalKeys', () => ({
   MODAL_KEY: {ALERT: 'Alert', COPY_SOURCE: 'CopySource'},
@@ -49,6 +55,12 @@ jest.mock('../constants/ModalKeys', () => ({
 }))
 jest.mock('../constants/CatToolConstants', () => ({
   SET_FIRST_LOAD: 'SET_FIRST_LOAD',
+  GET_JOB_METADATA: 'GET_JOB_METADATA',
+}))
+jest.mock('./notificationActions', () => ({
+  addNotification: jest.fn(),
+  removeNotification: jest.fn(),
+  removeAllNotifications: jest.fn(),
 }))
 jest.mock('lodash', () => ({
   isUndefined: (v) => typeof v === 'undefined',
@@ -56,6 +68,10 @@ jest.mock('lodash', () => ({
 
 import CatToolActions from './CatToolActions'
 import ModalsActions from './ModalsActions'
+import AppDispatcher from '../stores/AppDispatcher'
+import CatToolStore from '../stores/CatToolStore'
+import {getJobMetadata} from '../api/getJobMetadata'
+import {addNotification} from './notificationActions'
 
 describe('CatToolActions.processErrors', () => {
   beforeEach(() => {
@@ -121,5 +137,74 @@ describe('CatToolActions.processErrors', () => {
       }),
       'Error',
     )
+  })
+})
+
+describe('CatToolActions.getJobMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    delete CatToolStore.jobMetadata
+  })
+
+  test('dispatches the fetched metadata and stores it', async () => {
+    const jobMetadata = {job: {mandatory_issues: ['r2']}, project: {}}
+    getJobMetadata.mockResolvedValue(jobMetadata)
+
+    CatToolActions.getJobMetadata({idJob: 1, password: 'pwd'})
+    await Promise.resolve()
+
+    expect(AppDispatcher.dispatch).toHaveBeenCalledWith({
+      actionType: 'GET_JOB_METADATA',
+      jobMetadata,
+    })
+    expect(CatToolStore.jobMetadata).toBe(jobMetadata)
+  })
+
+  test('notifies the user when the request fails instead of failing silently', async () => {
+    getJobMetadata.mockRejectedValue(new Error('boom'))
+
+    CatToolActions.getJobMetadata({idJob: 1, password: 'pwd'})
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({type: 'error'}),
+    )
+    expect(CatToolStore.jobMetadata).toBeUndefined()
+  })
+
+  test('does not overwrite a settings change that landed while the request was in flight', async () => {
+    let resolveRequest
+    getJobMetadata.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRequest = resolve
+      }),
+    )
+
+    CatToolActions.getJobMetadata({idJob: 1, password: 'pwd'})
+
+    // A save completes before the initial fetch resolves.
+    const newer = {job: {mandatory_issues: ['r2']}}
+    CatToolStore.jobMetadata = newer
+
+    resolveRequest({job: {mandatory_issues: ['r1', 'r2']}})
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(AppDispatcher.dispatch).not.toHaveBeenCalled()
+    expect(CatToolStore.jobMetadata).toBe(newer)
+  })
+
+  test('replays the cached metadata when it is already loaded', () => {
+    const cached = {job: {mandatory_issues: []}}
+    CatToolStore.jobMetadata = cached
+
+    CatToolActions.getJobMetadata({idJob: 1, password: 'pwd'})
+
+    expect(getJobMetadata).not.toHaveBeenCalled()
+    expect(AppDispatcher.dispatch).toHaveBeenCalledWith({
+      actionType: 'GET_JOB_METADATA',
+      jobMetadata: cached,
+    })
   })
 })

--- a/public/js/actions/SegmentActions.js
+++ b/public/js/actions/SegmentActions.js
@@ -27,6 +27,7 @@ import {sendSegmentVersionIssueComment} from '../api/sendSegmentVersionIssueComm
 import {getTagProjection} from '../api/getTagProjection'
 import {setCurrentSegment} from '../api/setCurrentSegment'
 import {setLastSegmentFromLocalStorage} from '../utils/segmentLocalStorage'
+import {isIssueMandatoryForCurrentRevision} from '../utils/mandatoryIssuesUtils'
 import {addNotification} from './notificationActions'
 import {updateGlobalWarnings} from './warningActions'
 import {addClassToSegment, removeClassToSegment} from './segmentClassActions'
@@ -266,15 +267,7 @@ const SegmentActions = {
        If is an ICE we allow to change the translation because is not possible to add an issue
      */
 
-    const mandatoryIssues = CatToolStore.getJobMetadata().job.mandatory_issues
-
-    const currentRevisionKey = `r${config.revisionNumber}`
-
-    const isMandatoryRevisionIssues = Array.isArray(mandatoryIssues)
-      ? mandatoryIssues.some(
-          (value) => typeof value === 'string' && value === currentRevisionKey,
-        )
-      : true
+    const isMandatoryRevisionIssues = isIssueMandatoryForCurrentRevision()
 
     if (
       config.isReview &&

--- a/public/js/components/review_extended/ReviewExtendedPanel.js
+++ b/public/js/components/review_extended/ReviewExtendedPanel.js
@@ -12,6 +12,9 @@ import SegmentStore from '../../stores/SegmentStore'
 import SegmentUtils from '../../utils/segmentUtils'
 import {SegmentContext} from '../segments/SegmentContext'
 import ModalsActions from '../../actions/ModalsActions'
+import CatToolStore from '../../stores/CatToolStore'
+import CatToolConstants from '../../constants/CatToolConstants'
+import {isIssueMandatoryForCurrentRevision} from '../../utils/mandatoryIssuesUtils'
 
 class ReviewExtendedPanel extends React.Component {
   static contextType = SegmentContext
@@ -31,6 +34,20 @@ class ReviewExtendedPanel extends React.Component {
       showAddIssueMessage: false,
       showAddIssueToSelectedTextMessage: false,
       issueEditing: undefined,
+    }
+    // Keep stable references: the store removes listeners by identity, so binding inline on
+    // mount would leave the subscription behind forever.
+    this.onShowIssuesMessage = this.showIssuesMessage.bind(this)
+    this.onJobMetadataChange = this.clearStaleIssueRequirement.bind(this)
+  }
+
+  /**
+   * The requirement can be switched off from the settings panel while this panel is open, so
+   * drop a warning that no longer applies instead of leaving it on screen.
+   */
+  clearStaleIssueRequirement() {
+    if (!isIssueMandatoryForCurrentRevision()) {
+      this.setState({showAddIssueMessage: false})
     }
   }
 
@@ -61,6 +78,9 @@ class ReviewExtendedPanel extends React.Component {
   }
 
   showIssuesMessage(sid, type) {
+    // The event is broadcast to every mounted panel, so ignore the ones aimed elsewhere.
+    if (sid !== this.props.segment.sid) return
+
     switch (type) {
       case this.addIssueToApproveMessageType:
         this.setState({
@@ -99,14 +119,22 @@ class ReviewExtendedPanel extends React.Component {
     // this.props.setParentLoader(false);
     SegmentStore.addListener(
       SegmentConstants.SHOW_ISSUE_MESSAGE,
-      this.showIssuesMessage.bind(this),
+      this.onShowIssuesMessage,
+    )
+    CatToolStore.addListener(
+      CatToolConstants.GET_JOB_METADATA,
+      this.onJobMetadataChange,
     )
   }
 
   componentWillUnmount() {
     SegmentStore.removeListener(
       SegmentConstants.SHOW_ISSUE_MESSAGE,
-      this.showIssuesMessage,
+      this.onShowIssuesMessage,
+    )
+    CatToolStore.removeListener(
+      CatToolConstants.GET_JOB_METADATA,
+      this.onJobMetadataChange,
     )
   }
 
@@ -116,8 +144,10 @@ class ReviewExtendedPanel extends React.Component {
   render() {
     let issues = this.getAllIssues()
     let thereAreIssuesClass = issues.length > 0 ? 'thereAreIssues' : ''
+    const showAddIssueMessage =
+      this.state.showAddIssueMessage && isIssueMandatoryForCurrentRevision()
     let cornerClass = classnames({
-      error: this.state.showAddIssueMessage,
+      error: showAddIssueMessage,
       warning: this.state.showAddIssueToSelectedTextMessage,
       're-open-view re-issues': true,
     })
@@ -139,7 +169,7 @@ class ReviewExtendedPanel extends React.Component {
           selection={this.props.selectionObj}
           segmentVersion={this.state.versionNumber}
         />
-        {this.state.showAddIssueMessage ? (
+        {showAddIssueMessage ? (
           <div className="re-warning-not-added-issue">
             <p>
               You must add an issue from the list below before approving this

--- a/public/js/components/review_extended/ReviewExtendedPanel.test.js
+++ b/public/js/components/review_extended/ReviewExtendedPanel.test.js
@@ -7,6 +7,9 @@ import SegmentActions from '../../actions/SegmentActions'
 import SegmentUtils from '../../utils/segmentUtils'
 import ModalsActions from '../../actions/ModalsActions'
 import SegmentConstants from '../../constants/SegmentConstants'
+import CatToolStore from '../../stores/CatToolStore'
+import CatToolConstants from '../../constants/CatToolConstants'
+import {isIssueMandatoryForCurrentRevision} from '../../utils/mandatoryIssuesUtils'
 
 jest.mock('./ReviewExtendedIssuesContainer', () => () => (
   <div data-testid="issues-container" />
@@ -41,6 +44,21 @@ jest.mock('../../stores/SegmentStore', () => {
   store.setMaxListeners(0)
   return store
 })
+
+jest.mock('../../stores/CatToolStore', () => {
+  const {EventEmitter} = require('events')
+  const store = new EventEmitter()
+  store.setMaxListeners(0)
+  return store
+})
+
+jest.mock('../../constants/CatToolConstants', () => ({
+  GET_JOB_METADATA: 'GET_JOB_METADATA',
+}))
+
+jest.mock('../../utils/mandatoryIssuesUtils', () => ({
+  isIssueMandatoryForCurrentRevision: jest.fn(() => true),
+}))
 
 jest.mock('../../actions/SegmentActions', () => ({
   closeSegmentIssuePanel: jest.fn(),
@@ -81,10 +99,12 @@ describe('ReviewExtendedPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     SegmentUtils.isIceSegment.mockReturnValue(false)
+    isIssueMandatoryForCurrentRevision.mockReturnValue(true)
   })
 
   afterEach(() => {
     SegmentStore.removeAllListeners()
+    CatToolStore.removeAllListeners()
   })
 
   describe('wrapper class', () => {
@@ -103,7 +123,9 @@ describe('ReviewExtendedPanel', () => {
           ],
         }),
       })
-      expect(container.querySelector('.re-wrapper')).toHaveClass('thereAreIssues')
+      expect(container.querySelector('.re-wrapper')).toHaveClass(
+        'thereAreIssues',
+      )
     })
   })
 
@@ -116,7 +138,9 @@ describe('ReviewExtendedPanel', () => {
     test('calls closeSegmentIssuePanel with segment sid on click', () => {
       const {container} = renderPanel()
       fireEvent.click(container.querySelector('.re-close-balloon'))
-      expect(SegmentActions.closeSegmentIssuePanel).toHaveBeenCalledWith('seg-1')
+      expect(SegmentActions.closeSegmentIssuePanel).toHaveBeenCalledWith(
+        'seg-1',
+      )
     })
   })
 
@@ -237,6 +261,70 @@ describe('ReviewExtendedPanel', () => {
       expect(
         screen.getByText(/select an issue from the list below/i),
       ).toBeInTheDocument()
+    })
+  })
+
+  describe('event targeting and cleanup', () => {
+    test('ignores an approve-warning aimed at a different segment', () => {
+      renderPanel()
+      act(() => {
+        SegmentStore.emit(SegmentConstants.SHOW_ISSUE_MESSAGE, 'seg-2', 1)
+      })
+      expect(
+        screen.queryByText(/you must add an issue/i),
+      ).not.toBeInTheDocument()
+    })
+
+    test('removes its store listeners on unmount', () => {
+      const {unmount} = renderPanel()
+      expect(
+        SegmentStore.listenerCount(SegmentConstants.SHOW_ISSUE_MESSAGE),
+      ).toBe(1)
+      expect(
+        CatToolStore.listenerCount(CatToolConstants.GET_JOB_METADATA),
+      ).toBe(1)
+
+      unmount()
+
+      expect(
+        SegmentStore.listenerCount(SegmentConstants.SHOW_ISSUE_MESSAGE),
+      ).toBe(0)
+      expect(
+        CatToolStore.listenerCount(CatToolConstants.GET_JOB_METADATA),
+      ).toBe(0)
+    })
+  })
+
+  describe('when the mandatory-issue requirement is lifted', () => {
+    test('clears an already visible approve-warning on a job metadata change', () => {
+      renderPanel()
+      act(() => {
+        SegmentStore.emit(SegmentConstants.SHOW_ISSUE_MESSAGE, 'seg-1', 1)
+      })
+      expect(
+        screen.getByText(/you must add an issue from the list below/i),
+      ).toBeInTheDocument()
+
+      isIssueMandatoryForCurrentRevision.mockReturnValue(false)
+      act(() => {
+        CatToolStore.emit(CatToolConstants.GET_JOB_METADATA, {})
+      })
+
+      expect(
+        screen.queryByText(/you must add an issue/i),
+      ).not.toBeInTheDocument()
+    })
+
+    test('does not render the approve-warning even if the flag is still set', () => {
+      isIssueMandatoryForCurrentRevision.mockReturnValue(false)
+      const {container} = renderPanel()
+      act(() => {
+        SegmentStore.emit(SegmentConstants.SHOW_ISSUE_MESSAGE, 'seg-1', 1)
+      })
+      expect(
+        screen.queryByText(/you must add an issue/i),
+      ).not.toBeInTheDocument()
+      expect(container.querySelector('.error')).not.toBeInTheDocument()
     })
   })
 

--- a/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.js
+++ b/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.js
@@ -5,6 +5,7 @@ import {updateJobMetadata} from '../../../../api/updateJobMetadata'
 import {Tagging} from '../OtherTab/Tagging'
 import {MandatoryIssues} from '../OtherTab/MandatoryIssues'
 import CatToolStore from '../../../../stores/CatToolStore'
+import CatToolActions from '../../../../actions/CatToolActions'
 import CatToolConstants from '../../../../constants/CatToolConstants'
 
 export const EditorOtherTab = () => {
@@ -31,26 +32,43 @@ export const EditorOtherTab = () => {
         characterCounterMode: currentProjectTemplate.characterCounterMode,
         subfilteringHandlers: currentProjectTemplate.subfilteringHandlers,
         mandatoryIssues: currentProjectTemplate.mandatoryIssues,
-      }).then(() => {
-        const jobMetadata = CatToolStore.getJobMetadata()
-        if (!jobMetadata) return
-
-        const updatedJobMetadata = {
-          ...jobMetadata,
-          job: {
-            ...jobMetadata.job,
-            character_counter_count_tags:
-              currentProjectTemplate.characterCounterCountTags,
-            character_counter_mode: currentProjectTemplate.characterCounterMode,
-            subfiltering_handlers: currentProjectTemplate.subfilteringHandlers,
-            mandatory_issues: currentProjectTemplate.mandatoryIssues,
-          },
-        }
-        CatToolStore.setJobMetadata(updatedJobMetadata)
-        CatToolStore.emitChange(CatToolConstants.GET_JOB_METADATA, {
-          jobMetadata: updatedJobMetadata,
-        })
       })
+        .then(() => {
+          // Fall back to an empty shape rather than bailing out: the initial metadata request
+          // may still be in flight, and dropping the update here would leave the editor acting
+          // on the pre-change settings until a reload.
+          const jobMetadata = CatToolStore.getJobMetadata() ?? {
+            job: {},
+            project: {},
+            files: [],
+          }
+
+          const updatedJobMetadata = {
+            ...jobMetadata,
+            job: {
+              ...jobMetadata.job,
+              character_counter_count_tags:
+                currentProjectTemplate.characterCounterCountTags,
+              character_counter_mode:
+                currentProjectTemplate.characterCounterMode,
+              subfiltering_handlers:
+                currentProjectTemplate.subfilteringHandlers,
+              mandatory_issues: currentProjectTemplate.mandatoryIssues,
+            },
+          }
+          CatToolStore.setJobMetadata(updatedJobMetadata)
+          CatToolStore.emitChange(CatToolConstants.GET_JOB_METADATA, {
+            jobMetadata: updatedJobMetadata,
+          })
+        })
+        .catch(() => {
+          CatToolActions.addNotification({
+            title: 'Error saving settings',
+            type: 'error',
+            text: 'Your editor settings could not be saved. Please retry!',
+            position: 'br',
+          })
+        })
     }
 
     previousCurrentProjectTemplate.current = {

--- a/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.test.js
+++ b/public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.test.js
@@ -1,11 +1,23 @@
 import React from 'react'
-import {render, screen, within} from '@testing-library/react'
+import {act, render, screen, within} from '@testing-library/react'
 import {EditorOtherTab} from './EditorOtherTab'
 import {SettingsPanelContext} from '../../SettingsPanelContext'
 import {updateJobMetadata} from '../../../../api/updateJobMetadata'
+import CatToolStore from '../../../../stores/CatToolStore'
+import CatToolActions from '../../../../actions/CatToolActions'
 
 jest.mock('../../../../api/updateJobMetadata', () => ({
   updateJobMetadata: jest.fn(() => Promise.resolve({})),
+}))
+
+jest.mock('../../../../stores/CatToolStore', () => ({
+  getJobMetadata: jest.fn(),
+  setJobMetadata: jest.fn(),
+  emitChange: jest.fn(),
+}))
+
+jest.mock('../../../../actions/CatToolActions', () => ({
+  addNotification: jest.fn(),
 }))
 
 jest.mock('../OtherTab/Tagging', () => ({
@@ -87,7 +99,9 @@ describe('EditorOtherTab', () => {
       })
 
       test('renders Tagging', () => {
-        expect(within(generalSection).getByTestId('tagging')).toBeInTheDocument()
+        expect(
+          within(generalSection).getByTestId('tagging'),
+        ).toBeInTheDocument()
       })
 
       test('renders MandatoryIssues', () => {
@@ -160,7 +174,10 @@ describe('EditorOtherTab', () => {
 
     test('calls updateJobMetadata when characterCounterMode changes', () => {
       const {rerender} = renderComponent()
-      reRenderComponent(rerender, {...baseTemplate, characterCounterMode: 'words'})
+      reRenderComponent(rerender, {
+        ...baseTemplate,
+        characterCounterMode: 'words',
+      })
       expect(updateJobMetadata).toHaveBeenCalledTimes(1)
       expect(updateJobMetadata).toHaveBeenCalledWith(
         expect.objectContaining({characterCounterMode: 'words'}),
@@ -169,7 +186,10 @@ describe('EditorOtherTab', () => {
 
     test('calls updateJobMetadata when characterCounterCountTags changes', () => {
       const {rerender} = renderComponent()
-      reRenderComponent(rerender, {...baseTemplate, characterCounterCountTags: true})
+      reRenderComponent(rerender, {
+        ...baseTemplate,
+        characterCounterCountTags: true,
+      })
       expect(updateJobMetadata).toHaveBeenCalledTimes(1)
       expect(updateJobMetadata).toHaveBeenCalledWith(
         expect.objectContaining({characterCounterCountTags: true}),
@@ -179,7 +199,10 @@ describe('EditorOtherTab', () => {
     test('calls updateJobMetadata when subfilteringHandlers changes', () => {
       const {rerender} = renderComponent()
       const handlers = {handler: 'test'}
-      reRenderComponent(rerender, {...baseTemplate, subfilteringHandlers: handlers})
+      reRenderComponent(rerender, {
+        ...baseTemplate,
+        subfilteringHandlers: handlers,
+      })
       expect(updateJobMetadata).toHaveBeenCalledTimes(1)
       expect(updateJobMetadata).toHaveBeenCalledWith(
         expect.objectContaining({subfilteringHandlers: handlers}),
@@ -219,6 +242,64 @@ describe('EditorOtherTab', () => {
       reRenderComponent(rerender, changedTemplate)
       reRenderComponent(rerender, changedTemplate)
       expect(updateJobMetadata).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('store update after a successful save', () => {
+    test('publishes the saved values so the editor stops using the previous settings', async () => {
+      CatToolStore.getJobMetadata.mockReturnValue({
+        job: {mandatory_issues: ['r1', 'r2']},
+        project: {},
+      })
+      const {rerender} = renderComponent()
+      reRenderComponent(rerender, {...baseTemplate, mandatoryIssues: ['r2']})
+
+      await act(async () => {})
+
+      expect(CatToolStore.setJobMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          job: expect.objectContaining({mandatory_issues: ['r2']}),
+        }),
+      )
+      expect(CatToolStore.emitChange).toHaveBeenCalled()
+    })
+
+    test('still publishes when the initial metadata request has not resolved yet', async () => {
+      CatToolStore.getJobMetadata.mockReturnValue(undefined)
+      const {rerender} = renderComponent()
+      reRenderComponent(rerender, {...baseTemplate, mandatoryIssues: ['r2']})
+
+      await act(async () => {})
+
+      expect(CatToolStore.setJobMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          job: expect.objectContaining({mandatory_issues: ['r2']}),
+        }),
+      )
+    })
+  })
+
+  describe('when the save fails', () => {
+    test('notifies the user instead of failing silently', async () => {
+      updateJobMetadata.mockRejectedValueOnce({status: 400})
+      const {rerender} = renderComponent()
+      reRenderComponent(rerender, {...baseTemplate, mandatoryIssues: ['r2']})
+
+      await act(async () => {})
+
+      expect(CatToolActions.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({type: 'error'}),
+      )
+    })
+
+    test('does not publish the unsaved value to the store', async () => {
+      updateJobMetadata.mockRejectedValueOnce({status: 400})
+      const {rerender} = renderComponent()
+      reRenderComponent(rerender, {...baseTemplate, mandatoryIssues: ['r2']})
+
+      await act(async () => {})
+
+      expect(CatToolStore.setJobMetadata).not.toHaveBeenCalled()
     })
   })
 })

--- a/public/js/components/settingsPanel/Contents/OtherTab/MandatoryIssues.js
+++ b/public/js/components/settingsPanel/Contents/OtherTab/MandatoryIssues.js
@@ -3,6 +3,8 @@ import {SettingsPanelContext} from '../../SettingsPanelContext'
 import {CreateProjectContext} from '../../../createProject/CreateProjectContext'
 import {Select} from '../../../common/Select'
 
+const ALL_REVISION_ROUNDS = ['r1', 'r2']
+
 const OPTIONS = [
   {
     id: 'r1,r2',
@@ -28,12 +30,25 @@ export const MandatoryIssues = () => {
 
   const {SELECT_HEIGHT} = useContext(CreateProjectContext)
 
-  const mandatoryIssue = currentProjectTemplate.mandatoryIssues ?? []
+  // A job with no stored value requires an issue in every round, so show that rather than
+  // "None" — an empty array is the one and only way to express "no round requires an issue".
+  const mandatoryIssue = Array.isArray(currentProjectTemplate.mandatoryIssues)
+    ? currentProjectTemplate.mandatoryIssues
+    : ALL_REVISION_ROUNDS
+
   const setMandatoryIssue = (value) =>
     modifyingCurrentTemplate((prevTemplate) => ({
       ...prevTemplate,
       mandatoryIssues: value === 'none' ? [] : value.split(','),
     }))
+
+  const activeOptionId =
+    mandatoryIssue.length === 0
+      ? 'none'
+      : // Match regardless of the stored order, which the backend does not constrain.
+        ALL_REVISION_ROUNDS.filter((round) =>
+          mandatoryIssue.includes(round),
+        ).join(',')
 
   return (
     <div className="options-box">
@@ -52,11 +67,7 @@ export const MandatoryIssues = () => {
           dropdownClassName="select-dropdown__wrapper-portal"
           maxHeightDroplist={SELECT_HEIGHT}
           options={OPTIONS}
-          activeOption={OPTIONS.find(
-            ({id}) =>
-              id ===
-              (mandatoryIssue.length === 0 ? 'none' : mandatoryIssue.join(',')),
-          )}
+          activeOption={OPTIONS.find(({id}) => id === activeOptionId)}
           checkSpaceToReverse={true}
           onSelect={(option) => setMandatoryIssue(option.id)}
         />

--- a/public/js/components/settingsPanel/Contents/OtherTab/MandatoryIssues.test.js
+++ b/public/js/components/settingsPanel/Contents/OtherTab/MandatoryIssues.test.js
@@ -110,4 +110,23 @@ describe('MandatoryIssues', () => {
     expect(result.otherField).toBe('preserved')
     expect(result.mandatoryIssues).toEqual(['r2'])
   })
+
+  describe('when the job has no stored value', () => {
+    // A missing value means every round requires an issue, so showing "None" would tell the
+    // owner the opposite of what the editor actually enforces.
+    test('shows "R1 + R2" when mandatoryIssues is undefined', () => {
+      renderMandatoryIssues(undefined)
+      expect(screen.getByTestId('active-option').textContent).toBe('R1 + R2')
+    })
+
+    test('shows "R1 + R2" when mandatoryIssues is null', () => {
+      renderMandatoryIssues(null)
+      expect(screen.getByTestId('active-option').textContent).toBe('R1 + R2')
+    })
+  })
+
+  test('matches an option regardless of the stored round order', () => {
+    renderMandatoryIssues(['r2', 'r1'])
+    expect(screen.getByTestId('active-option').textContent).toBe('R1 + R2')
+  })
 })

--- a/public/js/pages/CatTool.js
+++ b/public/js/pages/CatTool.js
@@ -264,10 +264,14 @@ function CatTool() {
       if (config.active_engine && config.active_engine.id) {
         const activeMT = config.active_engine
         if (activeMT) {
-          modifyingCurrentTemplate(() => ({
+          // Build on the template as it stands now, not on the snapshot captured before the
+          // engines request: settings loaded meanwhile would otherwise be discarded.
+          modifyingCurrentTemplate((currentTemplate) => ({
             ...prevTemplate,
+            ...currentTemplate,
             mt: {
               ...prevTemplate.mt,
+              ...currentTemplate.mt,
               id: activeMT.id,
             },
           }))

--- a/public/js/utils/mandatoryIssuesUtils.js
+++ b/public/js/utils/mandatoryIssuesUtils.js
@@ -1,0 +1,22 @@
+import CatToolStore from '../stores/CatToolStore'
+
+/**
+ * Whether the current revision round requires an issue before a segment can be approved.
+ *
+ * A job with no `mandatory_issues` entry predates the setting, so every round requires an
+ * issue. Job metadata that failed to load is treated the same way, so a network error can
+ * never silently drop the requirement.
+ *
+ * @returns {boolean}
+ */
+export const isIssueMandatoryForCurrentRevision = () => {
+  const mandatoryIssues = CatToolStore.getJobMetadata()?.job?.mandatory_issues
+
+  if (!Array.isArray(mandatoryIssues)) return true
+
+  const currentRevisionKey = `r${config.revisionNumber}`
+
+  return mandatoryIssues.some(
+    (value) => typeof value === 'string' && value === currentRevisionKey,
+  )
+}

--- a/public/js/utils/mandatoryIssuesUtils.test.js
+++ b/public/js/utils/mandatoryIssuesUtils.test.js
@@ -1,0 +1,60 @@
+import {isIssueMandatoryForCurrentRevision} from './mandatoryIssuesUtils'
+import CatToolStore from '../stores/CatToolStore'
+
+jest.mock('../stores/CatToolStore', () => ({
+  getJobMetadata: jest.fn(),
+}))
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  global.config = {revisionNumber: 1}
+})
+
+describe('isIssueMandatoryForCurrentRevision', () => {
+  test('returns true when the current revision is listed', () => {
+    CatToolStore.getJobMetadata.mockReturnValue({
+      job: {mandatory_issues: ['r1', 'r2']},
+    })
+    expect(isIssueMandatoryForCurrentRevision()).toBe(true)
+  })
+
+  test('returns false when the current revision is not listed', () => {
+    CatToolStore.getJobMetadata.mockReturnValue({
+      job: {mandatory_issues: ['r2']},
+    })
+    expect(isIssueMandatoryForCurrentRevision()).toBe(false)
+  })
+
+  test('returns false for an empty array, meaning no round requires an issue', () => {
+    CatToolStore.getJobMetadata.mockReturnValue({job: {mandatory_issues: []}})
+    expect(isIssueMandatoryForCurrentRevision()).toBe(false)
+  })
+
+  test('honours the revision number when resolving the key', () => {
+    global.config.revisionNumber = 2
+    CatToolStore.getJobMetadata.mockReturnValue({
+      job: {mandatory_issues: ['r2']},
+    })
+    expect(isIssueMandatoryForCurrentRevision()).toBe(true)
+  })
+
+  test('defaults to mandatory when the job has no stored value', () => {
+    CatToolStore.getJobMetadata.mockReturnValue({
+      job: {mandatory_issues: undefined},
+    })
+    expect(isIssueMandatoryForCurrentRevision()).toBe(true)
+  })
+
+  test('defaults to mandatory, without throwing, when job metadata failed to load', () => {
+    CatToolStore.getJobMetadata.mockReturnValue(undefined)
+    expect(() => isIssueMandatoryForCurrentRevision()).not.toThrow()
+    expect(isIssueMandatoryForCurrentRevision()).toBe(true)
+  })
+
+  test('defaults to mandatory when the stored value is not an array', () => {
+    CatToolStore.getJobMetadata.mockReturnValue({
+      job: {mandatory_issues: 'r2'},
+    })
+    expect(isIssueMandatoryForCurrentRevision()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Setting **Mandatory issue marking → Only R2** had no effect in R1: the approve gate still
demanded an issue, the warning stayed on screen, and the segment could not be approved.

The gate arithmetic added in #4713 is correct, and so is the whole persistence chain
(`job_metadata` schema → `JobMetadataController` → `JobsMetadataMarshaller::unMarshall` →
`MetaDataController::index`, including the Redis invalidation in `MetadataDao::set`). The real
problem is that when the saved value did not reach `CatToolStore`, **nothing reported it** — the
select kept showing "Only R2" while the editor went on enforcing the previous value. This PR
closes every silent path and makes the warning self-clear.

Root causes fixed:

1. **A rejected save was completely invisible.** `EditorOtherTab` had no `.catch()`, and
   `JSONValidator` is constructed with `throwExceptions: true`. The POST batches
   `character_counter_count_tags`, `character_counter_mode`, `subfiltering_handlers` and
   `mandatory_issues` in one request, so one bad value discards the mandatory-issues change too.
   Because the store update lives inside the `.then()`, nothing was persisted *and* nothing was
   updated locally.
2. **`SegmentActions` dereferenced job metadata unguarded.**
   `CatToolStore.getJobMetadata().job` throws a `TypeError` when the metadata request failed or
   has not yet resolved, aborting `clickOnApprovedButton` before it approves anything — "unable
   to approve", with no warning and no error.
3. **The warning never cleared.** `ReviewExtendedPanel.showIssuesMessage` ignored the target
   `sid`, so every mounted panel lit up regardless of which segment the event was for; the
   unmount cleanup removed a different function reference than the one it registered, so
   listeners leaked forever; and nothing reset `showAddIssueMessage` when the requirement was
   lifted.
4. **The settings select misreported the state.** A job with no stored value requires an issue in
   *every* round, but the select rendered "None" — the exact opposite of what the editor enforces.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/utils/mandatoryIssuesUtils.js` | New. Single definition of the per-round requirement via `isIssueMandatoryForCurrentRevision()`, shared by the approve gate and the review panel. Uses optional chaining and defaults to mandatory, so a failed metadata load can never silently drop the requirement |
| `public/js/actions/SegmentActions.js` | Replace the unguarded `CatToolStore.getJobMetadata().job.mandatory_issues` dereference with the shared helper |
| `public/js/actions/CatToolActions.js` | Add the missing `.catch()` on the initial metadata fetch (notifies the user); stop the in-flight `.then()` from overwriting a settings change that landed while the request was pending |
| `public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.js` | Add the missing `.catch()` so a rejected save raises a visible error; replace the `if (!jobMetadata) return` bail-out with an empty-shape fallback so an in-flight fetch no longer discards the update |
| `public/js/components/review_extended/ReviewExtendedPanel.js` | Ignore `SHOW_ISSUE_MESSAGE` events aimed at other segments; bind handlers once in the constructor so `removeListener` matches by identity and both subscriptions detach on unmount; clear the warning on `GET_JOB_METADATA` and gate the render on the live requirement |
| `public/js/components/settingsPanel/Contents/OtherTab/MandatoryIssues.js` | Show "R1 + R2" when the job has no stored value, matching what the editor enforces; match the active option regardless of stored round order |
| `public/js/pages/CatTool.js` | `getMTEngines` now merges the template as it stands instead of overwriting with a snapshot captured before the async engines request, which discarded settings loaded in that window |
| `public/js/utils/mandatoryIssuesUtils.test.js` | New. 7 tests: listed/unlisted round, empty array, revision-number resolution, and the three default-to-mandatory cases including the previously throwing undefined-store case |
| `public/js/components/review_extended/ReviewExtendedPanel.test.js` | 4 tests: cross-segment event ignored, listeners detached on unmount, warning cleared when the requirement is lifted, warning not rendered when inactive |
| `public/js/components/settingsPanel/Contents/OtherTab/MandatoryIssues.test.js` | 3 tests: `undefined`/`null` render "R1 + R2", and out-of-order rounds still match |
| `public/js/actions/CatToolActions.test.js` | 4 tests for the previously untested `getJobMetadata` action: success, rejection notifying the user, the no-clobber guard for a change landing mid-flight, and the cached replay branch |
| `public/js/components/settingsPanel/Contents/EditorOtherTab/EditorOtherTab.test.js` | 4 tests: the store is published after a save and when metadata is still loading, and a rejected save notifies the user without publishing the unsaved value |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Frontend-only change — no PHP was touched, so the PHP suites are not applicable and were not run.

`npx jest` — full frontend suite:

```
Test Suites: 2 failed, 2 skipped, 77 passed, 79 of 81 total
Tests:       4 failed, 15 skipped, 785 passed, 804 total
```

Passing tests go from 763 to 785 (+22 new). Every changed line is covered, including the two new
error handlers — those were the only uncovered changed lines, which is also what the test adequacy
gate measures, so they got their own tests in the second commit. The 2 failing suites fail identically on a clean
`develop` and are unrelated: `public/js/utils/textUtilsSanitizedHTML.test.js` and
`public/js/components/notificationsComponent/NotificationItem.test.js` are untracked local files
testing a `TEXT_UTILS.sanitizedHTML` function that does not exist in the source. They are not part
of this branch.

Import-cycle check, since #4530 deliberately removed them —
`npx madge --circular --extensions js,jsx public/js/pages/CatTool.js` reports **32 circular
dependencies both before and after** this change, and none of the new or changed files appear in
any cycle.

Not verified: which of the silent paths triggered the original report. Reading the `job_metadata`
row and observing the live request both required DB access that was unavailable. All the paths are
covered, and a rejected save now surfaces an error naming the failure.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-fable-5) — used to investigate the report and implement the fixes. All
findings and changes were reviewed against the source.

## Notes

`isIssueMandatoryForCurrentRevision()` is now the single source of truth for this requirement.
Any future reader of `mandatory_issues` should use it rather than reading the store directly —
that is what let the gate and the settings panel drift apart in the first place.

Two behaviours are intentionally preserved rather than "fixed":

- **A job with no `mandatory_issues` row still means "mandatory in every round."** Only the
  display was wrong. `MetaDataController::getJobMetaData()` backfills a default for
  `subfiltering_handlers` but not for `mandatory_issues`; backfilling it would be cleaner but
  changes backend behaviour, so it is left alone here.
- **An empty array remains the only way to express "no round requires an issue."**

Follow-up worth considering: the leaked-listener class of bug is invisible in this codebase
because `SegmentStore.js` calls `EventEmitter.prototype.setMaxListeners(0)`, which suppresses
Node's max-listener warning globally. Other components using the
`addListener(handler.bind(this))` / `removeListener(handler)` pattern likely leak the same way.
