### PR TITLE
🔒 security(templates): scope template deletion by owner uid

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,13 +1,15 @@
 {
-    "permissions": {
-        "deny": [
-            "Read(*docker/UpgradeVersion/*)",
-            "Edit(*docker/UpgradeVersion/*)",
-            "Bash(*docker/UpgradeVersion/*)",
-            "Read(*inc/config.ini.*)",
-            "Edit(*inc/config.ini.*)",
-            "Bash(*inc/config.ini.*)",
-            "Bash(* mysql *)"
-        ]
-    }
+  "permissions": {
+    "deny": [
+      "Read(*docker/UpgradeVersion/*)",
+      "Edit(*docker/UpgradeVersion/*)",
+      "Bash(*docker/UpgradeVersion/*)",
+      "Read(*inc/*config*.ini*)",
+      "Edit(*inc/*config*.ini*)",
+      "Bash(*inc/*config*.ini*)",
+      "Bash(*mysql*)",
+      "Bash(*mariadb*)",
+      "Bash(*mycli*)"
+    ]
+  }
 }

--- a/lib/Model/LQA/QAModelTemplate/QAModelTemplateDao.php
+++ b/lib/Model/LQA/QAModelTemplate/QAModelTemplateDao.php
@@ -76,9 +76,14 @@ class QAModelTemplateDao extends AbstractDao
         $conn->beginTransaction();
 
         try {
-            $stmt = $conn->prepare("UPDATE qa_model_templates SET deleted_at = :now WHERE id = :id AND `deleted_at` IS NULL;");
+            // Scoping this one statement by uid protects the whole cascade: when it matches nothing the
+            // method returns early, below, before any of the child tables are touched. The children are
+            // reached by id_template and carry no uid of their own, so the parent is the only place the
+            // ownership check can live.
+            $stmt = $conn->prepare("UPDATE qa_model_templates SET deleted_at = :now WHERE id = :id AND uid = :uid AND `deleted_at` IS NULL;");
             $stmt->execute([
                 'id' => $id,
+                'uid' => $uid,
                 'now' => (new DateTime())->format('Y-m-d H:i:s')
             ]);
 

--- a/lib/Model/Projects/ProjectTemplateDao.php
+++ b/lib/Model/Projects/ProjectTemplateDao.php
@@ -619,8 +619,11 @@ class ProjectTemplateDao extends AbstractDao
     public function remove(int $id, int $uid): int
     {
         $conn = $this->database->getConnection();
-        $stmt = $conn->prepare("DELETE FROM " . self::TABLE . " WHERE id = :id ");
-        $stmt->execute(['id' => $id]);
+        // The uid is the ownership boundary, so it belongs in the statement and not only in the cache
+        // keys below: ids are a global auto_increment sequence, and without it any authenticated user
+        // could delete another user's template by guessing one.
+        $stmt = $conn->prepare("DELETE FROM " . self::TABLE . " WHERE id = :id AND uid = :uid ");
+        $stmt->execute(['id' => $id, 'uid' => $uid]);
 
         $this->destroyFetchByIdCache($id, ProjectTemplateStruct::class);
         $this->destroyQueryByIdAndUserCache($conn, $id, $uid);

--- a/tests/unit/Core/DAO/TestQAModelTemplateDAO/QAModelTemplateDaoTest.php
+++ b/tests/unit/Core/DAO/TestQAModelTemplateDAO/QAModelTemplateDaoTest.php
@@ -280,6 +280,28 @@ class QAModelTemplateDaoTest extends AbstractTest
 
     #[Test]
     #[Group('PersistenceNeeded')]
+    public function removeIgnoresTemplateOwnedByAnotherUser(): void
+    {
+        $created = $this->create('Foreign Owner Template');
+
+        $count = $this->dao->remove($created->id, $this->uid + 999999);
+
+        // Read with raw SQL rather than through the DAO: the parent must still be un-deleted, and the
+        // children must still exist, which is what proves the cascade never ran for a foreign caller.
+        $this->assertSame(0, $count);
+        $conn = obtainTestDatabase()->getConnection();
+
+        $stmt = $conn->prepare("SELECT COUNT(*) FROM qa_model_templates WHERE id = :id AND deleted_at IS NULL");
+        $stmt->execute(['id' => $created->id]);
+        $this->assertSame(1, (int)$stmt->fetchColumn());
+
+        $stmt = $conn->prepare("SELECT COUNT(*) FROM qa_model_template_passfails WHERE id_template = :id");
+        $stmt->execute(['id' => $created->id]);
+        $this->assertGreaterThan(0, (int)$stmt->fetchColumn());
+    }
+
+    #[Test]
+    #[Group('PersistenceNeeded')]
     public function getAllPaginatedReturnsStructure(): void
     {
         $this->create('Paginated Test');

--- a/tests/unit/Core/Model/Projects/ProjectTemplateDaoRealSqlTest.php
+++ b/tests/unit/Core/Model/Projects/ProjectTemplateDaoRealSqlTest.php
@@ -263,6 +263,22 @@ class ProjectTemplateDaoRealSqlTest extends AbstractTest
         self::assertNull($this->dao->getByIdAndUser($struct->id, $this->uid));
     }
 
+    public function testRemoveIgnoresTemplateOwnedByAnotherUser(): void
+    {
+        $struct = $this->dao->save($this->newStruct('foreign owner'));
+        $this->trackTemplate($struct->id);
+
+        $affected = $this->dao->remove($struct->id, $this->uid + 999999);
+
+        // The row must survive, and the count is read with raw SQL on purpose: remove() invalidates the
+        // cache keys of the uid it is handed, so a cached read of the owner's key would survive a delete
+        // that really happened and let this pass for the wrong reason.
+        self::assertSame(0, $affected);
+        $stmt = $this->realSqlDb()->getConnection()->prepare("SELECT COUNT(*) FROM project_templates WHERE id = :id");
+        $stmt->execute(['id' => $struct->id]);
+        self::assertSame(1, (int)$stmt->fetchColumn());
+    }
+
     // ---- removeSubTemplateByIdAndUser ------------------------------------------------------------
 
     public function testRemoveSubTemplateZeroesField(): void


### PR DESCRIPTION
## Summary

`ProjectTemplateDao::remove()` and `QAModelTemplateDao::remove()` both received the caller's `uid`
and both ignored it, deleting on `WHERE id = :id` alone. Template ids come from a global
`auto_increment` sequence, so any authenticated user could delete another user's project templates or
QA model templates by guessing an id. This is CWE-862 (missing authorization), reported through the
vulnerability disclosure programme.

The `uid` now lives in the statement itself rather than only in the cache keys around it, so
ownership is enforced by the query and cannot be forgotten by a caller.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix (security: missing authorization)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Model/Projects/ProjectTemplateDao.php` | `remove()` deletes on `WHERE id = :id AND uid = :uid`; uid bound |
| `lib/Model/LQA/QAModelTemplate/QAModelTemplateDao.php` | `remove()` soft-deletes the parent on `WHERE id = :id AND uid = :uid`; the existing zero-rows early return then stops the child cascade before `qa_model_template_passfails`, `_passfail_options` and `_severities` are touched |
| `tests/unit/Core/Model/Projects/ProjectTemplateDaoRealSqlTest.php` | Regression test: a foreign uid gets 0 affected rows and the row survives |
| `tests/unit/Core/DAO/TestQAModelTemplateDAO/QAModelTemplateDaoTest.php` | Regression test: a foreign uid leaves the parent un-deleted and the children intact |
| `MateCat-docs` | Pointer bump recording two deferred follow-ups |
| `.claude/settings.json` | Unrelated: agent permission rules, see the second commit |

Both regression tests assert through raw SQL rather than through the DAO. `remove()` invalidates the
cache keys of the `uid` it is handed, so a cached read of the owner's key would survive a delete that
really happened and let the test pass for the wrong reason.

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite: `OK (9307 tests, 30119 assertions)`, exit 0.

PHPStan: `[OK] No errors` on both changed DAOs (per-file run; this project has no baseline, so every
reported error is a real one).

Each regression test was run against the unfixed code first and observed to fail — `remove()`
returned 1 and the foreign row was gone — before the fix was applied.

Every caller of these two methods was checked: only the controllers call them, each passing the
authenticated user's uid, so nothing internal depended on the unscoped behaviour.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

The `uid` can never be attacker-supplied: `param('uid')` appears nowhere in `lib`, and the API-key
path resolves the user from the key record's own `uid` column via `ApiKeyStruct::getUser()` after
`validSecret()`. So with the `uid` in the WHERE clause, id enumeration reaches only rows the caller
already owns.

Five sibling DAOs with the same `remove(int $id, int $uid)` shape were checked and are already
correctly scoped: `FiltersConfigTemplateDao`, `XliffConfigTemplateDao`, `CustomPayableRateDao`,
`MTQEWorkflowTemplateDao`, `MTQEPayableRateTemplateDao`. Two of seven were wrong, which is the
argument for an owner-scoped helper on the base DAO rather than repeating the clause by hand —
recorded as follow-up work, not done here.

Two deferred items are recorded in
`MateCat-docs/backend/work_in_progress/todo-things-left-behind-always-actual.md`:

1. `QAModelTemplateDao::update()` also writes on `WHERE id = :id` with no uid. Not exploitable today,
   because `QAModelTemplateController::edit()` pre-fetches with `get(['id','uid'])` and 404s first.
   Worth scoping anyway as defence in depth.
2. QA model templates soft-delete the parent but hard-delete their children. That inconsistency
   predates this change and is a data-model decision rather than a security one.

Production remains exposed until this ships.

The second commit is unrelated to the security fix and can be dropped if you would rather keep this
PR single-purpose: it tightens the repository's agent permission rules. The previous mysql deny
patterns only matched `mysql` followed by a space, so `mysqldump`, `mysqladmin`, `mysqlsh` and
`mariadb` all passed through; and `*inc/config.ini.*` required characters after the trailing dot, so
it covered `config.ini.prod` and `config.ini.sample` while leaving the live `inc/config.ini`
readable. `enabledPlugins` moved out of the shared file into `settings.local.json`, since editor
tooling is a personal choice.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209931119400831