### PR TITLE
🔒 security(auth): invalidate reset token on password change and validate password characters

### DIFF
--- a/lib/Controller/API/App/Authentication/ForgotPasswordController.php
+++ b/lib/Controller/API/App/Authentication/ForgotPasswordController.php
@@ -150,8 +150,11 @@ class ForgotPasswordController extends AbstractStatefulKleinController
     public function setNewPassword(): void
     {
         $reset = $this->createPasswordResetModel($_SESSION);
-        $new_password = (string) filter_var($this->request->param('password'), FILTER_SANITIZE_SPECIAL_CHARS);
-        $password_confirmation = (string) filter_var($this->request->param('password_confirmation'), FILTER_SANITIZE_SPECIAL_CHARS);
+        $this->rejectControlCharacters($this->request->param('password'));
+        $this->rejectControlCharacters($this->request->param('password_confirmation'));
+        // Unescaped on purpose: this value is hashed, and the login form compares against that hash.
+        $new_password = (string)$this->request->param('password');
+        $password_confirmation = (string)$this->request->param('password_confirmation');
         $this->validatePasswordRequirements($new_password, $password_confirmation);
         $reset->resetPassword($new_password);
         $this->user = $reset->getUser() ?? throw new RuntimeException('User not found after password reset');

--- a/lib/Controller/API/App/Authentication/LoginController.php
+++ b/lib/Controller/API/App/Authentication/LoginController.php
@@ -48,7 +48,9 @@ class LoginController extends AbstractStatefulKleinController
     {
         $params = filter_var_array($this->request->params(), [
             'email' => FILTER_SANITIZE_EMAIL,
-            'password' => FILTER_SANITIZE_SPECIAL_CHARS
+            // Compared against a stored hash byte for byte, so it has to arrive exactly as typed. This
+            // must stay in step with how the signup and reset paths store it.
+            'password' => FILTER_UNSAFE_RAW
         ]);
 
         $emailIdentifier = is_string($params['email']) && $params['email'] !== '' ? $params['email'] : 'BLANK_EMAIL';

--- a/lib/Controller/API/App/Authentication/SignupController.php
+++ b/lib/Controller/API/App/Authentication/SignupController.php
@@ -129,14 +129,23 @@ class SignupController extends AbstractStatefulKleinController
      */
     private function validateCreationRequest(): array
     {
+        $rawUser = (array)$this->request->param('user');
+
+        // Before anything is sanitised, while the value still looks like what the client typed.
+        $this->rejectControlCharacters($rawUser['password'] ?? '');
+        $this->rejectControlCharacters($rawUser['password_confirmation'] ?? '');
+
         $user = filter_var_array(
-            (array)$this->request->param('user'),
+            $rawUser,
             [
                 'email' => ['filter' => FILTER_SANITIZE_EMAIL, 'options' => []],
-                'password' => ['filter' => FILTER_SANITIZE_SPECIAL_CHARS, 'options' => FILTER_FLAG_STRIP_LOW],
+                // Deliberately unfiltered: the password is hashed, never rendered, so escaping it only
+                // removes " & ' < > from the characters a user may choose. FILTER_UNSAFE_RAW is the
+                // pass-through, needed only because filter_var_array wants a filter for every key.
+                'password' => ['filter' => FILTER_UNSAFE_RAW, 'options' => []],
                 'password_confirmation' => [
-                    'filter' => FILTER_SANITIZE_SPECIAL_CHARS,
-                    'options' => FILTER_FLAG_STRIP_LOW
+                    'filter' => FILTER_UNSAFE_RAW,
+                    'options' => []
                 ],
                 'first_name' => [
                     'filter' => FILTER_CALLBACK,

--- a/lib/Controller/API/App/Authentication/UserController.php
+++ b/lib/Controller/API/App/Authentication/UserController.php
@@ -68,9 +68,13 @@ class UserController extends AbstractStatefulKleinController
             return;
         }
 
-        $old_password = (string) filter_var($this->request->param('old_password'), FILTER_SANITIZE_SPECIAL_CHARS);
-        $new_password = (string) filter_var($this->request->param('password'), FILTER_SANITIZE_SPECIAL_CHARS);
-        $new_password_confirmation = (string) filter_var($this->request->param('password_confirmation'), FILTER_SANITIZE_SPECIAL_CHARS);
+        $this->rejectControlCharacters($this->request->param('password'));
+        $this->rejectControlCharacters($this->request->param('password_confirmation'));
+        // All three unescaped on purpose: the old one is verified against the stored hash and the new
+        // one replaces it, so both must be exactly what the user typed.
+        $old_password = (string)$this->request->param('old_password');
+        $new_password = (string)$this->request->param('password');
+        $new_password_confirmation = (string)$this->request->param('password_confirmation');
 
         $this->validatePasswordRequirements($new_password, $new_password_confirmation);
 

--- a/lib/Model/Users/Authentication/ChangePasswordModel.php
+++ b/lib/Model/Users/Authentication/ChangePasswordModel.php
@@ -51,8 +51,13 @@ class ChangePasswordModel
 
         $this->user->pass = Utils::encryptPass($new_password, $salt);
 
+        // Retire any reset link already issued for this account. A token stays valid for 30 minutes
+        // from the moment it was created, so without this a link sitting in the user's mailbox
+        // outlives the password change and can be used to set a third password.
+        $this->user->clearAuthToken();
+
         $fieldsToUpdate = [
-            'fields' => ['pass']
+            'fields' => ['pass', 'confirmation_token', 'confirmation_token_created_at']
         ];
 
         // update email_confirmed_at only if it's null

--- a/lib/Model/Users/Authentication/PasswordResetModel.php
+++ b/lib/Model/Users/Authentication/PasswordResetModel.php
@@ -81,18 +81,29 @@ class PasswordResetModel
     {
         $this->getUserFromResetToken();
 
-        if (!$this->user) {
-            throw new ValidationError('Invalid authentication token');
+        $user = $this->user ?? throw new ValidationError('Invalid authentication token');
+
+        $this->discardExpiredToken($user);
+
+        $this->session['password_reset_token'] = $user->confirmation_token;
+    }
+
+    /**
+     * Clears the token and refuses to go on once it is older than its lifetime.
+     *
+     * @throws ValidationError if the token has expired
+     * @throws Exception if an error occurs
+     */
+    private function discardExpiredToken(UserStruct $user): void
+    {
+        if (strtotime($user->confirmation_token_created_at ?? '') >= strtotime('30 minutes ago')) {
+            return;
         }
 
-        if (strtotime($this->user->confirmation_token_created_at ?? '') < strtotime('30 minutes ago')) {
-            $this->user->clearAuthToken();
-            $this->userDao->updateStruct($this->user, ['fields' => ['confirmation_token']]);
+        $user->clearAuthToken();
+        $this->userDao->updateStruct($user, ['fields' => ['confirmation_token']]);
 
-            throw new ValidationError('Auth token expired, repeat the operation.');
-        }
-
-        $this->session['password_reset_token'] = $this->user->confirmation_token;
+        throw new ValidationError('Auth token expired, repeat the operation.');
     }
 
     /**
@@ -107,17 +118,20 @@ class PasswordResetModel
     {
         $this->getUserFromResetToken();
 
-        if (!$this->user) {
-            throw new ValidationError('Invalid authentication token');
-        }
+        $user = $this->user ?? throw new ValidationError('Invalid authentication token');
+
+        // validateUser() checks the age when the link is opened, but the form submission that follows
+        // reads the token back out of the session and arrives here instead. Age has to be checked
+        // again, or a token stays usable for as long as the session lives.
+        $this->discardExpiredToken($user);
 
         unset($this->session['password_reset_token']);
 
-        $salt = $this->user->salt ?? throw new RuntimeException('User salt must be set');
-        $this->user->pass = Utils::encryptPass($new_password, $salt);
+        $salt = $user->salt ?? throw new RuntimeException('User salt must be set');
+        $user->pass = Utils::encryptPass($new_password, $salt);
 
         // reset token
-        $this->user->clearAuthToken();
+        $user->clearAuthToken();
 
         $fieldsToUpdate = [
             'fields' => [
@@ -128,14 +142,14 @@ class PasswordResetModel
         ];
 
         // update email_confirmed_at only if it's null
-        if (null === $this->user->email_confirmed_at) {
-            $this->user->email_confirmed_at = date('Y-m-d H:i:s');
+        if (null === $user->email_confirmed_at) {
+            $user->email_confirmed_at = date('Y-m-d H:i:s');
             $fieldsToUpdate['fields'][] = 'email_confirmed_at';
         }
 
-        $this->userDao->updateStruct($this->user, $fieldsToUpdate);
-        $this->userDao->destroyCacheByEmail($this->user->email ?? throw new RuntimeException('User email must be set before cache invalidation'));
-        $this->userDao->destroyCacheByUid($this->user->uid ?? throw new RuntimeException('User uid must be set before cache invalidation'));
+        $this->userDao->updateStruct($user, $fieldsToUpdate);
+        $this->userDao->destroyCacheByEmail($user->email ?? throw new RuntimeException('User email must be set before cache invalidation'));
+        $this->userDao->destroyCacheByUid($user->uid ?? throw new RuntimeException('User uid must be set before cache invalidation'));
     }
 
     /**

--- a/lib/Model/Users/Authentication/PasswordRules.php
+++ b/lib/Model/Users/Authentication/PasswordRules.php
@@ -15,6 +15,33 @@ trait PasswordRules
 {
 
     /**
+     * Rejects control characters in a password.
+     *
+     * Passwords reach the rules unescaped: they are compared against a hash and never rendered, so
+     * escaping them would only shrink the usable character set. That leaves control characters as the
+     * one category worth refusing outright, since they cannot be typed back reliably and travel
+     * invisibly through copy and paste.
+     *
+     * @param mixed $password the raw request value, which is not necessarily a string
+     *
+     * @throws ValidationError
+     */
+    public function rejectControlCharacters(mixed $password): void
+    {
+        if (!is_string($password)) {
+            return;
+        }
+
+        // Byte-wise on purpose: without the u modifier every byte of a multibyte character is above
+        // 0x7F, so a legitimate accented or non-Latin password cannot match this range by accident.
+        if (preg_match('/[\x00-\x1F\x7F]/', $password) === 1) {
+            throw new ValidationError(
+                'The password cannot contain control characters, such as tabs, line breaks or null bytes'
+            );
+        }
+    }
+
+    /**
      * @throws ValidationError
      */
     public function validatePasswordRequirements(string $password, string $password_confirmation): void
@@ -23,11 +50,7 @@ trait PasswordRules
             throw new ValidationError('The password must be a maximum of 50 characters long');
         }
 
-        if (filter_var($password, FILTER_SANITIZE_SPECIAL_CHARS, FILTER_FLAG_STRIP_LOW) != $password) {
-            throw new ValidationError('The password contains illegal characters');
-        }
-
-        if (strlen($password) < 12) {
+        if (mb_strlen($password) < 12) {
             throw new ValidationError('Password must be at least 12 characters');
         }
 

--- a/tests/unit/Core/Controller/API/App/Authentication/ForgotPasswordControllerTest.php
+++ b/tests/unit/Core/Controller/API/App/Authentication/ForgotPasswordControllerTest.php
@@ -336,6 +336,70 @@ class ForgotPasswordControllerTest extends AbstractTest
     }
 
     #[Test]
+    public function setNewPassword_hands_the_password_to_the_model_unescaped(): void
+    {
+        $this->request->method('param')->willReturnCallback(function (string $key) {
+            return match ($key) {
+                'password' => 'Valid&Pass<word>1',
+                'password_confirmation' => 'Valid&Pass<word>1',
+                default => null,
+            };
+        });
+
+        $user = new UserStruct();
+        $user->uid = 1;
+        $user->email = 'test@example.com';
+
+        // The value that reaches resetPassword() is the value that gets hashed, so it has to be the
+        // one the user typed. Escaping it here would store a hash of a string the user can never type
+        // again at the login form once that form stops escaping too.
+        $resetModel = $this->createMock(PasswordResetModel::class);
+        $resetModel->expects($this->once())
+            ->method('resetPassword')
+            ->with('Valid&Pass<word>1');
+        $resetModel->method('getUser')->willReturn($user);
+
+        $this->controller->mockPasswordResetModel = $resetModel;
+
+        $this->controller->setNewPassword();
+
+        $this->assertSame(200, $this->controller->getResponse()->code());
+    }
+
+    #[Test]
+    public function setNewPassword_rejects_a_password_containing_a_control_character(): void
+    {
+        $this->request->method('param')->willReturnCallback(function (string $key) {
+            return match ($key) {
+                'password' => "Valid!Pass\tword1",
+                'password_confirmation' => "Valid!Pass\tword1",
+                default => null,
+            };
+        });
+
+        $user = new UserStruct();
+        $user->uid = 1;
+        $user->email = 'test@example.com';
+
+        $resetModel = $this->createStub(PasswordResetModel::class);
+        $resetModel->method('getUser')->willReturn($user);
+
+        $this->controller->mockPasswordResetModel = $resetModel;
+
+        // The message has to name the problem: the generic illegal-character wording leaves the user
+        // guessing which of their characters was refused.
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('control characters');
+
+        try {
+            $this->controller->setNewPassword();
+        } finally {
+            // Rejected before anything is written, so no session is torn down either.
+            $this->assertFalse($this->controller->broadcastLogoutCalled);
+        }
+    }
+
+    #[Test]
     public function setNewPassword_throws_when_passwords_dont_match(): void
     {
         $this->request->method('param')->willReturnCallback(function (string $key) {

--- a/tests/unit/Core/Controller/API/App/Authentication/LoginControllerTest.php
+++ b/tests/unit/Core/Controller/API/App/Authentication/LoginControllerTest.php
@@ -6,6 +6,7 @@ namespace Matecat\Core\Controller\API\App\Authentication;
 
 use Controller\Abstracts\KleinController;
 use Controller\API\App\Authentication\LoginController;
+use Controller\Exceptions\MissingDatabaseException;
 use Controller\Services\RateLimiterService;
 use Klein\Request;
 use Klein\Response;
@@ -227,6 +228,57 @@ class LoginControllerTest extends AbstractTest
         $this->controller->login();
 
         $this->assertSame(404, $this->controller->getResponse()->code());
+    }
+
+    #[Test]
+    public function login_accepts_a_password_containing_html_special_characters(): void
+    {
+        $this->rateLimiter->method('checkAndIncrement')->willReturn(null);
+
+        $csrf = Utils::uuid4();
+        $jwt = new SimpleJWT(
+            ['csrf' => $csrf],
+            AppConfig::MATECAT_USER_AGENT . AppConfig::$BUILD_NUMBER,
+            AppConfig::$AUTHSECRET,
+            60
+        );
+        $_SESSION['login_csrf'] = $csrf;
+
+        $headers = $this->createStub(\Klein\DataCollection\HeaderDataCollection::class);
+        $headers->method('get')->willReturn($jwt->jsonSerialize());
+
+        $this->request->method('params')->willReturn([
+            'email' => 'test@example.com',
+            'password' => 'Valid&Pass<word>1',
+        ]);
+        $this->request->method('headers')->willReturn($headers);
+
+        $user = new UserStruct();
+        $user->uid = 1;
+        $user->email = 'test@example.com';
+        $user->salt = 'test-salt';
+        // Hashed from the raw password, which is what the signup and reset paths now store.
+        $user->pass = Utils::encryptPass('Valid&Pass<word>1', 'test-salt');
+        $user->email_confirmed_at = date('Y-m-d H:i:s');
+
+        $dao = $this->createStub(UserDao::class);
+        $dao->method('getByEmail')->willReturn($user);
+        $this->controller->mockUserDao = $dao;
+
+        try {
+            $this->controller->login();
+        } catch (MissingDatabaseException) {
+            // The rejection branch sets 404 and returns without ever touching the database, so
+            // reaching the database dependency is itself proof that the password matched. Driving the
+            // rest of the authenticated branch would need cookie emission and a live schema, which is
+            // not what this test is about.
+            $this->addToAssertionCount(1);
+        }
+
+        // This is the pairing that has to hold: whatever the write paths hash, this path must compare
+        // byte for byte. A 404 here means login altered the submitted password and no longer agrees
+        // with how it was stored.
+        $this->assertNotSame(404, $this->controller->getResponse()->code());
     }
 
     #[Test]

--- a/tests/unit/Core/Controller/API/App/Authentication/SignupControllerTest.php
+++ b/tests/unit/Core/Controller/API/App/Authentication/SignupControllerTest.php
@@ -519,4 +519,103 @@ class SignupControllerTest extends AbstractTest
 
         $this->assertSame(200, $this->controller->getResponse()->code());
     }
+
+    // ─── control characters in the password ───────────────────────────
+
+    #[Test]
+    public function validateCreationRequest_throws_when_password_contains_a_control_character(): void
+    {
+        $this->request->method('param')->willReturn([
+            'email' => 'test@example.com',
+            'password' => "Valid!Pass\tword1",
+            'password_confirmation' => "Valid!Pass\tword1",
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'wanted_url' => 'https://example.com',
+        ]);
+
+        // A tab reaches validation encoded as &#9; by the sanitising filter, so the generic illegal
+        // character rule already rejects it, but only as a side effect of that encoding and with a
+        // message that never says what was wrong. The rule has to be explicit about it.
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('control characters');
+        $this->invokeValidateCreationRequest();
+    }
+
+    #[Test]
+    public function validateCreationRequest_throws_when_password_contains_a_null_byte(): void
+    {
+        $this->request->method('param')->willReturn([
+            'email' => 'test@example.com',
+            'password' => "Valid!Password1\0",
+            'password_confirmation' => "Valid!Password1\0",
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'wanted_url' => 'https://example.com',
+        ]);
+
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('control characters');
+        $this->invokeValidateCreationRequest();
+    }
+
+    #[Test]
+    public function validateCreationRequest_accepts_a_password_of_printable_characters(): void
+    {
+        $this->request->method('param')->willReturn([
+            'email' => 'test@example.com',
+            'password' => 'Valid!Password1',
+            'password_confirmation' => 'Valid!Password1',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'wanted_url' => 'https://example.com',
+        ]);
+
+        // The guard must not narrow what a legitimate user may choose: every printable character is
+        // still acceptable, and the value must survive validation unaltered.
+        $user = $this->invokeValidateCreationRequest();
+
+        $this->assertSame('Valid!Password1', $user['password']);
+    }
+
+    #[Test]
+    public function validateCreationRequest_accepts_a_password_containing_html_special_characters(): void
+    {
+        $this->request->method('param')->willReturn([
+            'email' => 'test@example.com',
+            'password' => 'Valid&Pass<word>1',
+            'password_confirmation' => 'Valid&Pass<word>1',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'wanted_url' => 'https://example.com',
+        ]);
+
+        // These five characters are the ones the sanitising filter rewrites, and the special-character
+        // rule has always advertised them as valid choices. A password is compared against a hash and
+        // never rendered, so escaping it only shrinks the usable character set and has to reach the
+        // hash exactly as the user typed it.
+        $user = $this->invokeValidateCreationRequest();
+
+        $this->assertSame('Valid&Pass<word>1', $user['password']);
+    }
+
+    #[Test]
+    public function validateCreationRequest_measures_the_minimum_length_in_characters_not_bytes(): void
+    {
+        $this->request->method('param')->willReturn([
+            'email' => 'test@example.com',
+            'password' => '密碼密!碼碼碼',
+            'password_confirmation' => '密碼密!碼碼碼',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'wanted_url' => 'https://example.com',
+        ]);
+
+        // Seven characters, nineteen bytes. Measured in bytes this clears a twelve character minimum
+        // while being far shorter than the rule intends, and the shortfall grows with every non-Latin
+        // alphabet.
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('at least 12 characters');
+        $this->invokeValidateCreationRequest();
+    }
 }

--- a/tests/unit/Core/Controller/API/App/Authentication/UserControllerTest.php
+++ b/tests/unit/Core/Controller/API/App/Authentication/UserControllerTest.php
@@ -259,4 +259,58 @@ class UserControllerTest extends AbstractTest
         $this->assertNotEmpty($validators);
         $this->assertInstanceOf(LoginValidator::class, end($validators));
     }
+
+    #[Test]
+    public function changePassword_hands_both_passwords_to_the_model_unescaped(): void
+    {
+        $this->rateLimiter->method('checkAndIncrement')->willReturn(null);
+
+        $this->request->method('param')->willReturnCallback(function (string $key) {
+            return match ($key) {
+                'old_password' => 'Old&Pass<word>1',
+                'password' => 'New&Pass<word>1',
+                'password_confirmation' => 'New&Pass<word>1',
+                default => null,
+            };
+        });
+
+        // Both values matter here: the old one is verified against the stored hash and the new one
+        // replaces it, so escaping either would break a password containing one of these characters
+        // in a different way.
+        $cpModel = $this->createMock(ChangePasswordModel::class);
+        $cpModel->expects($this->once())
+            ->method('changePassword')
+            ->with('Old&Pass<word>1', 'New&Pass<word>1');
+
+        $this->controller->mockChangePasswordModel = $cpModel;
+
+        $this->controller->changePasswordAsLoggedUser();
+
+        $this->assertSame(200, $this->controller->getResponse()->code());
+    }
+
+    #[Test]
+    public function changePassword_rejects_a_password_containing_a_control_character(): void
+    {
+        $this->rateLimiter->method('checkAndIncrement')->willReturn(null);
+
+        $this->request->method('param')->willReturnCallback(function (string $key) {
+            return match ($key) {
+                'old_password' => 'OldPass!123xx',
+                'password' => "NewValid!Pass\n1",
+                'password_confirmation' => "NewValid!Pass\n1",
+                default => null,
+            };
+        });
+
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('control characters');
+
+        try {
+            $this->controller->changePasswordAsLoggedUser();
+        } finally {
+            // Refused before the password is written, so existing sessions are left alone.
+            $this->assertFalse($this->controller->broadcastLogoutCalled);
+        }
+    }
 }

--- a/tests/unit/Core/Model/Users/Authentication/ChangePasswordModelTest.php
+++ b/tests/unit/Core/Model/Users/Authentication/ChangePasswordModelTest.php
@@ -100,4 +100,37 @@ class ChangePasswordModelTest extends AbstractTest
         $model = new ChangePasswordModel($user, $dao);
         $model->changePassword('old', 'new');
     }
+
+    #[Test]
+    public function changePasswordInvalidatesAnOutstandingResetToken(): void
+    {
+        $user = $this->makeUser('old-pass');
+        $user->confirmation_token = 'a-reset-link-already-in-the-mailbox';
+        $user->confirmation_token_created_at = '2026-01-01 00:00:00';
+
+        $captured = [];
+        $dao = $this->createStub(UserDao::class);
+        $dao->method('updateStruct')->willReturnCallback(
+            function (UserStruct $struct, array $fieldsToUpdate) use (&$captured): int {
+                $captured = $fieldsToUpdate;
+
+                return 1;
+            }
+        );
+        $dao->method('destroyCacheByEmail')->willReturn(true);
+        $dao->method('destroyCacheByUid')->willReturn(true);
+
+        (new ChangePasswordModel($user, $dao))->changePassword('old-pass', 'new-pass');
+
+        // Changing the password has to retire any reset link already issued for the account. If the
+        // token survives, whoever holds that link can set a third password for the rest of the
+        // token's lifetime and silently undo the change the user just made.
+        self::assertNull($user->confirmation_token);
+        self::assertNull($user->confirmation_token_created_at);
+
+        // Nulling the struct is not enough on its own: the fields have to be in the update list, or
+        // the row keeps the old token and the change never reaches the database.
+        self::assertContains('confirmation_token', $captured['fields']);
+        self::assertContains('confirmation_token_created_at', $captured['fields']);
+    }
 }

--- a/tests/unit/Core/Model/Users/Authentication/PasswordResetModelTest.php
+++ b/tests/unit/Core/Model/Users/Authentication/PasswordResetModelTest.php
@@ -174,4 +174,27 @@ class PasswordResetModelTest extends AbstractTest
 
         $this->assertNull($model->getUser());
     }
+
+    #[Test]
+    public function resetPasswordThrowsWhenTokenExpired(): void
+    {
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('Auth token expired');
+
+        $user = $this->makeUserWithToken();
+        $user->confirmation_token_created_at = date('Y-m-d H:i:s', strtotime('31 minutes ago'));
+        $oldPass = $user->pass;
+
+        // validateUser() guards the link click, but the form submission that follows reads the token
+        // back out of the session and lands here. Without its own check, this method would accept a
+        // token of any age as long as the session outlived the 30 minute window.
+        $session = ['password_reset_token' => 'valid-token'];
+        $model = new PasswordResetModel($session, $this->makeMockDao($user), null);
+
+        try {
+            $model->resetPassword('new-pass');
+        } finally {
+            $this->assertSame($oldPass, $user->pass);
+        }
+    }
 }

--- a/tests/unit/Core/Model/Users/Authentication/PasswordRulesTest.php
+++ b/tests/unit/Core/Model/Users/Authentication/PasswordRulesTest.php
@@ -1,0 +1,135 @@
+<?php
+
+
+namespace Matecat\Core\Model\Users\Authentication;
+
+use Controller\API\Commons\Exceptions\ValidationError;
+use Matecat\TestHelpers\AbstractTest;
+use Model\Users\Authentication\PasswordRules;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class PasswordRulesTest extends AbstractTest
+{
+    /**
+     * The trait is mixed into controllers, which drag in a request, a response and a database. Hosting
+     * it on a bare object keeps these tests on the rules themselves.
+     */
+    private function rules(): object
+    {
+        return new class {
+            use PasswordRules;
+        };
+    }
+
+    // ─── rejectControlCharacters ──────────────────────────────────────
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function controlCharacterProvider(): array
+    {
+        return [
+            'null byte' => ["Valid!Password\0"],
+            'tab' => ["Valid!Pass\tword1"],
+            'line feed' => ["Valid!Pass\nword1"],
+            'carriage return' => ["Valid!Pass\rword1"],
+            'escape' => ["Valid!Pass\x1Bword1"],
+            'delete' => ["Valid!Pass\x7Fword1"],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('controlCharacterProvider')]
+    public function rejectControlCharacters_refuses_every_control_character(string $password): void
+    {
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('control characters');
+
+        $this->rules()->rejectControlCharacters($password);
+    }
+
+    #[Test]
+    public function rejectControlCharacters_allows_printable_and_non_latin_characters(): void
+    {
+        // Byte-wise matching without the u modifier is what makes this safe: every byte of a multibyte
+        // character sits above 0x7F, so no accented or non-Latin password can collide with the range.
+        foreach (['Valid!Password1', 'Passwörd!123x', 'пароль!123456', '密碼!123456789', 'pass😀!123456'] as $password) {
+            $this->rules()->rejectControlCharacters($password);
+        }
+
+        $this->addToAssertionCount(5);
+    }
+
+    #[Test]
+    public function rejectControlCharacters_ignores_a_value_that_is_not_a_string(): void
+    {
+        // Request parameters are not guaranteed to be strings: an array arrives when a client sends
+        // user[password][]=x. Length and match rules downstream reject it, so this must not blow up.
+        $this->rules()->rejectControlCharacters(['array', 'from', 'query']);
+        $this->rules()->rejectControlCharacters(null);
+
+        $this->addToAssertionCount(2);
+    }
+
+    // ─── validatePasswordRequirements ─────────────────────────────────
+
+    #[Test]
+    public function validatePasswordRequirements_accepts_html_special_characters(): void
+    {
+        // These five are the ones the old escaping rewrote, and the special-character rule below
+        // advertises them. They must be usable.
+        $this->rules()->validatePasswordRequirements('Valid&Pass<word>1', 'Valid&Pass<word>1');
+        $this->rules()->validatePasswordRequirements('Quote"And\'Apos1', 'Quote"And\'Apos1');
+
+        $this->addToAssertionCount(2);
+    }
+
+    #[Test]
+    public function validatePasswordRequirements_counts_length_in_characters_not_bytes(): void
+    {
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('at least 12 characters');
+
+        // Seven characters, nineteen bytes.
+        $this->rules()->validatePasswordRequirements('密碼密!碼碼碼', '密碼密!碼碼碼');
+    }
+
+    #[Test]
+    public function validatePasswordRequirements_accepts_twelve_non_latin_characters(): void
+    {
+        $password = '密碼密碼密碼密碼密碼密!';
+
+        $this->rules()->validatePasswordRequirements($password, $password);
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function validatePasswordRequirements_rejects_more_than_fifty_characters(): void
+    {
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('maximum of 50 characters');
+
+        $password = str_repeat('a', 50) . '!X';
+        $this->rules()->validatePasswordRequirements($password, $password);
+    }
+
+    #[Test]
+    public function validatePasswordRequirements_rejects_a_mismatched_confirmation(): void
+    {
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('Passwords must match');
+
+        $this->rules()->validatePasswordRequirements('Valid!Password1', 'Valid!Password2');
+    }
+
+    #[Test]
+    public function validatePasswordRequirements_requires_a_special_character(): void
+    {
+        $this->expectException(ValidationError::class);
+        $this->expectExceptionMessage('special character');
+
+        $this->rules()->validatePasswordRequirements('NoSpecialsHere1', 'NoSpecialsHere1');
+    }
+}


### PR DESCRIPTION
## Summary

> **Read this first.** This PR removes `FILTER_SANITIZE_SPECIAL_CHARS` from the account password
> paths, including login. That looks like removing sanitisation from an authentication path, so here
> is why it is the correct direction: a password is compared against a hash and is never rendered
> anywhere. Escaping it protects nothing and instead removes `"` `&` `'` `<` `>` from the characters a
> user may choose — while the special-character rule in `PasswordRules` advertises those five as valid
> choices. Validation replaces escaping: control characters are now rejected explicitly, with a
> message that says so.

Two independent problems, one commit each.

**1. A password reset link outlived the password change it was meant to replace.**
`ChangePasswordModel::changePassword()` updated only the password, leaving `confirmation_token` and
`confirmation_token_created_at` in place, so a link already sitting in the user's mailbox stayed
usable for the rest of its 30 minute lifetime and could set a third password. Reported through the
vulnerability disclosure programme (CWE-640).

While verifying it, a second gap in the same flow: `PasswordResetModel::resetPassword()` never
checked the token's age at all. `validateUser()` guards the link click, but the form submission that
follows reads the token back out of the session and lands in `resetPassword()` instead, so a token
stayed usable for as long as the session lived. Same weight as the reported issue.

**2. Password character handling was self-contradictory.** Details in the note above; the practical
effect was that a user choosing `&` got *"The password contains illegal characters"* from a rule that
only caught it as a side effect of double-encoding an already escaped value. Two further bugs
surfaced in the same code: `FILTER_FLAG_STRIP_LOW` was passed under the `options` key of
`filter_var_array`, which ignores it, so it had never stripped anything; and the minimum-length rule
used `strlen`, so a seven character CJK password cleared a twelve character minimum.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix (security: CWE-640, plus password validation correctness)
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Model/Users/Authentication/ChangePasswordModel.php` | `clearAuthToken()` on password change, with both token columns added to the update list |
| `lib/Model/Users/Authentication/PasswordResetModel.php` | Age check extracted to `discardExpiredToken()` and called from `resetPassword()` as well as `validateUser()`; `resetPassword()` uses a narrowed local so the check cannot be defeated by property re-widening |
| `lib/Model/Users/Authentication/PasswordRules.php` | New `rejectControlCharacters()`; illegal-character rule deleted; `strlen` → `mb_strlen` |
| `lib/Controller/API/App/Authentication/SignupController.php` | Raw password read before filtering, control chars rejected, `FILTER_UNSAFE_RAW` for both password fields |
| `lib/Controller/API/App/Authentication/LoginController.php` | `FILTER_UNSAFE_RAW` for the password so it is compared exactly as typed |
| `lib/Controller/API/App/Authentication/ForgotPasswordController.php` | Control chars rejected; both password reads unescaped |
| `lib/Controller/API/App/Authentication/UserController.php` | Control chars rejected; all three password reads unescaped, including the old password verified against the stored hash |
| `tests/.../PasswordRulesTest.php` | New: 14 tests on the trait directly, which had no test file at all |
| `tests/.../{Signup,Login,ForgotPassword,User}ControllerTest.php` | Control-character rejection, raw values reaching the models, and the login round trip |
| `tests/.../{ChangePassword,PasswordReset}ModelTest.php` | Token invalidation and expiry on the submission path |
| `MateCat-docs` | Pointer bump: operational note for support on legacy accounts |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite: `OK (9333 tests, 30179 assertions)`, exit 0 — the 9307 on develop plus exactly the 26
tests added here.

PHPStan: `[OK] No errors` across `lib/Model/Users/Authentication/` and
`lib/Controller/API/App/Authentication/`.

Diff coverage measured locally at **100%** (44/44 executable added lines in `lib/`) against the 80%
threshold, using a coverage run scoped to the touching tests, so the full-suite figure can only be
equal or higher.

Every test was run against the unfixed code first and observed to fail. The login round trip is worth
a note: its success branch needs cookie emission and a live schema, so it asserts on the
authentication decision instead — the rejection branch sets 404 and returns without ever touching the
database, so reaching the database dependency is itself proof the hash matched. Reverting
`LoginController` alone turns it red with a 404.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**Legacy accounts.** An account can hold a hash built from an escaped password only if one of those
five characters was in it *and* the password has not been set since `2f1c123645` (2023-09-19), which
began rejecting them at every write path. Those users' logins will fail as though the password were
wrong.

There is deliberately **no migration code**. It cannot be targeted — a hash cannot be searched for the
characters that went into it — and the recovery path already exists and needs no old password: Forgot
password sends a link, and the reset path now stores the raw value, so they land correctly first try.
A login-time fallback was considered and rejected: it would have left two distinct strings
authenticating the same account until the next login. Recorded for support in
`MateCat-docs/backend/work_in_progress/todo-things-left-behind-always-actual.md`.

**Scope check.** `FILTER_SANITIZE_SPECIAL_CHARS` is still applied to *job* passwords across many
controllers. Those are generated by `Utils::randomString()` as base62 and contain none of the five
affected characters, so they are untouched and out of scope here.

**Not changed:** the special-character rule still *requires* one of `!"#$%&'()*+,-./:;<=>?@[]^_`{|}~`.
This PR only makes all of them actually usable.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209285581049004