### PR TITLE
🔒 security(jobs): authorize job metadata changes by project team membership

### DIFF
--- a/lib/Controller/API/App/JobMetadataController.php
+++ b/lib/Controller/API/App/JobMetadataController.php
@@ -3,11 +3,15 @@
 namespace Controller\API\App;
 
 use Controller\Abstracts\KleinController;
+use Controller\API\Commons\Exceptions\AuthorizationError;
 use Controller\API\Commons\Exceptions\NotFoundException;
 use Controller\API\Commons\Validators\ChunkPasswordValidator;
 use Controller\API\Commons\Validators\LoginValidator;
+use Controller\API\Commons\Validators\TeamAccessValidator;
 use Exception;
+use Model\Jobs\JobStruct;
 use Model\Jobs\MetadataDao;
+use Model\Projects\ProjectDao;
 use ReflectionException;
 use Utils\Validator\JSONSchema\JSONValidator;
 use Utils\Validator\JSONSchema\JSONValidatorObject;
@@ -18,7 +22,40 @@ class JobMetadataController extends KleinController
     protected function registerValidators(): void
     {
         $this->appendValidator(new LoginValidator($this));
-        $this->appendValidator(new ChunkPasswordValidator($this));
+
+        // The job password is a capability to work on the job, not permission to change how it
+        // behaves: these settings alter tag parsing, TM prioritisation and the issues a reviewer is
+        // required to fill in, for everyone on the job. The editor only offers them to the team that
+        // owns the project, so the same rule has to hold here rather than in the browser alone.
+        $teamValidator = new TeamAccessValidator($this);
+
+        $chunkValidator = new ChunkPasswordValidator($this);
+        $chunkValidator->onSuccess(function () use ($chunkValidator, $teamValidator) {
+            // The chunk is already in hand from the validator that just resolved it, so the job is not
+            // read a second time.
+            $teamValidator->setIdTeam($this->resolveTeamId($chunkValidator->getChunk()));
+        });
+
+        // Registration order is execution order, so the team check runs after the callback above has
+        // supplied the id_team. Appending it from inside the callback would not work: validateRequest()
+        // iterates a copy of the list and would never reach it.
+        $this->appendValidator($chunkValidator);
+        $this->appendValidator($teamValidator);
+    }
+
+    /**
+     * Reads the owning team from projects.id_team for the job the caller addressed.
+     *
+     * @throws AuthorizationError if the project has no team, since a project without a team has no
+     *                            members and there is nobody the membership check could match
+     * @throws ReflectionException
+     * @throws Exception
+     */
+    protected function resolveTeamId(JobStruct $chunk): int
+    {
+        $project = $chunk->getProject(new ProjectDao($this->getDatabase()));
+
+        return $project->id_team ?? throw new AuthorizationError('Not Authorized', 401);
     }
 
     /**

--- a/lib/Controller/API/Commons/Validators/TeamAccessValidator.php
+++ b/lib/Controller/API/Commons/Validators/TeamAccessValidator.php
@@ -22,6 +22,20 @@ class TeamAccessValidator extends Base
      */
     public ?TeamStruct $team = null;
 
+    private ?int $idTeam = null;
+
+    /**
+     * Names the team to check when the route carries no id_team parameter, for instance when the team
+     * is taken from the project a job belongs to.
+     *
+     * This says only *which* team is checked, never *whether* access is granted: membership below
+     * remains the sole authorization. Pass a value derived on the server, never a request parameter,
+     * or the CWE-639 hole described below reopens.
+     */
+    public function setIdTeam(int $idTeam): void
+    {
+        $this->idTeam = $idTeam;
+    }
 
     public function _validate(): void
     {
@@ -29,7 +43,7 @@ class TeamAccessValidator extends Base
         // requesting user's membership; the team_name request parameter is NOT an authorization
         // path (a name-based lookup would let any user read/act on any team — CWE-639 IDOR).
         $this->team = (new MembershipDao($this->controller->getDatabase()))->setCacheTTL(60 * 10)->findTeamByIdAndUser(
-            $this->request->param('id_team'),
+            $this->idTeam ?? $this->request->param('id_team'),
             $this->controller->getUser()
         );
 

--- a/tests/unit/Core/Controller/API/Commons/Validators/TeamAccessValidatorTest.php
+++ b/tests/unit/Core/Controller/API/Commons/Validators/TeamAccessValidatorTest.php
@@ -170,4 +170,42 @@ class TeamAccessValidatorTest extends AbstractTest
 
         $validator->_validate();
     }
+
+    // ─── setIdTeam: for routes that carry no id_team parameter ─────────
+
+    #[Test]
+    public function setIdTeam_checks_the_supplied_team_and_ignores_the_request(): void
+    {
+        // Some routes address a job, not a team, and derive the team from projects.id_team on the
+        // server. The supplied value has to win over anything the request happens to carry.
+        $this->setRequest(['id_team' => '99999999']);
+
+        $validator = new TeamAccessValidator($this->controller);
+        $validator->setIdTeam(self::TEAM_ID);
+        $validator->_validate();
+
+        $this->assertInstanceOf(TeamStruct::class, $validator->team);
+        $this->assertSame(self::TEAM_ID, $validator->team->id);
+    }
+
+    #[Test]
+    public function setIdTeam_names_the_team_but_does_not_grant_access(): void
+    {
+        // The whole point of the setter: it selects which team is checked, never whether the caller
+        // passes. A non-member must still be refused even when the team is handed over directly.
+        $attacker = new UserStruct();
+        $attacker->uid = self::ATTACKER_UID;
+        $attacker->email = 'attacker_9910000@example.org';
+        $this->setCtrlProp('user', $attacker);
+
+        $this->setRequest([]);
+
+        $validator = new TeamAccessValidator($this->controller);
+        $validator->setIdTeam(self::TEAM_ID);
+
+        $this->expectException(AuthorizationError::class);
+        $this->expectExceptionCode(401);
+
+        $validator->_validate();
+    }
 }

--- a/tests/unit/Core/Controllers/JobMetadataControllerTest.php
+++ b/tests/unit/Core/Controllers/JobMetadataControllerTest.php
@@ -3,6 +3,7 @@
 namespace Matecat\Core\Controllers;
 
 use Controller\API\App\JobMetadataController;
+use Controller\API\Commons\Exceptions\AuthorizationError;
 use Controller\API\Commons\Exceptions\NotFoundException;
 use Exception;
 use Klein\Request;
@@ -11,6 +12,7 @@ use Matecat\TestHelpers\AbstractTest;
 use Matecat\TestHelpers\ControllerSeedFragments;
 use Model\DataAccess\Database;
 use Model\FeaturesBase\FeatureSet;
+use Model\Jobs\JobStruct;
 use Model\Jobs\MetadataDao;
 use Model\Users\UserStruct;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -35,6 +37,30 @@ class TestableJobMetadataController extends JobMetadataController
 
     protected function registerValidators(): void
     {
+    }
+}
+
+/**
+ * Keeps the real registerValidators(), because for this endpoint the authorization lives in the
+ * validator chain rather than in the action body.
+ */
+class ValidatingJobMetadataController extends JobMetadataController
+{
+    public function __construct()
+    {
+    }
+
+    protected function initDependencies(): void
+    {
+    }
+
+    public function runValidators(): void
+    {
+        // registerValidators() is normally called by the base constructor, which this double skips, so
+        // it has to be invoked here or the chain would be empty and every assertion would pass for the
+        // wrong reason.
+        $this->registerValidators();
+        $this->validateRequest();
     }
 }
 
@@ -109,6 +135,12 @@ class JobMetadataControllerTest extends AbstractTest
         $this->seedProject(self::BASE, $this->owner);
         $this->seedFile(self::BASE);
         $this->seedJob(self::BASE, $this->owner, self::JOB_PASSWORD);
+
+        // seedProject points the project at teamId(BASE); the team, the user and the membership row
+        // have to exist for the team authorization on this endpoint to be exercised for real.
+        $this->seedTeam(self::BASE);
+        $this->seedUser(self::BASE, $this->owner);
+        $this->seedMembership(self::BASE);
     }
 
     /**
@@ -420,5 +452,81 @@ class JobMetadataControllerTest extends AbstractTest
         $this->assertArrayHasKey('password', $result);
         $this->assertArrayHasKey('key', $result);
         $this->assertSame('tm_prioritization', $result['key']);
+    }
+
+    // ─── team authorization on the validator chain ────────────────────
+
+    /**
+     * A controller carrying the real validator chain, authenticated as $uid and addressing the seeded
+     * job with its correct password. Everything an ordinary share-link holder would have.
+     */
+    private function validatingController(int $uid): ValidatingJobMetadataController
+    {
+        $controller = new ValidatingJobMetadataController();
+        $ref = new ReflectionClass(JobMetadataController::class);
+
+        $user = new UserStruct();
+        $user->uid = $uid;
+        $user->email = $this->owner;
+
+        $ref->getProperty('database')->setValue($controller, obtainTestDatabase());
+        $ref->getProperty('request')->setValue($controller, new Request());
+        $ref->getProperty('response')->setValue($controller, new Response());
+        $ref->getProperty('user')->setValue($controller, $user);
+        $ref->getProperty('userIsLogged')->setValue($controller, true);
+        $ref->getProperty('params')->setValue($controller, [
+            'id_job' => (string)$this->jobId(self::BASE),
+            'password' => self::JOB_PASSWORD,
+        ]);
+
+        return $controller;
+    }
+
+    #[Test]
+    public function validators_allow_a_member_of_the_project_team(): void
+    {
+        $this->validatingController($this->userId(self::BASE))->runValidators();
+
+        // Getting here means the chain resolved the job, read projects.id_team from it and matched the
+        // caller's membership.
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function validators_reject_a_job_link_holder_outside_the_project_team(): void
+    {
+        // The job id and password are entirely valid: this is exactly what someone handed a share link
+        // possesses. It is not enough, because these settings change how the job behaves for everybody
+        // working on it, and the editor only offers them to the owning team.
+        $this->expectException(AuthorizationError::class);
+
+        $this->validatingController($this->userId(self::BASE) + 999999)->runValidators();
+    }
+
+    #[Test]
+    public function resolveTeamId_rejects_a_project_with_no_team(): void
+    {
+        // A dedicated project id inside the reserved block, never read by another test: findById caches
+        // for a day and offers no invalidation for that key, so mutating the shared project would be
+        // invisible here and the assertion would pass for the wrong reason.
+        $orphanProjectId = self::BASE + 900;
+        $this->seedConnection()->exec(
+            "INSERT IGNORE INTO projects (id, id_customer, password, name, create_date, status_analysis, id_team) "
+            . "VALUES ($orphanProjectId, '{$this->owner}', 'projpw', 'CtrlTestOrphan', NOW(), 'DONE', NULL)"
+        );
+
+        $chunk = new JobStruct();
+        $chunk->id = $this->jobId(self::BASE);
+        $chunk->id_project = $orphanProjectId;
+
+        try {
+            // Must deny rather than hand a null to a team lookup that is typed to take an int.
+            $this->expectException(AuthorizationError::class);
+
+            $m = $this->reflector->getMethod('resolveTeamId');
+            $m->invoke($this->controller, $chunk);
+        } finally {
+            $this->seedConnection()->exec("DELETE FROM projects WHERE id = $orphanProjectId");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Writing job metadata was guarded only by `LoginValidator` and `ChunkPasswordValidator`, so any authenticated holder of a job link could change how the job behaves for everyone working on it — tag parsing, TM prioritisation, and the issues a reviewer is required to fill in. The editor only offers these settings to the team that owns the project, so the rule lived in the browser alone and the API did not enforce it.

Both write endpoints now also require membership of the team that owns the project, taken from `projects.id_team`.

Reported externally (Asana 1210137805342006).

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Controller/API/App/JobMetadataController.php` | Append `TeamAccessValidator` to `POST /metadata` and `DELETE /metadata/{key}`. New `resolveTeamId()` reads `projects.id_team` from the chunk `ChunkPasswordValidator` already resolved, inside its `onSuccess` callback, so the job is not queried twice. A project with no team is refused instead of handing `null` to an `int`-typed lookup. |
| `lib/Controller/API/Commons/Validators/TeamAccessValidator.php` | New `setIdTeam()` for routes that address a job rather than a team and derive the team on the server. Selects *which* team is checked, never *whether* access is granted — membership stays the sole authorization. |
| `tests/unit/Core/Controllers/JobMetadataControllerTest.php` | Real-DB validator-chain tests: team member allowed, job-link holder outside the team rejected, teamless project rejected. |
| `tests/unit/Core/Controller/API/Commons/Validators/TeamAccessValidatorTest.php` | `setIdTeam()` overrides the request parameter, and still refuses a non-member. |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite: `OK (9312 tests, 30126 assertions)` — `develop`'s 9307 plus the 5 added here, so nothing else shifted. `JobMetadataControllerTest` 14/14, `TeamAccessValidatorTest` 6/6. PHPStan reports `[OK] No errors` on both changed `lib/` files (this project has no baseline, so that is 0 errors outright). Diff coverage 100% — 11 of 11 added executable lines.

Manual testing, end to end against a local instance serving this branch, using a Bruno collection and `x-matecat-key` auth for a user who *is* a member of the owning team:

- `POST /api/app/jobs/1011/74f1bc6220d4/metadata` → `200`, row created
- `DELETE .../metadata/character_counter_count_tags` → `200`, row removed, pre-existing row untouched
- Same `POST` with a wrong job password → `404` from `ChunkPasswordValidator`, no `500`

That exercised the whole new chain on live code: chunk resolution, the `onSuccess` callback, `resolveTeamId()` reading `projects.id_team`, and the membership check. It also confirms the ordering constraint below holds in real dispatch, not just under test.

The negative team case — an authenticated user outside the owning team — is covered by unit tests rather than manually, since the available API key belongs to a team member.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**Existing callers are unaffected.** The other four `TeamAccessValidator` call sites pass no team id and keep reading `id_team` from the request, so their behaviour is unchanged.

**Validator ordering is load-bearing.** Both validators are appended *before* validation runs. `KleinController::validateRequest()` iterates a copy of the validator list, so one appended from inside an `onSuccess` callback would never execute. Registration order is execution order, which is what lets the team check run after the callback has supplied the id.

**`GET /metadata` is deliberately left readable by job link.** The editor needs these settings to render segments for translators and reviewers who are not team members, so restricting the read would break the job-link workflow. The reasoning and its limits are recorded in `MateCat-docs` (`backend/work_in_progress/todo-things-left-behind-always-actual.md`, commit `9edcdcc`) — chiefly that nothing gates reads per key, so a future *sensitive* setting in `job_metadata` would be exposed by default.

**`DELETE /metadata/{key}` also closes an unreported hole.** It had the same weak guard as the `POST` and was not part of the external report.

The `MateCat-docs` submodule pointer is intentionally not bumped in this PR, to keep the code change reviewable on its own; the docs commit is pushed to `main` there.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210137805342006