### PR TITLE
🔒 security(activity-log): restrict project activity log to owning-team members

### DIFF
--- a/lib/Controller/API/V2/ActivityLogController.php
+++ b/lib/Controller/API/V2/ActivityLogController.php
@@ -10,11 +10,14 @@
 namespace Controller\API\V2;
 
 use Controller\Abstracts\KleinController;
+use Controller\API\Commons\Exceptions\AuthorizationError;
 use Controller\API\Commons\Validators\ChunkPasswordValidator;
 use Controller\API\Commons\Validators\LoginValidator;
 use Controller\API\Commons\Validators\ProjectPasswordValidator;
+use Controller\API\Commons\Validators\TeamAccessValidator;
 use Model\ActivityLog\ActivityLogDao;
 use Model\ActivityLog\ActivityLogStruct;
+use Model\Projects\ProjectStruct;
 use ReflectionException;
 use Throwable;
 use View\API\V2\Json\Activity;
@@ -30,6 +33,8 @@ class ActivityLogController extends KleinController
         $validator = new ProjectPasswordValidator($this);
         $validator->validate();
 
+        $this->guardProjectTeamMembership($validator->getProject());
+
         $activityLogDao = new ActivityLogDao($this->getDatabase());
         $rawContent = $activityLogDao->getAllForProject($validator->getIdProject());
 
@@ -44,6 +49,8 @@ class ActivityLogController extends KleinController
     {
         $validator = new ProjectPasswordValidator($this);
         $validator->validate();
+
+        $this->guardProjectTeamMembership($validator->getProject());
 
         $activityLogDao = new ActivityLogDao($this->getDatabase());
         $rawContent = $activityLogDao->getLastActionInProject($validator->getIdProject());
@@ -72,6 +79,28 @@ class ActivityLogController extends KleinController
 
         $formatted = new Activity($rawLogContent, $this->featureSet);
         $this->response->json(['activity' => $formatted->render()]);
+    }
+
+    /**
+     * The project id and password only prove the caller reached the project through a shared link.
+     * The activity log lists the name, email and IP of everyone who worked on the project, so it is
+     * restricted to the team that owns the project, matching the "View Project Logs" entry the editor
+     * offers only to that team. lastOnJob is deliberately not guarded this way: it is scoped to a
+     * single job by its own password, the working capability of a collaborator on that job.
+     *
+     * @throws AuthorizationError if the project has no team, since a project without a team has no
+     *                            members and there is nobody the membership check could match
+     * @throws Throwable
+     */
+    private function guardProjectTeamMembership(?ProjectStruct $project): void
+    {
+        if ($project === null || $project->id_team === null) {
+            throw new AuthorizationError('Not Authorized', 401);
+        }
+
+        $teamValidator = new TeamAccessValidator($this);
+        $teamValidator->setIdTeam($project->id_team);
+        $teamValidator->validate();
     }
 
     protected function registerValidators(): void

--- a/lib/Controller/Views/ActivityLogController.php
+++ b/lib/Controller/Views/ActivityLogController.php
@@ -5,6 +5,7 @@ namespace Controller\Views;
 use Controller\Abstracts\BaseKleinViewController;
 use Controller\Abstracts\IController;
 use Controller\API\Commons\Validators\ProjectPasswordValidator;
+use Controller\API\Commons\Validators\TeamAccessValidator;
 use Controller\API\Commons\ViewValidators\ViewLoginRedirectValidator;
 use Exception;
 use Model\ActivityLog\ActivityLogDao;
@@ -23,12 +24,44 @@ class ActivityLogController extends BaseKleinViewController implements IControll
     protected function registerValidators(): void
     {
         $this->appendValidator(new ViewLoginRedirectValidator($this));
-        $this->appendValidator(
-            (new ProjectPasswordValidator($this))->onFailure(function () {
+
+        // The project id and password only prove the caller followed a shared link. The activity log
+        // lists the name, email and IP of everyone who worked on the project, so viewing it is
+        // restricted to the team that owns the project — the same rule the project menu applies when
+        // it offers "View Project Logs" only to that team.
+        $teamValidator = new TeamAccessValidator($this);
+
+        // Construct first, then attach the callbacks: a closure captures `use` variables by value at
+        // creation time, so $projectValidator must already be assigned before onSuccess() references it.
+        $projectValidator = new ProjectPasswordValidator($this);
+        $projectValidator
+            ->onSuccess(function () use ($projectValidator, $teamValidator) {
+                // The password validator has just resolved the project, so the owning team is taken
+                // from it rather than read again.
+                $project = $projectValidator->getProject();
+                if ($project === null || $project->id_team === null) {
+                    // A project with no team has nobody to be a member of; refuse without disclosing
+                    // whether the project exists, matching the wrong-password branch below.
+                    $this->setView("project_not_found.html", [], 404);
+                    $this->render();
+                }
+
+                $teamValidator->setIdTeam($project->id_team);
+            })
+            ->onFailure(function () {
                 $this->setView("project_not_found.html", [], 404);
                 $this->render();
-            })
-        );
+            });
+
+        $teamValidator->onFailure(function () {
+            $this->setView("project_not_found.html", [], 404);
+            $this->render();
+        });
+
+        // Registration order is execution order: the password validator resolves the project and
+        // seeds the team above, then the team validator confirms membership.
+        $this->appendValidator($projectValidator);
+        $this->appendValidator($teamValidator);
     }
 
     /**

--- a/tests/unit/Core/Controllers/ActivityLogV2ControllerTest.php
+++ b/tests/unit/Core/Controllers/ActivityLogV2ControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Matecat\Core\Controllers;
 
+use Controller\API\Commons\Exceptions\AuthorizationError;
 use Controller\API\V2\ActivityLogController;
 use Klein\Request;
 use Klein\Response;
@@ -10,6 +11,7 @@ use Matecat\TestHelpers\ControllerSeedFragments;
 use Model\DataAccess\Database;
 use Model\Exceptions\NotFoundException;
 use Model\FeaturesBase\FeatureSet;
+use Model\Users\UserStruct;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -50,6 +52,12 @@ class ActivityLogV2ControllerTest extends AbstractTest
     private const string JOB_PASSWORD = 'actlogpw';
     private const int ACTIVITY_ID = 9_041_900;
 
+    /** A logged-in user who is not a member of the project's team. */
+    private const int OUTSIDER_UID = 9_041_950;
+
+    /** A project owned by no team, to prove a null id_team is refused rather than trusted. */
+    private const int NO_TEAM_PROJECT_ID = 9_041_960;
+
     /** @var ReflectionClass<ActivityLogController> */
     private ReflectionClass $reflector;
     private TestableActivityLogV2Controller $controller;
@@ -77,6 +85,11 @@ class ActivityLogV2ControllerTest extends AbstractTest
         $this->reflector->getProperty('logger')->setValue($this->controller, $this->createMock(MatecatLogger::class));
         $this->reflector->getProperty('featureSet')->setValue($this->controller, new FeatureSet($this->createStub(\Model\DataAccess\IDatabase::class)));
         $this->reflector->getProperty('database')->setValue($this->controller, obtainTestDatabase());
+
+        // Production runs LoginValidator before the action, so the user is always identified by the
+        // time these methods execute. The test controller no-ops registerValidators(), so the tests
+        // set the user explicitly to reproduce that precondition for the team-membership check.
+        $this->setControllerUser($this->userId(self::BASE));
     }
 
     /**
@@ -96,6 +109,8 @@ class ActivityLogV2ControllerTest extends AbstractTest
         $owner = $this->ownerEmail(self::BASE);
 
         $this->seedUser(self::BASE);
+        $this->seedTeam(self::BASE);
+        $this->seedMembership(self::BASE);
         $this->seedProject(self::BASE, $owner);
         $this->seedFile(self::BASE);
         $this->seedJob(self::BASE, $owner, self::JOB_PASSWORD);
@@ -107,6 +122,14 @@ class ActivityLogV2ControllerTest extends AbstractTest
             . self::ACTIVITY_ID . ", " . $this->projectId(self::BASE) . ", " . $this->jobId(self::BASE)
             . ", 14, '127.0.0.1', " . $this->userId(self::BASE) . ", NOW())"
         );
+
+        // A project deliberately owned by no team, so the "null id_team" branch is exercised: a
+        // project without a team has nobody to be a member of and must be refused. No log row is
+        // needed — the team guard refuses before the log is ever read.
+        $conn->exec(
+            "INSERT IGNORE INTO projects (id, id_customer, password, name, create_date, status_analysis, id_team) "
+            . "VALUES (" . self::NO_TEAM_PROJECT_ID . ", '$owner', 'projpw', 'CtrlNoTeamProject', NOW(), 'DONE', NULL)"
+        );
     }
 
     /**
@@ -116,6 +139,7 @@ class ActivityLogV2ControllerTest extends AbstractTest
     {
         $conn = obtainTestDatabase()->getConnection();
         $conn->exec("DELETE FROM activity_log WHERE ID = " . self::ACTIVITY_ID);
+        $conn->exec("DELETE FROM projects WHERE id = " . self::NO_TEAM_PROJECT_ID);
         $this->cleanFragments(self::BASE);
     }
 
@@ -132,6 +156,18 @@ class ActivityLogV2ControllerTest extends AbstractTest
         $this->requestStub = new Request($params, [], [], $serverParams);
         $this->reflector->getProperty('request')->setValue($this->controller, $this->requestStub);
         $this->reflector->getProperty('params')->setValue($this->controller, $params);
+    }
+
+    /**
+     * Stand in for the user LoginValidator would have identified in production.
+     *
+     * @throws ReflectionException
+     */
+    private function setControllerUser(int $uid): void
+    {
+        $user = new UserStruct();
+        $user->uid = $uid;
+        $this->reflector->getProperty('user')->setValue($this->controller, $user);
     }
 
     // ─── allOnProject ───
@@ -198,6 +234,52 @@ class ActivityLogV2ControllerTest extends AbstractTest
         $this->controller->allOnProject();
     }
 
+    /**
+     * The project id + password only prove the caller followed a shared link. The log lists the name,
+     * email and IP of everyone who worked on the project, so a logged-in user who is not a member of
+     * the owning team must be refused even with the correct password.
+     *
+     * @throws Throwable
+     */
+    #[Test]
+    public function allOnProject_denies_a_non_member(): void
+    {
+        $this->setControllerUser(self::OUTSIDER_UID);
+        $this->setRequestParams([
+            'id_project' => (string) $this->projectId(self::BASE),
+            'password'   => 'projpw',
+        ]);
+
+        $this->responseMock->expects($this->never())->method('json');
+
+        $this->expectException(AuthorizationError::class);
+        $this->expectExceptionCode(401);
+
+        $this->controller->allOnProject();
+    }
+
+    /**
+     * A project with no team has nobody to be a member of, so the null id_team is refused rather than
+     * handed to the membership lookup.
+     *
+     * @throws Throwable
+     */
+    #[Test]
+    public function allOnProject_denies_a_project_with_no_team(): void
+    {
+        $this->setRequestParams([
+            'id_project' => (string) self::NO_TEAM_PROJECT_ID,
+            'password'   => 'projpw',
+        ]);
+
+        $this->responseMock->expects($this->never())->method('json');
+
+        $this->expectException(AuthorizationError::class);
+        $this->expectExceptionCode(401);
+
+        $this->controller->allOnProject();
+    }
+
     // ─── lastOnProject ───
 
     /**
@@ -244,7 +326,27 @@ class ActivityLogV2ControllerTest extends AbstractTest
         $this->controller->lastOnProject();
     }
 
-    // ─── lastOnJob ───
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function lastOnProject_denies_a_non_member(): void
+    {
+        $this->setControllerUser(self::OUTSIDER_UID);
+        $this->setRequestParams([
+            'id_project' => (string) $this->projectId(self::BASE),
+            'password'   => 'projpw',
+        ]);
+
+        $this->responseMock->expects($this->never())->method('json');
+
+        $this->expectException(AuthorizationError::class);
+        $this->expectExceptionCode(401);
+
+        $this->controller->lastOnProject();
+    }
+
+    // ─── lastOnJob (job password capability — team membership intentionally not required) ───
 
     /**
      * @throws Throwable

--- a/tests/unit/Core/Controllers/ActivityLogViewControllerTest.php
+++ b/tests/unit/Core/Controllers/ActivityLogViewControllerTest.php
@@ -13,6 +13,7 @@ namespace Matecat\Core\Controllers;
 use Controller\API\Commons\ViewValidators\ViewLoginRedirectValidator;
 use Controller\API\Commons\Validators\Base as ValidatorBase;
 use Controller\API\Commons\Validators\ProjectPasswordValidator;
+use Controller\API\Commons\Validators\TeamAccessValidator;
 use Controller\Exceptions\RenderTerminatedException;
 use Controller\Views\ActivityLogController;
 use Klein\DataCollection\DataCollection;
@@ -22,6 +23,7 @@ use Matecat\TestHelpers\AbstractTest;
 use Matecat\TestHelpers\ControllerSeedFragments;
 use Model\DataAccess\Database;
 use Model\FeaturesBase\FeatureSet;
+use Model\Teams\TeamStruct;
 use Model\Users\UserStruct;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
@@ -83,6 +85,12 @@ class ActivityLogViewControllerTest extends AbstractTest
     private const int ACTIVITY_ID = 9063020;
     private const string PROJECT_PASSWORD = 'projpw';
 
+    /** A logged-in user who is not a member of the project's team. */
+    private const int OUTSIDER_UID = 9063050;
+
+    /** A project owned by no team, to prove a null id_team is refused rather than trusted. */
+    private const int NO_TEAM_PROJECT_ID = 9063060;
+
     /** @var ReflectionClass<TestableActivityLogViewController> */
     private ReflectionClass $reflector;
     private TestableActivityLogViewController $controller;
@@ -135,6 +143,8 @@ class ActivityLogViewControllerTest extends AbstractTest
         $owner = $this->ownerEmail(self::BASE);
 
         $this->seedUser(self::BASE);
+        $this->seedTeam(self::BASE);
+        $this->seedMembership(self::BASE);
         $this->seedProject(self::BASE, $owner, self::PROJECT_PASSWORD);
         $this->seedFile(self::BASE);
         $this->seedJob(self::BASE, $owner);
@@ -157,10 +167,23 @@ class ActivityLogViewControllerTest extends AbstractTest
     /**
      * @throws \PDOException
      */
+    private function seedNoTeamProject(): void
+    {
+        $owner = $this->ownerEmail(self::BASE);
+        obtainTestDatabase()->getConnection()->exec(
+            "INSERT IGNORE INTO projects (id, id_customer, password, name, create_date, status_analysis, id_team) "
+            . "VALUES (" . self::NO_TEAM_PROJECT_ID . ", '$owner', '" . self::PROJECT_PASSWORD . "', 'CtrlNoTeamProject', NOW(), 'DONE', NULL)"
+        );
+    }
+
+    /**
+     * @throws \PDOException
+     */
     private function cleanTestData(): void
     {
         $conn = obtainTestDatabase()->getConnection();
         $conn->exec("DELETE FROM activity_log WHERE ID = " . self::ACTIVITY_ID);
+        $conn->exec("DELETE FROM projects WHERE id = " . self::NO_TEAM_PROJECT_ID);
         $this->cleanFragments(self::BASE);
     }
 
@@ -174,6 +197,33 @@ class ActivityLogViewControllerTest extends AbstractTest
         $paramsNamed = $this->createStub(DataCollection::class);
         $paramsNamed->method('all')->willReturn($params);
         $this->requestStub->method('paramsNamed')->willReturn($paramsNamed);
+    }
+
+    /**
+     * Populate the real validator chain on the controller and return it.
+     *
+     * @return list<mixed>
+     * @throws \Throwable
+     */
+    private function buildRealValidators(): array
+    {
+        $realReflector = new ReflectionClass(ActivityLogController::class);
+        $realReflector->getMethod('registerValidators')->invoke($this->controller);
+
+        /** @var list<mixed> $validators */
+        $validators = $this->reflector->getProperty('validators')->getValue($this->controller);
+
+        return $validators;
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    private function setControllerUser(int $uid): void
+    {
+        $user = new UserStruct();
+        $user->uid = $uid;
+        $this->reflector->getProperty('user')->setValue($this->controller, $user);
     }
 
     // ─── validateTheRequest ───
@@ -269,12 +319,8 @@ class ActivityLogViewControllerTest extends AbstractTest
     #[Test]
     public function projectPasswordValidatorOnFailureSetsProjectNotFoundTemplate(): void
     {
-        $realReflector = new ReflectionClass(ActivityLogController::class);
-        $realReflector->getMethod('registerValidators')->invoke($this->controller);
-
-        /** @var list<mixed> $validators */
-        $validators = $this->reflector->getProperty('validators')->getValue($this->controller);
-        $this->assertCount(2, $validators);
+        $validators = $this->buildRealValidators();
+        $this->assertCount(3, $validators);
         $passwordValidator = $validators[1];
         $this->assertInstanceOf(ProjectPasswordValidator::class, $passwordValidator);
 
@@ -291,13 +337,121 @@ class ActivityLogViewControllerTest extends AbstractTest
         }
     }
 
+    // ─── TeamAccessValidator onFailure closure ───
+
+    /**
+     * @throws \Throwable
+     */
+    #[Test]
+    public function teamAccessValidatorOnFailureSetsProjectNotFoundTemplate(): void
+    {
+        $validators = $this->buildRealValidators();
+        $this->assertCount(3, $validators);
+        $teamValidator = $validators[2];
+        $this->assertInstanceOf(TeamAccessValidator::class, $teamValidator);
+
+        $baseReflector = new ReflectionClass(ValidatorBase::class);
+        $callback = $baseReflector->getProperty('_failureCallback')->getValue($teamValidator);
+        $this->assertInstanceOf(\Closure::class, $callback);
+
+        try {
+            $callback(new \Exception('forced team access validator failure'));
+            $this->fail('Expected RenderTerminatedException');
+        } catch (RenderTerminatedException) {
+            $this->assertSame('project_not_found.html', $this->controller->lastTemplate);
+            $this->assertSame(404, $this->controller->lastViewCode);
+        }
+    }
+
+    // ─── real validator pipeline: team membership enforcement ───
+
+    /**
+     * A member of the project's team passes: the password validator resolves the project, its
+     * onSuccess seeds the team, and the team validator confirms membership without rendering.
+     *
+     * @throws \Throwable
+     */
+    #[Test]
+    public function realPipelineResolvesTeamForAProjectTeamMember(): void
+    {
+        $this->controller->params = [
+            'id_project' => (string) $this->projectId(self::BASE),
+            'password' => self::PROJECT_PASSWORD,
+        ];
+
+        $validators = $this->buildRealValidators();
+        $teamValidator = $validators[2];
+        $this->assertInstanceOf(TeamAccessValidator::class, $teamValidator);
+
+        $validators[1]->validate();
+        $validators[2]->validate();
+
+        $this->assertInstanceOf(TeamStruct::class, $teamValidator->team);
+        $this->assertSame($this->teamId(self::BASE), $teamValidator->team->id);
+    }
+
+    /**
+     * A logged-in user outside the owning team is refused with the non-disclosing 404, even with the
+     * correct project password.
+     *
+     * @throws \Throwable
+     */
+    #[Test]
+    public function realPipelineBlocksNonTeamMember(): void
+    {
+        $this->setControllerUser(self::OUTSIDER_UID);
+        $this->controller->params = [
+            'id_project' => (string) $this->projectId(self::BASE),
+            'password' => self::PROJECT_PASSWORD,
+        ];
+
+        $validators = $this->buildRealValidators();
+
+        $validators[1]->validate();
+
+        try {
+            $validators[2]->validate();
+            $this->fail('Expected RenderTerminatedException');
+        } catch (RenderTerminatedException) {
+            $this->assertSame('project_not_found.html', $this->controller->lastTemplate);
+            $this->assertSame(404, $this->controller->lastViewCode);
+        }
+    }
+
+    /**
+     * A project with no team has nobody to be a member of, so the onSuccess seeding refuses the null
+     * id_team rather than passing it to the membership lookup.
+     *
+     * @throws \Throwable
+     */
+    #[Test]
+    public function realPipelineBlocksProjectWithoutTeam(): void
+    {
+        $this->seedNoTeamProject();
+
+        $this->controller->params = [
+            'id_project' => (string) self::NO_TEAM_PROJECT_ID,
+            'password' => self::PROJECT_PASSWORD,
+        ];
+
+        $validators = $this->buildRealValidators();
+
+        try {
+            $validators[1]->validate();
+            $this->fail('Expected RenderTerminatedException');
+        } catch (RenderTerminatedException) {
+            $this->assertSame('project_not_found.html', $this->controller->lastTemplate);
+            $this->assertSame(404, $this->controller->lastViewCode);
+        }
+    }
+
     // ─── registerValidators (production hook) ───
 
     /**
      * @throws \Throwable
      */
     #[Test]
-    public function registerValidatorsAppendsViewLoginRedirectAndProjectPasswordValidators(): void
+    public function registerValidatorsAppendsLoginProjectPasswordAndTeamAccessValidators(): void
     {
         $realReflector = new ReflectionClass(ActivityLogController::class);
         /** @var ActivityLogController $realController */
@@ -311,8 +465,9 @@ class ActivityLogViewControllerTest extends AbstractTest
 
         /** @var list<mixed> $validators */
         $validators = $realReflector->getProperty('validators')->getValue($realController);
-        $this->assertCount(2, $validators);
+        $this->assertCount(3, $validators);
         $this->assertInstanceOf(ViewLoginRedirectValidator::class, $validators[0]);
         $this->assertInstanceOf(ProjectPasswordValidator::class, $validators[1]);
+        $this->assertInstanceOf(TeamAccessValidator::class, $validators[2]);
     }
 }


### PR DESCRIPTION
## Summary

The project activity log lists the name, email and IP address of everyone who worked on a project. It was guarded only by a login check plus the project id and password, so any authenticated holder of a shared project link could read it — including a user in no team on the project. The restriction to the owning team lived only in the project menu that offers "View Project Logs", never on the server, so replaying the endpoint bypassed it.

Both project-scoped surfaces now also require membership of the team that owns the project, taken from `projects.id_team`.

Reported externally (Asana 1210138066060776); confirmed as an IDOR (CWE-639).

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Controller/Views/ActivityLogController.php` | `registerValidators()` now appends `TeamAccessValidator`, seeded in `ProjectPasswordValidator`'s `onSuccess` from the project it just resolved (no second query). A non-member — or a project with no team — is refused with the same non-disclosing `project_not_found.html` 404 the wrong-password branch returns. |
| `lib/Controller/API/V2/ActivityLogController.php` | New private `guardProjectTeamMembership(?ProjectStruct)` runs after `ProjectPasswordValidator` in `allOnProject` and `lastOnProject`, seeding `TeamAccessValidator->setIdTeam($project->id_team)`. A project with no team is refused rather than handing `null` to the membership lookup. |
| `tests/unit/Core/Controllers/ActivityLogViewControllerTest.php` | Real-DB pipeline tests: member resolves the team, non-member blocked with 404, teamless project blocked, plus the team `onFailure` closure. |
| `tests/unit/Core/Controllers/ActivityLogV2ControllerTest.php` | Real-DB tests: member allowed, non-member rejected (401) on both project endpoints, teamless project rejected. |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite: `OK (9345 tests, 30208 assertions)`, 0 failures. `ActivityLogV2ControllerTest` 10/10, `ActivityLogViewControllerTest` 10/10. PHPStan reports `[OK] No errors` on both changed controllers (this project has no baseline, so that is 0 errors outright). Every line added by this diff is covered — the view controller 49/49 statements, and both `guardProjectTeamMembership` call sites plus its body in the API controller. Each new test was proven red against the unfixed code before the fix was written.

Manual testing, end to end against a local instance serving this branch, using a Bruno collection and `x-matecat-key` auth. As a user who is **not** a member of the target project's team, requesting another team's project log:

- Before the fix: `GET /api/v2/activity/project/{id}/{password}` → `200` with the full log — names, emails and IPs of that team's users.
- After the fix: the same request → `403`, refused at `TeamAccessValidator`, no log body.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**Why the API guard is per-method, not in `registerValidators()`.** This controller multiplexes three actions with mutually exclusive password validators: `allOnProject`/`lastOnProject` use `ProjectPasswordValidator` (project id + password), while `lastOnJob` uses `ChunkPasswordValidator` (job id + password). `registerValidators()` runs for whichever action the route resolved to and cannot tell them apart, so the only validator common to all three — `LoginValidator` — lives there, and each per-route password check is chosen inside its method. The view controller has a single action, so its team check goes into the chain exactly like `JobMetadataController` (#4723).

**`lastOnJob` is deliberately left on its job-password capability.** It is scoped to a single job by the job password — the working capability of a collaborator on that job — and returns only that job's last action, not the project-wide log. This matches `GET /metadata`, which stays open to job-link holders. No frontend calls it; the UI uses the project-scoped `/last`. The reasoning and its residual exposure (one activity row to a job-password holder) are recorded in `MateCat-docs` (`backend/work_in_progress/todo-things-left-behind-always-actual.md`, commit `d32493b`).

**Refusal is non-disclosing on the view.** A non-member gets the same `project_not_found.html` 404 as a wrong password, so the view does not confirm whether a project exists.

The `MateCat-docs` submodule pointer is intentionally not bumped in this PR, to keep the code change reviewable on its own; the docs commit is pushed to `main` there.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210138066060776