### PR TITLE
🐛 fix(cattool): default mandatory issues to r1/r2 when unset

### DIFF
--- a/public/js/pages/CatTool.js
+++ b/public/js/pages/CatTool.js
@@ -649,9 +649,9 @@ function CatTool() {
           },
         },
         icuEnabled: !!jobMetadata.project.icu_enabled ?? false,
-        ...(Array.isArray(jobMetadata.job.mandatory_issues) && {
-          mandatoryIssues: jobMetadata.job.mandatory_issues,
-        }),
+        mandatoryIssues: Array.isArray(jobMetadata.job.mandatory_issues)
+          ? jobMetadata.job.mandatory_issues
+          : ['r1', 'r2'],
       }))
     }
   }, [

--- a/public/js/pages/CatTool.test.js
+++ b/public/js/pages/CatTool.test.js
@@ -459,7 +459,7 @@ describe('CatTool', () => {
       expect(result.mandatoryIssues).toEqual(['r1', 'r2'])
     })
 
-    test('does not add mandatoryIssues when mandatory_issues is not an array', async () => {
+    test('defaults mandatoryIssues to r1/r2 when mandatory_issues is not an array', async () => {
       await act(async () => renderCatTool())
       await act(async () => {
         emitJobMetadata(makeJobMetadata(null))
@@ -467,9 +467,20 @@ describe('CatTool', () => {
 
       const updater = getLastTemplateUpdater()
       expect(updater).not.toBeNull()
-      // Empty prevTemplate: if mandatory_issues is null the key must not appear
       const result = updater({})
-      expect('mandatoryIssues' in result).toBe(false)
+      expect(result.mandatoryIssues).toEqual(['r1', 'r2'])
+    })
+
+    test('defaults mandatoryIssues to r1/r2 when mandatory_issues is undefined', async () => {
+      await act(async () => renderCatTool())
+      await act(async () => {
+        emitJobMetadata(makeJobMetadata(undefined))
+      })
+
+      const updater = getLastTemplateUpdater()
+      expect(updater).not.toBeNull()
+      const result = updater({})
+      expect(result.mandatoryIssues).toEqual(['r1', 'r2'])
     })
 
     test('spreads empty array when mandatory_issues is []', async () => {


### PR DESCRIPTION
## Summary

Default `mandatoryIssues` to `['r1', 'r2']` when the job's `mandatory_issues`
field isn't an array, instead of omitting the key entirely.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `public/js/pages/CatTool.js` | Default `mandatoryIssues` to `['r1', 'r2']` when `mandatory_issues` is not an array |
| `public/js/pages/CatTool.test.js` | Update/add tests for the default-fallback behavior |

## Testing

- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code

## Notes