### PR TITLE
🔒 security(teams): escape team name per output context and refuse link-shaped names

### DIFF
--- a/lib/Controller/API/V2/TeamMembersController.php
+++ b/lib/Controller/API/V2/TeamMembersController.php
@@ -12,6 +12,7 @@ namespace Controller\API\V2;
 use Controller\Abstracts\KleinController;
 use Controller\API\Commons\Validators\LoginValidator;
 use Controller\API\Commons\Validators\TeamAccessValidator;
+use Controller\Traits\TeamInvitationRateLimitTrait;
 use Exception;
 use Model\Teams\PendingInvitations;
 use Model\Teams\TeamDao;
@@ -25,6 +26,8 @@ use View\API\V2\Json\Membership;
 
 class TeamMembersController extends KleinController
 {
+
+    use TeamInvitationRateLimitTrait;
 
     protected function registerValidators(): void
     {
@@ -84,6 +87,10 @@ class TeamMembersController extends KleinController
             is_array($params['members']) ? $params['members'] : [],
             'is_string'
         ));
+        if ($this->isOverInvitationRateLimit($this->response, $this->user, '/api/v2/teams/members')) {
+            return;
+        }
+
         $model->addMemberEmails($members);
         $full_members_list = $model->updateMembers();
 

--- a/lib/Controller/API/V2/TeamsController.php
+++ b/lib/Controller/API/V2/TeamsController.php
@@ -74,10 +74,18 @@ class TeamsController extends KleinController
             );
         }
 
+        // Check what the reader will end up seeing, not what was typed. The email templates
+        // escape with double_encode: false so that names stored before names were kept as
+        // typed still render correctly, which means entity text passes through to the
+        // recipient and is turned back into characters by the mail client's HTML parser.
+        // Without decoding first, "evil&#46;com" would satisfy the rules below and still
+        // arrive as a clickable "evil.com".
+        $decoded = html_entity_decode($name, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
         // a scheme ("https://", "javascript:") or a "www." prefix
-        $hasUrlPrefix = preg_match('~[a-z][a-z0-9+.-]*://|\bwww\.~i', $name) === 1;
+        $hasUrlPrefix = preg_match('~[a-z][a-z0-9+.-]*://|\bwww\.~i', $decoded) === 1;
         // a bare hostname: one or more dot-separated labels ending in a letters-only TLD
-        $hasHostname = preg_match('~(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}~i', $name) === 1;
+        $hasHostname = preg_match('~(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}~i', $decoded) === 1;
 
         if ($hasUrlPrefix || $hasHostname) {
             throw new InvalidArgumentException(

--- a/lib/Controller/API/V2/TeamsController.php
+++ b/lib/Controller/API/V2/TeamsController.php
@@ -14,6 +14,7 @@ use Controller\Abstracts\KleinController;
 use Controller\API\Commons\Exceptions\AuthorizationError;
 use Controller\API\Commons\Validators\LoginValidator;
 use Controller\API\Commons\Validators\TeamAccessValidator;
+use Controller\Traits\TeamInvitationRateLimitTrait;
 use Exception;
 use InvalidArgumentException;
 use Model\Teams\MembershipDao;
@@ -28,6 +29,63 @@ use View\API\V2\Json\Team;
 
 class TeamsController extends KleinController
 {
+
+    use TeamInvitationRateLimitTrait;
+
+    private const int NAME_MAX_LENGTH = 100;
+
+    /**
+     * Normalise a team name on the way in.
+     *
+     * The name is no longer entity-encoded before it is stored, so the two things that
+     * encoding used to take care of have to be done explicitly. Control and format
+     * characters are removed: a name is a single line of text, and CR/LF in particular would
+     * otherwise travel into the Subject header of the membership emails. Runs of whitespace
+     * collapse so a name cannot be padded out to look like separate lines.
+     *
+     * Everything else is preserved verbatim; making the value safe for a given output is
+     * that output's job.
+     */
+    private function sanitizeTeamName(?string $raw): string
+    {
+        $name = preg_replace('/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]+/u', ' ', $raw ?? '') ?? '';
+        $name = preg_replace('/\s+/u', ' ', $name) ?? $name;
+
+        return trim($name);
+    }
+
+    /**
+     * Reject a team name that reads as a link.
+     *
+     * The name is quoted back in the invitation email MateCat sends, on the team owner's
+     * behalf, to any address that owner types in. Mail clients auto-link bare URLs and
+     * bare hostnames, so a name like "verify at example.com" needs no markup to become a
+     * clickable link in a message carrying MateCat's domain and signature. Holding names
+     * to plain text keeps that transactional email from carrying someone else's URL.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function assertNameIsPlainText(string $name): void
+    {
+        if (mb_strlen($name) > self::NAME_MAX_LENGTH) {
+            throw new InvalidArgumentException(
+                "Wrong parameter: name must be at most " . self::NAME_MAX_LENGTH . " characters",
+                400
+            );
+        }
+
+        // a scheme ("https://", "javascript:") or a "www." prefix
+        $hasUrlPrefix = preg_match('~[a-z][a-z0-9+.-]*://|\bwww\.~i', $name) === 1;
+        // a bare hostname: one or more dot-separated labels ending in a letters-only TLD
+        $hasHostname = preg_match('~(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}~i', $name) === 1;
+
+        if ($hasUrlPrefix || $hasHostname) {
+            throw new InvalidArgumentException(
+                "Wrong parameter: name cannot contain a URL or a domain name",
+                400
+            );
+        }
+    }
 
     protected function registerValidators(): void
     {
@@ -49,9 +107,12 @@ class TeamsController extends KleinController
         $params = $this->request->paramsPost()->getIterator()->getArrayCopy();
 
         $params = filter_var_array($params, [
+            // The name is stored as the user typed it and escaped by each output instead.
+            // Encoding it here put entity text in the column, which a JavaScript string or a
+            // JSON response can never decode back, so names containing & < > displayed wrong
+            // everywhere. sanitizeTeamName() below does the part that must happen on the way in.
             'name' => [
-                'filter' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-                'flags' => FILTER_FLAG_ENCODE_LOW | FILTER_FLAG_NO_ENCODE_QUOTES | FILTER_FLAG_STRIP_BACKTICK
+                'filter' => FILTER_UNSAFE_RAW
             ],
             'type' => [
                 'filter' => FILTER_SANITIZE_SPECIAL_CHARS
@@ -62,11 +123,13 @@ class TeamsController extends KleinController
             ]
         ]);
 
-        $params['name'] = trim($params['name']);
+        $params['name'] = $this->sanitizeTeamName(is_string($params['name']) ? $params['name'] : null);
 
         if (empty($params['name'])) {
             throw new InvalidArgumentException("Wrong parameter: name is empty", 400);
         }
+
+        $this->assertNameIsPlainText($params['name']);
 
         if (empty($params['type'])) {
             throw new InvalidArgumentException("Wrong parameter: type is empty", 400);
@@ -92,6 +155,11 @@ class TeamsController extends KleinController
         }
         $model->setUser($this->user);
 
+        // creating a team also invites every member passed with it
+        if ($this->isOverInvitationRateLimit($this->response, $this->user, '/api/v2/teams')) {
+            return;
+        }
+
         $team = $model->create();
         $formatted = new Team($userDao, null);
 
@@ -112,9 +180,12 @@ class TeamsController extends KleinController
 
         // sanitize params
         $params = filter_var_array($this->params, [
+            // The name is stored as the user typed it and escaped by each output instead.
+            // Encoding it here put entity text in the column, which a JavaScript string or a
+            // JSON response can never decode back, so names containing & < > displayed wrong
+            // everywhere. sanitizeTeamName() below does the part that must happen on the way in.
             'name' => [
-                'filter' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-                'flags' => FILTER_FLAG_ENCODE_LOW | FILTER_FLAG_NO_ENCODE_QUOTES | FILTER_FLAG_STRIP_BACKTICK
+                'filter' => FILTER_UNSAFE_RAW
             ],
             'id_team' => [
                 'filter' => FILTER_VALIDATE_INT
@@ -125,11 +196,14 @@ class TeamsController extends KleinController
 
         $org = new TeamStruct();
         $org->id = $teamId;
-        $org->name = trim($params['name']);
+        $name = $this->sanitizeTeamName(is_string($params['name']) ? $params['name'] : null);
+        $org->name = $name;
 
         if (empty($org->name)) {
             throw new InvalidArgumentException("Wrong parameter: name is empty", 400);
         }
+
+        $this->assertNameIsPlainText($org->name);
 
         $membershipDao = new MembershipDao($this->getDatabase());
         $org = $membershipDao->findTeamByIdAndUser($teamId, $this->user);
@@ -138,7 +212,7 @@ class TeamsController extends KleinController
             throw new AuthorizationError("Not Authorized", 401);
         }
 
-        $org->name = trim($params['name']);
+        $org->name = $name;
 
         $teamDao = new TeamDao($this->getDatabase());
 

--- a/lib/Controller/Traits/TeamInvitationRateLimitTrait.php
+++ b/lib/Controller/Traits/TeamInvitationRateLimitTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Controller\Traits;
+
+use Controller\Services\RateLimiterService;
+use Exception;
+use Klein\Response;
+use Model\Users\UserStruct;
+use Utils\Tools\Utils;
+
+/**
+ * Rate limit for the endpoints that make MateCat send team invitations.
+ *
+ * Adding a member emails whatever address the caller supplies, from MateCat's domain,
+ * quoting a team name the caller also controls. Nothing bounded how often that could be
+ * done, so the invitation flow could be driven as a delivery channel for arbitrary text.
+ * The per-request cap in {@see \Model\Teams\TeamModel::MAX_MEMBER_EMAILS} bounds one
+ * call; this bounds how many calls.
+ */
+trait TeamInvitationRateLimitTrait
+{
+
+    use RateLimiterTrait;
+
+    /**
+     * Requests allowed per counter window. Comfortable for building a real team by hand,
+     * useless as a mailing volume.
+     */
+    protected const int MAX_INVITATION_REQUESTS = 10;
+
+    /**
+     * Injection seam: tests supply a service backed by a fake Redis client.
+     */
+    protected ?RateLimiterService $invitationRateLimiter = null;
+
+    /**
+     * @return bool true when the caller is over the limit, in which case the 429 has
+     *              already been placed on the response and the action must return.
+     *
+     * @throws Exception
+     */
+    protected function isOverInvitationRateLimit(Response $response, ?UserStruct $user, string $route): bool
+    {
+        // The account is the thing being limited; the address is only a fallback so an
+        // unresolved user cannot skip the counter altogether.
+        $identifier = $user->email ?? Utils::getRealIpAddr() ?? '127.0.0.1';
+
+        $limited = $this->checkAndIncrementRateLimit(
+            $response,
+            $identifier,
+            $route,
+            self::MAX_INVITATION_REQUESTS,
+            $this->invitationRateLimiter
+        );
+
+        return $limited instanceof Response;
+    }
+
+}

--- a/lib/Controller/Views/CattoolController.php
+++ b/lib/Controller/Views/CattoolController.php
@@ -48,6 +48,7 @@ use Utils\Engines\Intento;
 use Utils\Registry\AppConfig;
 use Utils\Templating\PHPTalBoolean;
 use Utils\Templating\PHPTalMap;
+use Utils\Templating\PHPTalString;
 use Utils\Tools\CatUtils;
 use Utils\Tools\Utils;
 
@@ -236,7 +237,10 @@ class CattoolController extends BaseKleinViewController
             'tag_projection_languages' => new PHPTalMap(LexiQaAndTagProjectionLanguages::$tagProjectionAllowedLanguages),
             'targetIsCJK' => new PHPTalBoolean(CatUtils::isCJK($chunkStruct->target)),
             'target_code' => $chunkStruct->target,
-            'team_name' => $jobOwnership['team']->name ?? '',
+            // The team name is user supplied and lands inside an inline <script>, where
+            // PHPTAL emits interpolations verbatim. PHPTalString renders it as its own
+            // quoted JSON literal so it cannot close the literal or the script element.
+            'team_name' => new PHPTalString($jobOwnership['team']->name ?? ''),
             'tms_enabled' => new PHPTalBoolean((bool)$chunkStruct->id_tms),
             'translation_engines_intento_providers' => new PHPTalMap(Intento::getProviderList()),
             'translation_matches_enabled' => new PHPTalBoolean(true),

--- a/lib/Model/Teams/TeamModel.php
+++ b/lib/Model/Teams/TeamModel.php
@@ -22,6 +22,12 @@ use Utils\Redis\RedisHandler;
 class TeamModel
 {
 
+    /**
+     * Upper bound on the addresses a single invitation request may queue.
+     * Well above any real team roster, far below a usable mailing volume.
+     */
+    public const int MAX_MEMBER_EMAILS = 50;
+
     /** @var list<string> */
     protected array $member_emails = [];
 
@@ -68,8 +74,23 @@ class TeamModel
         return $this->teamDao->getDatabaseHandler();
     }
 
+    /**
+     * Every added address becomes an email MateCat sends on this user's behalf, so the
+     * number one request can queue is bounded. Nothing in the invitation flow limited it
+     * before, which let a single call fan out an unbounded number of messages carrying
+     * attacker-chosen text to attacker-chosen recipients.
+     *
+     * @throws InvalidArgumentException
+     */
     public function addMemberEmail(string $email): void
     {
+        if (count($this->member_emails) >= self::MAX_MEMBER_EMAILS) {
+            throw new InvalidArgumentException(
+                "Wrong parameter: no more than " . self::MAX_MEMBER_EMAILS . " members can be added at once",
+                400
+            );
+        }
+
         $this->member_emails[] = $email;
     }
 
@@ -80,6 +101,8 @@ class TeamModel
 
     /**
      * @param list<string> $emails
+     *
+     * @throws InvalidArgumentException
      */
     public function addMemberEmails(array $emails): void
     {

--- a/lib/Utils/Email/AbstractEmail.php
+++ b/lib/Utils/Email/AbstractEmail.php
@@ -75,6 +75,20 @@ abstract class AbstractEmail
     /**
      * @return string
      */
+    /**
+     * Make a value safe to place in a mail header.
+     *
+     * Team names are stored as the user typed them, so a name carrying CR or LF could
+     * otherwise continue the Subject header into one of its own. PHPMailer strips line breaks
+     * from headers as well, but a header context should not depend on a library internal.
+     */
+    protected function headerSafe(?string $value): string
+    {
+        $collapsed = preg_replace('/\s+/u', ' ', str_replace(["\r", "\n"], ' ', $value ?? ''));
+
+        return trim($collapsed ?? '');
+    }
+
     protected function _buildMessageContent(): string
     {
         ob_start();

--- a/lib/Utils/Email/MembershipCreatedEmail.php
+++ b/lib/Utils/Email/MembershipCreatedEmail.php
@@ -60,7 +60,7 @@ class MembershipCreatedEmail extends AbstractEmail
         $this->teamDao = $teamDao;
 
         $this->sender = $sender;
-        $this->title = "You've been added to team " . $this->membership->getTeam($teamDao)->name;
+        $this->title = "You've been added to team " . $this->headerSafe($this->membership->getTeam($teamDao)->name);
     }
 
     /**

--- a/lib/Utils/Email/MembershipDeletedEmail.php
+++ b/lib/Utils/Email/MembershipDeletedEmail.php
@@ -43,7 +43,7 @@ class MembershipDeletedEmail extends AbstractEmail
     {
         $this->user = $removed_user;
         $this->sender = $sender;
-        $this->title = "You've been removed from team " . $team->name;
+        $this->title = "You've been removed from team " . $this->headerSafe($team->name);
         $this->team = $team;
 
         $this->_setLayout('skeleton.html');

--- a/lib/Utils/Templating/PHPTalMap.php
+++ b/lib/Utils/Templating/PHPTalMap.php
@@ -22,6 +22,8 @@ class PHPTalMap implements ArrayAccess, JsonSerializable, Stringable
 
     use ArrayAccessTrait;
 
+    private const int JSON_FLAGS = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP;
+
     /** @var array<array-key, mixed> */
     private array $storage = [];
 
@@ -55,7 +57,12 @@ class PHPTalMap implements ArrayAccess, JsonSerializable, Stringable
 
     public function __toString(): string
     {
-        return json_encode($this->storage) ?: '{}';
+        // PHPTAL emits interpolations inside a <script> element verbatim, so the
+        // encoded map has to be safe on its own: without JSON_HEX_TAG a value
+        // containing "</script>" would close the element and turn the rest of the
+        // page into markup. The remaining flags keep the literal from breaking out
+        // of a surrounding quote. See PHPTalString for the single-value case.
+        return json_encode($this->storage, self::JSON_FLAGS) ?: '{}';
     }
 
     /**

--- a/lib/Utils/Templating/PHPTalString.php
+++ b/lib/Utils/Templating/PHPTalString.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Utils\Templating;
+
+use Stringable;
+
+/**
+ * Wraps a string for interpolation into a JavaScript literal inside a PHPTAL
+ * <script> block.
+ *
+ * PHPTAL does not escape `${...}` interpolations placed inside a <script>
+ * element: the value is emitted verbatim. A template that supplies its own
+ * quotes — `name: '${value}'` — therefore lets any apostrophe in the value close
+ * the literal and append arbitrary JavaScript, and any `</script>` in the value
+ * close the element.
+ *
+ * This class renders the value as a complete JSON string literal, quotes
+ * included, so the template must NOT add quotes of its own:
+ *
+ *     name: ${value},
+ *
+ * `<`, `>`, `&`, `'` and `"` are emitted as `\uXXXX` escapes, as is every
+ * non-ASCII character — which also neutralises U+2028 and U+2029, valid JSON but
+ * literal line terminators inside a JavaScript string before ES2019.
+ *
+ * @see PHPTalMap for the same contract over an array, and PHPTalBoolean over a bool.
+ */
+class PHPTalString implements Stringable
+{
+
+    private const int FLAGS = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP;
+
+    private string $value;
+
+    public function __construct(?string $value)
+    {
+        $this->value = $value ?? '';
+    }
+
+    public function __toString(): string
+    {
+        $encoded = json_encode($this->value, self::FLAGS);
+
+        // json_encode only fails here on malformed UTF-8; an empty literal is a safe
+        // fallback because the template relies on this value carrying its own quotes.
+        return is_string($encoded) ? $encoded : '""';
+    }
+
+}

--- a/lib/View/Emails/Team/email_invited_to_team.html
+++ b/lib/View/Emails/Team/email_invited_to_team.html
@@ -1,6 +1,6 @@
 <p>Hi <?= $email ?>, </p>
 <p>
-    <?= $sender['first_name'] . " " . $sender['last_name'] ?> has invited you join the team "<?= $team['name'] ?>" on Matecat.
+    <?= $sender['first_name'] . " " . $sender['last_name'] ?> has invited you join the team "<?= htmlspecialchars($team['name'], ENT_QUOTES, 'UTF-8', false) ?>" on Matecat.
 </p>
 
 <p>

--- a/lib/View/Emails/Team/membership_created_content.html
+++ b/lib/View/Emails/Team/membership_created_content.html
@@ -1,7 +1,7 @@
 
 <p>Hi <?= $user['first_name'] ?>, </p>
 <p>
-<?= $sender['first_name'] . " " . $sender['last_name'] ?> added you to the team <?= $team['name'] ?> on Matecat.
+<?= $sender['first_name'] . " " . $sender['last_name'] ?> added you to the team <?= htmlspecialchars($team['name'], ENT_QUOTES, 'UTF-8', false) ?> on Matecat.
 
 </p>
 

--- a/lib/View/Emails/Team/membership_deleted_content.html
+++ b/lib/View/Emails/Team/membership_deleted_content.html
@@ -2,7 +2,7 @@
 <p>Hi <?= $user['first_name'] ?>, </p>
 
 <p>
-    <?= $sender['first_name'] . " " . $sender['last_name'] ?> removed you from the team <?= $team['name'] ?>
+    <?= $sender['first_name'] . " " . $sender['last_name'] ?> removed you from the team <?= htmlspecialchars($team['name'], ENT_QUOTES, 'UTF-8', false) ?>
 </p>
 
 <p>

--- a/lib/View/Emails/skeleton.html
+++ b/lib/View/Emails/skeleton.html
@@ -3,7 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title><?=$title?></title>
+    <title><?= htmlspecialchars((string)$title, ENT_QUOTES, 'UTF-8', false) ?></title>
     <style>
         /* -------------------------------------
             GLOBAL RESETS
@@ -296,7 +296,7 @@
 
                 <!-- START CENTERED WHITE CONTAINER -->
                 <?php if ( $showTitle ) { ?>
-                <span class="preheader"><?=$title?></span>
+                <span class="preheader"><?= htmlspecialchars((string)$title, ENT_QUOTES, 'UTF-8', false) ?></span>
                 <?php } ?>
                 <table class="main">
 
@@ -315,7 +315,7 @@
                                 <?php if ( $showTitle ) { ?>
                                 <tr>
                                     <td>
-                                        <h1><?=$title?></h1>
+                                        <h1><?= htmlspecialchars((string)$title, ENT_QUOTES, 'UTF-8', false) ?></h1>
                                     </td>
                                 </tr>
                                 <?php } ?>

--- a/lib/View/templates/_index.html
+++ b/lib/View/templates/_index.html
@@ -75,7 +75,7 @@
                     targetIsCJK: ${targetIsCJK||string:false},
                     target_code: '${target_code}',
                     target_rfc: '${target_code}',
-                    team_name: '${team_name || string: 0}',
+                    team_name: ${team_name},
                     tms_enabled: ${tms_enabled},
                     translation_matches_enabled: ${translation_matches_enabled},
                     user_plugins: ${user_plugins},

--- a/public/css/sass/components/common/TeamModal.scss
+++ b/public/css/sass/components/common/TeamModal.scss
@@ -11,6 +11,13 @@
     align-items: center;
     justify-content: space-between;
 
+    .team-name-error {
+      margin: 8px 0 0;
+      color: colors.$redDefault;
+      font-size: 12px;
+      line-height: 16px;
+    }
+
     .container-input {
       display: flex;
       gap: 5px;

--- a/public/js/actions/ManageActions.js
+++ b/public/js/actions/ManageActions.js
@@ -576,7 +576,9 @@ let ManageActions = {
    * @param members
    */
   createTeam: function (teamName, members) {
-    createTeam(teamName, members).then((response) => {
+    // returned so the caller can surface a rejection: the server refuses names that read
+    // as a link, and without this the 400 was an unhandled rejection and the user saw nothing
+    return createTeam(teamName, members).then((response) => {
       let team = response.team
       this.showReloadSpinner()
       UserActions.setTeamInStorage(team.id)
@@ -657,7 +659,8 @@ let ManageActions = {
   },
 
   changeTeamName: function (team, newName) {
-    updateTeamName(team, newName).then(function (data) {
+    // returned for the same reason as createTeam above
+    return updateTeamName(team, newName).then(function (data) {
       AppDispatcher.dispatch({
         actionType: ManageConstants.UPDATE_TEAM_NAME,
         oldTeam: team,

--- a/public/js/components/modals/CreateTeam.js
+++ b/public/js/components/modals/CreateTeam.js
@@ -8,12 +8,14 @@ import {EMAIL_PATTERN} from '../../constants/Constants'
 import ManageActions from '../../actions/ManageActions'
 import ModalsActions from '../../actions/ModalsActions'
 import {ApplicationWrapperContext} from '../common/ApplicationWrapper/ApplicationWrapperContext'
+import {getApiErrorMessage} from '../../utils/getApiErrorMessage'
 
 export const CreateTeam = () => {
   const {userInfo} = useContext(ApplicationWrapperContext)
 
   const [teamName, setTeamName] = useState('')
   const [emailsCollection, setEmailsCollection] = useState([])
+  const [nameError, setNameError] = useState(null)
 
   const onChangeAddMembers = useCallback(
     (emails) => setEmailsCollection(emails),
@@ -21,8 +23,13 @@ export const CreateTeam = () => {
   )
 
   const sendCreate = () => {
+    setNameError(null)
+    // The modal used to close before the request settled, so a name the server refuses — it
+    // rejects names that read as a link — looked like a successful creation. Close only on
+    // success, and keep the reason next to the field otherwise.
     ManageActions.createTeam(teamName, emailsCollection)
-    ModalsActions.onCloseModal()
+      .then(() => ModalsActions.onCloseModal())
+      .catch((rejection) => setNameError(getApiErrorMessage(rejection)))
   }
 
   const {user, metadata} = userInfo
@@ -54,8 +61,16 @@ export const CreateTeam = () => {
             placeholder="Team name"
             type="text"
             value={teamName}
-            onChange={(e) => setTeamName(e.currentTarget.value)}
+            onChange={(e) => {
+              setNameError(null)
+              setTeamName(e.currentTarget.value)
+            }}
           />
+          {nameError && (
+            <p className="team-name-error" role="alert">
+              {nameError}
+            </p>
+          )}
         </div>
       </div>
       <div>

--- a/public/js/components/modals/ModifyTeam.js
+++ b/public/js/components/modals/ModifyTeam.js
@@ -9,6 +9,7 @@ import {
 import IconSearch from '../icons/IconSearch'
 import IconClose from '../icons/IconClose'
 import ManageActions from '../../actions/ManageActions'
+import {getApiErrorMessage} from '../../utils/getApiErrorMessage'
 import ModalsActions from '../../actions/ModalsActions'
 import IconEdit from '../icons/IconEdit'
 import Checkmark from '../../../img/icons/Checkmark'
@@ -30,6 +31,7 @@ export const ModifyTeam = ({team}) => {
   const [teamState, setTeamState] = useState(team)
   const [teamName, setTeamName] = useState(teamState.get('name'))
   const [isModifyingName, setIsModifyingName] = useState(false)
+  const [nameError, setNameError] = useState(null)
   const [emailsCollection, setEmailsCollection] = useState([])
   const [searchMember, setSearchMember] = useState('')
   const [removeUserId, setRemoveUserId] = useState()
@@ -203,7 +205,14 @@ export const ModifyTeam = ({team}) => {
 
   const saveTeamName = () => {
     if (teamName && teamName != teamState.get('name')) {
+      setNameError(null)
+      // The server refuses names that read as a link, because the name is quoted back in the
+      // invitation email. Keep the editor open on a rejection so the reason is visible next to
+      // the value that caused it and can be corrected in place.
       ManageActions.changeTeamName(teamState.toJS(), teamName)
+        .then(() => setIsModifyingName(false))
+        .catch((rejection) => setNameError(getApiErrorMessage(rejection)))
+      return
     }
     setIsModifyingName(false)
   }
@@ -256,7 +265,10 @@ export const ModifyTeam = ({team}) => {
                 className="team-modal-input"
                 type="text"
                 value={teamName}
-                onChange={(e) => setTeamName(e.currentTarget.value)}
+                onChange={(e) => {
+                  setNameError(null)
+                  setTeamName(e.currentTarget.value)
+                }}
                 autoFocus
                 onKeyDown={handleEnterKeyConfirmName}
               />
@@ -272,6 +284,7 @@ export const ModifyTeam = ({team}) => {
                 size={BUTTON_SIZE.ICON_STANDARD}
                 onClick={() => {
                   setIsModifyingName(false)
+                  setNameError(null)
                   setTeamName(teamState.get('name'))
                 }}
               >
@@ -290,6 +303,11 @@ export const ModifyTeam = ({team}) => {
                 <IconEdit size={18} />
               </Button>
             </div>
+          )}
+          {nameError && (
+            <p className="team-name-error" role="alert">
+              {nameError}
+            </p>
           )}
         </div>
       </div>

--- a/public/js/utils/getApiErrorMessage.js
+++ b/public/js/utils/getApiErrorMessage.js
@@ -1,0 +1,28 @@
+const GENERIC_MESSAGE = 'Something went wrong. Please try again.'
+
+/**
+ * Pull a message worth showing out of an API rejection.
+ *
+ * The api/ clients reject with {response, errors}. `errors` normally comes from the
+ * {errors: [{code, message}]} envelope the backend renders for a 4xx, but those clients fall
+ * back to the whole body when it carries no `errors` key, and a response with an empty body
+ * rejects with {response} alone. All three shapes end up here.
+ */
+export const getApiErrorMessage = (rejection, fallback = GENERIC_MESSAGE) => {
+  const {errors} = rejection ?? {}
+
+  if (Array.isArray(errors)) {
+    const message = errors
+      .map((error) => error?.message)
+      .filter((message) => typeof message === 'string' && message.length > 0)
+      .join(' ')
+
+    return message.length > 0 ? message : fallback
+  }
+
+  if (typeof errors?.message === 'string' && errors.message.length > 0) {
+    return errors.message
+  }
+
+  return fallback
+}

--- a/public/js/utils/getApiErrorMessage.test.js
+++ b/public/js/utils/getApiErrorMessage.test.js
@@ -1,0 +1,56 @@
+import {getApiErrorMessage} from './getApiErrorMessage'
+
+const FALLBACK = 'Something went wrong. Please try again.'
+
+describe('getApiErrorMessage', () => {
+  test('returns the message from the errors envelope the backend renders for a 4xx', () => {
+    const rejection = {
+      response: {status: 400},
+      errors: [
+        {
+          code: 400,
+          message: 'Wrong parameter: name cannot contain a URL or a domain name',
+        },
+      ],
+    }
+
+    expect(getApiErrorMessage(rejection)).toBe(
+      'Wrong parameter: name cannot contain a URL or a domain name',
+    )
+  })
+
+  test('joins every message when the envelope carries more than one', () => {
+    const rejection = {
+      errors: [{message: 'First problem.'}, {message: 'Second problem.'}],
+    }
+
+    expect(getApiErrorMessage(rejection)).toBe('First problem. Second problem.')
+  })
+
+  test('reads a message off a bare object, since the api clients fall back to the whole body', () => {
+    expect(getApiErrorMessage({errors: {message: 'Plain message'}})).toBe(
+      'Plain message',
+    )
+  })
+
+  test('falls back when the response had no body to reject with', () => {
+    expect(getApiErrorMessage({response: {status: 500}})).toBe(FALLBACK)
+  })
+
+  test.each([
+    ['nothing at all', undefined],
+    ['null', null],
+    ['an empty errors array', {errors: []}],
+    ['entries without a message', {errors: [{code: 400}]}],
+    ['an empty message', {errors: [{message: ''}]}],
+    ['a non-string message', {errors: [{message: 42}]}],
+  ])('falls back given %s', (_label, rejection) => {
+    expect(getApiErrorMessage(rejection)).toBe(FALLBACK)
+  })
+
+  test('allows the caller to choose the fallback', () => {
+    expect(getApiErrorMessage({}, 'Could not rename the team.')).toBe(
+      'Could not rename the team.',
+    )
+  })
+})

--- a/tests/unit/Core/Controller/Traits/TeamInvitationRateLimitTraitTest.php
+++ b/tests/unit/Core/Controller/Traits/TeamInvitationRateLimitTraitTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Matecat\Core\Controller\Traits;
+
+use Controller\Services\RateLimiterService;
+use Controller\Traits\TeamInvitationRateLimitTrait;
+use Klein\Response;
+use Matecat\TestHelpers\AbstractTest;
+use Model\Users\UserStruct;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Exposes the trait's protected surface so the guard can be exercised on its own, with a
+ * stubbed limiter instead of Redis.
+ */
+class InvitationRateLimitHost
+{
+    use TeamInvitationRateLimitTrait;
+
+    public function __construct(?RateLimiterService $limiter)
+    {
+        $this->invitationRateLimiter = $limiter;
+    }
+
+    public function isOverLimit(Response $response, ?UserStruct $user, string $route): bool
+    {
+        return $this->isOverInvitationRateLimit($response, $user, $route);
+    }
+
+    public static function maxRequests(): int
+    {
+        return self::MAX_INVITATION_REQUESTS;
+    }
+}
+
+class TeamInvitationRateLimitTraitTest extends AbstractTest
+{
+
+    private function userWithEmail(?string $email): UserStruct
+    {
+        $user = new UserStruct();
+        $user->email = $email;
+
+        return $user;
+    }
+
+    #[Test]
+    public function reportsNotOverTheLimitWhenTheLimiterAllowsTheCall(): void
+    {
+        $limiter = $this->createStub(RateLimiterService::class);
+        $limiter->method('checkAndIncrement')->willReturn(null);
+
+        $host = new InvitationRateLimitHost($limiter);
+
+        $this->assertFalse($host->isOverLimit(new Response(), $this->userWithEmail('a@example.org'), '/route'));
+    }
+
+    #[Test]
+    public function reportsOverTheLimitWhenTheLimiterRefusesTheCall(): void
+    {
+        $limiter = $this->createStub(RateLimiterService::class);
+        $limiter->method('checkAndIncrement')->willReturn(new Response());
+
+        $host = new InvitationRateLimitHost($limiter);
+
+        $this->assertTrue($host->isOverLimit(new Response(), $this->userWithEmail('a@example.org'), '/route'));
+    }
+
+    /**
+     * The account is what gets limited, so the counter has to be keyed on the caller's
+     * address and not on something shared such as the route alone.
+     */
+    #[Test]
+    public function countsAgainstTheCallersEmailAndTheGivenRoute(): void
+    {
+        $limiter = $this->createMock(RateLimiterService::class);
+        $limiter->expects($this->once())
+            ->method('checkAndIncrement')
+            ->with(
+                $this->isInstanceOf(Response::class),
+                'owner@example.org',
+                '/api/v2/teams/members',
+                InvitationRateLimitHost::maxRequests()
+            )
+            ->willReturn(null);
+
+        $host = new InvitationRateLimitHost($limiter);
+        $host->isOverLimit(new Response(), $this->userWithEmail('owner@example.org'), '/api/v2/teams/members');
+    }
+
+    /**
+     * An unresolved user must still be counted, otherwise the guard could be skipped
+     * outright rather than merely keyed differently.
+     */
+    #[Test]
+    public function stillCountsWhenNoUserEmailIsAvailable(): void
+    {
+        $limiter = $this->createMock(RateLimiterService::class);
+        $limiter->expects($this->once())
+            ->method('checkAndIncrement')
+            ->with(
+                $this->isInstanceOf(Response::class),
+                $this->logicalAnd($this->isString(), $this->logicalNot($this->equalTo(''))),
+                '/route',
+                InvitationRateLimitHost::maxRequests()
+            )
+            ->willReturn(null);
+
+        $host = new InvitationRateLimitHost($limiter);
+        $host->isOverLimit(new Response(), null, '/route');
+    }
+
+    #[Test]
+    public function theLimitIsSmallEnoughToBeUselessAsAMailingVolume(): void
+    {
+        $this->assertLessThanOrEqual(20, InvitationRateLimitHost::maxRequests());
+        $this->assertGreaterThan(1, InvitationRateLimitHost::maxRequests());
+    }
+
+}

--- a/tests/unit/Core/Controllers/TeamsControllerTest.php
+++ b/tests/unit/Core/Controllers/TeamsControllerTest.php
@@ -35,6 +35,7 @@ use PDOException;
 use PDOStatement;
 use PHPUnit\Event\NoPreviousThrowableException;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Exception as PHPUnitException;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -242,6 +243,96 @@ class TeamsControllerTest extends AbstractTest
     }
 
     /**
+     * The team name is quoted back in the invitation email MateCat sends to any address
+     * the owner supplies, and mail clients auto-link anything that looks like a URL. A
+     * name that reads as a link therefore turns that email into a carrier for someone
+     * else's destination, so link-shaped names are refused. Reported externally as
+     * "Hyperlink Injection in Team name".
+     *
+     * @throws Exception
+     * @throws TypeError
+     */
+    #[Test]
+    #[DataProvider('linkShapedNames')]
+    public function create_throws_when_name_looks_like_a_link(string $name): void
+    {
+        $this->setRequestParams(['name' => $name, 'type' => Teams::GENERAL]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('name cannot contain a URL or a domain name');
+
+        $this->controller->create();
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function linkShapedNames(): array
+    {
+        return [
+            'the reported payload' => ['https://bing.com'],
+            'scheme only' => ['http://x'],
+            'javascript scheme' => ['javascript://comment'],
+            'www prefix' => ['www.example.com'],
+            'bare hostname' => ['example.com'],
+            'hostname inside a pretext' => ['Verify your account at evil-login.co now'],
+            'uppercase' => ['HTTPS://EVIL.COM'],
+            'subdomain' => ['login.microsoftonline.com'],
+        ];
+    }
+
+    /**
+     * @throws Exception
+     * @throws TypeError
+     */
+    #[Test]
+    public function create_throws_when_name_is_longer_than_the_maximum(): void
+    {
+        $this->setRequestParams(['name' => str_repeat('a', 101), 'type' => Teams::GENERAL]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('name must be at most 100 characters');
+
+        $this->controller->create();
+    }
+
+    /**
+     * The guard must not reject the ordinary names people actually use: it stops at the
+     * next check (type) rather than complaining about the name.
+     *
+     * @throws Exception
+     * @throws TypeError
+     */
+    #[Test]
+    #[DataProvider('acceptableNames')]
+    public function create_accepts_a_plain_team_name(string $name): void
+    {
+        $this->setRequestParams(['name' => $name, 'type' => '']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('type is empty');
+
+        $this->controller->create();
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function acceptableNames(): array
+    {
+        return [
+            'plain' => ['Marketing Team'],
+            'apostrophe' => ["O'Brien & Sons"],
+            'version number' => ['Localisation 2.0'],
+            'abbreviation with single letters' => ['Acme S.r.l.'],
+            'non ascii' => ['Équipe Française'],
+            'exactly at the limit' => [str_repeat('a', 100)],
+        ];
+    }
+
+    /**
      * @throws Exception
      * @throws TypeError
      */
@@ -303,6 +394,93 @@ class TeamsControllerTest extends AbstractTest
         $this->assertSame(Teams::GENERAL, $captured['team']['type']);
         $this->assertSame($user->uid, $captured['team']['created_by']);
         $this->assertGreaterThan(0, $captured['team']['id']);
+    }
+
+    /**
+     * Names are stored as typed. Encoding them on the way in put entity text in the column,
+     * which neither a JSON response nor a JavaScript string can decode back, so a team called
+     * "A & B" displayed as "A &amp; B" everywhere. Each output escapes instead.
+     *
+     * @throws Exception
+     * @throws TypeError
+     * @throws PDOException
+     */
+    #[Test]
+    #[DataProvider('namesWithHtmlSignificantCharacters')]
+    public function create_stores_the_name_exactly_as_typed(string $typed): void
+    {
+        $this->actAsFactoryUser();
+        $this->setRequestParams(['name' => $typed, 'type' => Teams::GENERAL]);
+
+        $captured = null;
+        $this->responseMock->expects($this->once())
+            ->method('json')
+            ->with($this->callback(function (array $data) use (&$captured): bool {
+                $captured = $data;
+                return true;
+            }));
+
+        $this->controller->create();
+
+        $this->assertIsArray($captured);
+        $this->assertSame($typed, $captured['team']['name'], 'the payload must return the name as typed');
+
+        $stmt = obtainTestDatabase()->getConnection()->query(
+            "SELECT name FROM teams WHERE id = " . (int)$captured['team']['id']
+        );
+        $stored = $stmt instanceof PDOStatement ? $stmt->fetchColumn() : null;
+        $this->assertSame($typed, $stored, 'the column must hold the name as typed, not entity text');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function namesWithHtmlSignificantCharacters(): array
+    {
+        return [
+            'ampersand' => ['A & B'],
+            'apostrophe' => ["O'Brien Team"],
+            'double quote' => ['The "Best" Team'],
+            'angle brackets' => ['Team <core>'],
+            'entity-looking text typed literally' => ['A &amp; B'],
+            'non ascii' => ['Équipe Française'],
+        ];
+    }
+
+    /**
+     * Store-time encoding used to remove control characters as a side effect. It is now done
+     * on purpose: a name is one line of text, and CR/LF would otherwise reach the Subject
+     * header of the membership emails.
+     *
+     * @throws Exception
+     * @throws TypeError
+     * @throws PDOException
+     */
+    #[Test]
+    public function create_strips_control_characters_and_collapses_whitespace(): void
+    {
+        $this->actAsFactoryUser();
+        $this->setRequestParams([
+            'name' => "Team\r\nBcc: victim\tand\x00more   spaces",
+            'type' => Teams::GENERAL,
+        ]);
+
+        $captured = null;
+        $this->responseMock->expects($this->once())
+            ->method('json')
+            ->with($this->callback(function (array $data) use (&$captured): bool {
+                $captured = $data;
+                return true;
+            }));
+
+        $this->controller->create();
+
+        $this->assertIsArray($captured);
+        $stored = $captured['team']['name'];
+        $this->assertIsString($stored);
+        $this->assertSame('Team Bcc: victim and more spaces', $stored);
+        $this->assertStringNotContainsString("\r", $stored);
+        $this->assertStringNotContainsString("\n", $stored);
     }
 
     // ─── getTeamList() happy path ───
@@ -372,6 +550,64 @@ class TeamsControllerTest extends AbstractTest
         $this->expectExceptionMessage('name is empty');
 
         $this->controller->update();
+    }
+
+    /**
+     * Renaming has to be guarded as well as creating: the invitation email quotes whatever
+     * the name is at send time, so a team created with a plain name could otherwise be
+     * renamed to a link before members are added.
+     *
+     * @throws Exception
+     * @throws TypeError
+     * @throws ReflectionException
+     */
+    #[Test]
+    public function update_throws_when_name_looks_like_a_link(): void
+    {
+        $user = $this->actAsFactoryUser();
+        $team = (new TeamDao(obtainTestDatabase()))->createUserTeam($user, [
+            'type' => Teams::GENERAL,
+            'name' => 'Updatable Team',
+        ]);
+
+        $this->setRequestParams(['id_team' => (string)$team->id, 'name' => 'https://bing.com']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('name cannot contain a URL or a domain name');
+
+        $this->controller->update();
+    }
+
+    /**
+     * The rename is refused before it reaches the database, so the stored name is intact.
+     *
+     * @throws Exception
+     * @throws TypeError
+     * @throws ReflectionException
+     * @throws PDOException
+     */
+    #[Test]
+    public function update_leaves_the_stored_name_untouched_when_it_looks_like_a_link(): void
+    {
+        $user = $this->actAsFactoryUser();
+        $team = (new TeamDao(obtainTestDatabase()))->createUserTeam($user, [
+            'type' => Teams::GENERAL,
+            'name' => 'Untouched Team',
+        ]);
+
+        $this->setRequestParams(['id_team' => (string)$team->id, 'name' => 'evil.com']);
+
+        try {
+            $this->controller->update();
+            $this->fail('expected the link-shaped name to be refused');
+        } catch (InvalidArgumentException) {
+            // expected
+        }
+
+        $stmt = obtainTestDatabase()->getConnection()->query("SELECT name FROM teams WHERE id = " . (int)$team->id);
+        $stored = $stmt instanceof PDOStatement ? $stmt->fetchColumn() : null;
+        $this->assertSame('Untouched Team', $stored);
     }
 
     // ─── update() happy path ───

--- a/tests/unit/Core/Controllers/TeamsControllerTest.php
+++ b/tests/unit/Core/Controllers/TeamsControllerTest.php
@@ -279,6 +279,13 @@ class TeamsControllerTest extends AbstractTest
             'hostname inside a pretext' => ['Verify your account at evil-login.co now'],
             'uppercase' => ['HTTPS://EVIL.COM'],
             'subdomain' => ['login.microsoftonline.com'],
+            // The email templates escape with double_encode: false, so entity text reaches the
+            // recipient and their mail client turns it back into a dot. The rule has to be
+            // applied to what the reader sees, not to what was typed.
+            'dot smuggled as a decimal entity' => ['evil&#46;com'],
+            'dot smuggled as a hex entity' => ['evil&#x2E;com'],
+            'dot smuggled as a named entity' => ['evil&period;com'],
+            'scheme smuggled as an entity' => ['https&#58;//evil.com'],
         ];
     }
 

--- a/tests/unit/Core/Model/TeamModelTest.php
+++ b/tests/unit/Core/Model/TeamModelTest.php
@@ -68,6 +68,56 @@ class TeamModelTest extends AbstractTest
         $this->assertSame(['a@example.org'], $ref->getValue($model));
     }
 
+    /**
+     * Each queued address is an email MateCat sends on the caller's behalf, so one request
+     * cannot queue an unbounded number of them. Nothing bounded this before, which made the
+     * invitation flow usable as a bulk delivery channel.
+     */
+    public function test_addMemberEmail_refuses_more_than_the_maximum(): void
+    {
+        $struct = new TeamStruct(['name' => 'test', 'type' => Teams::GENERAL, 'created_by' => $this->user->uid]);
+        $model = new TeamModel($struct, new UserDao(obtainTestDatabase()), new TeamDao(obtainTestDatabase()));
+
+        for ($i = 0; $i < TeamModel::MAX_MEMBER_EMAILS; $i++) {
+            $model->addMemberEmail("member$i@example.org");
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage('no more than ' . TeamModel::MAX_MEMBER_EMAILS . ' members can be added at once');
+
+        $model->addMemberEmail('one-too-many@example.org');
+    }
+
+    public function test_addMemberEmail_accepts_exactly_the_maximum(): void
+    {
+        $struct = new TeamStruct(['name' => 'test', 'type' => Teams::GENERAL, 'created_by' => $this->user->uid]);
+        $model = new TeamModel($struct, new UserDao(obtainTestDatabase()), new TeamDao(obtainTestDatabase()));
+
+        for ($i = 0; $i < TeamModel::MAX_MEMBER_EMAILS; $i++) {
+            $model->addMemberEmail("member$i@example.org");
+        }
+
+        $ref = new ReflectionProperty($model, 'member_emails');
+        $this->assertCount(TeamModel::MAX_MEMBER_EMAILS, $ref->getValue($model));
+    }
+
+    public function test_addMemberEmails_refuses_a_batch_over_the_maximum(): void
+    {
+        $struct = new TeamStruct(['name' => 'test', 'type' => Teams::GENERAL, 'created_by' => $this->user->uid]);
+        $model = new TeamModel($struct, new UserDao(obtainTestDatabase()), new TeamDao(obtainTestDatabase()));
+
+        $batch = [];
+        for ($i = 0; $i <= TeamModel::MAX_MEMBER_EMAILS; $i++) {
+            $batch[] = "member$i@example.org";
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(400);
+
+        $model->addMemberEmails($batch);
+    }
+
     public function test_addMemberEmails_appends_multiple(): void
     {
         $struct = new TeamStruct(['name' => 'test', 'type' => Teams::GENERAL, 'created_by' => $this->user->uid]);

--- a/tests/unit/Core/Utils/Email/InvitedToTeamEmailTest.php
+++ b/tests/unit/Core/Utils/Email/InvitedToTeamEmailTest.php
@@ -45,6 +45,61 @@ class InvitedToTeamEmailTest extends AbstractTest
         $this->assertSame('invited@example.com', $vars['email']);
     }
 
+    /**
+     * The template used to echo the team name unescaped and relied on the name having been
+     * entity-encoded when it was stored. Escaping now happens where the value is written,
+     * so the email is safe on its own terms rather than on an assumption about the column.
+     */
+    #[Test]
+    public function theTeamNameIsEscapedInTheRenderedBody(): void
+    {
+        $team = $this->makeTeam();
+        $team->name = '<img src=x onerror=alert(1)>';
+
+        $body = $this->renderBody($team);
+
+        $this->assertStringNotContainsString('<img', $body);
+        $this->assertStringContainsString('&lt;img src=x onerror=alert(1)&gt;', $body);
+    }
+
+    /**
+     * A name that was already entity-encoded on the way into the database must not be
+     * encoded a second time, or the reader sees "&amp;lt;" instead of "<".
+     */
+    #[Test]
+    public function anAlreadyEncodedTeamNameIsNotEncodedTwice(): void
+    {
+        $team = $this->makeTeam();
+        $team->name = '&lt;Encoded&gt; &amp; Co';
+
+        $body = $this->renderBody($team);
+
+        $this->assertStringContainsString('&lt;Encoded&gt; &amp; Co', $body);
+        $this->assertStringNotContainsString('&amp;lt;', $body);
+    }
+
+    #[Test]
+    public function anOrdinaryTeamNameIsRenderedAsIs(): void
+    {
+        $team = $this->makeTeam();
+        $team->name = 'Marketing Team';
+
+        $this->assertStringContainsString('Marketing Team', $this->renderBody($team));
+    }
+
+    /**
+     * Renders the invitation body through the production template path.
+     *
+     * @throws \ReflectionException
+     */
+    private function renderBody(TeamStruct $team): string
+    {
+        $email = new InvitedToTeamEmail($this->makeUser(), 'invited@example.com', $team);
+        $method = new ReflectionMethod(InvitedToTeamEmail::class, '_buildMessageContent');
+
+        return (string)$method->invoke($email);
+    }
+
     #[Test]
     public function sendCallsDoSendOnce(): void
     {

--- a/tests/unit/Core/Utils/Email/MembershipEmailTest.php
+++ b/tests/unit/Core/Utils/Email/MembershipEmailTest.php
@@ -40,6 +40,84 @@ class MembershipEmailTest extends AbstractTest
         return $sender;
     }
 
+    /**
+     * Team names are stored as typed, so a name carrying CR/LF must not be able to continue
+     * the Subject header into one of its own.
+     */
+    public function testMembershipCreatedEmailSubjectCannotCarryLineBreaks(): void
+    {
+        $membership = $this->makeMembershipWithTeam();
+        $team = new TeamStruct();
+        $team->id = 10;
+        $team->name = "Evil\r\nBcc: victim";
+        (new ReflectionProperty(MembershipStruct::class, 'team'))->setValue($membership, $team);
+
+        $email = new MembershipCreatedEmail(
+            $this->makeSender(),
+            $membership,
+            $this->makeUserDao(),
+            $this->makeTeamDao()
+        );
+
+        $title = (new ReflectionProperty($email, 'title'))->getValue($email);
+        $this->assertIsString($title);
+        $this->assertStringNotContainsString("\r", $title);
+        $this->assertStringNotContainsString("\n", $title);
+        $this->assertStringContainsString('Evil Bcc: victim', $title);
+    }
+
+    public function testMembershipDeletedEmailSubjectCannotCarryLineBreaks(): void
+    {
+        $email = new MembershipDeletedEmail(
+            $this->makeSender(),
+            $this->makeUser(),
+            $this->makeTeam("Evil\nBcc: victim")
+        );
+
+        $title = (new ReflectionProperty($email, 'title'))->getValue($email);
+        $this->assertIsString($title);
+        $this->assertStringNotContainsString("\n", $title);
+    }
+
+    /**
+     * The shared email layout prints the subject as the document title, the preheader and the
+     * <h1>. The subject of a membership email contains the team name, which is now stored as
+     * typed, so the layout has to escape it.
+     */
+    public function testTheLayoutEscapesATeamNameCarriedInTheTitle(): void
+    {
+        $email = new MembershipDeletedEmail(
+            $this->makeSender(),
+            $this->makeUser(),
+            $this->makeTeam('<img src=x onerror=alert(1)>')
+        );
+
+        $method = new ReflectionMethod($email, '_buildHTMLMessage');
+        $html = (string)$method->invoke($email, '<p>body</p>');
+
+        $this->assertStringNotContainsString('<img src=x', $html);
+        $this->assertStringContainsString('&lt;img src=x onerror=alert(1)&gt;', $html);
+    }
+
+    /**
+     * A name that is still entity-encoded from before names were stored as typed must not be
+     * encoded a second time, or the reader sees "&amp;lt;".
+     */
+    public function testTheLayoutDoesNotDoubleEncodeALegacyEncodedTeamName(): void
+    {
+        $email = new MembershipDeletedEmail(
+            $this->makeSender(),
+            $this->makeUser(),
+            $this->makeTeam('A &amp; B')
+        );
+
+        $method = new ReflectionMethod($email, '_buildHTMLMessage');
+        $html = (string)$method->invoke($email, '<p>body</p>');
+
+        $this->assertStringContainsString('A &amp; B', $html);
+        $this->assertStringNotContainsString('&amp;amp;', $html);
+    }
+
     private function makeMembershipWithTeam(): MembershipStruct
     {
         $struct = new MembershipStruct();

--- a/tests/unit/Core/Utils/Templating/PHPTalStringTest.php
+++ b/tests/unit/Core/Utils/Templating/PHPTalStringTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Matecat\Core\Utils\Templating;
+
+use Matecat\TestHelpers\AbstractTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Utils\Templating\PHPTalString;
+
+class PHPTalStringTest extends AbstractTest
+{
+
+    #[Test]
+    public function rendersTheValueAsAQuotedLiteralSoTheTemplateNeedsNoQuotes(): void
+    {
+        $this->assertSame('"Acme Team"', (string)new PHPTalString('Acme Team'));
+    }
+
+    #[Test]
+    public function nullRendersAsAnEmptyLiteral(): void
+    {
+        $this->assertSame('""', (string)new PHPTalString(null));
+    }
+
+    #[Test]
+    public function emptyStringRendersAsAnEmptyLiteral(): void
+    {
+        $this->assertSame('""', (string)new PHPTalString(''));
+    }
+
+    /**
+     * The characters that could end the literal or the surrounding <script> element
+     * must never reach the output unescaped.
+     */
+    #[Test]
+    #[DataProvider('breakoutCharacters')]
+    public function escapesEveryCharacterThatCouldEndTheLiteralOrTheScriptElement(string $char): void
+    {
+        $rendered = (string)new PHPTalString('a' . $char . 'b');
+
+        $this->assertStringNotContainsString($char, substr($rendered, 1, -1));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function breakoutCharacters(): array
+    {
+        return [
+            'apostrophe' => ["'"],
+            'quote' => ['"'],
+            'less than' => ['<'],
+            'greater than' => ['>'],
+            'ampersand' => ['&'],
+        ];
+    }
+
+    #[Test]
+    public function neutralisesAnApostropheBreakoutPayload(): void
+    {
+        $rendered = (string)new PHPTalString("x'-alert(1)-'");
+
+        $this->assertSame('"x\u0027-alert(1)-\u0027"', $rendered);
+        $this->assertStringNotContainsString("'", $rendered);
+    }
+
+    #[Test]
+    public function neutralisesAScriptClosingPayload(): void
+    {
+        $rendered = (string)new PHPTalString('</script><img src=x onerror=alert(1)>');
+
+        $this->assertStringNotContainsString('<', $rendered);
+        $this->assertStringNotContainsString('>', $rendered);
+    }
+
+    /**
+     * U+2028 and U+2029 are legal JSON but were literal line terminators inside a
+     * JavaScript string before ES2019, so they must come out escaped too.
+     */
+    #[Test]
+    public function escapesLineAndParagraphSeparators(): void
+    {
+        $rendered = (string)new PHPTalString("a\u{2028}b\u{2029}c");
+
+        $this->assertStringNotContainsString("\u{2028}", $rendered);
+        $this->assertStringNotContainsString("\u{2029}", $rendered);
+    }
+
+    /**
+     * Escaping must not change what the browser ends up with: the rendered literal has
+     * to decode back to the original value.
+     */
+    #[Test]
+    #[DataProvider('roundTripValues')]
+    public function theRenderedLiteralDecodesBackToTheOriginalValue(string $value): void
+    {
+        $this->assertSame($value, json_decode((string)new PHPTalString($value)));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function roundTripValues(): array
+    {
+        return [
+            'plain' => ['Acme Team'],
+            'apostrophe in a real name' => ["O'Brien & Sons"],
+            'angle brackets' => ['<Ltd>'],
+            'non ascii' => ['Équipe Ünicode 日本語'],
+            'emoji' => ['Team 🚀'],
+            'backslash' => ['C:\\path'],
+        ];
+    }
+
+}

--- a/tests/unit/Core/View/CattoolTeamNameScriptContextTest.php
+++ b/tests/unit/Core/View/CattoolTeamNameScriptContextTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Matecat\Core\View;
+
+use Matecat\TestHelpers\AbstractTest;
+use PHPTAL;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Utils\Templating\PHPTalString;
+
+/**
+ * Regression guard for the team name reaching the cattool page inside an inline
+ * <script>.
+ *
+ * PHPTAL emits interpolations verbatim inside a CDATA-marked <script> block, so a
+ * template that supplies its own quotes — `team_name: '${team_name}'` — lets an
+ * apostrophe in the team name close the literal and append JavaScript. The team name
+ * is attacker controlled: `TeamsController` sanitizes it with
+ * FILTER_SANITIZE_FULL_SPECIAL_CHARS and FILTER_FLAG_NO_ENCODE_QUOTES, which encodes
+ * tags but deliberately keeps quotes.
+ *
+ * These tests pin both halves of the fix: the templates must not add quotes, and the
+ * value must arrive wrapped so it carries its own.
+ */
+class CattoolTeamNameScriptContextTest extends AbstractTest
+{
+
+    private const string BREAKOUT = "x'-alert(1)-'";
+
+    /**
+     * The tracked source template, plus the built page when a build is present locally:
+     * lib/View/index.html is a build artifact and is not in the repository, so this must not
+     * require it.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function cattoolTemplates(): array
+    {
+        return [
+            'source template' => [__DIR__ . '/../../../../lib/View/templates/_index.html'],
+            'built page' => [__DIR__ . '/../../../../lib/View/index.html'],
+        ];
+    }
+
+    /**
+     * The whole fix rests on the template NOT quoting the interpolation, so pin it:
+     * re-adding quotes around ${team_name} reopens the injection.
+     */
+    #[Test]
+    #[DataProvider('cattoolTemplates')]
+    public function theTemplateDoesNotWrapTheTeamNameInterpolationInQuotes(string $template): void
+    {
+        if (!file_exists($template)) {
+            // build artifact absent: the source template case already covers the rule
+            $this->markTestSkipped("$template is not present in this checkout");
+        }
+
+        $contents = file_get_contents($template);
+        $this->assertIsString($contents, "cannot read $template");
+
+        $this->assertMatchesRegularExpression(
+            '/^\s*team_name:\s*\$\{team_name}\s*,\s*$/m',
+            $contents,
+            'team_name must be interpolated unquoted so PHPTalString can supply the quotes'
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/team_name:\s*[\'"]\$\{/',
+            $contents,
+            'team_name must not be wrapped in template-supplied quotes'
+        );
+    }
+
+    /**
+     * End to end through PHPTAL itself, in the same output mode and CDATA-marked block
+     * shape the cattool page uses.
+     */
+    #[Test]
+    public function aBreakoutPayloadStaysInsideTheLiteralWhenRenderedByPhptal(): void
+    {
+        $rendered = $this->renderScriptBlock(new PHPTalString(self::BREAKOUT));
+
+        // the payload arrives as one JavaScript string that decodes back to itself,
+        // and not a single apostrophe survives to close that string early
+        preg_match('/team_name: (".*"),/', $rendered, $matches);
+        $this->assertCount(2, $matches, 'team_name must render as a quoted literal');
+        $this->assertSame(self::BREAKOUT, json_decode($matches[1]));
+        $this->assertStringNotContainsString(chr(39), $rendered);
+    }
+
+    /**
+     * Proves the guard above can fail: the previous, quote-supplying template shape does
+     * let the payload out. Without this the test above could pass for the wrong reason.
+     */
+    #[Test]
+    public function theSupersededQuotedShapeIsShownToBeExploitable(): void
+    {
+        $rendered = $this->renderScriptBlock(self::BREAKOUT, "team_name: '\${team_name}',");
+
+        $this->assertStringContainsString("team_name: 'x'-alert(1)-''", $rendered);
+    }
+
+    #[Test]
+    public function aLegitimateNameSurvivesUnchangedForTheBrowser(): void
+    {
+        $rendered = $this->renderScriptBlock(new PHPTalString("O'Brien & Sons <Ltd>"));
+
+        $this->assertMatchesRegularExpression('/team_name: (".*")/', $rendered);
+        preg_match('/team_name: (".*"),/', $rendered, $matches);
+        $this->assertSame("O'Brien & Sons <Ltd>", json_decode($matches[1]));
+    }
+
+    /**
+     * Renders a minimal copy of the cattool inline-config block.
+     */
+    private function renderScriptBlock(mixed $teamName, string $line = 'team_name: ${team_name},'): string
+    {
+        $templatePath = tempnam(sys_get_temp_dir(), 'phptal_') . '.html';
+        file_put_contents(
+            $templatePath,
+            "<html><body>\n"
+            . "<script type=\"text/javascript\">\n"
+            . "/*<![CDATA[*/\n"
+            . "var config = {\n"
+            . "    " . $line . "\n"
+            . "    done: true\n"
+            . "}\n"
+            . "/*]]>*/\n"
+            . "</script>\n"
+            . "</body></html>"
+        );
+
+        try {
+            $view = new PHPTAL($templatePath);
+            $view->setOutputMode(PHPTAL::HTML5);
+            $view->team_name = $teamName;
+
+            return $view->execute();
+        } finally {
+            unlink($templatePath);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

A VDP report (Asana 1210490775845986) flagged that a team name set to `https://bing.com` becomes clickable in
the team-invitation email. That part is real but low impact: MateCat never emits an `<a>`, the recipient's mail
client auto-links bare URL text, and the recipient always sees the literal URL — no anchor-text spoofing.

While reproducing it I found a **stored XSS in the same field**, which the report missed. The team name was
interpolated into a single-quoted JS string in the cattool inline config, and the write filter kept apostrophes,
so `x'-alert(1)-'` executed for anyone opening a job in that team. The inline script carries a nonce, so CSP
does not help. That is the main change here.

PHPTAL does **not** escape `${...}` inside a `<script>` block wrapped in `/*<![CDATA[*/ … /*]]>*/` — the value
is emitted verbatim. So the fix cannot rely on the template engine; each output context has to escape for
itself.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

Escaping moves from the write boundary to each output. The name is stored as the user typed it; every context
that renders it escapes for that context.

| File | Change |
|------|--------|
| `lib/Utils/Templating/PHPTalString.php` | New. Renders a value as its own JSON string literal (`JSON_HEX_TAG`, `JSON_HEX_APOS`, `JSON_HEX_QUOT`, `JSON_HEX_AMP`), so the template adds no quotes to break out of. Non-ASCII is escaped too, which neutralises U+2028/U+2029. |
| `lib/Utils/Templating/PHPTalMap.php` | Same hex flags on `__toString`, closing `</script>` breakout for every map rendered into a script block. |
| `lib/Controller/Views/CattoolController.php` | `team_name` passed as a `PHPTalString`. |
| `lib/View/templates/_index.html` | The value now carries its own quoting, so the template no longer wraps it in single quotes. |
| `lib/Controller/API/V2/TeamsController.php` | Stores the name as typed (`FILTER_UNSAFE_RAW`); `sanitizeTeamName()` strips control/format/separator codepoints and collapses whitespace; `assertNameIsPlainText()` rejects URL- and domain-shaped names and caps length at 100. The rule is applied to the **HTML-decoded** name, so `evil&#46;com` cannot smuggle a dot past it. |
| `lib/View/Emails/Team/*.html` (3 files) | Team name echoed through `htmlspecialchars(…, ENT_QUOTES, 'UTF-8', false)`. |
| `lib/View/Emails/skeleton.html` | Found during the audit: `$title` was echoed raw at three sites (`<title>`, preheader, `<h1>`). Now escaped — this protects every email using the shared layout, not just team ones. |
| `lib/Utils/Email/AbstractEmail.php` + 2 membership emails | `headerSafe()` strips CR/LF and collapses whitespace for subject lines. PHPMailer already strips them in `secureHeader()`; this stops a header context from depending on a vendor internal. |
| `lib/Controller/Traits/TeamInvitationRateLimitTrait.php`, `TeamMembersController.php`, `TeamModel.php` | The report's secondary point — unbounded invitations. 10 invite requests per window, 50 emails per request. |
| `public/js/**`, `TeamModal.scss` | The new 400 was being discarded: `ManageActions.createTeam`/`changeTeamName` returned nothing, so the modals closed as if the call had succeeded. Both now return the promise, surface the message below the input, and close only on success. `getApiErrorMessage()` handles the three rejection shapes the api clients produce. |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

`OK (9444 tests, 30462 assertions)`; whole-tree PHPStan reports 0 errors (this project has no baseline).

New coverage: `PHPTalStringTest`, `CattoolTeamNameScriptContextTest` (asserts the payload is inert in the new
shape **and** that the superseded quoted shape was exploitable, so the regression cannot silently return),
`TeamInvitationRateLimitTraitTest`, plus cases in `TeamsControllerTest` (link-shaped names including four
entity-smuggling variants, length cap, acceptable names, raw-storage round-trip, control-character stripping),
`TeamModelTest`, `InvitedToTeamEmailTest`, `MembershipEmailTest`, and `getApiErrorMessage.test.js`.

Manual: confirmed `x'-alert(1)-'` executes on the old template and is inert on the new one; confirmed
`evil&#46;com` passed validation before the decode fix and reaches the reader as `evil.com`.

**Not verified by execution:** the frontend. `yarn build:dev` fails on this machine with
`Cannot find module '@rolldown/binding-darwin-arm64'` and jest cannot start (`setupFiles.jest.js`
config failure) — both pre-existing and unrelated to this branch, so I did not touch `node_modules`
or the lockfile. The JS was checked by inspection and prettier; the stylesheet compiles standalone.
CI is the gate for those.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

Follow-up work, all recorded in the docs repo:

1. **`double_encode: false` is load-bearing.** Rows written before this change are still entity-encoded; that
   flag makes them render correctly instead of double-escaped text. Dropping it requires migrating `teams.name`
   first. No migration is included here — legacy rows keep displaying as entity text on the manage page,
   unchanged from before, cosmetic only. In dev, 0 of 27 names contain `& < > ' "`; production was never
   measured. Doing that migration would retire entity smuggling as a class rather than decoding around it.

2. **The bare-hostname rule is deliberately broad and will reject legitimate names**: `Node.js Team`,
   `asp.net crew`, `Alpha.Beta`, `dept.marketing`, `Team.Global`. A curated-TLD variant clears all but
   `asp.net crew` while still rejecting every attack case — happy to swap if reviewers prefer that trade.

3. **API consumers outside this repo now receive raw names** where they previously got entity-encoded ones
   (`lib/View/API/V2/Json/Team.php`). Anything that renders that field into HTML without escaping would be
   newly exposed. This cannot be verified from this repository.

4. `lqa_categories` / `lqa_flat_categories` are also user-named values passed through `PHPTalMap`. The hex
   flags now protect the script-block case, but those call sites were not otherwise audited.

5. The length cap measures the raw string rather than the decoded one — conservative, but inconsistent with
   the link rule.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210490775845986
  - https://app.asana.com/0/0/1209414840425926