### PR TITLE
🔒 security(auth): harden the authenticated session lifecycle

### DIFF
--- a/lib/Controller/Abstracts/Authentication/AuthenticationHelper.php
+++ b/lib/Controller/Abstracts/Authentication/AuthenticationHelper.php
@@ -163,6 +163,23 @@ class AuthenticationHelper
     }
 
     /**
+     * Rotate the session id, discarding the old server-side entry so the previous id cannot be
+     * replayed. Called when the session becomes authenticated; see {@see setUserSession()}.
+     *
+     * The active-session check deliberately reads session_status() rather than going through
+     * {@see sessionIsActive()}: subclasses override that seam to exercise the session writes
+     * without a real session, and calling session_regenerate_id() without one raises a warning.
+     */
+    protected function regenerateSessionId(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE || headers_sent()) {
+            return;
+        }
+
+        session_regenerate_id(true);
+    }
+
+    /**
      * @throws ReflectionException
      * @throws Exception
      * @throws TypeError
@@ -170,6 +187,12 @@ class AuthenticationHelper
     protected function setUserSession(): void
     {
         if ($this->sessionIsActive()) {
+            // This is the transition from anonymous to authenticated, and the only place it
+            // happens: every login path (password, signup confirmation, OAuth) reaches it through
+            // fromRequest(). The id must not survive the transition, or anyone who learned it
+            // beforehand would be holding an authenticated session.
+            $this->regenerateSessionId();
+
             $this->session['cid'] = $this->user->getEmail();
             $this->session['uid'] = $this->user->getUid();
             $this->session['user'] = $this->user;

--- a/tests/unit/Core/Controllers/Authentication/AuthenticationHelperRefactoredTest.php
+++ b/tests/unit/Core/Controllers/Authentication/AuthenticationHelperRefactoredTest.php
@@ -13,6 +13,8 @@ use Model\Users\UserDao;
 use Model\Users\UserStruct;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -347,6 +349,49 @@ class AuthenticationHelperRefactoredTest extends AbstractTest
         // The real implementation guards on session_status() so it stays silent under PHPUnit,
         // where no session is running. Without that guard PHP emits a warning here.
         $this->assertSame(PHP_SESSION_NONE, session_status());
+    }
+
+    #[Test]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function regenerateSessionIdRotatesARealSessionAndDropsTheOldEntry(): void
+    {
+        // No other test can reach the real session_regenerate_id() call. By the time the suite is
+        // running PHPUnit has written output, and PHP then refuses to start a session at all
+        // ("Session cannot be started after headers have already been sent"), so the guard in
+        // regenerateSessionId() always returns early. A separate process has produced no output
+        // yet, which makes the real call reachable exactly here. use_cookies is off so nothing
+        // attempts to emit a Set-Cookie header.
+        session_start(['use_cookies' => false, 'cache_limiter' => '']);
+        $this->assertSame(PHP_SESSION_ACTIVE, session_status(), 'precondition: a real session must be running');
+
+        $_SESSION['probe'] = 'carried-over';
+        $oldId             = session_id();
+
+        $helper = new AuthenticationHelper(
+            $_SESSION, $this->userDaoMock, $this->apiKeyDaoMock, $this->profileBuilderMock, $this->cookieStoreMock
+        );
+
+        $method = new \ReflectionMethod(AuthenticationHelper::class, 'regenerateSessionId');
+        $method->invoke($helper);
+
+        $newId = session_id();
+        $this->assertNotSame($oldId, $newId, 'the session id must change once the session is authenticated');
+        $this->assertSame('carried-over', $_SESSION['probe'], 'session data must survive the rotation');
+
+        // The delete_old_session argument is load-bearing: without it the previous id remains
+        // replayable and the rotation is cosmetic. Assert the old entry is really gone rather than
+        // trusting the argument. Skipped rather than silently passing under another save handler,
+        // where the on-disk layout below would not apply.
+        if (ini_get('session.save_handler') !== 'files') {
+            $this->markTestSkipped('old-entry removal is asserted against the files save handler only');
+        }
+
+        $savePath = session_save_path() ?: sys_get_temp_dir();
+        session_write_close();
+
+        $this->assertFileExists($savePath . '/sess_' . $newId, 'precondition: the new entry must be on disk');
+        $this->assertFileDoesNotExist($savePath . '/sess_' . $oldId, 'the old session entry must be deleted');
     }
 
     #[Test]

--- a/tests/unit/Core/Controllers/Authentication/AuthenticationHelperRefactoredTest.php
+++ b/tests/unit/Core/Controllers/Authentication/AuthenticationHelperRefactoredTest.php
@@ -265,6 +265,90 @@ class AuthenticationHelperRefactoredTest extends AbstractTest
         $this->assertSame(['profile' => true], $session['user_profile']);
     }
 
+    // ─── Session fixation: the id is rotated on the anonymous → authenticated hop ──────────
+
+    #[Test]
+    public function cookiePathRotatesTheSessionIdExactlyOnce(): void
+    {
+        $user        = new UserStruct();
+        $user->uid   = 5;
+        $user->email = 'cookie@example.com';
+
+        $this->userDaoMock->method('getByUid')->with(5)->willReturn($user);
+        $this->cookieStoreMock->method('getCredentials')->willReturn(['user' => ['uid' => 5]]);
+
+        $session = [];
+        $helper  = $this->createHelper($session);
+
+        $this->assertTrue($helper->isLogged());
+
+        // Every login path — password, signup confirmation, OAuth — establishes the cookie and
+        // then rebuilds the helper, landing here. An id known before the login must not still be
+        // valid after it.
+        $this->assertSame(1, $helper->regeneratedSessionIds);
+    }
+
+    #[Test]
+    public function alreadyAuthenticatedSessionDoesNotRotateTheSessionId(): void
+    {
+        $user        = new UserStruct();
+        $user->uid   = 7;
+        $user->email = 'in@example.com';
+
+        $session = [
+            'user'         => $user,
+            'user_profile' => ['uid' => 7, 'email' => 'in@example.com'],
+        ];
+
+        $helper = $this->createHelper($session);
+
+        // isLogged() proves the session branch really was taken — without it a silent failure
+        // into the catch block would also report zero rotations and the test would prove nothing.
+        $this->assertTrue($helper->isLogged());
+
+        // This is the hot path: it runs on every authenticated request. Rotating here would churn
+        // the id continuously and race parallel requests, and it buys nothing — the privilege
+        // transition already happened.
+        $this->assertSame(0, $helper->regeneratedSessionIds);
+    }
+
+    #[Test]
+    public function apiKeyAuthenticationDoesNotRotateTheSessionId(): void
+    {
+        $user        = new UserStruct();
+        $user->uid   = 42;
+        $user->email = 'api@example.com';
+        $this->userDaoMock->method('getByUid')->with(42)->willReturn($user);
+
+        $apiRecord = new ApiKeyStruct(
+            ['api_key' => 'k1', 'api_secret' => 's1', 'uid' => 42, 'enabled' => true, 'create_date' => '2024-01-01', 'last_update' => '2024-01-01']
+        );
+        $this->apiKeyDaoMock->method('findByKey')->with('k1')->willReturn($apiRecord);
+
+        $session = [];
+        $helper  = $this->createHelper($session, 'k1', 's1');
+
+        // API-key callers carry no session at all, so there is nothing to rotate.
+        $this->assertTrue($helper->isLogged());
+        $this->assertSame(0, $helper->regeneratedSessionIds);
+    }
+
+    #[Test]
+    public function regenerateSessionIdIsANoOpWithoutAnActiveSession(): void
+    {
+        $session = [];
+        $helper  = new AuthenticationHelper(
+            $session, $this->userDaoMock, $this->apiKeyDaoMock, $this->profileBuilderMock, $this->cookieStoreMock
+        );
+
+        $method = new \ReflectionMethod(AuthenticationHelper::class, 'regenerateSessionId');
+        $method->invoke($helper);
+
+        // The real implementation guards on session_status() so it stays silent under PHPUnit,
+        // where no session is running. Without that guard PHP emits a warning here.
+        $this->assertSame(PHP_SESSION_NONE, session_status());
+    }
+
     #[Test]
     public function realSessionGuardIsEvaluatedOnCookiePath(): void
     {
@@ -372,6 +456,8 @@ class AuthenticationHelperRefactoredTest extends AbstractTest
 
 class TestableAuthenticationHelper extends AuthenticationHelper
 {
+    public int $regeneratedSessionIds = 0;
+
     public static function create(
         array &$session,
         UserDao $userDao,
@@ -395,5 +481,10 @@ class TestableAuthenticationHelper extends AuthenticationHelper
     protected function sessionIsActive(): bool
     {
         return true;
+    }
+
+    protected function regenerateSessionId(): void
+    {
+        $this->regeneratedSessionIds++;
     }
 }


### PR DESCRIPTION
## Summary

Hardening of the authenticated-session lifecycle. This PR is intended to collect several related
items; the first one is in place and the rest are listed under Notes so they can be added here rather
than opened separately.

**Landed in this PR: the session id is now rotated when the session becomes authenticated.**
`session_regenerate_id()` previously appeared nowhere in the codebase, so the session id a visitor
arrived with was the same id they held after logging in. Anyone who learned that id beforehand was
therefore holding an authenticated session once the victim logged in — the session-fixation shape.

Found while evaluating a VDP report (Asana 1209415042331079, "session not expired on logout"). That
report is already fixed — the Redis login-token ring in `2f33780326` revokes the cookie on logout and
`session_destroy()` clears the session — and it is **not** what this PR addresses. Fixation was an
adjacent gap turned up by reading that code, and it is cheap to close.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Controller/Abstracts/Authentication/AuthenticationHelper.php` | New `regenerateSessionId()`, called from `setUserSession()`. Uses `session_regenerate_id(true)` so the old server-side entry is deleted — without the `true` the previous id stays replayable and the change would be cosmetic. |
| `tests/unit/.../AuthenticationHelperRefactoredTest.php` | Five cases plus a `regenerateSessionId()` seam on the existing `TestableAuthenticationHelper`. The fifth is process-isolated and exercises the real `session_regenerate_id(true)`. |

**Why `setUserSession()` is the right place.** It is the single point where the session goes from
anonymous to authenticated. All three login paths set the auth cookie and then call
`AuthenticationHelper::fromRequest()`, which authenticates from that cookie and lands here:

- password login — `LoginController.php:123`
- signup confirmation — `SignupController.php:73`
- OAuth sign-in — `OAuthSignInModel.php:201`

It is deliberately **not** on the already-authenticated per-request branch, which would rotate the id
on every request, churn `Set-Cookie`, and race parallel requests for no benefit — the privilege
transition has already happened by then. I also checked for a path that writes the session user
directly and would bypass this: there is none. The only other `session['user']` assignments are on
`ProjectStructure`'s own array, not `$_SESSION`.

The active-session check inside `regenerateSessionId()` reads `session_status()` directly rather than
going through the existing `sessionIsActive()` seam. That is intentional and commented: subclasses
override that seam to exercise the session writes without a real session, and calling
`session_regenerate_id()` without one raises a warning.

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite green. Absolute test counts are not stable between runs in this suite, so rather than
quoting one number I measured a baseline on the same tree immediately before and after: 9383 tests /
30312 assertions → 9384 / 30317, i.e. exactly the one added case and its five assertions. PHPStan
reports 0 errors on the changed files (this project has no baseline).

The five cases: the id rotates exactly once on the login hop; it does **not** rotate on the
already-authenticated path; it does not rotate for API-key callers, which carry no session; the real
method is a no-op without an active session; and — process-isolated — a real session really is
rotated and its previous entry really is dropped.

**Why one case needs `#[RunInSeparateProcess]`.** The Test-Guard adequacy gate first flagged this at
75% diff coverage, and it was right: `session_regenerate_id(true)` was the one added line no test
reached. It cannot be reached in the normal suite. Once PHPUnit has written output, PHP refuses to
start a session at all — `session_start(): Session cannot be started after headers have already been
sent` — so the guard inside `regenerateSessionId()` always returns early. I checked whether
`use_cookies => false` avoided this; it does not, the refusal is unconditional. A separate process has
produced no output yet, so the real call is reachable there and only there. That test also asserts the
old session entry is gone, which is the part of `delete_old_session` actually worth pinning down.
This is the first process-isolated test in the suite; it passes both in isolation and in a full run.

I mutation-checked the suite rather than trusting green: removing the production call makes the
rotation test fail, and restoring it makes it pass. Worth noting that two of these tests were
vacuous when first written — a `UserStruct` with no email leaves `isLogged()` false, and an array in
`session['user']` type-errors into the catch block, and both of those report zero rotations for
entirely the wrong reason. Each now asserts `isLogged()` first so a silent authentication failure
cannot masquerade as "correctly did not rotate".

Manual testing is **not** checked deliberately: the rotation is verified through the seam, and the
real `session_regenerate_id()` call is guarded to no-op without an active session, which is the case
under PHPUnit. Confirming the id visibly changes across a live login needs a browser or Bruno run
against a dev instance and has not been done.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**`session.use_strict_mode = 1` is not in this PR.** It was set separately in the `docker` submodule
and is currently uncommitted there. The code change stands on its own — it closes fixation even with
strict mode off — but the additional layer, PHP refusing an id it never issued, only reaches
production if that ini actually ships there. Worth confirming how the production php.ini is managed.

Remaining items in this area, intended for this PR:

1. **Password change and reset do not revoke existing login tokens.** `SessionTokenStoreHandler` has
   no purge-all operation and no password-related code calls it. A user who suspects their cookie was
   stolen cannot evict the holder by changing their password; only logging out that exact cookie
   revokes it, which is not discoverable behaviour. This is the highest-value item left.
2. **Two call sites reach into authentication without the token store**, so their validity check
   consults the JWT signature and expiry but not the revocation ring: `AuthCookie::getData():205`
   (invalid-cookie path, which additionally leaves a stale ring entry) and
   `AuthCookie::setCredentials():99` (the revamp branch). Neither is exploitable today — the second
   requires an already-live session — but this is how a fail-closed check quietly becomes fail-open.

Accepted, not a defect: two concurrent requests that both authenticate from the cookie into an empty
session will each rotate, orphaning one session entry until `gc_maxlifetime`. Both belong to the same
user and both are legitimately authenticated, so there is no security consequence.
