### PR TITLE
🔒 security(auth): revoke every login token on password change and reset

### DIFF
--- a/lib/Controller/API/App/Authentication/ForgotPasswordController.php
+++ b/lib/Controller/API/App/Authentication/ForgotPasswordController.php
@@ -10,6 +10,7 @@
 namespace Controller\API\App\Authentication;
 
 use Controller\Abstracts\AbstractStatefulKleinController;
+use Controller\Abstracts\Authentication\SessionTokenStoreHandler;
 use Controller\Abstracts\FlashMessage;
 use Controller\API\Commons\Exceptions\ValidationError;
 use Controller\Traits\RateLimiterTrait;
@@ -183,7 +184,7 @@ class ForgotPasswordController extends AbstractStatefulKleinController
      */
     protected function createPasswordResetModel(array &$session, ?string $token = null): PasswordResetModel
     {
-        return new PasswordResetModel($session, new UserDao($this->getDatabase()), $token);
+        return new PasswordResetModel($session, new UserDao($this->getDatabase()), new SessionTokenStoreHandler(), $token);
     }
 
     /**

--- a/lib/Controller/API/App/Authentication/UserController.php
+++ b/lib/Controller/API/App/Authentication/UserController.php
@@ -3,6 +3,7 @@
 namespace Controller\API\App\Authentication;
 
 use Controller\Abstracts\AbstractStatefulKleinController;
+use Controller\Abstracts\Authentication\SessionTokenStoreHandler;
 use Controller\API\Commons\Exceptions\ValidationError;
 use Controller\API\Commons\Validators\LoginValidator;
 use Controller\Traits\RateLimiterTrait;
@@ -98,7 +99,7 @@ class UserController extends AbstractStatefulKleinController
 
     protected function createChangePasswordModel(): ChangePasswordModel
     {
-        return new ChangePasswordModel($this->user, new UserDao($this->getDatabase()));
+        return new ChangePasswordModel($this->user, new UserDao($this->getDatabase()), new SessionTokenStoreHandler());
     }
 
     protected function registerValidators(): void

--- a/lib/Controller/Abstracts/Authentication/SessionTokenStoreHandler.php
+++ b/lib/Controller/Abstracts/Authentication/SessionTokenStoreHandler.php
@@ -128,4 +128,47 @@ class SessionTokenStoreHandler
         $this->_removeObjectCacheMapElement($key, $loginCookieValue);
     }
 
+    /**
+     * Revokes every login token issued to a user.
+     *
+     * Drops the whole per-user token map, so no authentication cookie minted before this call can
+     * pass {@see isLoginCookieStillActive()} again. Called when the account's credentials change
+     * and every device has to authenticate afresh.
+     *
+     * This does not end sessions that are already running: the session branch of
+     * AuthenticationHelper::authenticate() never consults this map.
+     *
+     * @param int $userId The unique identifier of the user.
+     *
+     * @return void
+     * @throws ReflectionException If there is an issue with the cache operation.
+     * @throws Exception
+     */
+    public function revokeAllLoginTokens(int $userId): void
+    {
+        $this->_cacheSetConnection();
+
+        // _cacheSetConnection() either sets a connection or rethrows, so this is unreachable at
+        // runtime. It stays because the property is nullable and the calls below are not.
+        if (self::$cache_con === null) {
+            return;
+        }
+
+        $key = sprintf(self::ACTIVE_USER_LOGIN_TOKENS_MAP, $userId);
+
+        // _setInCacheMap() writes each token twice: as a field of the map, and as a standalone
+        // reverse-pointer key under the same md5 name. Field names are therefore also reverse-key
+        // names, so one HKEYS yields both sets. The reverse keys do expire on their own, but a
+        // stale one still holds the map's name — and that name is reused on the next login, so
+        // leaving them behind aims a dangling pointer at a live map.
+        /** @var list<string> $tokens */
+        $tokens = self::$cache_con->hkeys($key);
+
+        if (!empty($tokens)) {
+            self::$cache_con->del($tokens);
+        }
+
+        self::$cache_con->del($key);
+    }
+
 }

--- a/lib/Model/Users/Authentication/ChangePasswordModel.php
+++ b/lib/Model/Users/Authentication/ChangePasswordModel.php
@@ -9,6 +9,7 @@
 
 namespace Model\Users\Authentication;
 
+use Controller\Abstracts\Authentication\SessionTokenStoreHandler;
 use Controller\API\Commons\Exceptions\ValidationError;
 use Exception;
 use Model\Users\UserDao;
@@ -23,11 +24,13 @@ class ChangePasswordModel
 
     private UserStruct $user;
     private UserDao $userDao;
+    private SessionTokenStoreHandler $tokenStore;
 
-    public function __construct(UserStruct $user, UserDao $userDao)
+    public function __construct(UserStruct $user, UserDao $userDao, SessionTokenStoreHandler $tokenStore)
     {
         $this->user = $user;
         $this->userDao = $userDao;
+        $this->tokenStore = $tokenStore;
     }
 
     /**
@@ -79,7 +82,14 @@ class ChangePasswordModel
 
         $this->userDao->updateStruct($this->user, $fieldsToUpdate);
         $this->userDao->destroyCacheByEmail($this->user->email ?? throw new RuntimeException('User email must be set before cache invalidation'));
-        $this->userDao->destroyCacheByUid($this->user->uid ?? throw new RuntimeException('User uid must be set before cache invalidation'));
+
+        $uid = $this->user->uid ?? throw new RuntimeException('User uid must be set before cache invalidation');
+        $this->userDao->destroyCacheByUid($uid);
+
+        // Every other device is still holding a login cookie that the old password minted, so the
+        // change has to retire them. The acting device is logged out separately by the controller's
+        // broadcastLogout(), which only ever removes the cookie it was presented with.
+        $this->tokenStore->revokeAllLoginTokens($uid);
     }
 
 }

--- a/lib/Model/Users/Authentication/PasswordResetModel.php
+++ b/lib/Model/Users/Authentication/PasswordResetModel.php
@@ -8,6 +8,7 @@
 
 namespace Model\Users\Authentication;
 
+use Controller\Abstracts\Authentication\SessionTokenStoreHandler;
 use Controller\API\Commons\Exceptions\ValidationError;
 use Exception;
 use Model\Users\AuthTokenScope;
@@ -30,19 +31,22 @@ class PasswordResetModel
     /** @var array<string, mixed> */
     protected array $session;
     protected UserDao $userDao;
+    protected SessionTokenStoreHandler $tokenStore;
 
     /**
      * @param array<string, mixed> $session reference to global $_SESSSION var
      * @param UserDao $userDao
+     * @param SessionTokenStoreHandler $tokenStore
      * @param string|null $token
      *
      * @throws TypeError
      */
-    public function __construct(array &$session, UserDao $userDao, ?string $token = null)
+    public function __construct(array &$session, UserDao $userDao, SessionTokenStoreHandler $tokenStore, ?string $token = null)
     {
         $this->token = $token;
         $this->session =& $session;
         $this->userDao = $userDao;
+        $this->tokenStore = $tokenStore;
         if (empty($token)) {
             $this->token = $session['password_reset_token'];
         }
@@ -163,7 +167,14 @@ class PasswordResetModel
 
         $this->userDao->updateStruct($user, $fieldsToUpdate);
         $this->userDao->destroyCacheByEmail($user->email ?? throw new RuntimeException('User email must be set before cache invalidation'));
-        $this->userDao->destroyCacheByUid($user->uid ?? throw new RuntimeException('User uid must be set before cache invalidation'));
+
+        $uid = $user->uid ?? throw new RuntimeException('User uid must be set before cache invalidation');
+        $this->userDao->destroyCacheByUid($uid);
+
+        // Until now this flow revoked nothing at all: the user arrives without an authentication
+        // cookie, so removeLoginCookieFromStore() was handed an empty value and returned early.
+        // Anyone holding a stolen cookie kept working straight through the reset.
+        $this->tokenStore->revokeAllLoginTokens($uid);
     }
 
     /**

--- a/tests/unit/Core/Controllers/Authentication/SessionTokenStoreHandlerTest.php
+++ b/tests/unit/Core/Controllers/Authentication/SessionTokenStoreHandlerTest.php
@@ -119,6 +119,65 @@ class SessionTokenStoreHandlerTest extends AbstractTest
         $this->assertContains('hdel', $methodsCalled);
     }
 
+    #[Test]
+    public function revokeAllLoginTokensDeletesEveryTokenAndThenTheMap(): void
+    {
+        $deleted = [];
+        $redis   = $this->createStub(Client::class);
+        $redis->method('__call')
+            ->willReturnCallback(function (string $method, array $args) use (&$deleted) {
+                if ($method === 'hkeys') {
+                    $this->assertSame('active_user_login_tokens:123', $args[0]);
+
+                    return [md5('cookie-one'), md5('cookie-two')];
+                }
+
+                if ($method === 'del') {
+                    $deleted[] = $args[0];
+
+                    return 1;
+                }
+
+                return null;
+            });
+
+        SessionTokenStoreHandler::setCacheConnection($redis);
+        (new SessionTokenStoreHandler())->revokeAllLoginTokens(123);
+
+        // Both the reverse keys and the map itself, so no dangling pointer survives.
+        $this->assertSame(
+            [[md5('cookie-one'), md5('cookie-two')], 'active_user_login_tokens:123'],
+            $deleted
+        );
+    }
+
+    #[Test]
+    public function revokeAllLoginTokensStillDropsTheMapWhenItHoldsNoTokens(): void
+    {
+        $deleted = [];
+        $redis   = $this->createStub(Client::class);
+        $redis->method('__call')
+            ->willReturnCallback(function (string $method, array $args) use (&$deleted) {
+                if ($method === 'hkeys') {
+                    return [];
+                }
+
+                if ($method === 'del') {
+                    $deleted[] = $args[0];
+
+                    return 1;
+                }
+
+                return null;
+            });
+
+        SessionTokenStoreHandler::setCacheConnection($redis);
+        (new SessionTokenStoreHandler())->revokeAllLoginTokens(123);
+
+        // An empty map must not produce a del([]) — Redis rejects DEL with no keys.
+        $this->assertSame(['active_user_login_tokens:123'], $deleted);
+    }
+
     protected function tearDown(): void
     {
         SessionTokenStoreHandler::setCacheConnection(null);

--- a/tests/unit/Core/Model/Users/Authentication/ChangePasswordModelTest.php
+++ b/tests/unit/Core/Model/Users/Authentication/ChangePasswordModelTest.php
@@ -2,6 +2,7 @@
 
 
 namespace Matecat\Core\Model\Users\Authentication;
+use Controller\Abstracts\Authentication\SessionTokenStoreHandler;
 use Controller\API\Commons\Exceptions\ValidationError;
 use Matecat\TestHelpers\AbstractTest;
 use Model\Users\Authentication\ChangePasswordModel;
@@ -24,6 +25,16 @@ class ChangePasswordModelTest extends AbstractTest
         return $user;
     }
 
+    /**
+     * A stub rather than a mock: these cases do not assert on revocation, and a mock with no
+     * configured expectations is a PHPUnit notice. The revocation assertions live in their own
+     * case below, which builds a mock explicitly.
+     */
+    private function makeTokenStore(): SessionTokenStoreHandler
+    {
+        return $this->createStub(SessionTokenStoreHandler::class);
+    }
+
     private function makeMockDao(): UserDao
     {
         $dao = $this->createStub(UserDao::class);
@@ -35,12 +46,43 @@ class ChangePasswordModelTest extends AbstractTest
     }
 
     #[Test]
+    public function changePasswordRevokesEveryLoginTokenForTheUser(): void
+    {
+        $user  = $this->makeUser();
+        $store = $this->createMock(SessionTokenStoreHandler::class);
+
+        // Other devices are still holding cookies minted under the old password, so the change has
+        // to retire all of them — not merely the one presented by the device making the change,
+        // which is all broadcastLogout() removes.
+        $store->expects($this->once())
+            ->method('revokeAllLoginTokens')
+            ->with($user->uid);
+
+        (new ChangePasswordModel($user, $this->makeMockDao(), $store))
+            ->changePassword('old-pass', 'new-secure-pass!');
+    }
+
+    #[Test]
+    public function aRejectedPasswordChangeRevokesNothing(): void
+    {
+        $store = $this->createMock(SessionTokenStoreHandler::class);
+        $store->expects($this->never())->method('revokeAllLoginTokens');
+
+        $this->expectException(ValidationError::class);
+
+        // Revocation has to sit behind the old-password check. A wrong guess must not be able to
+        // log every one of the account's devices out.
+        (new ChangePasswordModel($this->makeUser(), $this->makeMockDao(), $store))
+            ->changePassword('wrong-pass', 'new-secure-pass!');
+    }
+
+    #[Test]
     public function changePasswordSucceeds(): void
     {
         $user = $this->makeUser('old-pass');
         $dao = $this->makeMockDao();
 
-        $model = new ChangePasswordModel($user, $dao);
+        $model = new ChangePasswordModel($user, $dao, $this->makeTokenStore());
         $model->changePassword('old-pass', 'new-pass-123!');
 
         $this->assertTrue(Utils::verifyPass('new-pass-123!', $user->salt, $user->pass));
@@ -55,7 +97,7 @@ class ChangePasswordModelTest extends AbstractTest
         $user = $this->makeUser('old-pass');
         $dao = $this->makeMockDao();
 
-        $model = new ChangePasswordModel($user, $dao);
+        $model = new ChangePasswordModel($user, $dao, $this->makeTokenStore());
         $model->changePassword('wrong-pass', 'new-pass-123!');
     }
 
@@ -68,7 +110,7 @@ class ChangePasswordModelTest extends AbstractTest
         $user = $this->makeUser('old-pass');
         $dao = $this->makeMockDao();
 
-        $model = new ChangePasswordModel($user, $dao);
+        $model = new ChangePasswordModel($user, $dao, $this->makeTokenStore());
         $model->changePassword('old-pass', 'old-pass');
     }
 
@@ -79,7 +121,7 @@ class ChangePasswordModelTest extends AbstractTest
         $user->email_confirmed_at = null;
         $dao = $this->makeMockDao();
 
-        $model = new ChangePasswordModel($user, $dao);
+        $model = new ChangePasswordModel($user, $dao, $this->makeTokenStore());
         $model->changePassword('old-pass', 'new-pass-123!');
 
         $this->assertNotNull($user->email_confirmed_at);
@@ -100,7 +142,7 @@ class ChangePasswordModelTest extends AbstractTest
         $user->email = 'a@b.com';
         $dao = $this->makeMockDao();
 
-        $model = new ChangePasswordModel($user, $dao);
+        $model = new ChangePasswordModel($user, $dao, $this->makeTokenStore());
         $model->changePassword('old', 'new');
     }
 
@@ -116,7 +158,7 @@ class ChangePasswordModelTest extends AbstractTest
         $user->salt = '';
         $user->pass = Utils::encryptPass('old-pass', '');
 
-        $model = new ChangePasswordModel($user, $this->makeMockDao());
+        $model = new ChangePasswordModel($user, $this->makeMockDao(), $this->makeTokenStore());
         $model->changePassword('old-pass', 'new-pass');
 
         $this->assertSame(32, strlen((string)$user->salt));
@@ -128,7 +170,7 @@ class ChangePasswordModelTest extends AbstractTest
     {
         $user = $this->makeUser();
 
-        $model = new ChangePasswordModel($user, $this->makeMockDao());
+        $model = new ChangePasswordModel($user, $this->makeMockDao(), $this->makeTokenStore());
         $model->changePassword('old-pass', 'new-pass');
 
         $this->assertSame('test-salt', $user->salt);
@@ -157,7 +199,7 @@ class ChangePasswordModelTest extends AbstractTest
                 return 1;
             });
 
-        (new ChangePasswordModel($user, $dao))->changePassword('old-pass', 'new-pass');
+        (new ChangePasswordModel($user, $dao, $this->makeTokenStore()))->changePassword('old-pass', 'new-pass');
 
         $this->assertContains('salt', $captured);
         $this->assertContains('pass', $captured);
@@ -182,7 +224,7 @@ class ChangePasswordModelTest extends AbstractTest
         $dao->method('destroyCacheByEmail')->willReturn(true);
         $dao->method('destroyCacheByUid')->willReturn(true);
 
-        (new ChangePasswordModel($user, $dao))->changePassword('old-pass', 'new-pass');
+        (new ChangePasswordModel($user, $dao, $this->makeTokenStore()))->changePassword('old-pass', 'new-pass');
 
         // Changing the password has to retire any reset link already issued for the account. If the
         // token survives, whoever holds that link can set a third password for the rest of the

--- a/tests/unit/Core/Model/Users/Authentication/PasswordResetModelTest.php
+++ b/tests/unit/Core/Model/Users/Authentication/PasswordResetModelTest.php
@@ -2,6 +2,7 @@
 
 
 namespace Matecat\Core\Model\Users\Authentication;
+use Controller\Abstracts\Authentication\SessionTokenStoreHandler;
 use Controller\API\Commons\Exceptions\ValidationError;
 use Matecat\TestHelpers\AbstractTest;
 use Model\Users\Authentication\PasswordResetModel;
@@ -26,6 +27,16 @@ class PasswordResetModelTest extends AbstractTest
         return $user;
     }
 
+    /**
+     * A stub rather than a mock: these cases do not assert on revocation, and a mock with no
+     * configured expectations is a PHPUnit notice. The revocation assertions live in their own
+     * case below, which builds a mock explicitly.
+     */
+    private function makeTokenStore(): SessionTokenStoreHandler
+    {
+        return $this->createStub(SessionTokenStoreHandler::class);
+    }
+
     private function makeMockDao(?UserStruct $user = null): UserDao
     {
         $dao = $this->createStub(UserDao::class);
@@ -42,7 +53,7 @@ class PasswordResetModelTest extends AbstractTest
     {
         $session = [];
         $dao = $this->makeMockDao();
-        $model = new PasswordResetModel($session, $dao, 'my-token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'my-token');
 
         $ref = new ReflectionProperty($model, 'token');
         $this->assertSame('my-token', $ref->getValue($model));
@@ -53,7 +64,7 @@ class PasswordResetModelTest extends AbstractTest
     {
         $session = ['password_reset_token' => 'session-token'];
         $dao = $this->makeMockDao();
-        $model = new PasswordResetModel($session, $dao, null);
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), null);
 
         $ref = new ReflectionProperty($model, 'token');
         $this->assertSame('session-token', $ref->getValue($model));
@@ -67,7 +78,7 @@ class PasswordResetModelTest extends AbstractTest
 
         $session = [];
         $dao = $this->makeMockDao(null);
-        $model = new PasswordResetModel($session, $dao, 'bad-token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'bad-token');
         $model->validateUser();
     }
 
@@ -82,7 +93,7 @@ class PasswordResetModelTest extends AbstractTest
 
         $session = [];
         $dao = $this->makeMockDao($user);
-        $model = new PasswordResetModel($session, $dao, 'valid-token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'valid-token');
         $model->validateUser();
     }
 
@@ -93,10 +104,42 @@ class PasswordResetModelTest extends AbstractTest
 
         $session = [];
         $dao = $this->makeMockDao($user);
-        $model = new PasswordResetModel($session, $dao, 'valid-token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'valid-token');
         $model->validateUser();
 
         $this->assertSame('valid-token', $session['password_reset_token']);
+    }
+
+    #[Test]
+    public function resetPasswordRevokesEveryLoginTokenForTheUser(): void
+    {
+        $user  = $this->makeUserWithToken();
+        $store = $this->createMock(SessionTokenStoreHandler::class);
+
+        // This flow previously revoked nothing at all: the user arrives with no authentication
+        // cookie, so removeLoginCookieFromStore() was handed an empty value and returned early.
+        // Anyone holding a stolen cookie kept working straight through the reset.
+        $store->expects($this->once())
+            ->method('revokeAllLoginTokens')
+            ->with($user->uid);
+
+        $session = [];
+        (new PasswordResetModel($session, $this->makeMockDao($user), $store, 'valid-token'))
+            ->resetPassword('new-secure-pass!');
+    }
+
+    #[Test]
+    public function aRejectedResetRevokesNothing(): void
+    {
+        $store = $this->createMock(SessionTokenStoreHandler::class);
+        $store->expects($this->never())->method('revokeAllLoginTokens');
+
+        $session = [];
+        $model   = new PasswordResetModel($session, $this->makeMockDao(), $store, 'wrong-token');
+
+        // An unusable token must not be able to log the account's devices out.
+        $this->expectException(ValidationError::class);
+        $model->resetPassword('new-secure-pass!');
     }
 
     #[Test]
@@ -107,7 +150,7 @@ class PasswordResetModelTest extends AbstractTest
 
         $session = [];
         $dao = $this->makeMockDao($user);
-        $model = new PasswordResetModel($session, $dao, 'valid-token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'valid-token');
         $model->resetPassword('new-secure-pass!');
 
         $this->assertNotSame($oldPass, $user->pass);
@@ -122,7 +165,7 @@ class PasswordResetModelTest extends AbstractTest
 
         $session = [];
         $dao = $this->makeMockDao(null);
-        $model = new PasswordResetModel($session, $dao, 'bad-token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'bad-token');
         $model->resetPassword('new-pass!');
     }
 
@@ -134,7 +177,7 @@ class PasswordResetModelTest extends AbstractTest
 
         $session = [];
         $dao = $this->makeMockDao($user);
-        $model = new PasswordResetModel($session, $dao, 'valid-token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'valid-token');
         $model->resetPassword('new-pass!');
 
         $this->assertNotNull($user->email_confirmed_at);
@@ -145,7 +188,7 @@ class PasswordResetModelTest extends AbstractTest
     {
         $session = ['wanted_url' => 'https://example.com/target'];
         $dao = $this->makeMockDao();
-        $model = new PasswordResetModel($session, $dao, 'token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'token');
 
         $url = $model->flushWantedURL();
 
@@ -158,7 +201,7 @@ class PasswordResetModelTest extends AbstractTest
     {
         $session = [];
         $dao = $this->makeMockDao();
-        $model = new PasswordResetModel($session, $dao, 'token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'token');
 
         $url = $model->flushWantedURL();
 
@@ -170,7 +213,7 @@ class PasswordResetModelTest extends AbstractTest
     {
         $session = [];
         $dao = $this->makeMockDao();
-        $model = new PasswordResetModel($session, $dao, 'token');
+        $model = new PasswordResetModel($session, $dao, $this->makeTokenStore(), 'token');
 
         $this->assertNull($model->getUser());
     }
@@ -189,7 +232,7 @@ class PasswordResetModelTest extends AbstractTest
         // back out of the session and lands here. Without its own check, this method would accept a
         // token of any age as long as the session outlived the 30 minute window.
         $session = ['password_reset_token' => 'valid-token'];
-        $model = new PasswordResetModel($session, $this->makeMockDao($user), null);
+        $model = new PasswordResetModel($session, $this->makeMockDao($user), $this->makeTokenStore(), null);
 
         try {
             $model->resetPassword('new-pass');
@@ -212,7 +255,7 @@ class PasswordResetModelTest extends AbstractTest
             $user->pass = null;
 
             $session = [];
-            $model = new PasswordResetModel($session, $this->makeMockDao($user), 'valid-token');
+            $model = new PasswordResetModel($session, $this->makeMockDao($user), $this->makeTokenStore(), 'valid-token');
             $model->resetPassword('new-pass');
 
             $this->assertSame(32, strlen((string)$user->salt));
@@ -232,7 +275,7 @@ class PasswordResetModelTest extends AbstractTest
         $user = $this->makeUserWithToken();
 
         $session = [];
-        $model = new PasswordResetModel($session, $this->makeMockDao($user), 'valid-token');
+        $model = new PasswordResetModel($session, $this->makeMockDao($user), $this->makeTokenStore(), 'valid-token');
         $model->resetPassword('new-pass');
 
         $this->assertSame('test-salt', $user->salt);


### PR DESCRIPTION
## Summary

Password change and password reset did not actually revoke anything. Both flows call
`broadcastLogout()`, which looks like it signs every device out but removes only the **presented**
cookie's single field — and in the reset flow the user arrives with no cookie at all, so **zero**
tokens were revoked. Anyone holding a stolen login cookie kept working straight through a password
reset. This adds a real purge-all and calls it from both flows.

Also flips `session.use_strict_mode` to `1` in the `docker` submodule, so PHP stops adopting
session ids supplied by the client.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Controller/Abstracts/Authentication/SessionTokenStoreHandler.php` | New `revokeAllLoginTokens(int $userId)`: `HKEYS` the user's token map, `DEL` those keys, then `DEL` the map. Field names and reverse-key names are the same `md5($cookieValue)` string, so one `HKEYS` yields both sets. |
| `lib/Model/Users/Authentication/ChangePasswordModel.php` | Calls the purge after the existing struct update and cache invalidation. Constructor gains a `SessionTokenStoreHandler`. |
| `lib/Model/Users/Authentication/PasswordResetModel.php` | Same call, same position. Constructor gains the handler as its third argument. |
| `lib/Controller/API/App/Authentication/UserController.php` | Passes the handler into `createChangePasswordModel()`. |
| `lib/Controller/API/App/Authentication/ForgotPasswordController.php` | Passes the handler into `createPasswordResetModel()`. |
| `docker` (submodule pointer) | `session.use_strict_mode = 0` → `1` in `web-node/data/etc/php/8.3/apache2/php.ini`. |
| `tests/unit/Core/Controllers/Authentication/SessionTokenStoreHandlerTest.php` | Deletion order and content, plus the empty-map case (`DEL` with zero keys is an error). |
| `tests/unit/Core/Model/Users/Authentication/ChangePasswordModelTest.php` | Revocation happens on success; a rejected change revokes nothing. |
| `tests/unit/Core/Model/Users/Authentication/PasswordResetModelTest.php` | Same two cases for the reset flow. |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

PHPStan on the five changed `lib/` files reports `[OK] No errors`. Note this repo has **no**
baseline — the checkbox wording above is the template's; every reported error has to be fixed, and
none are.

The four model-level tests were mutation-checked: removing the `revokeAllLoginTokens()` call from
the production path makes them fail. Assertions bind to `$user->uid` rather than a literal, so they
cannot pass by coincidence.

Reverse keys do expire on their own via `setex`, but a stale one still holds the **map's** name —
and that name is reused on the next login, so leaving it behind aims a dangling pointer at a live
map. Hence one `DEL` covering both.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**Known limits, stated rather than hidden.**

This kills **cookies**, not sessions already live. `AuthenticationHelper::authenticate()` checks
`$_SESSION['user']` before it ever reaches the token ring, and that branch never consults the ring —
so a session that is already open survives the purge until it dies of idleness
(`gc_maxlifetime = 1440`). Closing that is a follow-up PR: make the ring the sole authority and let
the PHP session be a data cache only, at which point `DEL active_user_login_tokens:<uid>` *is*
complete revocation.

API keys are unaffected by design: `authenticate()` checks them first and consults neither ring nor
session. Creation is gated behind `InternalUserValidator`, so this is staff-only. Follow-up worth
having: require the current password to create a key.

No re-issue or re-stamp path after the purge — that would be a purge-then-immediately-re-arm
sequence, the same shape as the `revamp` self-heal that makes the existing cookie refresh mint a
replacement token on expiry.

**Submodule pointer.** This branch bumps the `docker` gitlink. The submodule commit must be pushed
to `docker` `main` before this merges, or `git submodule update` breaks for everyone.
