### PR TITLE
✨ feat(segments): blink sticky project bar for off-screen file changes

### DIFF
--- a/public/js/components/common/VirtualList/Rows/RowSegment.js
+++ b/public/js/components/common/VirtualList/Rows/RowSegment.js
@@ -208,8 +208,6 @@ export const ProjectBar = ({
           () => setIsBlinkingState(false),
           BLINK_ANIMATION_DURATION,
         )
-      } else {
-        setIsBlinkingState(false)
       }
     }
 

--- a/public/js/components/common/VirtualList/Rows/RowSegment.js
+++ b/public/js/components/common/VirtualList/Rows/RowSegment.js
@@ -8,6 +8,8 @@ import CatToolStore from '../../../../stores/CatToolStore'
 import ModalsActions from '../../../../actions/ModalsActions'
 import SegmentUtils from '../../../../utils/segmentUtils'
 
+const BLINK_ANIMATION_DURATION = 3600
+
 const LinkIcon = () => {
   return (
     <svg
@@ -99,14 +101,13 @@ export const ProjectBar = ({
   sideOpen,
   listRef,
   isSticky,
-  isBlinking,
+  isSegmentOpenedNotRendered,
 }) => {
   const [isFileChange, setIsFileChange] = useState(false)
   const [isBlinkingState, setIsBlinkingState] = useState(false)
 
   const ref = useRef()
   const previousFileIdRef = useRef()
-  const isBlikingRef = useRef()
 
   const openInstructionsModal = (id_file) => {
     const props = {
@@ -151,7 +152,6 @@ export const ProjectBar = ({
     const container = ref.current
     const filenameElement = ref.current.firstChild
     const wordcounterElement = ref.current.children[1]
-
     if (
       isSticky &&
       idFileSegment !== previousFileIdRef.current &&
@@ -172,10 +172,7 @@ export const ProjectBar = ({
 
     previousFileIdRef.current = idFileSegment
 
-    return () => {
-      clearTimeout(tmOutReset)
-      setIsBlinkingState(false)
-    }
+    return () => clearTimeout(tmOutReset)
   }, [isSticky, idFileSegment])
 
   useEffect(() => {
@@ -202,18 +199,22 @@ export const ProjectBar = ({
   }, [isSticky, listRef])
 
   useEffect(() => {
-    let tmOut
+    let tmOutBlink
 
-    if (isSticky) {
-      if (isBlinking) {
-        isBlikingRef.current = true
-        setTimeout(() => (isBlikingRef.current = false), 300)
+    if (isSticky && typeof isSegmentOpenedNotRendered === 'symbol') {
+      if (isSegmentOpenedNotRendered.description === 'true') {
+        setIsBlinkingState(true)
+        tmOutBlink = setTimeout(
+          () => setIsBlinkingState(false),
+          BLINK_ANIMATION_DURATION,
+        )
+      } else {
+        setIsBlinkingState(false)
       }
-      if (isFileChange && isBlikingRef.current) setIsBlinkingState(true)
     }
 
-    return () => clearTimeout(tmOut)
-  }, [isSticky, isBlinking, isFileChange])
+    return () => clearTimeout(tmOutBlink)
+  }, [isSticky, isSegmentOpenedNotRendered])
 
   const previousScrollTopRef = useRef(0)
   const isScrollingReverseRef = useRef(false)

--- a/public/js/components/common/VirtualList/Rows/RowSegment.test.js
+++ b/public/js/components/common/VirtualList/Rows/RowSegment.test.js
@@ -191,6 +191,116 @@ describe('ProjectBar', () => {
     })
   })
 
+  describe('blink animation (isSegmentOpenedNotRendered)', () => {
+    const BLINK_ANIMATION_DURATION = 3600
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('does not blink by default (no isSegmentOpenedNotRendered prop)', () => {
+      const {container} = render(
+        <ProjectBar {...defaultProjectBarProps} isSticky={true} />,
+      )
+      expect(
+        container.querySelector('.projectbar-filename'),
+      ).not.toHaveClass('project-bar-blink')
+    })
+
+    it('blinks when isSegmentOpenedNotRendered describes "true"', () => {
+      const {container} = render(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={true}
+          isSegmentOpenedNotRendered={Symbol(true)}
+        />,
+      )
+      expect(container.querySelector('.projectbar-filename')).toHaveClass(
+        'project-bar-blink',
+      )
+    })
+
+    it('does not blink when isSegmentOpenedNotRendered describes "false"', () => {
+      const {container} = render(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={true}
+          isSegmentOpenedNotRendered={Symbol(false)}
+        />,
+      )
+      expect(
+        container.querySelector('.projectbar-filename'),
+      ).not.toHaveClass('project-bar-blink')
+    })
+
+    it('does not blink when not sticky, even if the signal says true', () => {
+      const {container} = render(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={false}
+          isSegmentOpenedNotRendered={Symbol(true)}
+        />,
+      )
+      expect(
+        container.querySelector('.projectbar-filename'),
+      ).not.toHaveClass('project-bar-blink')
+    })
+
+    it('clears the blink automatically after the animation duration, even without an animationend event', () => {
+      jest.useFakeTimers()
+      const {container} = render(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={true}
+          isSegmentOpenedNotRendered={Symbol(true)}
+        />,
+      )
+      expect(container.querySelector('.projectbar-filename')).toHaveClass(
+        'project-bar-blink',
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(BLINK_ANIMATION_DURATION)
+      })
+
+      expect(
+        container.querySelector('.projectbar-filename'),
+      ).not.toHaveClass('project-bar-blink')
+    })
+
+    it('re-triggers the blink when a new Symbol signal describes "true" again', () => {
+      jest.useFakeTimers()
+      const {container, rerender} = render(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={true}
+          isSegmentOpenedNotRendered={Symbol(true)}
+        />,
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(BLINK_ANIMATION_DURATION)
+      })
+      expect(
+        container.querySelector('.projectbar-filename'),
+      ).not.toHaveClass('project-bar-blink')
+
+      act(() => {
+        rerender(
+          <ProjectBar
+            {...defaultProjectBarProps}
+            isSticky={true}
+            isSegmentOpenedNotRendered={Symbol(true)}
+          />,
+        )
+      })
+
+      expect(container.querySelector('.projectbar-filename')).toHaveClass(
+        'project-bar-blink',
+      )
+    })
+  })
+
   describe('scroll direction tracking', () => {
     it('detects forward scroll', () => {
       const listRef = createMockListRef(0)

--- a/public/js/components/segments/SegmentsContainer.js
+++ b/public/js/components/segments/SegmentsContainer.js
@@ -206,6 +206,7 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
   const [clientConnected, setClientConnected] = useState()
   const [clientId, setClientId] = useState()
   const [firstRowIdVisible, setFirstRowIdVisible] = useState()
+  const [isSegmentOpenedNotRendered, setIsSegmentOpenedNotRendered] = useState()
 
   const persistenceVariables = useRef({
     lastScrolled: undefined,
@@ -218,6 +219,8 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
   const rowsRenderedHeight = useRef(new Map())
   const cachedRowsHeightMap = useRef(new Map())
   const cachedSegmentsToJS = useRef(new Map())
+  const previousOpenedFileIdRef = useRef()
+  const lastProjectBarPropsRef = useRef()
   const {guess_tags: guessTagActive, dictation: speechToTextActive} =
     userInfo?.metadata ?? {}
 
@@ -470,11 +473,16 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
     recalcHeight()
     window.addEventListener('resize', recalcHeight)
 
-    const wrapperEl = document.getElementById('context-preview-wrapper')
+    const elements = [
+      document.getElementById('context-preview-wrapper'),
+      document.querySelector('header'),
+    ].filter(Boolean)
+
     let observer
-    if (wrapperEl) {
+
+    if (elements.length) {
       observer = new ResizeObserver(recalcHeight)
-      observer.observe(wrapperEl)
+      elements.forEach((el) => observer.observe(el))
     }
 
     return () => {
@@ -876,46 +884,69 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
     }
   }
 
-  const goToFirstSegment = () => SegmentActions.scrollToSegment(firstJobSegment)
-
-  const getProjectBar = () => {
-    if (typeof firstRowIdVisible !== 'undefined') {
-      const props = getSegmentPropsBySid(firstRowIdVisible)
-
-      const index = rows.findIndex(({id}) =>
-        scrollToSid?.toString().indexOf('-') === -1
-          ? parseInt(id) === parseInt(scrollToSid)
-          : id === scrollToSid,
+  useEffect(() => {
+    const openSegment = (sid) => {
+      const index = essentialRows.findIndex(({id}) =>
+        sid?.toString().indexOf('-') === -1
+          ? parseInt(id) === parseInt(sid)
+          : id === sid,
       )
 
       let isOnScreen = false
       if (index !== -1 && listRef.current) {
-        const rowTop = rows
+        const rowTop = essentialRows
           .slice(0, index)
           .reduce((sum, row) => sum + row.height, 0)
-        const rowBottom = rowTop + rows[index].height
+        const rowBottom = rowTop + essentialRows[index].height
         const scrollTop = listRef.current.scrollTop
         const viewportBottom = scrollTop + listRef.current.clientHeight
         isOnScreen = rowBottom > scrollTop && rowTop < viewportBottom
       }
 
-      return (
-        props && (
-          <div
-            className={`sticky-project-bar ${props.sideOpen ? 'sticky-project-bar-slide-right' : ''}`}
-          >
-            <ProjectBar
-              {...{
-                ...props,
-                listRef: listRef.current,
-                isSticky: true,
-                isBlinking: scrollToSid && !isOnScreen,
-              }}
-            />
-          </div>
-        )
-      )
+      const {segment} = cachedSegmentsToJS.current.get(sid) ?? {}
+      const fileId = segment
+        ? SegmentUtils.getSegmentFileId(segment)
+        : undefined
+      const isFileChanged =
+        typeof previousOpenedFileIdRef.current === 'number' &&
+        fileId !== previousOpenedFileIdRef.current
+      previousOpenedFileIdRef.current = fileId
+
+      setIsSegmentOpenedNotRendered(Symbol(!isOnScreen && isFileChanged))
     }
+
+    SegmentStore.addListener(SegmentConstants.OPEN_SEGMENT, openSegment)
+
+    return () =>
+      SegmentStore.removeListener(SegmentConstants.OPEN_SEGMENT, openSegment)
+  }, [essentialRows])
+
+  const goToFirstSegment = () => SegmentActions.scrollToSegment(firstJobSegment)
+
+  const getProjectBar = () => {
+    const props =
+      (typeof firstRowIdVisible !== 'undefined' &&
+        getSegmentPropsBySid(firstRowIdVisible)) ||
+      lastProjectBarPropsRef.current
+
+    if (!props) return
+
+    lastProjectBarPropsRef.current = props
+
+    return (
+      <div
+        className={`sticky-project-bar ${props.sideOpen ? 'sticky-project-bar-slide-right' : ''}`}
+      >
+        <ProjectBar
+          {...{
+            ...props,
+            listRef: listRef.current,
+            isSticky: true,
+            isSegmentOpenedNotRendered,
+          }}
+        />
+      </div>
+    )
   }
 
   return (

--- a/public/js/components/segments/SegmentsContainer.test.js
+++ b/public/js/components/segments/SegmentsContainer.test.js
@@ -10,6 +10,15 @@ import CommentsConstants from '../../constants/CommentsConstants'
 import SegmentActions from '../../actions/SegmentActions'
 import SegmentsContainer from './SegmentsContainer'
 
+global.ResizeObserver = class ResizeObserver {
+  constructor(cb) {
+    this.cb = cb
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
 // --- Mocks ---
 
 jest.mock('react-hotkeys-hook', () => ({
@@ -73,6 +82,7 @@ jest.mock('../../constants/SegmentConstants', () => ({
   SCROLL_TO_SELECTED_SEGMENT: 'SCROLL_TO_SELECTED_SEGMENT',
   OPEN_SIDE: 'OPEN_SIDE',
   CLOSE_SIDE: 'CLOSE_SIDE',
+  OPEN_SEGMENT: 'OPEN_SEGMENT',
 }))
 
 jest.mock('../../constants/CatToolConstants', () => ({
@@ -322,6 +332,10 @@ describe('SegmentsContainer', () => {
         SegmentConstants.CLOSE_SIDE,
         expect.any(Function),
       )
+      expect(SegmentStore.addListener).toHaveBeenCalledWith(
+        SegmentConstants.OPEN_SEGMENT,
+        expect.any(Function),
+      )
     })
 
     test('registers all CatToolStore listeners on mount', () => {
@@ -355,10 +369,39 @@ describe('SegmentsContainer', () => {
         SegmentConstants.SCROLL_TO_SEGMENT,
         expect.any(Function),
       )
+      expect(SegmentStore.removeListener).toHaveBeenCalledWith(
+        SegmentConstants.OPEN_SEGMENT,
+        expect.any(Function),
+      )
       expect(CatToolStore.removeListener).toHaveBeenCalledWith(
         CatToolConstants.CLIENT_CONNECT,
         expect.any(Function),
       )
+    })
+  })
+
+  describe('OPEN_SEGMENT event (sticky project bar blink signal)', () => {
+    test('does not crash when fired with no rows/segments loaded', () => {
+      renderComponent()
+      expect(() => {
+        act(() => {
+          mockSegmentStoreListeners[SegmentConstants.OPEN_SEGMENT]('1')
+        })
+      }).not.toThrow()
+    })
+
+    test('does not crash when fired after segments are rendered', () => {
+      renderComponent()
+      act(() => {
+        mockSegmentStoreListeners[SegmentConstants.RENDER_SEGMENTS](
+          makeSegments(['1', '2', '3']),
+        )
+      })
+      expect(() => {
+        act(() => {
+          mockSegmentStoreListeners[SegmentConstants.OPEN_SEGMENT]('2')
+        })
+      }).not.toThrow()
     })
   })
 


### PR DESCRIPTION
## Summary

Blink the sticky project bar when the opened segment is both off-screen and
belongs to a different file than the previously opened one, instead of
relying on scroll position alone. Also fixes the sticky bar unmounting
during transient data reloads, which used to wipe the file-change tracking
ref and break the blink/slide detection.

## Type

- [x] `feat` — new user-facing feature

## Changes

| File | Change |
|------|--------|
| `public/js/components/segments/SegmentsContainer.js` | Track opened segment's on-screen + file-changed state; cache last resolved project bar props to avoid unmounting the sticky bar during data gaps |
| `public/js/components/common/VirtualList/Rows/RowSegment.js` | Blink sticky bar driven by the new signal; add a timeout safety net so the blink always clears |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

Manually verified: opening an off-screen segment in a different file blinks
the sticky bar; blink clears reliably even if scrolling interrupts the
animation; sticky bar no longer disappears during segment reloads.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code

## Notes