### PR TITLE
🐛 fix(segments): sticky bar blinking after segment click

### DIFF
--- a/public/js/components/common/VirtualList/Rows/RowSegment.js
+++ b/public/js/components/common/VirtualList/Rows/RowSegment.js
@@ -102,6 +102,7 @@ export const ProjectBar = ({
   listRef,
   isSticky,
   isSegmentOpenedNotRendered,
+  previousOpenedFileIdRef,
 }) => {
   const [isFileChange, setIsFileChange] = useState(false)
   const [isBlinkingState, setIsBlinkingState] = useState(false)
@@ -221,6 +222,8 @@ export const ProjectBar = ({
       listRef?.scrollTop < previousScrollTopRef.current
   }
   previousScrollTopRef.current = listRef?.scrollTop
+
+  if (isSticky) previousOpenedFileIdRef.current = currentSegment.id_file
 
   return (
     <div

--- a/public/js/components/common/VirtualList/Rows/RowSegment.test.js
+++ b/public/js/components/common/VirtualList/Rows/RowSegment.test.js
@@ -42,6 +42,7 @@ const defaultProjectBarProps = {
   sideOpen: false,
   isSticky: false,
   listRef: null,
+  previousOpenedFileIdRef: {current: undefined},
 }
 
 const createMockListRef = (scrollTop = 0) => {
@@ -344,6 +345,55 @@ describe('ProjectBar', () => {
         />,
       )
       expect(listRef.scrollTop).toBe(50)
+    })
+  })
+
+  describe('previousOpenedFileIdRef syncing (isSticky=true)', () => {
+    it('sets the ref to the rendered segment file id when sticky', () => {
+      const previousOpenedFileIdRef = {current: undefined}
+      render(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={true}
+          previousOpenedFileIdRef={previousOpenedFileIdRef}
+        />,
+      )
+      expect(previousOpenedFileIdRef.current).toBe(mockSegment.id_file)
+    })
+
+    it('updates the ref again when the sticky bar re-renders for a different file', () => {
+      const previousOpenedFileIdRef = {current: undefined}
+      const segmentFile2 = {...mockSegment, id_file: 2}
+      const {rerender} = render(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={true}
+          previousOpenedFileIdRef={previousOpenedFileIdRef}
+        />,
+      )
+      expect(previousOpenedFileIdRef.current).toBe(1)
+
+      rerender(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={true}
+          segment={segmentFile2}
+          previousOpenedFileIdRef={previousOpenedFileIdRef}
+        />,
+      )
+      expect(previousOpenedFileIdRef.current).toBe(2)
+    })
+
+    it('does not touch the ref when not sticky', () => {
+      const previousOpenedFileIdRef = {current: 'unchanged'}
+      render(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={false}
+          previousOpenedFileIdRef={previousOpenedFileIdRef}
+        />,
+      )
+      expect(previousOpenedFileIdRef.current).toBe('unchanged')
     })
   })
 })

--- a/public/js/components/segments/SegmentsContainer.js
+++ b/public/js/components/segments/SegmentsContainer.js
@@ -943,6 +943,7 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
             listRef: listRef.current,
             isSticky: true,
             isSegmentOpenedNotRendered,
+            previousOpenedFileIdRef,
           }}
         />
       </div>


### PR DESCRIPTION
## Summary

Clicking a segment directly left `previousOpenedFileIdRef` stale, so the next
scroll-driven `OPEN_SEGMENT` event saw a false file change and triggered the
sticky project bar's blink animation. The sticky `ProjectBar` now syncs the
ref to the currently rendered segment's file on every render while sticky,
so the ref always reflects reality.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `public/js/components/common/VirtualList/Rows/RowSegment.js` | `ProjectBar` now accepts `previousOpenedFileIdRef` and syncs it to the rendered segment's file id while sticky |
| `public/js/components/segments/SegmentsContainer.js` | Pass `previousOpenedFileIdRef` down to the sticky `ProjectBar` |
| `public/js/components/common/VirtualList/Rows/RowSegment.test.js` | Add coverage for the new ref-syncing behavior |

## Testing

- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

None.