### PR TITLE
✨ feat(modals): add option to include locked segments when replacing all

### DIFF
--- a/public/js/api/replaceAllIntoSegments/replaceAllIntoSegments.js
+++ b/public/js/api/replaceAllIntoSegments/replaceAllIntoSegments.js
@@ -26,6 +26,7 @@ export const replaceAllIntoSegments = async ({
   matchcase,
   exactmatch,
   replace,
+  includeLocked,
   revisionNumber = config.revisionNumber,
 }) => {
   const paramsData = {
@@ -40,6 +41,7 @@ export const replaceAllIntoSegments = async ({
     replace,
     inCurrentChunkOnly: true, // replace is fixed in context of current chunk
     revision_number: revisionNumber,
+    includeLocked,
   }
   const formData = new FormData()
 

--- a/public/js/components/header/cattol/search/Search.js
+++ b/public/js/components/header/cattol/search/Search.js
@@ -12,17 +12,16 @@ import SearchUtils from './searchUtils'
 import SegmentConstants from '../../../../constants/SegmentConstants'
 import SegmentActions from '../../../../actions/SegmentActions'
 import CatToolActions from '../../../../actions/CatToolActions'
-import ConfirmMessageModal from '../../../modals/ConfirmMessageModal'
 import AlertModal from '../../../modals/AlertModal'
 import ModalsActions from '../../../../actions/ModalsActions'
 import {tagSignatures} from '../../../segments/utils/DraftMatecatUtils/tagModel'
 import CommonUtils from '../../../../utils/commonUtils'
 import {
   REVISE_STEP_NUMBER,
-  SEGMENTS_STATUS,
 } from '../../../../constants/Constants'
 import {Select} from '../../../common/Select'
 import {segmentTranslation} from '../../../../setTranslationUtil'
+import {MODAL_KEY} from '../../../../constants/ModalKeys'
 
 class Search extends React.Component {
   constructor(props) {
@@ -241,48 +240,12 @@ class Search extends React.Component {
   handleReplaceAllClick(event) {
     event.preventDefault()
     let props = {
-      modalName: 'confirmReplace',
-      text: 'Do you really want to replace this text in all search results?',
-      successText: 'Continue',
-      successCallback: () => {
-        SearchUtils.execReplaceAll(this.state.search)
-          .then(() => {
-            const currentId = SegmentStore.getCurrentSegmentId()
-            SegmentActions.removeAllSegments()
-            CatToolActions.onRender({
-              firstLoad: false,
-              segmentToOpen: currentId,
-            })
-          })
-          .catch((errors) => {
-            ModalsActions.showModalComponent(
-              AlertModal,
-              {
-                text: errors?.length
-                  ? errors[0].message
-                  : 'We got an error, please contact support',
-              },
-              'Replace All Alert',
-            )
-          })
-        ModalsActions.onCloseModal()
-        CatToolActions.storeSearchResults({
-          total: 0,
-          searchResults: [],
-          occurrencesList: [],
-          searchResultsDictionary: {},
-          featuredSearchResult: null,
-        })
-      },
-      cancelText: 'Cancel',
-      cancelCallback: function () {
-        ModalsActions.onCloseModal()
-      },
+      search: this.state.search,
     }
     ModalsActions.showModalComponent(
-      ConfirmMessageModal,
+      MODAL_KEY.REPLACE_ALL,
       props,
-      'Confirmation required',
+      'Replace text in all results',
     )
   }
 

--- a/public/js/components/header/cattol/search/searchUtils.js
+++ b/public/js/components/header/cattol/search/searchUtils.js
@@ -360,7 +360,7 @@ let SearchUtils = {
    * Executes the replace all for segments if all the params are ok
    * @returns {boolean}
    */
-  execReplaceAll: function (params) {
+  execReplaceAll: function (params, includeLocked) {
     // $('.search-display .numbers').text('No segments found');
     // this.applySearch();
 
@@ -429,6 +429,7 @@ let SearchUtils = {
       matchcase: p['match-case'],
       exactmatch: p['exact-match'],
       replace,
+      includeLocked,
     })
   },
 

--- a/public/js/components/modals/ReplaceAllModal.js
+++ b/public/js/components/modals/ReplaceAllModal.js
@@ -1,0 +1,91 @@
+import React, {useRef} from 'react'
+import SegmentStore from '../../stores/SegmentStore'
+import SegmentActions from '../../actions/SegmentActions'
+import ModalsActions from '../../actions/ModalsActions'
+import SearchUtils from '../header/cattol/search/searchUtils'
+import CatToolActions from '../../actions/CatToolActions'
+import AlertModal from './AlertModal'
+
+export const HIDE_UNLOCK_ALL_SEGMENTS_MODAL_STORAGE =
+  'unlock-segments-modal' + config.id_job
+export const ReplaceAllModal = ({search}) => {
+  const checkbox = useRef()
+  const successCallback = () => {
+    SearchUtils.execReplaceAll(search, checkbox.current.checked)
+      .then(() => {
+        const currentId = SegmentStore.getCurrentSegmentId()
+        SegmentActions.removeAllSegments()
+        CatToolActions.onRender({
+          firstLoad: false,
+          segmentToOpen: currentId,
+        })
+      })
+      .catch((errors) => {
+        ModalsActions.showModalComponent(
+          AlertModal,
+          {
+            text: errors?.length
+              ? errors[0].message
+              : 'We got an error, please contact support',
+          },
+          'Replace All Alert',
+        )
+      })
+    ModalsActions.onCloseModal()
+    CatToolActions.storeSearchResults({
+      total: 0,
+      searchResults: [],
+      occurrencesList: [],
+      searchResultsDictionary: {},
+      featuredSearchResult: null,
+    })
+  }
+
+  const checkboxCheck = () => {
+    if (checkbox.current.checked) {
+      localStorage.setItem(HIDE_UNLOCK_ALL_SEGMENTS_MODAL_STORAGE, 1)
+    }
+  }
+
+  return (
+    <div className="message-modal">
+      <div className="matecat-modal-middle">
+        <div className={'ui one column grid'}>
+          <div className="column left aligned" style={{fontSize: '18px'}}>
+            You are about to replace this text in all search results.
+            <br />
+            To let you easily review these changes, modified segments will
+            revert to <b>{config.isReview ? 'translated' : 'draft'}</b> status.
+          </div>
+          <div className="column left aligned">
+            <input
+              id="checkbox_unlock"
+              type="checkbox"
+              className=""
+              ref={checkbox}
+            />
+            <label htmlFor="checkbox_unlock">
+              {` Include locked segments`}
+            </label>
+          </div>
+          <div className="column right aligned">
+            <div
+              className="ui button cancel-button"
+              onClick={() => {
+                ModalsActions.onCloseModal()
+              }}
+            >
+              Cancel
+            </div>
+            <div
+              className="ui primary button right floated"
+              onClick={successCallback}
+            >
+              Replace all
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/public/js/components/modals/ReplaceAllModal.test.js
+++ b/public/js/components/modals/ReplaceAllModal.test.js
@@ -1,0 +1,172 @@
+import React from 'react'
+import {render, screen, fireEvent, act} from '@testing-library/react'
+import {ReplaceAllModal} from './ReplaceAllModal'
+import SegmentStore from '../../stores/SegmentStore'
+import SegmentActions from '../../actions/SegmentActions'
+import ModalsActions from '../../actions/ModalsActions'
+import CatToolActions from '../../actions/CatToolActions'
+import SearchUtils from '../header/cattol/search/searchUtils'
+import AlertModal from './AlertModal'
+
+jest.mock('../../stores/SegmentStore', () => ({
+  __esModule: true,
+  default: {
+    getCurrentSegmentId: jest.fn(),
+  },
+}))
+
+jest.mock('../../actions/SegmentActions', () => ({
+  __esModule: true,
+  default: {
+    removeAllSegments: jest.fn(),
+  },
+}))
+
+jest.mock('../../actions/ModalsActions', () => ({
+  __esModule: true,
+  default: {
+    onCloseModal: jest.fn(),
+    showModalComponent: jest.fn(),
+  },
+}))
+
+jest.mock('../../actions/CatToolActions', () => ({
+  __esModule: true,
+  default: {
+    onRender: jest.fn(),
+    storeSearchResults: jest.fn(),
+  },
+}))
+
+jest.mock('../header/cattol/search/searchUtils', () => ({
+  __esModule: true,
+  default: {
+    execReplaceAll: jest.fn(),
+  },
+}))
+
+const search = {
+  searchSource: 'foo',
+  searchTarget: 'bar',
+  replaceTarget: 'baz',
+  selectStatus: 'all',
+  matchCase: false,
+  exactMatch: false,
+}
+
+describe('ReplaceAllModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    config.isReview = false
+  })
+
+  test('renders the confirmation copy, checkbox and actions', () => {
+    render(<ReplaceAllModal search={search} />)
+
+    expect(
+      screen.getByText(/You are about to replace this text/),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText('Include locked segments')).not.toBeChecked()
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+    expect(screen.getByText('Replace all')).toBeInTheDocument()
+  })
+
+  test('shows the draft status by default', () => {
+    render(<ReplaceAllModal search={search} />)
+
+    expect(screen.getByText('draft')).toBeInTheDocument()
+  })
+
+  test('shows the translated status when the job is in review', () => {
+    config.isReview = true
+    render(<ReplaceAllModal search={search} />)
+
+    expect(screen.getByText('translated')).toBeInTheDocument()
+  })
+
+  test('cancel closes the modal without running the replace', () => {
+    render(<ReplaceAllModal search={search} />)
+
+    fireEvent.click(screen.getByText('Cancel'))
+
+    expect(ModalsActions.onCloseModal).toHaveBeenCalled()
+    expect(SearchUtils.execReplaceAll).not.toHaveBeenCalled()
+  })
+
+  test('replace all runs the search params through execReplaceAll with includeLocked false by default', async () => {
+    SearchUtils.execReplaceAll.mockResolvedValue({})
+    render(<ReplaceAllModal search={search} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Replace all'))
+    })
+
+    expect(SearchUtils.execReplaceAll).toHaveBeenCalledWith(search, false)
+    expect(ModalsActions.onCloseModal).toHaveBeenCalled()
+    expect(CatToolActions.storeSearchResults).toHaveBeenCalledWith({
+      total: 0,
+      searchResults: [],
+      occurrencesList: [],
+      searchResultsDictionary: {},
+      featuredSearchResult: null,
+    })
+  })
+
+  test('replace all passes includeLocked true when the checkbox is checked', async () => {
+    SearchUtils.execReplaceAll.mockResolvedValue({})
+    render(<ReplaceAllModal search={search} />)
+
+    fireEvent.click(screen.getByLabelText('Include locked segments'))
+    await act(async () => {
+      fireEvent.click(screen.getByText('Replace all'))
+    })
+
+    expect(SearchUtils.execReplaceAll).toHaveBeenCalledWith(search, true)
+  })
+
+  test('reloads the current segment on a successful replace', async () => {
+    SegmentStore.getCurrentSegmentId.mockReturnValue('1-1')
+    SearchUtils.execReplaceAll.mockResolvedValue({})
+    render(<ReplaceAllModal search={search} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Replace all'))
+    })
+
+    expect(SegmentActions.removeAllSegments).toHaveBeenCalled()
+    expect(CatToolActions.onRender).toHaveBeenCalledWith({
+      firstLoad: false,
+      segmentToOpen: '1-1',
+    })
+  })
+
+  test('shows the first error message when the replace fails', async () => {
+    SearchUtils.execReplaceAll.mockRejectedValue([{message: 'boom'}])
+    render(<ReplaceAllModal search={search} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Replace all'))
+    })
+
+    expect(ModalsActions.showModalComponent).toHaveBeenCalledWith(
+      AlertModal,
+      {text: 'boom'},
+      'Replace All Alert',
+    )
+  })
+
+  test('shows a generic error message when the replace fails without errors', async () => {
+    SearchUtils.execReplaceAll.mockRejectedValue(undefined)
+    render(<ReplaceAllModal search={search} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Replace all'))
+    })
+
+    expect(ModalsActions.showModalComponent).toHaveBeenCalledWith(
+      AlertModal,
+      {text: 'We got an error, please contact support'},
+      'Replace All Alert',
+    )
+  })
+})

--- a/public/js/components/modals/modalRegistry.js
+++ b/public/js/components/modals/modalRegistry.js
@@ -11,6 +11,7 @@ import AlertModal from './AlertModal'
 import RevisionFeedbackModal from './RevisionFeedbackModal'
 import CopySourceModal from './CopySourceModal'
 import {UnlockAllSegmentsModal} from './UnlockAllSegmentsModal'
+import {ReplaceAllModal} from './ReplaceAllModal'
 
 const modalRegistry = {
   [MODAL_KEY.CONFIRM_MESSAGE]: ConfirmMessageModal,
@@ -25,6 +26,7 @@ const modalRegistry = {
   [MODAL_KEY.REVISION_FEEDBACK]: RevisionFeedbackModal,
   [MODAL_KEY.COPY_SOURCE]: CopySourceModal,
   [MODAL_KEY.UNLOCK_ALL_SEGMENTS]: UnlockAllSegmentsModal,
+  [MODAL_KEY.REPLACE_ALL]: ReplaceAllModal,
 }
 
 export const resolveModal = (componentOrKey) => {

--- a/public/js/components/segments/SegmentFooterTabMatches.js
+++ b/public/js/components/segments/SegmentFooterTabMatches.js
@@ -169,13 +169,6 @@ class SegmentFooterTabMatches extends React.Component {
 
   getMatchInfo(match) {
     const penaltyPercRef = createRef()
-    console.log(
-      match,
-      match.source,
-      match.target,
-      config.target_rfc,
-      config.source_rfc,
-    )
     return (
       <ul className="graysmall-details">
         <li className="graydesc graydesc-sourcekey">

--- a/public/js/constants/ModalKeys.js
+++ b/public/js/constants/ModalKeys.js
@@ -11,6 +11,7 @@ export const MODAL_KEY = {
   REVISION_FEEDBACK: 'RevisionFeedback',
   COPY_SOURCE: 'CopySource',
   UNLOCK_ALL_SEGMENTS: 'UnlockAllSegments',
+  REPLACE_ALL: 'ReplaceAll',
 }
 
 export const COPY_SOURCE_COOKIE = 'source_copied_to_target'


### PR DESCRIPTION
## Summary

Adds a checkbox to the Replace All confirmation dialog letting the user include locked
segments in the replacement. The old generic `ConfirmMessageModal` wiring in `Search.js` is
replaced with a dedicated `ReplaceAllModal` that owns this option and the replace-all flow.

## Type

- [x] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/modals/ReplaceAllModal.js` | New modal with an "include locked segments" checkbox for the replace-all flow |
| `public/js/components/modals/ReplaceAllModal.test.js` | Test coverage for the new modal |
| `public/js/components/header/cattol/search/Search.js` | Replace `ConfirmMessageModal` wiring with `MODAL_KEY.REPLACE_ALL` |
| `public/js/components/header/cattol/search/searchUtils.js` | `execReplaceAll` accepts and forwards `includeLocked` |
| `public/js/api/replaceAllIntoSegments/replaceAllIntoSegments.js` | Forward `includeLocked` to the replace-all API call |
| `public/js/constants/ModalKeys.js` | Add `REPLACE_ALL` modal key |
| `public/js/components/modals/modalRegistry.js` | Register `ReplaceAllModal` under `REPLACE_ALL` |
| `public/js/components/segments/SegmentFooterTabMatches.js` | Remove leftover debug `console.log` in `getMatchInfo` |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

`yarn test` passes: 78 suites / 790 tests passing (15 skipped, as expected), including the new
`ReplaceAllModal.test.js` (9 tests).

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code

## Notes

While adding test coverage, found and fixed a bug in the new `ReplaceAllModal`: it declared its
props parameter as `(search)` instead of `({search})`, so it received the whole props object
instead of just the search params, and would have passed the wrong shape into
`execReplaceAll`/`replaceAllIntoSegments`.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217073743718043