### PR TITLE
✨ feat(lara): send multiline when the project uses paragraph segmentation

### DIFF
--- a/lib/Controller/API/App/CreateProjectController.php
+++ b/lib/Controller/API/App/CreateProjectController.php
@@ -243,8 +243,11 @@ class CreateProjectController extends AbstractStatefulKleinController
         $deepl_id_glossary = filter_var($this->request->param('deepl_id_glossary'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
         $deepl_formality = filter_var($this->request->param('deepl_formality'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
         $deepl_engine_type = filter_var($this->request->param('deepl_engine_type'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW]);
+        $segmentation_rule = filter_var($this->request->param('segmentation_rule'), FILTER_SANITIZE_SPECIAL_CHARS, ['flags' => FILTER_FLAG_STRIP_LOW | FILTER_FLAG_STRIP_HIGH]);
+        $segmentation_rule = Constants::validateSegmentationRules($segmentation_rule ?: null);
 
         $icu_enabled = filter_var($this->request->param('icu_enabled'), FILTER_VALIDATE_BOOLEAN);
+
         $mandatory_issues = filter_var(
             $this->request->param('mandatory_issues'),
             FILTER_SANITIZE_FULL_SPECIAL_CHARS,
@@ -436,6 +439,10 @@ class CreateProjectController extends AbstractStatefulKleinController
         $data['project_features'] = $this->appendFeaturesToProject($data['mt_engine']);
         $data['team'] = $this->setTeam($id_team ?: null);
 
+        if (!empty($segmentation_rule)) {
+            $data[ProjectsMetadataMarshaller::SEGMENTATION_RULE->value] = $segmentation_rule;
+        }
+
         $this->setMetadataFromPostInput($data);
 
         return $data;
@@ -496,11 +503,17 @@ class CreateProjectController extends AbstractStatefulKleinController
         // new raw counter model
         $options = [ProjectsMetadataMarshaller::WORD_COUNT_TYPE_KEY->value => ProjectsMetadataMarshaller::WORD_COUNT_RAW->value];
 
-        if (isset($data['mt_quality_value_in_editor'])) {
-            $options[ProjectsMetadataMarshaller::MT_QUALITY_VALUE_IN_EDITOR->value] = $data['mt_quality_value_in_editor'];
+        if (isset($data[ProjectsMetadataMarshaller::MT_QUALITY_VALUE_IN_EDITOR->value])) {
+            $options[ProjectsMetadataMarshaller::MT_QUALITY_VALUE_IN_EDITOR->value] = $data[ProjectsMetadataMarshaller::MT_QUALITY_VALUE_IN_EDITOR->value];
         }
 
-        $options[ProjectsMetadataMarshaller::ICU_ENABLED->value] = $data['icu_enabled'];
+        // 'standard' and '' are normalized to null by Constants::validateSegmentationRules(), so only
+        // 'patent' and 'paragraph' ever reach the metadata. Lara reads this key to enable multiline.
+        if (!empty($data[ProjectsMetadataMarshaller::SEGMENTATION_RULE->value])) {
+            $options[ProjectsMetadataMarshaller::SEGMENTATION_RULE->value] = $data[ProjectsMetadataMarshaller::SEGMENTATION_RULE->value];
+        }
+
+        $options[ProjectsMetadataMarshaller::ICU_ENABLED->value] = $data[ProjectsMetadataMarshaller::ICU_ENABLED->value];
 
         $this->metadata = $options;
     }

--- a/lib/Utils/Constants/Constants.php
+++ b/lib/Utils/Constants/Constants.php
@@ -23,11 +23,15 @@ class Constants
     const string PUBLIC_TM = "Public TM";
     const string NO_DESCRIPTION_TM = "No description";
 
+    const string SEG_RULE_STANDARD = 'standard';
+    const string SEG_RULE_PATENT = 'patent';
+    const string SEG_RULE_PARAGRAPH = 'paragraph';
+
     /** @var list<string> */
     public static array $allowed_seg_rules = [
-        'standard',
-        'patent',
-        'paragraph',
+        self::SEG_RULE_STANDARD,
+        self::SEG_RULE_PATENT,
+        self::SEG_RULE_PARAGRAPH,
         ''
     ];
 
@@ -37,7 +41,7 @@ class Constants
     public static function validateSegmentationRules(?string $segmentation_rule = ''): ?string
     {
         //normalize segmentation rule to what it's used internally
-        if ($segmentation_rule == 'standard' || $segmentation_rule == '') {
+        if ($segmentation_rule == self::SEG_RULE_STANDARD || $segmentation_rule == '') {
             return null;
         }
 

--- a/lib/Utils/Engines/Lara.php
+++ b/lib/Utils/Engines/Lara.php
@@ -27,6 +27,7 @@ use Stomp\Transport\Message;
 use Throwable;
 use TypeError;
 use Utils\ActiveMQ\AMQHandler;
+use Utils\Constants\Constants;
 use Utils\Constants\EngineConstants;
 use Utils\Engines\Lara\Headers;
 use Utils\Engines\Lara\HttpClientInterface;
@@ -272,6 +273,14 @@ class Lara extends AbstractEngine
         $laraStyleGuidelineId = $_config['lara_style_guideline_id'] ?? null;
         $laraModel = $_config['lara_model'] ?? '';
 
+        // Projects segmented by paragraph send whole paragraphs to Lara: ask Lara to treat them as
+        // multiline, it is not trained to split a single large block of text by itself.
+        // Computed for both branches below because both log it.
+        $multiline = !empty($_config['id_project'])
+            && $metadataDao->setCacheTTL(86400)
+                ->getValue($_config['id_project'], ProjectsMetadataMarshaller::SEGMENTATION_RULE->value)
+            === Constants::SEG_RULE_PARAGRAPH;
+
         if (empty($_config['translation'])) {
             // This is a normal request, not Lara Think
             $reasoning = false;
@@ -289,7 +298,7 @@ class Lara extends AbstractEngine
                 // call lara
                 $translateOptions = new TranslateOptions();
                 $translateOptions->setAdaptTo($_config['keys']);
-                $translateOptions->setMultiline(false);
+                $translateOptions->setMultiline($multiline);
                 $translateOptions->setContentType('application/xliff+xml');
                 $headers = new Headers();
 
@@ -371,7 +380,7 @@ class Lara extends AbstractEngine
                     'style_guideline_id' => $laraStyleGuidelineId,
                     'model' => $laraModel,
                     'glossaries' => is_array($laraGlossaries ?? null) ? implode(",", $laraGlossaries) : null,
-                    'multiline' => false,
+                    'multiline' => $multiline,
                     'translation' => $translation,
                     'score' => $score ?? null,
                     'extra_headers' => $headers->getArrayCopy(),
@@ -436,7 +445,7 @@ class Lara extends AbstractEngine
                 'source' => $_config['source'],
                 'target' => $_config['target'],
                 'content_type' => 'application/xliff+xml',
-                'multiline' => false,
+                'multiline' => $multiline,
                 'translation' => $translation,
                 'score' => $score ?? null,
                 'reasoning' => $reasoning,

--- a/tests/unit/Core/Controllers/CreateProjectControllerTest.php
+++ b/tests/unit/Core/Controllers/CreateProjectControllerTest.php
@@ -12,6 +12,7 @@ use Matecat\Locales\Languages;
 use Matecat\TestHelpers\AbstractTest;
 use Matecat\TestHelpers\ControllerSeedFragments;
 use Model\FeaturesBase\FeatureSet;
+use Model\Projects\ProjectsMetadataMarshaller;
 use Model\Teams\TeamStruct;
 use Model\Users\UserStruct;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -220,6 +221,121 @@ class CreateProjectControllerTest extends AbstractTest
         $data = $this->invokePrivate('validateTheRequest');
 
         $this->assertSame(0, $data['tms_engine']);
+    }
+
+    // ─── segmentation_rule ───
+
+    /**
+     * Reads the private metadata property filled in by setMetadataFromPostInput().
+     *
+     * @return array<string, mixed>
+     * @throws ReflectionException
+     */
+    private function controllerMetadata(): array
+    {
+        /** @var array<string, mixed> $metadata */
+        $metadata = $this->reflector->getProperty('metadata')->getValue($this->controller);
+
+        return $metadata;
+    }
+
+    /**
+     * The paragraph rule must be persisted as project metadata: Lara reads it back to enable
+     * multiline, without which it receives whole paragraphs it is not trained to split.
+     *
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_stores_paragraph_segmentation_rule_in_metadata(): void
+    {
+        $_COOKIE['upload_token'] = '33333333-3333-3333-3333-333333333333';
+        $params = $this->validRequestParams();
+        $params['segmentation_rule'] = Constants::SEG_RULE_PARAGRAPH;
+        $this->setRequestParams($params);
+
+        /** @var array<string, mixed> $data */
+        $data = $this->invokePrivate('validateTheRequest');
+
+        $key = ProjectsMetadataMarshaller::SEGMENTATION_RULE->value;
+        $this->assertSame(Constants::SEG_RULE_PARAGRAPH, $data[$key]);
+        $this->assertSame(Constants::SEG_RULE_PARAGRAPH, $this->controllerMetadata()[$key]);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_stores_patent_segmentation_rule_in_metadata(): void
+    {
+        $_COOKIE['upload_token'] = '44444444-4444-4444-4444-444444444444';
+        $params = $this->validRequestParams();
+        $params['segmentation_rule'] = Constants::SEG_RULE_PATENT;
+        $this->setRequestParams($params);
+
+        /** @var array<string, mixed> $data */
+        $data = $this->invokePrivate('validateTheRequest');
+
+        $key = ProjectsMetadataMarshaller::SEGMENTATION_RULE->value;
+        $this->assertSame(Constants::SEG_RULE_PATENT, $data[$key]);
+        $this->assertSame(Constants::SEG_RULE_PATENT, $this->controllerMetadata()[$key]);
+    }
+
+    /**
+     * 'standard' (labelled "General" in the UI) is the default and is normalized to null by
+     * Constants::validateSegmentationRules(), so it must not create a metadata row at all —
+     * that absence is what makes Lara keep multiline disabled.
+     *
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_does_not_store_standard_segmentation_rule(): void
+    {
+        $_COOKIE['upload_token'] = '55555555-5555-5555-5555-555555555555';
+        $params = $this->validRequestParams();
+        $params['segmentation_rule'] = Constants::SEG_RULE_STANDARD;
+        $this->setRequestParams($params);
+
+        /** @var array<string, mixed> $data */
+        $data = $this->invokePrivate('validateTheRequest');
+
+        $key = ProjectsMetadataMarshaller::SEGMENTATION_RULE->value;
+        $this->assertArrayNotHasKey($key, $data);
+        $this->assertArrayNotHasKey($key, $this->controllerMetadata());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_does_not_store_segmentation_rule_when_param_is_omitted(): void
+    {
+        $_COOKIE['upload_token'] = '66666666-6666-6666-6666-666666666666';
+        $this->setRequestParams($this->validRequestParams());
+
+        /** @var array<string, mixed> $data */
+        $data = $this->invokePrivate('validateTheRequest');
+
+        $key = ProjectsMetadataMarshaller::SEGMENTATION_RULE->value;
+        $this->assertArrayNotHasKey($key, $data);
+        $this->assertArrayNotHasKey($key, $this->controllerMetadata());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Test]
+    public function validateTheRequest_throws_on_unknown_segmentation_rule(): void
+    {
+        $_COOKIE['upload_token'] = '88888888-8888-8888-8888-888888888888';
+        $params = $this->validRequestParams();
+        $params['segmentation_rule'] = 'nonexistent-rule';
+        $this->setRequestParams($params);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Segmentation rule not allowed: nonexistent-rule');
+        $this->expectExceptionCode(-4);
+
+        $this->invokePrivate('validateTheRequest');
     }
 
     /**

--- a/tests/unit/Core/Engines/LaraEngineTest.php
+++ b/tests/unit/Core/Engines/LaraEngineTest.php
@@ -15,6 +15,7 @@ use Lara\Memories;
 use Lara\Memory;
 use Lara\TextBlock;
 use Lara\TextResult;
+use Lara\TranslateOptions;
 use Matecat\TestHelpers\AbstractTest;
 use Model\Engines\Structs\EngineStruct;
 use Model\TmKeyManagement\MemoryKeyStruct;
@@ -24,6 +25,7 @@ use ReflectionProperty;
 use RuntimeException;
 use stdClass;
 use Throwable;
+use Utils\Constants\Constants;
 use Utils\Constants\EngineConstants;
 use Utils\Engines\Lara;
 use Utils\Engines\Lara\HeaderField;
@@ -149,6 +151,172 @@ class LaraEngineTest extends AbstractTest
         self::assertSame(200, $response->responseStatus);
         self::assertCount(1, $response->matches);
         self::assertSame('glossary translation', $response->matches[0]->raw_translation);
+    }
+    /**
+     * Builds a LaraClient mock that captures the TranslateOptions handed to translate(),
+     * so a test can assert on what was actually sent to Lara.
+     *
+     * @param TranslateOptions|null $captured Filled in with the options of the single translate() call.
+     */
+    private function mockClientCapturingOptions(?TranslateOptions &$captured, string $translation): LaraClient
+    {
+        $client = $this->createMock(LaraClient::class);
+        $client->method('getHttpClient')->willReturn(new TestHttpClient());
+        $client->expects(self::once())
+            ->method('translate')
+            ->willReturnCallback(
+                function ($text, $source, $target, $options) use (&$captured, $translation): TextResult {
+                    $captured = $options;
+
+                    return new TextResult('application/xliff+xml', 'en-US', [
+                        new TextBlock($translation, true),
+                    ]);
+                }
+            );
+
+        return $client;
+    }
+    /**
+     * Runs get() against a project whose segmentation_rule metadata is $segmentationRule
+     * (null means: no metadata row at all) and returns the multiline flag actually sent to Lara.
+     *
+     * @throws LaraException
+     * @throws Exception
+     */
+    private function multilineSentForSegmentationRule(?string $segmentationRule, bool $withIdProject = true): ?bool
+    {
+        $idProject = 1;
+        $key = ProjectsMetadataMarshaller::SEGMENTATION_RULE->value;
+
+        $metadataDao = new MetadataDao(obtainTestDatabase());
+        // set()/delete() both destroy the metadata cache, so the setCacheTTL(86400) read
+        // inside get() cannot serve a value seeded by a sibling test.
+        $metadataDao->delete($idProject, $key);
+        if ($segmentationRule !== null) {
+            $metadataDao->set($idProject, $key, $segmentationRule);
+            self::assertSame($segmentationRule, $metadataDao->getValue($idProject, $key));
+        }
+
+        $captured = null;
+        $this->engine->setMockClient($this->mockClientCapturingOptions($captured, 'translated segment'));
+
+        $config = [
+            'segment' => 'source segment',
+            'source' => 'en-US',
+            'target' => 'it-IT',
+            'keys' => ['k1'],
+            'context_list_before' => [],
+            'context_list_after' => [],
+        ];
+
+        if ($withIdProject) {
+            $config['id_project'] = $idProject;
+        }
+
+        try {
+            $response = $this->engine->get($config);
+        } finally {
+            // Keep project 1 metadata clean so sibling suites are unaffected.
+            $metadataDao->delete($idProject, $key);
+        }
+
+        self::assertSame(200, $response->responseStatus);
+        self::assertSame('translated segment', $response->matches[0]->raw_translation);
+        self::assertInstanceOf(TranslateOptions::class, $captured);
+
+        return $captured->isMultiline();
+    }
+    /**
+     * Paragraph segmentation produces one segment per paragraph, so Lara receives large
+     * multi-sentence blocks. Lara is not trained to split such a block itself, and quality
+     * drops when it is asked to: multiline must be enabled for these projects.
+     *
+     * @throws LaraException
+     * @throws Exception
+     */
+    #[Test]
+    public function getSendsMultilineTrueWhenProjectSegmentationRuleIsParagraph(): void
+    {
+        self::assertTrue($this->multilineSentForSegmentationRule(Constants::SEG_RULE_PARAGRAPH));
+    }
+    /**
+     * Only 'paragraph' flips the flag: 'patent' still segments by sentence.
+     *
+     * @throws LaraException
+     * @throws Exception
+     */
+    #[Test]
+    public function getSendsMultilineFalseWhenProjectSegmentationRuleIsPatent(): void
+    {
+        self::assertFalse($this->multilineSentForSegmentationRule(Constants::SEG_RULE_PATENT));
+    }
+    /**
+     * 'standard'/'General' is normalized to null by Constants::validateSegmentationRules() and
+     * therefore never stored, exactly like every project created before this feature existed.
+     * No row must mean multiline = false.
+     *
+     * @throws LaraException
+     * @throws Exception
+     */
+    #[Test]
+    public function getSendsMultilineFalseWhenProjectHasNoSegmentationRuleMetadata(): void
+    {
+        self::assertFalse($this->multilineSentForSegmentationRule(null));
+    }
+    /**
+     * Callers that do not provide id_project (no project context) cannot be resolved to a
+     * segmentation rule and must default to false rather than reading metadata for project 0.
+     *
+     * @throws LaraException
+     * @throws Exception
+     */
+    #[Test]
+    public function getSendsMultilineFalseWhenIdProjectIsMissing(): void
+    {
+        self::assertFalse(
+            $this->multilineSentForSegmentationRule(Constants::SEG_RULE_PARAGRAPH, false)
+        );
+    }
+    /**
+     * Regression test: $multiline used to be computed inside the non-Think branch only, while the
+     * "Lara Think" branch (translation already produced by the browser) logs it too. That raised
+     * "Warning: Undefined variable $multiline" on every Think contribution. phpunit.xml does not
+     * enable failOnWarning, so this test installs its own handler to turn the warning into a failure.
+     *
+     * @throws LaraException
+     * @throws Exception
+     */
+    #[Test]
+    public function getLaraThinkRequestDoesNotEmitUndefinedVariableWarning(): void
+    {
+        $idProject = 1;
+        $key = ProjectsMetadataMarshaller::SEGMENTATION_RULE->value;
+
+        $metadataDao = new MetadataDao(obtainTestDatabase());
+        $metadataDao->delete($idProject, $key);
+        $metadataDao->set($idProject, $key, Constants::SEG_RULE_PARAGRAPH);
+
+        set_error_handler(static function (int $severity, string $message): bool {
+            throw new RuntimeException($message);
+        }, E_WARNING);
+
+        try {
+            $response = $this->engine->get([
+                'segment' => 'source segment',
+                'source' => 'en-US',
+                'target' => 'it-IT',
+                'id_project' => $idProject,
+                'translation' => 'already translated',
+                'reasoning' => false,
+                'lara_model' => 'think',
+            ]);
+        } finally {
+            restore_error_handler();
+            $metadataDao->delete($idProject, $key);
+        }
+
+        self::assertSame(200, $response->responseStatus);
+        self::assertSame('already translated', $response->matches[0]->raw_translation);
     }
     /**
      * @throws LaraException


### PR DESCRIPTION
## Summary

Lara's translation quality drops when it receives one very large block of text with
`multiline=false`: it is not trained to split such a block into smaller units. Projects created
with the **paragraph** segmentation rule produce exactly those blocks (one segment = one
paragraph). This PR persists the segmentation rule chosen at project creation and sends
`multiline=true` to Lara for those projects only.

## Type

- [x] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Controller/API/App/CreateProjectController.php` | validate `segmentation_rule` through the existing `Constants::validateSegmentationRules()` and store it in the project metadata — the v1 API already did this, the app endpoint dropped the param |
| `lib/Utils/Engines/Lara.php` | read `segmentation_rule` from the project metadata and set `TranslateOptions::setMultiline()` only for `paragraph`; the value is computed once, above the branch split, so the "Lara Think" branch no longer logs an undefined variable |
| `lib/Utils/Constants/Constants.php` | add `SEG_RULE_STANDARD` / `SEG_RULE_PATENT` / `SEG_RULE_PARAGRAPH` and reuse them in `$allowed_seg_rules` and `validateSegmentationRules()` |
| `tests/unit/Core/Engines/LaraEngineTest.php` | 5 tests asserting the `multiline` flag actually sent to Lara, plus a regression test for the undefined variable |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

```
tests/unit/Core/Engines/LaraEngineTest.php   OK (53 tests, 183 assertions)
phpstan (4 changed lib files + the test)     [OK] No errors
full suite                                   9570 tests, 30723 assertions
```

The full run reports 4 failures, all in `Core\Controllers\CommentControllerTest::*broker_unavailable*`:
those tests assert a `Throwable` is raised when ActiveMQ is unreachable, and ActiveMQ *is* reachable
in the container used for the run. Environmental, unrelated to this change.

New tests capture the `TranslateOptions` handed to `LaraClient::translate()` and assert
`isMultiline()`:

| Project metadata | `multiline` sent |
|---|---|
| `segmentation_rule = paragraph` | `true` |
| `segmentation_rule = patent` | `false` |
| no `segmentation_rule` row (General / legacy projects) | `false` |
| no `id_project` in the engine config | `false` |

The regression test installs its own `E_WARNING` handler (`phpunit.xml` does not set
`failOnWarning`) and fails with `Undefined variable $multiline` against the pre-fix code.

Manual: created projects from the UI with each segmentation rule and checked `project_metadata` —
`Paragraph` stores `paragraph`, `Patent` stores `patent`, `General` stores no row (it is normalized
to `null`), and the Lara debug log shows `multiline => true` only for the paragraph project.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

- Behaviour change worth a look: an invalid `segmentation_rule` now makes app project creation fail
  with `Segmentation rule not allowed` (code `-4`) instead of being silently ignored. This matches
  `ConvertFileController` and the v1 API, and the upload/conversion step already rejected it.
- No frontend change was needed: `public/js/pages/NewProject.js` already sends `segmentation_rule`
  to the create-project endpoint.
- Pre-existing projects have no metadata row, so they keep sending `multiline=false` — no change in
  behaviour for them.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215494642627900