### PR TITLE
🔒 security(split): require project ownership or team membership to restructure jobs

### DIFF
--- a/lib/Controller/API/V2/SplitJobController.php
+++ b/lib/Controller/API/V2/SplitJobController.php
@@ -4,7 +4,9 @@ namespace Controller\API\V2;
 
 use Controller\Abstracts\KleinController;
 use Controller\API\Commons\Exceptions\AuthenticationError;
+use Controller\API\Commons\Exceptions\AuthorizationError;
 use Controller\API\Commons\Validators\LoginValidator;
+use Controller\API\Commons\Validators\ProjectAccessValidator;
 use Exception;
 use InvalidArgumentException;
 use Model\Exceptions\NotFoundException;
@@ -16,6 +18,7 @@ use Model\Projects\ProjectDao;
 use Model\Projects\ProjectsMetadataMarshaller;
 use Model\Projects\ProjectStruct;
 use ReflectionException;
+use Throwable;
 use TypeError;
 use Utils\Session\SessionStore;
 
@@ -68,13 +71,13 @@ class SplitJobController extends KleinController
      * — through ProjectPasswordValidator instead of getProjectData(). Its response shape is kept below
      * so retiring it changed nothing for the api-key callers.
      *
-     * @throws Exception
+     * @throws Throwable
      * @throws \TypeError
      */
     public function merge(): void
     {
         $request = $this->validateTheRequest();
-        $projectStructure = $this->getProjectData(
+        $projectStructure = $this->loadProjectForRestructure(
             $request['project_id'],
             $request['project_pass'],
             $request['split_raw_words']
@@ -96,7 +99,7 @@ class SplitJobController extends KleinController
     }
 
     /**
-     * @throws Exception
+     * @throws Throwable
      */
     public function check(): void
     {
@@ -114,7 +117,7 @@ class SplitJobController extends KleinController
     }
 
     /**
-     * @throws Exception
+     * @throws Throwable
      * @throws TypeError
      */
     public function apply(): void
@@ -138,11 +141,11 @@ class SplitJobController extends KleinController
      *
      * @return array{0: JobSplitMergeManager, 1: SplitMergeProjectData}
      *
-     * @throws Exception
+     * @throws Throwable
      */
     private function checkSplit(array $request): array
     {
-        $projectStructure = $this->getProjectData(
+        $projectStructure = $this->loadProjectForRestructure(
             $request['project_id'],
             $request['project_pass'],
             $request['split_raw_words']
@@ -220,6 +223,58 @@ class SplitJobController extends KleinController
     protected function getProjectJobs(ProjectStruct $project): array
     {
         return (new JobDao($this->getDatabase()))->getNotDeletedByProjectId((int) $project->id);
+    }
+
+    /**
+     * Resolve the project a restructure is about, and refuse a caller who has no standing over it.
+     *
+     * Every route on this controller goes through here rather than calling getProjectData() directly, so
+     * that there is one place the authorization can be read from and no fourth action can be added past
+     * it. getProjectData() stays the data seam the tests replace; the check is deliberately outside it.
+     *
+     * @return array{data: SplitMergeProjectData, pManager: JobSplitMergeManager, count_type: string, project: ProjectStruct}
+     *
+     * @throws Throwable
+     */
+    private function loadProjectForRestructure(int $project_id, string $project_pass, bool $split_raw_words = false): array
+    {
+        $projectStructure = $this->getProjectData($project_id, $project_pass, $split_raw_words);
+        $this->enforceRestructureAccess($projectStructure['project']);
+
+        return $projectStructure;
+    }
+
+    /**
+     * The project's owner or a member of its team, and nobody else.
+     *
+     * Until this check the project password was the whole authorization: LoginValidator asked only that
+     * the caller be *somebody*, and ProjectDao::findByIdAndPassword asked only that the pair match. A
+     * translator or reviewer removed from the team, holding a manage URL from when they were in it, kept
+     * the ability to split, merge and re-split every job in the project — as did any authenticated
+     * identity that came by an id and password some other way. The password proves knowledge of the
+     * project, not standing over it.
+     *
+     * The owner is allowed explicitly rather than left to the membership lookup, because a project
+     * outlives its owner's membership of the team it sits in: it can be moved to another team, or the
+     * owner can be removed from the one it is in. On the development dataset that is 1 project of 1205,
+     * plus 9 more carrying no team at all — membership alone would take those away from the person who
+     * created them, which would be a regression and not a fix.
+     *
+     * Compared strictly, and only when the owner is non-empty: a project created by an unauthenticated
+     * caller carries id_customer = '' (CreateProjectController), and an empty owner must match nobody.
+     *
+     * @throws AuthorizationError
+     * @throws Throwable
+     */
+    protected function enforceRestructureAccess(ProjectStruct $project): void
+    {
+        $ownerEmail = $project->id_customer;
+
+        if ($ownerEmail !== '' && $ownerEmail === $this->getUser()->email) {
+            return;
+        }
+
+        (new ProjectAccessValidator($this, $project))->validate();
     }
 
     /**

--- a/tests/unit/Core/Controllers/SplitJobControllerTest.php
+++ b/tests/unit/Core/Controllers/SplitJobControllerTest.php
@@ -5,6 +5,7 @@ namespace Matecat\Core\Controllers;
 use ArrayObject;
 use Controller\API\App\SplitJobController as AppSplitJobController;
 use Controller\API\Commons\Exceptions\AuthenticationError;
+use Controller\API\Commons\Exceptions\AuthorizationError;
 use Controller\API\Commons\Validators\LoginValidator;
 use Controller\API\V2\SplitJobController;
 use InvalidArgumentException;
@@ -302,8 +303,7 @@ class SplitJobControllerTest extends AbstractTest
     {
         $job = $this->makeJobStub(99, 'jp', false);
 
-        $project = new ProjectStruct();
-        $project->id = 1;
+        $project = $this->makeOwnedProject();
 
         // splitResult is seeded here only to prove merge() ignores it: nothing on the merge path sets
         // it, so echoing it back — as this endpoint used to — could only ever emit null.
@@ -346,8 +346,7 @@ class SplitJobControllerTest extends AbstractTest
     {
         $job = $this->makeJobStub(99, 'jp', false);
 
-        $project = new ProjectStruct();
-        $project->id = 1;
+        $project = $this->makeOwnedProject();
 
         $splitResult = new ArrayObject(['chunks' => [1, 2, 3]]);
         $data        = new SplitMergeProjectData(1);
@@ -388,8 +387,7 @@ class SplitJobControllerTest extends AbstractTest
     {
         $job = $this->makeJobStub(99, 'jp', false);
 
-        $project = new ProjectStruct();
-        $project->id = 1;
+        $project = $this->makeOwnedProject();
 
         $splitResult = new ArrayObject(['chunks' => [1, 2]]);
         $data        = new SplitMergeProjectData(1);
@@ -435,8 +433,7 @@ class SplitJobControllerTest extends AbstractTest
     {
         $job = $this->makeJobStub(10, 'pw', false);
 
-        $project = new ProjectStruct();
-        $project->id = 1;
+        $project = $this->makeOwnedProject();
 
         $data     = new SplitMergeProjectData(1);
         $pManager = $this->createStub(JobSplitMergeManager::class);
@@ -465,8 +462,7 @@ class SplitJobControllerTest extends AbstractTest
     {
         $job = $this->makeJobStub(99, 'correct_pw', false);
 
-        $project = new ProjectStruct();
-        $project->id = 1;
+        $project = $this->makeOwnedProject();
 
         $data     = new SplitMergeProjectData(1);
         $pManager = $this->createStub(JobSplitMergeManager::class);
@@ -540,6 +536,234 @@ class SplitJobControllerTest extends AbstractTest
         } finally {
             $this->cleanFragments($base);
         }
+    }
+
+    // ─── who may restructure a project ───────────────────────────────
+
+    /**
+     * The project password proves knowledge of the project, not standing over it. Before this check a
+     * removed team member who had kept a manage URL could still split, merge and re-split every job in
+     * the project, and so could any authenticated identity that came by the pair some other way.
+     */
+    #[Test]
+    public function merge_refusesACallerWhoIsNeitherOwnerNorTeamMember(): void
+    {
+        $base = self::REAL_DB_BASE + 100;
+
+        try {
+            $this->seedRestructureScope($base, member: false);
+            $this->stubRestructureRequest($base);
+
+            $this->expectException(AuthorizationError::class);
+            $this->controller->merge();
+        } finally {
+            $this->cleanFragments($base);
+        }
+    }
+
+    #[Test]
+    public function check_refusesACallerWhoIsNeitherOwnerNorTeamMember(): void
+    {
+        $base = self::REAL_DB_BASE + 200;
+
+        try {
+            $this->seedRestructureScope($base, member: false);
+            $this->stubRestructureRequest($base);
+
+            $this->expectException(AuthorizationError::class);
+            $this->controller->check();
+        } finally {
+            $this->cleanFragments($base);
+        }
+    }
+
+    #[Test]
+    public function apply_refusesACallerWhoIsNeitherOwnerNorTeamMember(): void
+    {
+        $base = self::REAL_DB_BASE + 300;
+
+        try {
+            $this->seedRestructureScope($base, member: false);
+            $this->stubRestructureRequest($base);
+
+            $this->expectException(AuthorizationError::class);
+            $this->controller->apply();
+        } finally {
+            $this->cleanFragments($base);
+        }
+    }
+
+    /**
+     * A team member who does not own the project may restructure it: the membership is the standing.
+     */
+    #[Test]
+    public function aTeamMemberWhoIsNotTheOwnerMayRestructure(): void
+    {
+        $base = self::REAL_DB_BASE + 400;
+
+        try {
+            $project = $this->seedRestructureScope($base, member: true);
+
+            $this->callPrivate('enforceRestructureAccess', $project);
+            self::assertNotSame($project->id_customer, $this->controller->getUser()->email);
+        } finally {
+            $this->cleanFragments($base);
+        }
+    }
+
+    /**
+     * The owner is allowed explicitly rather than left to the membership lookup. A project outlives the
+     * owner's membership of its team — moved to another team, or the owner removed from the one it is in
+     * — and on the development dataset 1 project of 1205 is already in that state, plus 9 carrying no
+     * team at all. Membership alone would take those away from the person who created them.
+     */
+    #[Test]
+    public function theOwnerMayRestructureWithoutBelongingToTheProjectTeam(): void
+    {
+        $base = self::REAL_DB_BASE + 500;
+
+        try {
+            $project = $this->seedRestructureScope($base, member: false);
+            $project->id_customer = $this->controller->getUser()->email ?? '';
+
+            $this->callPrivate('enforceRestructureAccess', $project);
+            self::assertTrue(true, 'no AuthorizationError for the owner');
+        } finally {
+            $this->cleanFragments($base);
+        }
+    }
+
+    #[Test]
+    public function theOwnerMayRestructureAProjectThatCarriesNoTeam(): void
+    {
+        $base = self::REAL_DB_BASE + 600;
+
+        try {
+            $project = $this->seedRestructureScope($base, member: false);
+            $project->id_customer = $this->controller->getUser()->email ?? '';
+            $project->id_team     = null;
+
+            $this->callPrivate('enforceRestructureAccess', $project);
+            self::assertTrue(true, 'no AuthorizationError for the owner of a team-less project');
+        } finally {
+            $this->cleanFragments($base);
+        }
+    }
+
+    /**
+     * A project created by an unauthenticated caller carries id_customer = '' (CreateProjectController),
+     * so the owner branch must not treat an empty owner as a match for an equally empty caller identity.
+     *
+     * Defence in depth rather than a reachable state: isLogged() requires a non-empty email, so a caller
+     * that got past LoginValidator has one. The emptiness check costs a comparison and removes the need
+     * to keep believing that.
+     */
+    #[Test]
+    public function anEmptyProjectOwnerMatchesAnEmptyCallerIdentity(): void
+    {
+        $base = self::REAL_DB_BASE + 700;
+
+        try {
+            $project = $this->seedRestructureScope($base, member: false);
+            $project->id_customer = '';
+
+            $this->reflector->getProperty('user')->setValue(
+                $this->controller,
+                new UserStruct(['uid' => $this->userId($base), 'email' => ''])
+            );
+
+            $this->expectException(AuthorizationError::class);
+            $this->callPrivate('enforceRestructureAccess', $project);
+        } finally {
+            $this->cleanFragments($base);
+        }
+    }
+
+    /**
+     * A project the acting user owns, so the restructure authorization clears without touching a
+     * database and the test stays about its own subject.
+     */
+    private function makeOwnedProject(): ProjectStruct
+    {
+        $email = 'ctrlowner@example.org';
+
+        $this->reflector->getProperty('user')->setValue(
+            $this->controller,
+            new UserStruct(['uid' => 987, 'email' => $email])
+        );
+        $this->reflector->getProperty('userIsLogged')->setValue($this->controller, true);
+
+        $project              = new ProjectStruct();
+        $project->id          = 1;
+        $project->id_customer = $email;
+
+        return $project;
+    }
+
+    /**
+     * Seed a real team, user and membership row, point the controller at the test database and act as
+     * that user. Returns the project the restructure is about — owned by somebody else, so the caller's
+     * standing rests on the membership alone unless a test overrides id_customer.
+     */
+    private function seedRestructureScope(int $base, bool $member): ProjectStruct
+    {
+        $this->seedUser($base);
+        $this->seedTeam($base);
+
+        if ($member) {
+            $this->seedMembership($base);
+        }
+
+        $this->reflector->getProperty('database')->setValue($this->controller, obtainTestDatabase());
+        $this->reflector->getProperty('user')->setValue(
+            $this->controller,
+            new UserStruct(['uid' => $this->userId($base), 'email' => 'ctrluser_' . $base . '@example.org'])
+        );
+        $this->reflector->getProperty('userIsLogged')->setValue($this->controller, true);
+
+        $project              = new ProjectStruct();
+        $project->id          = $this->projectId($base);
+        $project->id_customer = 'someone_else_' . $base . '@example.org';
+        $project->id_team     = $this->teamId($base);
+
+        return $project;
+    }
+
+    /**
+     * A merge/check/apply request whose project and job resolve, so the only thing that can refuse it is
+     * the authorization check.
+     */
+    private function stubRestructureRequest(int $base): void
+    {
+        $job = $this->makeJobStub(99, 'jp', false);
+
+        $data = new SplitMergeProjectData($this->projectId($base));
+
+        $this->controller->fakeJobs        = [$job];
+        $this->controller->fakeProjectData = [
+            'data'       => $data,
+            'pManager'   => $this->createStub(JobSplitMergeManager::class),
+            'count_type' => 'eq_word_count',
+            'project'    => $this->seedRestructureProject($base),
+        ];
+
+        $this->stubRequestParams([
+            'project_id'   => (string)$this->projectId($base),
+            'project_pass' => 'pp',
+            'job_id'       => '99',
+            'job_pass'     => 'jp',
+            'num_split'    => '2',
+        ]);
+    }
+
+    private function seedRestructureProject(int $base): ProjectStruct
+    {
+        $project              = new ProjectStruct();
+        $project->id          = $this->projectId($base);
+        $project->id_customer = 'someone_else_' . $base . '@example.org';
+        $project->id_team     = $this->teamId($base);
+
+        return $project;
     }
 
     /**


### PR DESCRIPTION
## Summary

Split, merge and split-check were authorized by the project password alone. `LoginValidator` asked
only that the caller be somebody, and `ProjectDao::findByIdAndPassword()` asked only that the id and
password match — nothing in the chain read `projects.id_team` or membership. Any authenticated
identity holding a manage URL could split, merge and re-split every job in the project: a translator
or reviewer removed from the team who kept an old link, anyone that link was forwarded to, or any
api-key pair that came by an id and password some other way. Removal from the team revoked nothing
here.

All nine routes now require the caller to be the project's owner or a member of the project's team.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Controller/API/V2/SplitJobController.php` | `loadProjectForRestructure()` wraps `getProjectData()` and calls the new `enforceRestructureAccess()`; `merge()` and `checkSplit()` go through it, so all nine routes are covered by one enforcement site. `enforceRestructureAccess()` admits the project owner, otherwise defers to `ProjectAccessValidator`. `@throws` widened to `Throwable` on the four affected methods. |
| `tests/unit/Core/Controllers/SplitJobControllerTest.php` | Seven tests: an outsider is refused on `merge`, `check` and `apply`; a team member who is not the owner is allowed; the owner is allowed when outside the project's team and when the project carries no team; an empty owner does not match an empty caller identity. Five pre-existing happy-path tests now build their project through a `makeOwnedProject()` helper. |
| `MateCat-docs` | Pointer advanced onto the pruned left-behind list — the fixed item removed, the surviving `!=` job-password comparison kept as its own entry, and a follow-up recorded to confirm no integration restructures a project outside its own team. |

Why the owner is admitted explicitly rather than left to the membership lookup: a project outlives
its owner's membership of the team it sits in — it can be moved to another team, or the owner removed
from the one it is in. Measured on the development dataset, that is 1 project of 1205 whose owner is
not in its team, plus 9 carrying no team at all. Membership alone would take those 10 away from the
people who created them, which would be a regression rather than a fix.

Why the check is not inside `getProjectData()`: that method is the seam the tests replace
(`TestableSplitJobController` overrides it), so a check placed there would be stubbed away by every
test that uses the double. The wrapper keeps `getProjectData()` as the data seam and puts the
authorization somewhere a test cannot silently remove it.

`ProjectAccessValidator` was reused rather than widened — its five other call sites would have
inherited whatever looser rule this change needed. `ProjectPasswordValidator` could not serve these
routes at all: it hardcodes the parameter names `id_project`/`password`, while these routes use
`project_id`/`project_pass`, which is also why the check runs mid-action rather than through
`registerValidators()` — the same shape as `ChangeProjectNameController:58`.

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite: `OK (9610 tests, 30832 assertions)`. Changed-file suite: `OK (32 tests, 71 assertions)`.
PHPStan on both changed files: `[OK] No errors`.

Each of the three production lines added here was mutation-checked — removed, and the test that
pins it confirmed failing. That includes the `!== ''` guard on the owner comparison, which an
earlier version of the empty-owner test did not actually pin.

Verified against a running instance, both directions:

- owner api key → `POST /api/v2/projects/{id}/{pass}/jobs/{id_job}/{job_pass}/split/3/check` → **200**
  with the split plan, unchanged.
- an authenticated session for a user who is neither the owner nor a member of the project's team,
  holding both the project and job passwords → **403**,
  `"Not Authorized, the user does not belong to team 12"`, no split plan in the body, the refusal
  arriving through `enforceRestructureAccess` → `ProjectAccessValidator`.

The wire status is 403 rather than 401 because `Bootstrap.php:220` maps `AuthorizationError` to 403
whatever code the exception itself carries; the 401 visible in the JSON body is that exception's own
code and matches how every other `ProjectAccessValidator` refusal already answers.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

This is an outward-facing tightening: an api-key pair whose user is neither the project's owner nor a
member of its team now gets 403 where it previously got the split plan. That is the point of the
change, and these routes were never advertised as cross-team, but it was only measured against the
development dataset. Recorded as follow-up in the left-behind list: check the access log for
split/merge calls whose key owner sits outside the project's team, over a window long enough to catch
a monthly batch job. If any exist they are a deliberate decision to make, not a reason to widen the
predicate back.

Two adjacent items were left out on purpose and remain recorded:

- `checkSplitAccess()` compares the job password with `!=` rather than `hash_equals()`. Not a
  practical collision risk (`Utils::randomString()` emits base62, and only two numeric strings
  compare numerically), but it is not constant-time either. Kept separate so the authorization tests
  here pin one thing.
- `check` and `apply` still answer 401 where 404 is correct — a pre-existing inconsistency with
  `merge`, and a behaviour change of its own.

The dev-environment error response for the refusal includes a full stack trace with absolute paths.
Pre-existing, environment-dependent, out of scope here.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217153252912156