### PR TITLE
🐛 fix(segments): add scroll offset when detecting first visible row

### DIFF
--- a/public/js/components/common/VirtualList/VirtualList.js
+++ b/public/js/components/common/VirtualList/VirtualList.js
@@ -17,6 +17,7 @@ const VirtualList = forwardRef(
       itemStyle = () => ({}),
       onScroll = () => {},
       renderedRange = () => {},
+      findFirstVisibleRow,
     },
     ref,
   ) => {
@@ -36,7 +37,11 @@ const VirtualList = forwardRef(
 
       const scrollOffset = parent?.scrollTop ?? 0
 
-      const firstVisible = virtualItems.find((item) => item.end > scrollOffset)
+      const firstVisible = virtualItems.find((item) =>
+        typeof findFirstVisibleRow === 'function'
+          ? findFirstVisibleRow(item, scrollOffset)
+          : item.end > scrollOffset,
+      )
 
       return firstVisible?.index ?? null
     }
@@ -133,6 +138,7 @@ VirtualList.propTypes = {
   itemStyle: PropTypes.func,
   onScroll: PropTypes.func,
   renderedRange: PropTypes.func,
+  findFirstVisibleRow: PropTypes.func,
 }
 
 VirtualList.displayName = 'VirtualList'

--- a/public/js/components/common/VirtualList/VirtualList.test.js
+++ b/public/js/components/common/VirtualList/VirtualList.test.js
@@ -167,6 +167,34 @@ describe('VirtualList', () => {
     })
   })
 
+  describe('findFirstVisibleRow', () => {
+    it('uses the default lookup when findFirstVisibleRow is not provided', () => {
+      const items = createItems(5)
+      const setFirstRowIdVisible = jest.fn()
+      renderVirtualList({items, setFirstRowIdVisible})
+      expect(setFirstRowIdVisible).toHaveBeenCalledWith('item-0')
+    })
+
+    it('uses a custom findFirstVisibleRow to pick a later row', () => {
+      const items = createItems(5)
+      const setFirstRowIdVisible = jest.fn()
+      const findFirstVisibleRow = (item, scrollOffset) =>
+        item.end > scrollOffset + 60
+      renderVirtualList({items, setFirstRowIdVisible, findFirstVisibleRow})
+      expect(setFirstRowIdVisible).toHaveBeenCalledWith('item-1')
+    })
+
+    it('calls findFirstVisibleRow with the virtual item and current scroll offset', () => {
+      const items = createItems(3)
+      const findFirstVisibleRow = jest.fn(() => true)
+      renderVirtualList({items, findFirstVisibleRow})
+      expect(findFirstVisibleRow).toHaveBeenCalledWith(
+        expect.objectContaining({index: 0, end: 50}),
+        0,
+      )
+    })
+  })
+
   describe('itemStyle', () => {
     it('calls itemStyle for each rendered item', () => {
       const itemStyle = jest.fn(() => ({}))

--- a/public/js/components/segments/SegmentsContainer.js
+++ b/public/js/components/segments/SegmentsContainer.js
@@ -381,6 +381,11 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
     setScrollTopVisible(scrollValue > 400)
   }, [essentialRows])
 
+  const findFirstVisibleRow = useCallback(
+    (item, scrollOffset) => item.end > scrollOffset + 30,
+    [],
+  )
+
   // segments details - ex. div collection type ecc.
   const segmentsDetails = useMemo(() => {
     const getCollectionType = (segment) => {
@@ -990,6 +995,7 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
         }
         renderedRange={renderedRange}
         setFirstRowIdVisible={setFirstRowIdVisible}
+        findFirstVisibleRow={findFirstVisibleRow}
       />
       {scrollTopVisible && (
         <div

--- a/public/js/components/segments/SegmentsContainer.test.js
+++ b/public/js/components/segments/SegmentsContainer.test.js
@@ -49,6 +49,7 @@ jest.mock('../../utils/shortcuts', () => ({
 const mockSegmentStoreListeners = {}
 const mockCatToolStoreListeners = {}
 const mockCommentsStoreListeners = {}
+let mockCapturedFindFirstVisibleRow
 
 jest.mock('../../stores/SegmentStore', () => ({
   addListener: jest.fn((event, cb) => {
@@ -158,9 +159,12 @@ jest.mock('../common/VirtualList/VirtualList', () => {
         renderedRange,
         header,
         items = [],
+        findFirstVisibleRow,
       },
       ref,
     ) => {
+      mockCapturedFindFirstVisibleRow = findFirstVisibleRow
+
       React.useEffect(() => {
         if (setFirstRowIdVisible) setFirstRowIdVisible(items[0]?.id)
         if (renderedRange) renderedRange([0, items.length - 1])
@@ -257,6 +261,7 @@ afterEach(() => {
 describe('SegmentsContainer', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockCapturedFindFirstVisibleRow = undefined
     // Re-register listeners after clearAllMocks resets the mock implementations
     SegmentStore.addListener.mockImplementation((event, cb) => {
       mockSegmentStoreListeners[event] = cb
@@ -274,6 +279,13 @@ describe('SegmentsContainer', () => {
     test('renders the VirtualList', () => {
       const {getByTestId} = renderComponent()
       expect(getByTestId('virtual-list')).toBeInTheDocument()
+    })
+
+    test('passes a findFirstVisibleRow that requires a 30px scroll offset', () => {
+      renderComponent()
+      expect(typeof mockCapturedFindFirstVisibleRow).toBe('function')
+      expect(mockCapturedFindFirstVisibleRow({end: 50}, 10)).toBe(true)
+      expect(mockCapturedFindFirstVisibleRow({end: 30}, 10)).toBe(false)
     })
 
     test('does not render scroll-to-top button initially', () => {


### PR DESCRIPTION
## Summary

Adds an optional `findFirstVisibleRow` threshold to `VirtualList`'s first-visible-row
detection, used by `SegmentsContainer` to require a 30px scroll offset before a row is
considered visible — avoiding premature switching of the tracked row near scroll boundaries.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `public/js/components/common/VirtualList/VirtualList.js` | Add optional `findFirstVisibleRow` prop to customize first-visible-row detection |
| `public/js/components/common/VirtualList/VirtualList.test.js` | Add test coverage for the `findFirstVisibleRow` prop |
| `public/js/components/segments/SegmentsContainer.js` | Pass a `findFirstVisibleRow` callback requiring a 30px scroll offset |
| `public/js/components/segments/SegmentsContainer.test.js` | Add test coverage asserting the 30px offset behavior |

## Testing

- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

## AI Disclosure

- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

None.