### PR TITLE
💄 style(segments): align sticky file icon padding across breakpoints

### DIFF
--- a/public/css/sass/components/SegmentsContainer.scss
+++ b/public/css/sass/components/SegmentsContainer.scss
@@ -86,6 +86,10 @@
   padding-left: 4.5%;
   background-color: colors.$grey5;
 
+  @media screen and (max-width: 1180px) {
+    padding-left: 6%;
+  }
+
   &.sticky-project-bar-compressed {
     padding-top: 10px;
   }

--- a/public/css/sass/style.scss
+++ b/public/css/sass/style.scss
@@ -610,7 +610,7 @@ section {
   position: relative;
   float: left;
   width: 88%;
-  margin-left: 5%;
+  margin-left: 4.5%;
   min-width: 700px;
   //height: 100%;
   /*-webkit-transition: all 100ms ease-in;*/
@@ -1934,7 +1934,7 @@ section.opened.editor .status {
   color: colors.$white !important;
 }
 .per-grey {
-  background: #B6B8BB !important;
+  background: #b6b8bb !important;
   color: colors.$white !important;
 }
 .per-red {
@@ -2147,6 +2147,10 @@ section.opened.editor .status {
   }
   section.slide-right .sid {
     left: -8%;
+  }
+
+  .projectbar {
+    padding-left: 6%;
   }
 }
 


### PR DESCRIPTION
## Summary

Align the sticky project bar / file icon padding with the content-frame margin so they
stay in sync across responsive breakpoints.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| public/css/sass/style.scss | Change `.content-frame` margin-left from 5% to 4.5%; add `.projectbar` padding-left at a narrow breakpoint; lowercase a hex color |
| public/css/sass/components/SegmentsContainer.scss | Add padding-left adjustment for the sticky project bar at max-width 1180px |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

Verified sticky file icon alignment against the content frame across viewport widths.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes