### PR TITLE
✨ feat(analyze): gate the merge button on the caller's project access

### DIFF
--- a/public/css/sass/commons/_analyze.scss
+++ b/public/css/sass/commons/_analyze.scss
@@ -562,11 +562,12 @@ body.analyze {
             justify-content: space-evenly;
           }
 
-          // Greys the split button out for a caller the split endpoints would refuse, while leaving it
-          // hoverable so the Tooltip explaining why still fires. Semantic's own `disabled` class cannot
-          // be used here: it sets `pointer-events: none !important`, which takes the hover away with
-          // the click. Same reasoning as .open-outsource-disabled above.
-          .split.split-not-allowed {
+          // Greys the split and merge buttons out for a caller the restructure endpoints would refuse,
+          // while leaving them hoverable so the Tooltip explaining why still fires. Semantic's own
+          // `disabled` class cannot be used here: it sets `pointer-events: none !important`, which takes
+          // the hover away with the click. Same reasoning as .open-outsource-disabled above.
+          .split.split-not-allowed,
+          .merge.merge-not-allowed {
             cursor: default !important;
             opacity: 0.45;
           }

--- a/public/js/components/analyze/AnalyzeChunksResume.js
+++ b/public/js/components/analyze/AnalyzeChunksResume.js
@@ -22,6 +22,8 @@ import HelpCircle from '../../../img/icons/HelpCircle'
 
 const SPLIT_NOT_ALLOWED_HINT =
   'Only the project owner or a member of its team can split a job'
+const MERGE_NOT_ALLOWED_HINT =
+  'Only the project owner or a member of its team can merge a job'
 
 class AnalyzeChunksResume extends React.Component {
   constructor(props) {
@@ -35,18 +37,19 @@ class AnalyzeChunksResume extends React.Component {
     }
 
     this.jobLinkRef = {}
-    this.splitButtonRef = {}
+    this.refusedButtonRef = {}
   }
 
   // Tooltip positions itself from children.ref.current.getBoundingClientRect(), so the child it wraps
   // has to carry a ref object or the tooltip silently lands at the top-left of the page. One per job,
-  // following the jobLinkRef idiom above.
-  getSplitButtonRef = (idJob) => {
-    if (!this.splitButtonRef[idJob]) {
-      this.splitButtonRef[idJob] = React.createRef()
+  // following the jobLinkRef idiom above. Split and merge share the map because a job renders one or
+  // the other, never both: merge belongs to the multi-chunk branch, split to the single-chunk one.
+  getRefusedButtonRef = (idJob) => {
+    if (!this.refusedButtonRef[idJob]) {
+      this.refusedButtonRef[idJob] = React.createRef()
     }
 
-    return this.splitButtonRef[idJob]
+    return this.refusedButtonRef[idJob]
   }
 
   showDetails = (idJob) => (evt) => {
@@ -337,13 +340,36 @@ class AnalyzeChunksResume extends React.Component {
                   </div>
 
                   <div className="activity-icons splitted">
-                    <div
-                      className="merge ui blue basic button"
-                      onClick={this.openMergeModal(jobsAnalysis[indexJob].id)}
-                    >
-                      <Merge size={18} />
-                      Merge
-                    </div>
+                    {/* Merge is the same restructure operation as split and goes through the same
+                        authorization — SplitJobController::merge() reaches enforceRestructureAccess()
+                        exactly as apply() does — so it answers to the same flag. Leaving it live while
+                        split is greyed out offers the caller the half of the pair the API also
+                        refuses. */}
+                    {config.splitEnabled ? (
+                      <div
+                        className="merge ui blue basic button"
+                        onClick={this.openMergeModal(jobsAnalysis[indexJob].id)}
+                      >
+                        <Merge size={18} />
+                        Merge
+                      </div>
+                    ) : (
+                      <Tooltip
+                        content={MERGE_NOT_ALLOWED_HINT}
+                        stylePointerElement={{display: 'inline-flex'}}
+                      >
+                        <div
+                          ref={this.getRefusedButtonRef(
+                            jobsAnalysis[indexJob].id,
+                          )}
+                          className="merge ui blue basic button merge-not-allowed"
+                          aria-disabled={true}
+                        >
+                          <Merge size={18} />
+                          Merge
+                        </div>
+                      </Tooltip>
+                    )}
                   </div>
                 </div>
                 {chunksHtml}
@@ -473,7 +499,7 @@ class AnalyzeChunksResume extends React.Component {
                           stylePointerElement={{display: 'inline-flex'}}
                         >
                           <div
-                            ref={this.getSplitButtonRef(
+                            ref={this.getRefusedButtonRef(
                               jobsAnalysis[indexJob].id,
                             )}
                             className={

--- a/public/js/components/analyze/AnalyzeChunksResume.test.js
+++ b/public/js/components/analyze/AnalyzeChunksResume.test.js
@@ -37,18 +37,41 @@ const jobsAnalysis = [
   },
 ]
 
-const renderComponent = () =>
+// A job that was already split: two chunks under one id, which is the only branch that renders Merge.
+const secondChunk = {...chunk, password: 'b6c963d5gf63'}
+
+const splitProject = project.setIn(
+  ['jobs'],
+  fromJS([
+    {id: JOB_ID, password: chunk.password},
+    {id: JOB_ID, password: secondChunk.password},
+  ]),
+)
+
+const splitJobsAnalysis = [{...jobsAnalysis[0], chunks: [chunk, secondChunk]}]
+
+const renderComponent = ({
+  projectProp = project,
+  jobsAnalysisProp = jobsAnalysis,
+} = {}) =>
   render(
     <AnalyzeChunksResume
-      project={project}
-      jobsAnalysis={jobsAnalysis}
+      project={projectProp}
+      jobsAnalysis={jobsAnalysisProp}
       status="DONE"
       showAnalysis={true}
       openAnalysisReport={() => {}}
     />,
   )
 
+const renderSplitJob = () =>
+  renderComponent({
+    projectProp: splitProject,
+    jobsAnalysisProp: splitJobsAnalysis,
+  })
+
 const splitButton = () => screen.queryByText('Split')?.closest('.split.button')
+const mergeButton = () => screen.queryByText('Merge')?.closest('.merge.button')
 
 describe('AnalyzeChunksResume split button', () => {
   beforeEach(() => {
@@ -116,6 +139,68 @@ describe('AnalyzeChunksResume split button', () => {
     expect(
       await screen.findByText(
         'Only the project owner or a member of its team can split a job',
+      ),
+    ).toBeInTheDocument()
+  })
+})
+
+// Merge is the other half of the same restructure permission: SplitJobController::merge() runs the same
+// enforceRestructureAccess() as apply(), so a caller who may not split may not merge either. These
+// mirror the split cases above rather than sharing them, because the two buttons live in different
+// render branches — merge only exists for a job that already has more than one chunk.
+describe('AnalyzeChunksResume merge button', () => {
+  beforeEach(() => {
+    global.config = {
+      basepath: 'http://localhost/',
+      enableMultiDomainApi: false,
+      jobAnalysis: false,
+      splitFeatureAvailable: true,
+      splitEnabled: true,
+    }
+    jest.spyOn(ModalsActions, 'openMergeModal').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('is clickable when the caller may merge', async () => {
+    renderSplitJob()
+
+    const button = mergeButton()
+    expect(button).toBeInTheDocument()
+    expect(button).not.toHaveClass('merge-not-allowed')
+
+    await userEvent.click(button)
+
+    expect(ModalsActions.openMergeModal).toHaveBeenCalledTimes(1)
+  })
+
+  test('stays visible but inert when the caller may not merge', async () => {
+    global.config.splitEnabled = false
+
+    renderSplitJob()
+
+    const button = mergeButton()
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveClass('merge-not-allowed')
+    expect(button).toHaveAttribute('aria-disabled', 'true')
+
+    await userEvent.click(button)
+
+    expect(ModalsActions.openMergeModal).not.toHaveBeenCalled()
+  })
+
+  test('explains on hover why the caller may not merge', async () => {
+    global.config.splitEnabled = false
+
+    renderSplitJob()
+
+    await userEvent.hover(mergeButton())
+
+    expect(
+      await screen.findByText(
+        'Only the project owner or a member of its team can merge a job',
       ),
     ).toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary

Follow-up to #4752, which gated the **split** button on the caller's project access and left the
**merge** button live for everyone. Merge is the other half of the same permission — `SplitJobController::merge()`
reaches `enforceRestructureAccess()` exactly as `apply()` does — so the analyze page was still offering an
action the API answers 403 to.

The merge button now follows the split button: it stays on the page, goes inert, and explains on hover why,
for a caller who is neither the project owner, a member of its team, nor an internal user.

This is UI state only. The endpoints already enforce independently, so getting this wrong shows the wrong
button state rather than granting anything.

## Type

- [x] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/analyze/AnalyzeChunksResume.js` | Merge button branches on `config.splitEnabled`, the same flag the split button already uses. Refused state renders a `Tooltip` around an inert `div` — `merge-not-allowed` class, `aria-disabled`, no `onClick`. New `MERGE_NOT_ALLOWED_HINT` string. |
| `public/js/components/analyze/AnalyzeChunksResume.js` | `splitButtonRef` / `getSplitButtonRef` renamed to `refusedButtonRef` / `getRefusedButtonRef`. The ref is load-bearing, not decoration: `Tooltip` positions itself from `children.ref.current.getBoundingClientRect()`, so the refused merge button needs one too. One map serves both buttons because a job renders one or the other, never both — merge belongs to the multi-chunk branch, split to the single-chunk one. |
| `public/css/sass/commons/_analyze.scss` | `.merge.merge-not-allowed` joined to the existing `.split.split-not-allowed` rule. Semantic's own `disabled` class still cannot be used: it sets `pointer-events: none !important`, which would take the hover away with the click and silence the tooltip. |
| `public/js/components/analyze/AnalyzeChunksResume.test.js` | Three merge cases mirroring the split ones — clickable when allowed, visible-but-inert when not, and the hover hint. They need their own fixture: merge only renders for a job that already has more than one chunk. |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior

Frontend only — no PHP changed, so the PHP suite and PHPStan are not applicable to this diff.

`npx jest --watchAll=false` — full frontend suite: **87 suites passed, 888 tests passed, 15 pending, 0 failed.**

The three new cases were mutation-checked: swapping the gate from `config.splitEnabled` to
`config.splitFeatureAvailable` fails the inert case and the hover-hint case, while the clickable case
correctly survives (both flags are true there). So the tests hold the gate rather than passing by accident.

Not yet done and worth a reviewer's eye: **manual verification in a browser.** `yarn build:dev`, then open
the analyze page of a split project three ways — as the project owner, as a member of its team, and as
neither — and confirm the merge button is live for the first two and greyed with the tooltip for the third.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

Pre-existing asymmetry left alone rather than widened into this PR: the split button is additionally
guarded by `!config.jobAnalysis && config.splitFeatureAvailable`, and the merge button is guarded by
neither. It makes no difference on the analyze page, which hard-codes `split_feature_available` to true,
but `JobMenu` on the dashboard does gate merge on availability. Recorded as follow-up work.

The dashboard is intentionally untouched. It emits availability only — with no project in context it
cannot decide whether this caller may restructure — so `config.splitEnabled` does not exist there and
gating on it would disable merge for everyone.
