### PR TITLE
🐛 fix(segments): correct sticky project bar file id tracking for jsont2 split files

### DIFF
--- a/public/js/components/common/VirtualList/Rows/RowSegment.js
+++ b/public/js/components/common/VirtualList/Rows/RowSegment.js
@@ -223,7 +223,7 @@ export const ProjectBar = ({
   }
   previousScrollTopRef.current = listRef?.scrollTop
 
-  if (isSticky) previousOpenedFileIdRef.current = currentSegment.id_file
+  if (isSticky) previousOpenedFileIdRef.current = idFileSegment
 
   return (
     <div

--- a/public/js/components/common/VirtualList/Rows/RowSegment.test.js
+++ b/public/js/components/common/VirtualList/Rows/RowSegment.test.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import {render, act} from '@testing-library/react'
 import RowSegment, {ProjectBar} from './RowSegment'
+import SegmentUtils from '../../../../utils/segmentUtils'
 
 global.ResizeObserver = class ResizeObserver {
   constructor(cb) {
@@ -394,6 +395,19 @@ describe('ProjectBar', () => {
         />,
       )
       expect(previousOpenedFileIdRef.current).toBe('unchanged')
+    })
+
+    it('uses the resolved file id rather than segment.id_file when they diverge (e.g. jsont2 split files)', () => {
+      jest.spyOn(SegmentUtils, 'getSegmentFileId').mockReturnValue(999)
+      const previousOpenedFileIdRef = {current: undefined}
+      render(
+        <ProjectBar
+          {...defaultProjectBarProps}
+          isSticky={true}
+          previousOpenedFileIdRef={previousOpenedFileIdRef}
+        />,
+      )
+      expect(previousOpenedFileIdRef.current).toBe(999)
     })
   })
 })


### PR DESCRIPTION
## Summary

Fixes the sticky project bar occasionally re-triggering its file-change animation
on jsont2 split files. The previously opened file id was tracked from
`segment.id_file` instead of the resolved file id used everywhere else in the
component (`SegmentUtils.getSegmentFileId`), which the jsont2 plugin overrides to
return `segment.id_file_part`.

## Type

- [x] `fix` — bug fix

## Changes

| File | Change |
|------|--------|
| `public/js/components/common/VirtualList/Rows/RowSegment.js` | Track the previously opened file id using the resolved `idFileSegment` instead of `segment.id_file` |
| `public/js/components/common/VirtualList/Rows/RowSegment.test.js` | Add regression test covering the divergence between `segment.id_file` and the resolved file id (jsont2 split files) |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

`yarn test public/js/components/common/VirtualList/Rows/RowSegment.test.js` passes (24/24).

## AI Disclosure

- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

None.