### PR TITLE
🐛 fix(review): stop replace-all from destroying reviewed word count and LQA issues

### DIFF
--- a/lib/Controller/API/App/GetSearchController.php
+++ b/lib/Controller/API/App/GetSearchController.php
@@ -403,8 +403,19 @@ class GetSearchController extends AbstractStatefulKleinController
                 $replacedTranslation = Utils::stripBOM((string)($old_translation->translation ?? ''));
             } else {
                 $filter = MateCatFilter::getInstance($this->getFeatureSet(), $this->chunk->source, $this->chunk->target);
-                $replacedTranslation = $filter->fromLayer1ToLayer0($this->getReplacedSegmentTranslation((string)($old_translation->translation ?? ''), $queryParams));
-                $replacedTranslation = Utils::stripBOM($replacedTranslation);
+                $originalTranslation = (string)($old_translation->translation ?? '');
+                $replacement         = $this->getReplacedSegmentTranslation($originalTranslation, $queryParams);
+
+                // A replacement that yields the same text is not an edit. Writing it anyway would demote the
+                // segment through getNewStatus() and, on a lower transition, soft-delete its LQA issues via
+                // ReviewedWordCountModel::decreaseCounters() -> flagIssuesToBeDeleted() — discarding review
+                // work on a segment nobody actually changed. Skip it, as the guards above do.
+                if ($replacement === $originalTranslation) {
+                    $db->rollback();
+                    continue;
+                }
+
+                $replacedTranslation = Utils::stripBOM($filter->fromLayer1ToLayer0($replacement));
             }
 
             // Setup $new_translation

--- a/lib/Plugins/Features/ReviewExtended/ReviewedWordCountModel.php
+++ b/lib/Plugins/Features/ReviewExtended/ReviewedWordCountModel.php
@@ -143,12 +143,13 @@ class ReviewedWordCountModel implements IReviewedWordCountModel
     {
         // when downgrading a revision to translation, the issues must be removed (from R1, R2 or both)
         $this->flagIssuesToBeDeleted($chunkReview->source_page);
-        $chunkReview->reviewed_words_count -= $this->_segment->raw_word_count;
         $chunkReview->penalty_points -= $this->getPenaltyPointsForSourcePage($chunkReview->source_page);
 
         if (!$this->_event->isAReplaceAllEvent()) {
+            $chunkReview->reviewed_words_count -= $this->_segment->raw_word_count;
             $this->_event->setFinalRevisionToRemove($chunkReview->source_page);
         }
+
         $this->_event->setChunkReviewForPassFailUpdate($chunkReview);
     }
 
@@ -211,8 +212,10 @@ class ReviewedWordCountModel implements IReviewedWordCountModel
                     // in that case, we must add the reviewed word count
                     // otherwise remove the previous final flag to allow the new one
                     $this->increaseCountersButCheckForFinalRevision($chunkReview);
-                } elseif ($this->aFinalRevisionExistsForThisChunk($chunkReview) && $this->_event->isLowerTransition(
-                    )) {  // check for lower transition, we want to not decrement when upgrading statuses
+                } elseif (
+                    $this->aFinalRevisionExistsForThisChunk($chunkReview)
+                    && $this->_event->isLowerTransition()
+                ) {  // check for lower transition, we want to not decrement when upgrading statuses
 
                     // This case fits any chunkReview record when an event exists on it.
                     // Whenever a revision is lower reviewed, we expect the upper revisions to be invalidated.

--- a/tests/unit/Core/Controllers/GetSearchControllerTest.php
+++ b/tests/unit/Core/Controllers/GetSearchControllerTest.php
@@ -921,6 +921,85 @@ class GetSearchControllerTest extends AbstractTest
         $this->assertNotNull($updated);
     }
 
+    /**
+     * A replace whose replacement equals what is already there is not an edit. It must not demote the
+     * segment, because a lower transition soft-deletes that segment's LQA issues — throwing away a
+     * reviewer's work on a segment nobody actually changed.
+     */
+    #[Test]
+    public function updateSegments_skipsSegmentsWhoseReplacementLeavesTheTextUnchanged(): void
+    {
+        $dao    = new \Model\Translations\SegmentTranslationDao(obtainTestDatabase());
+        $before = $dao->findBySegmentAndJob(self::TEST_SEGMENT_1, self::TEST_JOB_ID);
+        $this->assertNotNull($before);
+
+        $queryParams = new SearchQueryParamsStruct([
+            'job' => self::TEST_JOB_ID,
+            'password' => self::TEST_JOB_PASSWORD,
+            'target' => 'mondo',
+            'replacement' => 'mondo',
+            'isMatchCaseRequested' => false,
+            'isExactMatchRequested' => false,
+        ]);
+
+        $search_results = [
+            new SegmentTranslationStruct([
+                'id_segment' => self::TEST_SEGMENT_1,
+                'id_job' => self::TEST_JOB_ID,
+                'translation' => $before->translation,
+                'status' => 'TRANSLATED',
+            ]),
+        ];
+
+        $committed = $this->invokePrivate('updateSegments', [$search_results, self::TEST_JOB_ID, $queryParams]);
+
+        $this->assertSame([], $committed, 'a no-op replacement must commit nothing');
+
+        $after = $dao->findBySegmentAndJob(self::TEST_SEGMENT_1, self::TEST_JOB_ID);
+        $this->assertNotNull($after);
+        $this->assertSame($before->translation, $after->translation);
+        $this->assertSame($before->status, $after->status);
+    }
+
+    /**
+     * The unchanged-text skip belongs to the forward replace only. Undo/redo carries the historical text
+     * AND status, and the counters are driven purely by the status transition, so a replay whose text
+     * happens to match must still be written or the counters never move back.
+     */
+    #[Test]
+    public function updateSegments_historyReplayIsNotSkippedWhenTheTextIsIdentical(): void
+    {
+        $dao    = new \Model\Translations\SegmentTranslationDao(obtainTestDatabase());
+        $before = $dao->findBySegmentAndJob(self::TEST_SEGMENT_1, self::TEST_JOB_ID);
+        $this->assertNotNull($before);
+
+        $queryParams = new SearchQueryParamsStruct([
+            'job' => self::TEST_JOB_ID,
+            'password' => self::TEST_JOB_PASSWORD,
+            'target' => 'mondo',
+            'replacement' => 'mondo',
+            'isMatchCaseRequested' => false,
+            'isExactMatchRequested' => false,
+        ]);
+
+        $search_results = [
+            new SegmentTranslationStruct([
+                'id_segment' => self::TEST_SEGMENT_1,
+                'id_job' => self::TEST_JOB_ID,
+                'translation' => $before->translation,
+                'status' => 'DRAFT',
+            ]),
+        ];
+
+        $committed = $this->invokePrivate('updateSegments', [$search_results, self::TEST_JOB_ID, $queryParams, true]);
+
+        $this->assertCount(1, $committed, 'a history replay must be written even when the text does not change');
+
+        $after = $dao->findBySegmentAndJob(self::TEST_SEGMENT_1, self::TEST_JOB_ID);
+        $this->assertNotNull($after);
+        $this->assertSame('DRAFT', $after->status);
+    }
+
     #[Test]
     public function updateSegments_throws_not_found_when_project_is_missing(): void
     {

--- a/tests/unit/Core/Features/ReviewExtended/ReviewedWordCountModelTest.php
+++ b/tests/unit/Core/Features/ReviewExtended/ReviewedWordCountModelTest.php
@@ -376,6 +376,87 @@ class ReviewedWordCountModelTest extends AbstractTest
         $model->evaluateChunkReviewEventTransitions();
     }
 
+    /**
+     * A replace-all rewrites many segments at once without anyone opening them in the editor, so no reviewer
+     * un-reviewed anything: the reviewed word count must survive the event untouched.
+     *
+     * The penalty points are a different matter. flagIssuesToBeDeleted() runs outside the guard and
+     * BatchReviewProcessor deletes those issue rows regardless, so their points must still come off the
+     * counter — otherwise qa_chunk_reviews.penalty_points drifts away from qa_entries.
+     */
+    #[Test]
+    public function evaluateChunkReviewEventTransitions_lowerTransitionOnAReplaceAllKeepsTheReviewedWordCountButStillDropsThePenaltyPoints(): void
+    {
+        $issue                 = $this->createStub(EntryWithCategoryStruct::class);
+        $issue->source_page    = 2;
+        $issue->penalty_points = 5;
+
+        $partial = null;
+
+        $event = $this->createMock(TranslationEvent::class);
+        $event->method('isAReplaceAllEvent')->willReturn(true);
+        $event->method('getIssuesToDelete')->willReturn([$issue]);
+        $event->expects($this->once())
+            ->method('setChunkReviewForPassFailUpdate')
+            ->willReturnCallback(function (ChunkReviewStruct $chunkReview) use (&$partial) {
+                // evaluateChunkReviewEventTransitions() builds a fresh delta struct per iteration instead of
+                // mutating the one handed to buildModel(), so the value under test only exists here.
+                $partial = clone $chunkReview;
+            });
+
+        $model = $this->buildModel(
+            isChangingStatus: true,
+            isLowerTransition: true,
+            currentEventOnChunk: false,
+            event: $event,
+            sourcePagesWithFinalRevisions: [2],
+        );
+
+        $model->evaluateChunkReviewEventTransitions();
+
+        $this->assertNotNull($partial);
+        $this->assertSame(0, $partial->reviewed_words_count);
+        $this->assertSame(-5.0, (float)$partial->penalty_points);
+    }
+
+    /**
+     * The positive control for the case above: an ordinary lower transition on a single segment still takes
+     * the segment's words off the reviewed count and the source page's points off the penalty total, each
+     * exactly once.
+     */
+    #[Test]
+    public function evaluateChunkReviewEventTransitions_lowerTransitionDecreasesTheCountersExactlyOnce(): void
+    {
+        $issue                 = $this->createStub(EntryWithCategoryStruct::class);
+        $issue->source_page    = 2;
+        $issue->penalty_points = 5;
+
+        $partial = null;
+
+        $event = $this->createMock(TranslationEvent::class);
+        $event->method('isAReplaceAllEvent')->willReturn(false);
+        $event->method('getIssuesToDelete')->willReturn([$issue]);
+        $event->expects($this->once())
+            ->method('setChunkReviewForPassFailUpdate')
+            ->willReturnCallback(function (ChunkReviewStruct $chunkReview) use (&$partial) {
+                $partial = clone $chunkReview;
+            });
+
+        $model = $this->buildModel(
+            isChangingStatus: true,
+            isLowerTransition: true,
+            currentEventOnChunk: false,
+            event: $event,
+            sourcePagesWithFinalRevisions: [2],
+        );
+
+        $model->evaluateChunkReviewEventTransitions();
+
+        $this->assertNotNull($partial);
+        $this->assertSame(-10, $partial->reviewed_words_count);
+        $this->assertSame(-5.0, (float)$partial->penalty_points);
+    }
+
     #[Test]
     public function evaluateChunkReviewEventTransitions_withEmptyChunkReviewsDoesNothing(): void
     {


### PR DESCRIPTION
## Summary

Two defects let a replace-all destroy review data.

**Reviewed word count.** A replace-all rewrites many segments at once with nothing open in the
editor, so no reviewer un-reviewed anything — yet the count was decremented anyway. It is now
guarded, together with the final-revision removal so a later re-approval does not re-add the words.
The penalty-points subtraction deliberately stays unguarded and adjacent to
`flagIssuesToBeDeleted()`: `BatchReviewProcessor` deletes those issue rows regardless, so the points
must come off or `qa_chunk_reviews.penalty_points` drifts away from `qa_entries`.

**No-op replaces.** A replacement equal to the text already stored was still written, demoting the
segment through the review ladder and soft-deleting its LQA issues — discarding a reviewer's work on
a segment nobody changed. Those segments are now skipped, in the forward replace only: undo/redo
carries the historical text *and* status, and the counters are driven purely by the status
transition, so a replay must still be written even when its text matches.

## Type

<!-- Check one. -->

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

<!-- Key changes — what was modified and how.
     One line per file or logical group. -->

| File | Change |
|------|--------|
| `lib/Plugins/Features/ReviewExtended/ReviewedWordCountModel.php` | Guard the `reviewed_words_count` decrement and `setFinalRevisionToRemove()` behind `!isAReplaceAllEvent()`; keep `penalty_points` unconditional and paired with `flagIssuesToBeDeleted()` |
| `lib/Controller/API/App/GetSearchController.php` | In `updateSegments()`, skip forward-replace segments whose replacement equals the stored text |
| `tests/unit/Core/Features/ReviewExtended/ReviewedWordCountModelTest.php` | Two tests pinning counter behaviour on replace-all vs an ordinary lower transition |
| `tests/unit/Core/Controllers/GetSearchControllerTest.php` | Two tests: a no-op replace commits nothing; a history replay is still written when the text is identical |


## Testing

<!-- How did you verify this works? Check all that apply. -->

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

<!-- Paste relevant test output or describe manual testing steps. -->

## AI Disclosure

<!-- If AI tools were used to write or review code in this PR, disclose it.
     AI-assisted code is welcome, but you must understand everything you ship.
     Unreviewed AI output will not be merged. -->

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5) — used to analyse the failure modes, write the tests, and verify them by
mutation. All changes reviewed before committing.

## Notes

**Every test here was verified by mutation, not by a green run.** Each was confirmed to fail against
a deliberately broken version:

| Mutant | Caught by |
|---|---|
| replace-all guard removed | `...KeepsTheReviewedWordCountButStillDropsThePenaltyPoints` |
| `penalty_points` moved back inside the guard (reintroduces the drift) | same test |
| `penalty_points` subtracted twice | `...DecreasesTheCountersExactlyOnce` |
| identical-text guard removed | `...skipsSegmentsWhoseReplacementLeavesTheTextUnchanged` |
| identical-text guard always fires | `updateSegments_performs_replacement_on_seeded_segment` |
| identical-text guard applied to history replay too | `...historyReplayIsNotSkippedWhenTheTextIsIdentical` |

**Visible behaviour change:** a no-op replace-all that previously reported N segments replaced now
reports 0, because nothing is written. That is the intended correction, but it is user-visible.

Full suite: `OK (9676 tests, 31434 assertions)`, 0 failures. PHPStan level 8, no baseline: 0 errors
on both changed files.

<!-- Anything reviewers should know — breaking changes, follow-up work,
     deployment steps, or open questions. Leave blank if none. -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217358889808132