### PR TITLE
🐛 fix: resolve Sentry-reported production errors

### DIFF
--- a/public/js/actions/SegmentActions.js
+++ b/public/js/actions/SegmentActions.js
@@ -266,7 +266,7 @@ const SegmentActions = {
        If is an ICE we allow to change the translation because is not possible to add an issue
      */
 
-    const mandatoryIssues = CatToolStore.getJobMetadata().job.mandatory_issues
+    const mandatoryIssues = CatToolStore.getJobMetadata()?.job?.mandatory_issues
 
     const currentRevisionKey = `r${config.revisionNumber}`
 

--- a/public/js/actions/SegmentActions.test.js
+++ b/public/js/actions/SegmentActions.test.js
@@ -281,6 +281,14 @@ describe('SegmentActions.clickOnApprovedButton — mandatory issues gate', () =>
     expect(openIssuesSpy).toHaveBeenCalledWith({sid: '1-1'}, true)
   })
 
+  test('does not throw and defaults to required when job metadata has not loaded yet', () => {
+    CatToolStore.getJobMetadata.mockReturnValue(undefined)
+    expect(() =>
+      SegmentActions.clickOnApprovedButton(makeSegment(), false),
+    ).not.toThrow()
+    expect(openIssuesSpy).toHaveBeenCalledWith({sid: '1-1'}, true)
+  })
+
   test('opens issues panel when current revision is in mandatory_issues array', () => {
     CatToolStore.getJobMetadata.mockReturnValue({
       job: {mandatory_issues: ['r1', 'r2']},

--- a/public/js/components/analyze/AnalyzeHeader.test.js
+++ b/public/js/components/analyze/AnalyzeHeader.test.js
@@ -62,4 +62,19 @@ describe('AnalyzeHeader saving percentage flash', () => {
       'updated-count',
     )
   })
+
+  test('does not throw when unmounted while the flash timeout is pending', () => {
+    const {rerender, unmount} = render(
+      <AnalyzeHeader data={buildData(50)} project={project} />,
+    )
+
+    rerender(<AnalyzeHeader data={buildData(20)} project={project} />)
+    unmount()
+
+    expect(() => {
+      act(() => {
+        jest.advanceTimersByTime(400)
+      })
+    }).not.toThrow()
+  })
 })

--- a/public/js/components/createProject/UploadFileLocal.test.js
+++ b/public/js/components/createProject/UploadFileLocal.test.js
@@ -239,6 +239,25 @@ describe('UploadFileLocal', () => {
       expect(screen.getByText('test.docx')).toBeInTheDocument()
     })
 
+    test('upload response without a file entry does not crash', async () => {
+      fileUpload.mockImplementation((file, onProgress, onSuccess) => {
+        onProgress(100)
+        onSuccess(JSON.stringify([]))
+      })
+      renderWithContext()
+
+      const input = document.getElementById('fileInput')
+      const file = createMockFile('test.docx')
+
+      await act(async () => {
+        fireEvent.change(input, {target: {files: [file]}})
+      })
+
+      expect(
+        screen.getByText('Error during upload. Please try again.'),
+      ).toBeInTheDocument()
+    })
+
     test('conversion error shows error message', async () => {
       simulateUploadSuccess()
       convertFileRequest.mockRejectedValue({

--- a/public/js/components/createProject/hooks/useFileUploadManager.js
+++ b/public/js/components/createProject/hooks/useFileUploadManager.js
@@ -273,8 +273,13 @@ export function useFileUploadManager({
 
         const onSuccess = (responseText) => {
           const fileResponse = JSON.parse(responseText)[0]
-          const fileError = getFileErrorMessage(fileResponse)
-          if (fileResponse.error || fileError) {
+          // /fileupload/ answers 200 with an empty array when PHP receives the
+          // request without the file (empty $_FILES), so there is not always an
+          // entry to read here.
+          const fileError = fileResponse
+            ? getFileErrorMessage(fileResponse)
+            : 'Error during upload. Please try again.'
+          if (fileError || fileResponse?.error) {
             setFiles((prevFiles) =>
               prevFiles.map((f) =>
                 f.file === file

--- a/public/js/components/header/cattol/segment_filter/segment_filter.js
+++ b/public/js/components/header/cattol/segment_filter/segment_filter.js
@@ -272,10 +272,10 @@ let SegmentFilterUtils = {
     } else {
       nextGroupHash = groupsArray[0]
     }
-    const nextItem = segmentFilterData.serverData.grouping[nextGroupHash][0]
-    segmentTranslation(segment, status, () =>
-      SegmentActions.openSegment(nextItem),
-    )
+    const nextItem = segmentFilterData.serverData.grouping[nextGroupHash]?.[0]
+    segmentTranslation(segment, status, () => {
+      if (nextItem) SegmentActions.openSegment(nextItem)
+    })
   },
   gotoPreviousSegment: () => {
     var list = SegmentFilterUtils.getLastFilterData()['segment_ids']

--- a/public/js/components/header/cattol/segment_filter/segment_filter.test.js
+++ b/public/js/components/header/cattol/segment_filter/segment_filter.test.js
@@ -1,0 +1,45 @@
+import SegmentFilterUtils from './segment_filter'
+import SegmentStore from '../../../../stores/SegmentStore'
+import SegmentActions from '../../../../actions/SegmentActions'
+
+jest.mock('../../../../stores/SegmentStore', () => ({
+  getCurrentSegment: jest.fn(),
+}))
+jest.mock('../../../../actions/SegmentActions', () => ({
+  openSegment: jest.fn(),
+}))
+jest.mock('../../../../setTranslationUtil', () => ({
+  segmentTranslation: jest.fn((segment, status, callback) => callback()),
+}))
+
+describe('SegmentFilterUtils.goToNextRepetitionGroup', () => {
+  afterEach(() => {
+    SegmentFilterUtils.cachedStoredState = null
+    jest.clearAllMocks()
+  })
+
+  test('does not throw and does not open a segment when there is no repetition group', () => {
+    SegmentStore.getCurrentSegment.mockReturnValue({
+      sid: 1,
+      segment_hash: 'abc',
+    })
+    SegmentFilterUtils.cachedStoredState = {serverData: {grouping: {}}}
+
+    expect(() =>
+      SegmentFilterUtils.goToNextRepetitionGroup('translated'),
+    ).not.toThrow()
+
+    expect(SegmentActions.openSegment).not.toHaveBeenCalled()
+  })
+
+  test('opens the first item of the next repetition group', () => {
+    SegmentStore.getCurrentSegment.mockReturnValue({sid: 1, segment_hash: 'a'})
+    SegmentFilterUtils.cachedStoredState = {
+      serverData: {grouping: {a: [1], b: [2, 3]}},
+    }
+
+    SegmentFilterUtils.goToNextRepetitionGroup('translated')
+
+    expect(SegmentActions.openSegment).toHaveBeenCalledWith(2)
+  })
+})

--- a/public/js/components/projects/UserProjectDropdown.js
+++ b/public/js/components/projects/UserProjectDropdown.js
@@ -24,7 +24,7 @@ export const UserProjectDropdown = ({
 
   const selectedUser = users.find(({user}) => user.uid === idAssignee)
   const isPersonalTeam = userInfo
-    ? userInfo.teams.find(({id}) => id === project.id_team).type === 'personal'
+    ? userInfo.teams.find(({id}) => id === project.id_team)?.type === 'personal'
     : undefined
 
   const onChangeSearch = useCallback(

--- a/public/js/components/projects/UserProjectDropdown.test.js
+++ b/public/js/components/projects/UserProjectDropdown.test.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import {UserProjectDropdown} from './UserProjectDropdown'
+import {ApplicationWrapperContext} from '../common/ApplicationWrapper/ApplicationWrapperContext'
+import userMock from '../../../mocks/userMock'
+
+const renderWithContext = (project) =>
+  render(
+    <ApplicationWrapperContext.Provider value={{userInfo: userMock}}>
+      <UserProjectDropdown
+        users={[]}
+        project={project}
+        openAddMember={jest.fn()}
+        changeUser={jest.fn()}
+        idAssignee={undefined}
+      />
+    </ApplicationWrapperContext.Provider>,
+  )
+
+describe('UserProjectDropdown', () => {
+  test('does not throw when the project team is not in the user teams list', () => {
+    expect(() => renderWithContext({id_team: 999999999})).not.toThrow()
+  })
+
+  test('does not disable assignment when the project team is not in the user teams list', () => {
+    renderWithContext({id_team: 999999999})
+
+    expect(screen.getByTestId('project-teams')).not.toBeDisabled()
+  })
+
+  test('disables assignment when the project belongs to the personal team', () => {
+    const personalTeam = userMock.teams.find(({type}) => type === 'personal')
+    renderWithContext({id_team: personalTeam.id})
+
+    expect(screen.getByTestId('project-teams')).toBeDisabled()
+  })
+})

--- a/public/js/components/quality_report/SegmentQRLine.js
+++ b/public/js/components/quality_report/SegmentQRLine.js
@@ -80,7 +80,11 @@ const SegmentQRLine = ({
         .toString()
         .replace(new RegExp(String.fromCharCode(parseInt('200B', 16)), 'g'), '')
         .replace(/·/g, ' ')
-      return await navigator.clipboard.writeText(plainText)
+      try {
+        await navigator.clipboard.writeText(plainText)
+      } catch {
+        // The browser or OS denied clipboard permission — nothing more we can do here.
+      }
     }
   }
 

--- a/public/js/components/segments/SegmentFooterTabConcordance.js
+++ b/public/js/components/segments/SegmentFooterTabConcordance.js
@@ -113,7 +113,11 @@ class SegmentFooterTabConcordance extends React.Component {
         .toString()
         .replace(new RegExp(String.fromCharCode(parseInt('200B', 16)), 'g'), '')
         .replace(/·/g, ' ')
-      return await navigator.clipboard.writeText(plainText)
+      try {
+        await navigator.clipboard.writeText(plainText)
+      } catch {
+        // The browser or OS denied clipboard permission — nothing more we can do here.
+      }
     }
   }
 

--- a/public/js/components/segments/SegmentFooterTabConcordance.test.js
+++ b/public/js/components/segments/SegmentFooterTabConcordance.test.js
@@ -1,0 +1,28 @@
+import SegmentFooterTabConcordance from './SegmentFooterTabConcordance'
+
+describe('SegmentFooterTabConcordance.prototype.copyText', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('does not reject when the browser denies clipboard permission', async () => {
+    jest
+      .spyOn(document, 'getSelection')
+      .mockReturnValue({toString: () => 'some concordance text'})
+    navigator.clipboard = {
+      writeText: jest
+        .fn()
+        .mockRejectedValue(new DOMException('denied', 'NotAllowedError')),
+    }
+
+    await expect(
+      SegmentFooterTabConcordance.prototype.copyText({
+        preventDefault: jest.fn(),
+      }),
+    ).resolves.not.toThrow()
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'some concordance text',
+    )
+  })
+})

--- a/public/js/components/segments/SegmentFooterTabMatches.js
+++ b/public/js/components/segments/SegmentFooterTabMatches.js
@@ -308,7 +308,11 @@ class SegmentFooterTabMatches extends React.Component {
         .toString()
         .replace(new RegExp(String.fromCharCode(parseInt('200B', 16)), 'g'), '')
         .replace(/·/g, ' ')
-      return await navigator.clipboard.writeText(plainText)
+      try {
+        await navigator.clipboard.writeText(plainText)
+      } catch {
+        // The browser or OS denied clipboard permission — nothing more we can do here.
+      }
     }
   }
 

--- a/public/js/components/segments/SegmentFooterTabMatches.test.js
+++ b/public/js/components/segments/SegmentFooterTabMatches.test.js
@@ -1,0 +1,26 @@
+import SegmentFooterTabMatches from './SegmentFooterTabMatches'
+
+describe('SegmentFooterTabMatches.prototype.copyText', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('does not reject when the browser denies clipboard permission', async () => {
+    jest
+      .spyOn(document, 'getSelection')
+      .mockReturnValue({toString: () => 'some matched text'})
+    navigator.clipboard = {
+      writeText: jest
+        .fn()
+        .mockRejectedValue(new DOMException('denied', 'NotAllowedError')),
+    }
+
+    await expect(
+      SegmentFooterTabMatches.prototype.copyText({preventDefault: jest.fn()}),
+    ).resolves.not.toThrow()
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'some matched text',
+    )
+  })
+})

--- a/public/js/components/segments/SegmentSource.js
+++ b/public/js/components/segments/SegmentSource.js
@@ -584,6 +584,18 @@ class SegmentSource extends React.Component {
     return proxy[sourceLanguageCode]
   }
 
+  updateOptionsToolbarVisibility = () => {
+    if (!this.editor) return
+
+    this.setState({
+      isShowingOptionsToolbar: !this.editor._latestEditorState
+        .getSelection()
+        .isCollapsed(),
+    })
+
+    this.helpAiAssistant()
+  }
+
   helpAiAssistant = () => {
     if (this.delayAiAssistant) clearTimeout(this.delayAiAssistant)
 
@@ -633,13 +645,7 @@ class SegmentSource extends React.Component {
           onDragStart: dragFragment,
           onMouseUp: () => {
             setTimeout(() => {
-              this.setState({
-                isShowingOptionsToolbar: !this.editor._latestEditorState
-                  .getSelection()
-                  .isCollapsed(),
-              })
-
-              this.helpAiAssistant()
+              this.updateOptionsToolbarVisibility()
             })
           },
           onKeyUp: (event) => {
@@ -649,13 +655,7 @@ class SegmentSource extends React.Component {
               event.key === 'ArrowUp' ||
               event.key === 'ArrowDown'
             ) {
-              this.setState({
-                isShowingOptionsToolbar: !this.editor._latestEditorState
-                  .getSelection()
-                  .isCollapsed(),
-              })
-
-              this.helpAiAssistant()
+              this.updateOptionsToolbarVisibility()
             }
           },
         }

--- a/public/js/components/segments/SegmentSource.test.js
+++ b/public/js/components/segments/SegmentSource.test.js
@@ -1,0 +1,48 @@
+import SegmentSource from './SegmentSource'
+import {segmentsMock} from '../../../mocks/segmentsMock'
+
+describe('SegmentSource.updateOptionsToolbarVisibility', () => {
+  beforeEach(() => {
+    global.config = {
+      ...global.config,
+      source_code: 'en-US',
+      target_code: 'it-IT',
+      tag_projection_languages: {},
+    }
+  })
+
+  const buildInstance = () =>
+    new SegmentSource({
+      segment: segmentsMock[0],
+      splitGroupLength: 1,
+    })
+
+  test('does not throw when the editor ref is null', () => {
+    const instance = buildInstance()
+    instance.editor = null
+    instance.setState = jest.fn()
+    instance.helpAiAssistant = jest.fn()
+
+    expect(() => instance.updateOptionsToolbarVisibility()).not.toThrow()
+    expect(instance.setState).not.toHaveBeenCalled()
+    expect(instance.helpAiAssistant).not.toHaveBeenCalled()
+  })
+
+  test('updates the toolbar visibility when the editor ref is set', () => {
+    const instance = buildInstance()
+    instance.editor = {
+      _latestEditorState: {
+        getSelection: () => ({isCollapsed: () => false}),
+      },
+    }
+    instance.setState = jest.fn()
+    instance.helpAiAssistant = jest.fn()
+
+    instance.updateOptionsToolbarVisibility()
+
+    expect(instance.setState).toHaveBeenCalledWith({
+      isShowingOptionsToolbar: true,
+    })
+    expect(instance.helpAiAssistant).toHaveBeenCalled()
+  })
+})

--- a/public/js/components/segments/SegmentsContainer.js
+++ b/public/js/components/segments/SegmentsContainer.js
@@ -465,9 +465,9 @@ function SegmentsContainer({isReview, startSegmentId, firstJobSegment}) {
   useEffect(() => {
     const recalcHeight = () => {
       const headerHeight =
-        document.getElementsByTagName('header')[0].offsetHeight
+        document.getElementsByTagName('header')[0]?.offsetHeight ?? 0
       const footerHeight =
-        document.getElementsByTagName('footer')[0].offsetHeight
+        document.getElementsByTagName('footer')[0]?.offsetHeight ?? 0
       const wrapperEl = document.getElementById('context-preview-wrapper')
       const wrapperHeight = wrapperEl ? wrapperEl.offsetHeight : 0
 

--- a/public/js/components/segments/SegmentsContainer.test.js
+++ b/public/js/components/segments/SegmentsContainer.test.js
@@ -561,3 +561,17 @@ describe('SegmentsContainer', () => {
     })
   })
 })
+
+describe('SegmentsContainer height calculation', () => {
+  test('does not throw when the page has no footer', () => {
+    document.querySelector('footer').remove()
+
+    expect(() => render(<SegmentsContainer />)).not.toThrow()
+  })
+
+  test('does not throw when the page has no header', () => {
+    document.querySelector('header').remove()
+
+    expect(() => render(<SegmentsContainer />)).not.toThrow()
+  })
+})

--- a/public/js/stores/ProjectsStore.js
+++ b/public/js/stores/ProjectsStore.js
@@ -46,6 +46,7 @@ const ProjectsStore = assign({}, EventEmitter.prototype, {
     let projectOld = this.projects.find(function (prj) {
       return prj.get('id') == project.get('id')
     })
+    if (!projectOld) return
     let indexProject = this.projects.indexOf(projectOld)
     const chunks = project
       .get('jobs')

--- a/public/js/stores/ProjectsStore.test.js
+++ b/public/js/stores/ProjectsStore.test.js
@@ -1,0 +1,29 @@
+import {fromJS} from 'immutable'
+import ProjectsStore from './ProjectsStore'
+
+describe('ProjectsStore.removeJob', () => {
+  afterEach(() => {
+    ProjectsStore.projects = fromJS([])
+  })
+
+  test('does not throw when the project is no longer in the store', () => {
+    ProjectsStore.projects = fromJS([])
+    const project = fromJS({id: 1, jobs: [{id: 10}]})
+    const job = fromJS({id: 10})
+
+    expect(() => ProjectsStore.removeJob(project, job)).not.toThrow()
+    expect(ProjectsStore.projects.size).toBe(0)
+  })
+
+  test('removes only the matching job, leaving the rest of the project', () => {
+    ProjectsStore.projects = fromJS([{id: 1, jobs: [{id: 10}, {id: 20}]}])
+    const project = fromJS({id: 1, jobs: [{id: 10}, {id: 20}]})
+    const job = fromJS({id: 10})
+
+    ProjectsStore.removeJob(project, job)
+
+    const remainingJobs = ProjectsStore.projects.get(0).get('jobs')
+    expect(remainingJobs.size).toBe(1)
+    expect(remainingJobs.get(0).get('id')).toBe(20)
+  })
+})

--- a/public/js/stores/SegmentStore.js
+++ b/public/js/stores/SegmentStore.js
@@ -1083,15 +1083,15 @@ const SegmentStore = assign({}, EventEmitter.prototype, {
     this._segments.forEach((segment) => {
       if (isUndefined(result)) {
         if (currentFind || current_sid === -1) {
+          const segmentStatus = segment.get('status')?.toUpperCase() ?? ''
           if (segment.get('readonly') === 'true' && !alsoMutedSegment) {
             return false
           } else if (
             status === SEGMENTS_STATUS.UNTRANSLATED &&
-            (segment.get('status').toUpperCase() === SEGMENTS_STATUS.DRAFT ||
-              segment.get('status').toUpperCase() === SEGMENTS_STATUS.NEW ||
+            (segmentStatus === SEGMENTS_STATUS.DRAFT ||
+              segmentStatus === SEGMENTS_STATUS.NEW ||
               (autopropagated &&
-                segment.get('status').toUpperCase() ===
-                  SEGMENTS_STATUS.TRANSLATED &&
+                segmentStatus === SEGMENTS_STATUS.TRANSLATED &&
                 segment.get('autopropagated_from') != 0)) &&
             (alsoMutedSegment ||
               (!alsoMutedSegment && !segment.get('muted'))) &&
@@ -1102,16 +1102,12 @@ const SegmentStore = assign({}, EventEmitter.prototype, {
           } else if (status === SEGMENTS_STATUS.UNAPPROVED && revisionNumber) {
             // Second pass
             if (
-              ((segment.get('status').toUpperCase() ===
-                SEGMENTS_STATUS.APPROVED ||
-                segment.get('status').toUpperCase() ===
-                  SEGMENTS_STATUS.APPROVED2 ||
-                segment.get('status').toUpperCase() ===
-                  SEGMENTS_STATUS.TRANSLATED) &&
+              ((segmentStatus === SEGMENTS_STATUS.APPROVED ||
+                segmentStatus === SEGMENTS_STATUS.APPROVED2 ||
+                segmentStatus === SEGMENTS_STATUS.TRANSLATED) &&
                 segment.get('revision_number') === revisionNumber) ||
               (autopropagated &&
-                segment.get('status').toUpperCase() ===
-                  SEGMENTS_STATUS.APPROVED &&
+                segmentStatus === SEGMENTS_STATUS.APPROVED &&
                 segment.get('autopropagated_from') != 0 &&
                 segment.get('revision_number') !== revisionNumber)
             ) {
@@ -1119,8 +1115,7 @@ const SegmentStore = assign({}, EventEmitter.prototype, {
               return false
             }
           } else if (
-            ((status && segment.get('status').toUpperCase() === status) ||
-              !status) &&
+            ((status && segmentStatus === status) || !status) &&
             (alsoMutedSegment ||
               (!alsoMutedSegment && !segment.get('muted'))) &&
             (lockedSegments || (!lockedSegments && !segment.get('ice_locked')))

--- a/public/js/stores/SegmentStore.js
+++ b/public/js/stores/SegmentStore.js
@@ -1187,6 +1187,8 @@ const SegmentStore = assign({}, EventEmitter.prototype, {
     return this._segments.get(index)
   },
   getSegmentIndex(sid) {
+    if (isUndefined(sid) || sid === null) return -1
+
     const index = this._segments.findIndex(function (segment) {
       if (sid.toString().indexOf('-') === -1) {
         return parseInt(segment.get('sid')) === parseInt(sid)

--- a/public/js/stores/SegmentStore.test.js
+++ b/public/js/stores/SegmentStore.test.js
@@ -26,3 +26,26 @@ describe('SegmentStore.getNextSegment', () => {
     expect(next.sid).toBe(3)
   })
 })
+
+describe('SegmentStore.getSegmentIndex', () => {
+  afterEach(() => {
+    SegmentStore._segments = fromJS([])
+  })
+
+  test('returns -1 instead of throwing when sid is undefined', () => {
+    SegmentStore._segments = fromJS([{sid: 1}, {sid: 2}])
+
+    let index
+    expect(() => {
+      index = SegmentStore.getSegmentIndex(undefined)
+    }).not.toThrow()
+
+    expect(index).toBe(-1)
+  })
+
+  test('finds the matching segment by numeric sid', () => {
+    SegmentStore._segments = fromJS([{sid: 1}, {sid: 2}])
+
+    expect(SegmentStore.getSegmentIndex(2)).toBe(1)
+  })
+})

--- a/public/js/stores/SegmentStore.test.js
+++ b/public/js/stores/SegmentStore.test.js
@@ -1,0 +1,28 @@
+import {fromJS} from 'immutable'
+import SegmentStore from './SegmentStore'
+import {SEGMENTS_STATUS} from '../constants/Constants'
+
+describe('SegmentStore.getNextSegment', () => {
+  afterEach(() => {
+    SegmentStore._segments = fromJS([])
+  })
+
+  test('skips a segment with no status instead of throwing', () => {
+    SegmentStore._segments = fromJS([
+      {sid: 1, status: SEGMENTS_STATUS.TRANSLATED, readonly: 'false'},
+      {sid: 2, readonly: 'false'},
+      {sid: 3, status: SEGMENTS_STATUS.NEW, readonly: 'false'},
+    ])
+
+    let next
+    expect(() => {
+      next = SegmentStore.getNextSegment({
+        current_sid: 1,
+        status: SEGMENTS_STATUS.UNTRANSLATED,
+        autopropagated: true,
+      })
+    }).not.toThrow()
+
+    expect(next.sid).toBe(3)
+  })
+})

--- a/public/js/utils/commonUtils.js
+++ b/public/js/utils/commonUtils.js
@@ -701,16 +701,18 @@ class DetectTripleClick {
       const {focusNode} = window.getSelection()
 
       if (focusNode?.parentNode) {
-        const rect = focusNode?.parentNode?.getBoundingClientRect()
-        const selectionWidth = this.getSelectionWidth()
-        const limitLeft =
-          typeof selectionWidth === 'object' ? selectionWidth.x : rect.x
-        const limitRight =
-          typeof selectionWidth === 'object'
-            ? rect.x + (selectionWidth.width + (selectionWidth.x - rect.x))
-            : rect.x + rect.width
+        const rect = focusNode.parentNode.getBoundingClientRect?.()
+        if (rect) {
+          const selectionWidth = this.getSelectionWidth()
+          const limitLeft =
+            typeof selectionWidth === 'object' ? selectionWidth.x : rect.x
+          const limitRight =
+            typeof selectionWidth === 'object'
+              ? rect.x + (selectionWidth.width + (selectionWidth.x - rect.x))
+              : rect.x + rect.width
 
-        if (e.clientX >= limitLeft && e.clientX <= limitRight) this.callback()
+          if (e.clientX >= limitLeft && e.clientX <= limitRight) this.callback()
+        }
       }
 
       this.reset()

--- a/public/js/utils/commonUtils.test.js
+++ b/public/js/utils/commonUtils.test.js
@@ -1,0 +1,54 @@
+import CommonUtils from './commonUtils'
+
+describe('CommonUtils.DetectTripleClick', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const tripleClick = (target) => {
+    for (let i = 0; i < 3; i++) {
+      target.dispatchEvent(
+        new MouseEvent('mousedown', {clientX: 10, bubbles: true}),
+      )
+    }
+  }
+
+  test('does not throw when the selection lands on a node without getBoundingClientRect (e.g. a browser-extension-injected node)', () => {
+    const target = document.createElement('div')
+    const callback = jest.fn()
+    // eslint-disable-next-line no-new
+    new CommonUtils.DetectTripleClick(target, callback)
+
+    jest.spyOn(window, 'getSelection').mockReturnValue({
+      focusNode: {parentNode: {}},
+    })
+
+    expect(() => tripleClick(target)).not.toThrow()
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  test('calls the callback when the click lands within the selection bounds', () => {
+    const target = document.createElement('div')
+    const callback = jest.fn()
+    // eslint-disable-next-line no-new
+    new CommonUtils.DetectTripleClick(target, callback)
+
+    jest.spyOn(window, 'getSelection').mockReturnValue({
+      rangeCount: 1,
+      getRangeAt: () => ({
+        cloneRange: () => ({
+          getBoundingClientRect: () => ({left: 0, right: 20}),
+        }),
+      }),
+      focusNode: {
+        parentNode: {
+          getBoundingClientRect: () => ({x: 0, width: 20}),
+        },
+      },
+    })
+
+    tripleClick(target)
+
+    expect(callback).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Collects fixes for errors reported in Sentry (org `translated`, project `matecat`). More fixes will
be added to this PR as issues are triaged.

### `MATECAT-2RK` — segments area resize

93 events, 50 users, open since December 2023, last seen on `v4.1.1`.
`TypeError: Cannot read properties of undefined (reading 'offsetHeight')`.

`recalcHeight` in `SegmentsContainer` read `offsetHeight` directly off
`document.getElementsByTagName('header')[0]` and `getElementsByTagName('footer')[0]`, so an
unhandled `TypeError` was thrown whenever either element was absent from the DOM. The assumption
was inconsistent within the same block: the function already guarded
`#context-preview-wrapper`, and the `ResizeObserver` setup a few lines below filters missing
elements out with `.filter(Boolean)`. Missing header/footer now contribute `0`, so the segments
area may end up taller than intended rather than breaking the editor.

### `MATECAT-5JD` — project creation file upload

17 events, 16 users, first seen July 2026, currently **regressed**, last seen on `v4.1.1`.
`TypeError: Cannot destructure property 'ext' of 'e' as it is undefined.`

`onSuccess` in `useFileUploadManager` read `JSON.parse(responseText)[0]` and passed it straight to
`getFileErrorMessage`, which destructures it. On the server, `UploadHandler::post()` initialises
its response as `$info = []` and only fills it when `$_FILES` carries the upload, then answers
`200` through `flush()` regardless — so a request that reaches PHP without the file produces a
`200` with a body of `[]`, leaving `fileResponse` undefined and throwing on an upload the browser
considered successful. A response with no file entry is now treated as an upload failure and shown
on the file, matching what the surrounding branch already does for a file the server reports as
failed.

### `MATECAT-42D` — segments store next-segment lookup

30 events, 6 users, first seen September 2024, currently **regressed**, last seen on `v4.1.1`.
`TypeError: Cannot read properties of undefined (reading 'toUpperCase')`.

`getNextSegment` in `SegmentStore` called `segment.get('status').toUpperCase()` at every status
comparison while scanning the segment list, assuming every segment carries a `status` string. It
reached production through `getNextUntranslatedSegmentId`, called from `Segment.js` right after
opening a segment, and threw as soon as the scan reached a segment with no `status` field. The
status is now read once per segment through an optional chain, falling back to an empty string
that matches none of the `SEGMENTS_STATUS` values, so a segment missing its status is skipped like
any other segment that does not qualify, instead of aborting the whole scan.

### `MATECAT-4P3` — source editor options toolbar

43 events, 12 users, first seen October 2025, currently **regressed**, last seen on `v4.1.1`.
`TypeError: Cannot read properties of null (reading '_latestEditorState')`.

`onMouseUp` and `onKeyUp` on the source Draft.js editor each deferred the same block to
`this.editor._latestEditorState`, assuming the editor ref was still set by the time it ran. The
inline ref callback on the `Editor` element (`ref={(el) => (this.editor = el)}`) is recreated on
every render, so React nulls it and reassigns it around any re-render that happens between the
event and the deferred read — and `onMouseUp` always defers through a `setTimeout`, a window wide
enough for that to land on a null ref. The duplicated block is now a single guarded method shared
by both handlers, skipping the update instead of crashing when the ref is not set.

### `MATECAT-45R` — project team assignee dropdown

95 events, 9 users, first seen November 2024, currently **regressed**, last seen on `v4.1.1`,
on `/manage`. `TypeError: Cannot read properties of undefined (reading 'type')`.

`isPersonalTeam` read `.type` straight off `userInfo.teams.find(({id}) => id === project.id_team)`,
assuming the project's team is always one of the current user's teams. On `/manage`, a project can
belong to a team the viewing user is not a member of, so the lookup returns `undefined` and the
read throws. The type is now read through an optional chain, so a project whose team the user does
not belong to is treated as not personal, matching the common case and leaving assignment enabled
rather than crashing the dropdown.

### `MATECAT-5JB` — repetition group navigation

5 events, 3 users, first seen July 2026, currently **regressed**, last seen on `v4.1.1`.
`TypeError: Cannot read properties of undefined (reading '0')`.

`goToNextRepetitionGroup` read `grouping[nextGroupHash][0]` straight from the segment filter's
stored state, assuming there is always a repetition group to move to. When the grouping data holds
no groups, `nextGroupHash` falls back to `groupsArray[0]`, which is `undefined` for an empty array,
and the read throws. The next item is now read through an optional chain and only opened when one
was actually found — the segment still gets translated either way, only the jump to a next
repetition group is skipped. Calling `openSegment` with `undefined` would have been worse than the
crash it replaced: it resolves to no matching segment and clears the whole segment list.

### `MATECAT-5HV` — analyze header saving-words indicator

9 events, 8 users, first seen July 2026, currently **regressed**, last seen on `v4.1.0`.
`TypeError: Cannot read properties of null (reading 'classList')`.

`componentDidMount` and `componentDidUpdate` in `AnalyzeHeader` each schedule a `setTimeout` that
reads `self.containerSavingWords.classList`, unguarded, while the sibling
`containerAnalysisComplete` ref right next to it is already read through an optional chain. Both
refs are attached the same way, through an inline callback recreated on every render (same pattern
as `MATECAT-4P3`), so either can be null by the time a 400ms deferred callback runs — most reliably
once the component has unmounted before then. The two deferred reads are now guarded the same way
the sibling ref already is; the synchronous reads earlier in each method are left untouched since
React has already attached the ref by the time those run.

### `MATECAT-5HJ` — segment lookup with a missing sid

4 events, 4 users, first seen July 2026, currently **regressed**, last seen on `v4.1.1`.
`TypeError: Cannot read properties of undefined (reading 'toString')`.

`getSegmentIndex`, a shared lookup called from roughly 20 places in `SegmentStore`, called
`sid.toString()` unguarded before searching the segment list. The copy-source-to-target keyboard
shortcut reads `sid` off the current segment and passes it through `replaceEditAreaTextContent`
regardless of whether that segment actually carries an `sid` field, so a current segment missing
it threw as soon as this shared lookup ran. A missing `sid` is now treated as "not found" (`-1`),
matching what an actual failed lookup already returns, instead of crashing every one of this
function's callers.

### `MATECAT-5HP` — copy-to-clipboard rejects unhandled on permission denial

8 events, 6 users, first seen July 2026, currently **ongoing**, last seen on `v4.1.1`.
`NotAllowedError: The request is not allowed by the user agent or the platform in the current
context, possibly because the user denied permission.`

`copyText` overrides the browser's native copy/cut to strip formatting characters (zero-width
spaces, middle dots used to render spaces visually) before writing the plain text back to the
clipboard, but never handled `navigator.clipboard.writeText` rejecting — which it does whenever
the browser or OS denies clipboard permission (seen here on Safari). Being an `async` function
used directly as an `onCopy`/`onCut` handler, that rejection had nowhere to go but an unhandled
promise rejection. The identical handler is duplicated in `SegmentFooterTabConcordance` and
`SegmentQRLine` — same code, same trigger. All three now wrap the write in a `try`/`catch` that
gives up silently on denial, since there's nothing more the app can do at that point.

### `MATECAT-5JS` — approve button before job metadata has loaded

7 events, 7 users, first seen August 2026, currently **ongoing**, last seen on `v4.1.0`.
`TypeError: Cannot read properties of undefined (reading 'job')`.

`clickOnApprovedButton` read `CatToolStore.getJobMetadata().job.mandatory_issues` unguarded to
decide whether the current revision requires an issue before approving a segment. Job metadata
loads asynchronously, so clicking approve before it resolves threw instead of falling through to
the existing safe default. Read through an optional chain, a missing job metadata still evaluates
to a non-array value, which already falls into the same "mandatory issues required" default the
code uses whenever it can't positively confirm otherwise — no behavior change beyond not crashing.

### `MATECAT-5JZ` — triple-click detection on a non-element selection parent

1 event, 1 user, first seen August 2026, `new`, last seen on `v4.1.1`.
`TypeError: t?.parentNode?.getBoundingClientRect is not a function`.

`DetectTripleClick` called `getBoundingClientRect()` on the focus node's parent unconditionally,
assuming it is always a real `Element`. It reached production with a `mousedown` landing on
`sider-quick-compose-btn`, a custom element the "Sider" browser extension injects into the editor,
where the selection's parent node has no `getBoundingClientRect` at all. `getSelectionWidth` right
below already guards the same kind of call by checking the method exists before using it; the same
guard is now applied here, with the whole geometry check nested under it so a click that can't be
measured is treated like one outside the selection instead of crashing — the existing
`reset()`/`return` flow after the block is unaffected either way.

### `MATECAT-4T8` — removing a job whose project already left the store

18 events, 4 users, first seen February 2026, currently **regressed**, last seen on `v4.1.1`,
on `/manage`. `TypeError: Cannot read properties of undefined (reading 'get')`.

`removeJob` looked up the project by id in `this.projects` and used its index unconditionally,
without checking whether the lookup actually found anything. When the project was no longer in
the store — e.g. a previous `removeJob` call for the last job of that project already removed it
via `removeProject` — the index resolved to a value `this.projects.get()` had nothing for, and the
read that followed threw. Now bails out when the project can't be found: there's nothing left in
the store to update, and the dispatch handler that calls `removeJob` re-renders the (unchanged)
project list right after regardless of what happened inside it.

## Type

<!-- Check one. -->

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/segments/SegmentsContainer.js` | guard the `header`/`footer` `offsetHeight` reads in `recalcHeight`, contributing `0` when the element is absent |
| `public/js/components/segments/SegmentsContainer.test.js` | add two regression tests covering a page with no `footer` and a page with no `header` |
| `public/js/components/createProject/hooks/useFileUploadManager.js` | treat an upload response with no file entry as a failure instead of destructuring `undefined` |
| `public/js/components/createProject/UploadFileLocal.test.js` | add a regression test driving `onSuccess` with an empty response array |
| `public/js/stores/SegmentStore.js` | read a segment's status once per comparison in `getNextSegment`, defaulting to `''` when absent |
| `public/js/stores/SegmentStore.test.js` | new file — regression test covering a segment list with a missing `status` field |
| `public/js/components/segments/SegmentSource.js` | extract `updateOptionsToolbarVisibility`, guarding against a null editor ref, shared by `onMouseUp`/`onKeyUp` |
| `public/js/components/segments/SegmentSource.test.js` | new file — regression tests for a null and a set editor ref |
| `public/js/components/projects/UserProjectDropdown.js` | read the matched team's `type` through an optional chain in `isPersonalTeam` |
| `public/js/components/projects/UserProjectDropdown.test.js` | new file — regression tests covering a project team absent from the user's teams, and the personal-team case |
| `public/js/components/header/cattol/segment_filter/segment_filter.js` | read the next repetition-group item through an optional chain in `goToNextRepetitionGroup`, only opening it when found |
| `public/js/components/header/cattol/segment_filter/segment_filter.test.js` | new file — regression tests covering an empty grouping and a normal jump to the next group |
| `public/js/components/analyze/AnalyzeHeader.js` | guard the two deferred `containerSavingWords.classList` reads with optional chaining, matching the sibling ref |
| `public/js/components/analyze/AnalyzeHeader.test.js` | new file — regression test unmounting before the deferred class toggle runs |
| `public/js/stores/SegmentStore.js` | return `-1` from `getSegmentIndex` when `sid` is `undefined`/`null`, instead of calling `.toString()` on it |
| `public/js/stores/SegmentStore.test.js` | add a `getSegmentIndex` describe block covering a missing `sid` and a normal numeric match |
| `public/js/components/segments/SegmentFooterTabMatches.js` | wrap `navigator.clipboard.writeText` in `try`/`catch` in `copyText` |
| `public/js/components/segments/SegmentFooterTabConcordance.js` | same fix, identical duplicated handler |
| `public/js/components/quality_report/SegmentQRLine.js` | same fix, identical duplicated handler |
| `public/js/components/segments/SegmentFooterTabMatches.test.js` | new file — regression test for a denied clipboard permission |
| `public/js/components/segments/SegmentFooterTabConcordance.test.js` | new file — same regression test for the sibling handler |
| `public/js/actions/SegmentActions.js` | read `CatToolStore.getJobMetadata()?.job?.mandatory_issues` through an optional chain in `clickOnApprovedButton` |
| `public/js/actions/SegmentActions.test.js` | add a case to the existing mandatory-issues-gate suite covering job metadata not loaded yet |
| `public/js/utils/commonUtils.js` | guard `getBoundingClientRect` on the selection's parent node in `DetectTripleClick`, matching the sibling check in `getSelectionWidth` |
| `public/js/utils/commonUtils.test.js` | new file — regression tests for a selection parent without `getBoundingClientRect` and for the normal triple-click case |
| `public/js/stores/ProjectsStore.js` | bail out of `removeJob` when the project can no longer be found in `this.projects` |
| `public/js/stores/ProjectsStore.test.js` | new file — regression tests for a project already removed and for the normal job-removal case |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Frontend-only changes, so the PHP suites were not run.

Every regression test was verified in both directions. With each fix reverted, its tests fail
reproducing the exact production error:

```
# MATECAT-2RK
Error message: "Cannot read properties of undefined (reading 'offsetHeight')"
> 469 |  document.getElementsByTagName('footer')[0].offsetHeight
> 467 |  document.getElementsByTagName('header')[0].offsetHeight

# MATECAT-5JD
useFileUploadManager.js:75:12
> const {ext, size, error} = file
TypeError: Cannot destructure property 'ext' of 'file' as it is undefined.

# MATECAT-42D
SegmentStore.js:1090:34
> (segment.get('status').toUpperCase() === SEGMENTS_STATUS.DRAFT ||
TypeError: Cannot read properties of undefined (reading 'toUpperCase')

# MATECAT-4P3
SegmentSource.js updateOptionsToolbarVisibility
> isShowingOptionsToolbar: !this.editor._latestEditorState.getSelection().isCollapsed()
TypeError: Cannot read properties of null (reading '_latestEditorState')

# MATECAT-45R
UserProjectDropdown.js:27
> userInfo.teams.find(({id}) => id === project.id_team).type === 'personal'
TypeError: Cannot read properties of undefined (reading 'type')

# MATECAT-5JB
segment_filter.js goToNextRepetitionGroup
> grouping[nextGroupHash][0]
TypeError: Cannot read properties of undefined (reading '0')

# MATECAT-5HV
AnalyzeHeader.js:401
> self.containerSavingWords.classList.remove('updated-count')
TypeError: Cannot read properties of null (reading 'classList')

# MATECAT-5HJ
SegmentStore.js getSegmentIndex
> if (sid.toString().indexOf('-') === -1) {
TypeError: Cannot read properties of undefined (reading 'toString')

# MATECAT-5HP
SegmentFooterTabMatches.js copyText
> return await navigator.clipboard.writeText(plainText)
NotAllowedError: The request is not allowed by the user agent or the platform...

# MATECAT-5JS
SegmentActions.js clickOnApprovedButton
> CatToolStore.getJobMetadata().job.mandatory_issues
TypeError: Cannot read properties of undefined (reading 'job')

# MATECAT-5JZ
commonUtils.js DetectTripleClick
> focusNode?.parentNode?.getBoundingClientRect()
TypeError: focusNode?.parentNode?.getBoundingClientRect is not a function

# MATECAT-4T8
ProjectsStore.js removeJob
> this.projects.get(indexProject).get('jobs').size === 1
TypeError: Cannot read properties of undefined (reading 'get')
```

With the fixes in place:

```
public/js/components/segments/       -> 24 suites, 193 passed, 4 skipped
public/js/components/createProject/  ->  2 suites,  37 passed
public/js/components/projects/       ->  6 suites,  26 passed, 1 skipped
public/js/components/header/         ->  5 suites,  11 passed, 3 skipped
public/js/components/analyze/        ->  2 suites,   8 passed
public/js/stores/ + actions/          -> 26 suites, 212 passed, 4 skipped
public/js/utils/                      -> 10 suites, 199 passed
public/js/stores/                     ->  4 suites,  23 passed
```

`prettier --check` is clean on every file changed in this PR.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**`MATECAT-2RK` — the exact production trigger is not proven.** Both `<header>` (from `Header.js`)
and `<footer>` (from `CattoolFooter.js`) are rendered under the same `{isUserLogged && ...}` branch
in `CatTool.js`, so both exist on mount. `recalcHeight` also runs on `window.resize` and from a
`ResizeObserver`, and the event carries `mechanism: onerror` / `handled: no`, which fits a resize
firing while the DOM is being torn down on navigation away from the CAT page. The guard is correct
regardless of the trigger, since it only removes an unchecked assumption the surrounding code
already avoids. 49 session replays are attached to the issue if someone wants to pin it down.

**`MATECAT-5JD` — the server side is left alone on purpose.** `UploadHandler::post()` returning
`200` with `[]` is the underlying contract problem, and the misconfiguration branch right below it
does `$info[0]->error = ...` against a possibly empty `$info`. Tightening that endpoint is a
larger, riskier change than the client-side guard needed to stop the crash, so it is worth a
separate PR.

Each commit carries a `Fixes MATECAT-...` reference, so both Sentry issues auto-close on merge.

**`MATECAT-5HP` — two more unguarded `navigator.clipboard.writeText` call sites left alone on
purpose.** `EditorLite.js` and `PreferencesModal.js` call it fire-and-forget with no `await`/
`.catch()` either, but neither is the reported bug's duplicated code and neither is currently
implicated by a Sentry issue — flagging them here rather than folding an unrelated cleanup into
this fix.

**Unrelated blocker worth flagging:** the jest suite currently fails to start with
`Module <rootDir>/setupFiles.jest.js in the setupFiles option was not found.` That message is
misleading. jest 30 resolves modules through `unrs-resolver`, a native Rust addon that loads a
per-platform binding from `@unrs/resolver-binding-<platform>`, and only one binding is installed
per `yarn install`. The `matecat` container mounts the host repo, so host and container share a
single `node_modules` while needing different bindings — host `darwin-arm64` vs container
`linux x86_64`. Only `@unrs/resolver-binding-darwin-arm64` is present, and inside the container
`require('unrs-resolver')` fails with `Cannot find native binding`. Each environment's
`yarn install` therefore fixes itself and breaks the other. Installing both bindings would let
them coexist; this is a follow-up, not part of this PR.
