### PR TITLE
🐛 fix(review): stop replace all drifting the chunk review counters

### DIFF
--- a/lib/Model/LQA/ChunkReviewDao.php
+++ b/lib/Model/LQA/ChunkReviewDao.php
@@ -311,6 +311,54 @@ class ChunkReviewDao extends AbstractDao
     }
 
     /**
+     * Reviewed words for one chunk phase, derived from the final revision records instead of from the
+     * segments' current status.
+     *
+     * getReviewedWordsCountForSecondPass() below asks which segments sit in this phase's status right now.
+     * That only answers the question for the *top* phase of a job, because only the top phase's status is
+     * terminal: the moment R2 approves a segment it stops being APPROVED, so R1's count loses it, and a job
+     * fully approved through R2 recounts R1 to zero. A final revision record instead states that this phase
+     * finished reviewing this segment, which stays true through promotion to APPROVED2, through a demotion
+     * back to TRANSLATED, and for a segment approved without any edit — all three of which the status test
+     * silently drops.
+     *
+     * Segments are grouped before summing: the final_revision flag is not guaranteed unique per
+     * (segment, source_page), so summing the events directly double counts wherever it is not.
+     *
+     * @throws PDOException
+     */
+    public function getReviewedWordsCountFromFinalRevisions(JobStruct $chunk, int $source_page): int
+    {
+        $sql = "SELECT COALESCE( SUM( reviewed.raw_word_count ), 0 )
+        FROM (
+            SELECT s.id, s.raw_word_count
+            FROM segment_translation_events ste
+            JOIN jobs j ON j.id = ste.id_job
+            JOIN segments s ON s.id = ste.id_segment
+                AND s.id <= j.job_last_segment
+                AND s.id >= j.job_first_segment
+            WHERE ste.id_job = :id_job
+                AND j.password = :password
+                AND ste.source_page = :source_page
+                AND ste.final_revision = 1
+            GROUP BY s.id, s.raw_word_count
+        ) reviewed
+        ";
+
+        $conn = $this->database->getConnection();
+        $stmt = $conn->prepare($sql);
+        $stmt->execute([
+            'id_job'      => $chunk->id,
+            'password'    => $chunk->password,
+            'source_page' => $source_page
+        ]);
+
+        $result = $stmt->fetch();
+
+        return (!$result || $result[0] === null) ? 0 : (int)$result[0];
+    }
+
+    /**
      * @param JobStruct $chunk
      * @param int|null $source_page
      *

--- a/lib/Model/LQA/ChunkReviewDao.php
+++ b/lib/Model/LQA/ChunkReviewDao.php
@@ -183,72 +183,74 @@ class ChunkReviewDao extends AbstractDao
     }
 
     /**
-     * Finds qa_chunk_reviews rows whose recorded penalty_points has drifted away from the true
-     * live sum of qa_entries.penalty_points (non-deleted, same job/source_page). Used by the
-     * standing consistency check and the batch repair CLI task — both need the same identity
-     * (id, id_job, password, source_page) plus the recorded vs. actual values for reporting.
+     * Finds qa_chunk_reviews rows whose recorded penalty_points has drifted away from the true live
+     * sum of qa_entries.penalty_points (non-deleted, same job/source_page), within a window of job
+     * ids. Callers get the identity (id, id_job, password, source_page) plus the recorded vs. actual
+     * values for reporting.
      *
-     * @param int|null $minJobId Only consider jobs above this id. A starting watermark, not a cap.
+     * The window is mandatory and has no "everything" form, because unwindowed this is a different
+     * query rather than the same one without a filter: it drives from a full index scan of `jobs`
+     * and materialises one temporary-table row per chunk review in the instance. Bounded on
+     * r.id_job it drives from qa_chunk_reviews instead, with jobs joined eq_ref.
+     *
+     * @param int      $minJobId Inclusive lower bound on the job id.
+     * @param int      $maxJobId Inclusive upper bound on the job id.
      * @param int|null $limit    Maximum rows to return; null is unbounded. Anything that renders the
-     *                           result — a console table, an alert email — should pass one and report
-     *                           countPenaltyPointsMismatches() as the total, or a first run after
-     *                           deploy can emit an unbounded report.
+     *                           result — a console table, an alert email — should pass one.
      *
      * @return array<int, array{id:int,id_job:int,password:string,source_page:int,recorded_penalty_points:float,actual_penalty_points:float}>
      * @throws PDOException
      */
-    public function findPenaltyPointsMismatches(?int $minJobId = null, ?int $limit = null): array
+    public function findPenaltyPointsMismatchesByJobRange(int $minJobId, int $maxJobId, ?int $limit = null): array
     {
-        [$sql, $parameters] = $this->penaltyPointsMismatchesQuery($minJobId);
-
-        $sql .= " ORDER BY r.id_job, r.source_page";
-
-        // Interpolated, not bound: execute() with an array binds every value as a string, which turns
-        // LIMIT into LIMIT '50' and a syntax error. The int cast is the injection guard. Same shape as
-        // ProjectDao::getProjectsByUser().
-        if ($limit !== null) {
-            $sql .= " LIMIT " . (int)$limit;
-        }
-
-        $conn = $this->database->getConnection();
-        $stmt = $conn->prepare($sql);
-        $stmt->execute($parameters);
-
-        /** @var array<int, array{id:int,id_job:int,password:string,source_page:int,recorded_penalty_points:float,actual_penalty_points:float}> $rows */
-        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-        return $rows;
+        return $this->queryPenaltyPointsMismatches(
+            "WHERE r.id_job BETWEEN :min_job_id AND :max_job_id",
+            ['min_job_id' => $minJobId, 'max_job_id' => $maxJobId],
+            $limit
+        );
     }
 
     /**
-     * How many rows findPenaltyPointsMismatches() would return unbounded.
+     * The same drift query, windowed by when the job was created rather than by its id.
      *
-     * Lets a caller render a page of the drift while still reporting the true total, so a capped
-     * alert email reads "showing 50 of 812" instead of quietly looking like the whole picture. Built
-     * from the same predicate as the page so the count and the page can never disagree.
+     * Anchored on jobs.create_date because that is the only indexed timestamp on the driving side
+     * (create_date_idx), so the window range-scans instead of filtering after the fact. Note what
+     * that does and does not select: jobs *created* in the window, not reviews *performed* in it. A
+     * job created last year and reviewed this morning is outside every recent window, so this is a
+     * way to check recent work cheaply, never a way to prove the instance is clean.
      *
+     * The bounds are half-open — [from, to) — so consecutive windows neither overlap nor leave a gap
+     * at the boundary.
+     *
+     * @param string   $from Inclusive lower bound, 'Y-m-d H:i:s'.
+     * @param string   $to   Exclusive upper bound, 'Y-m-d H:i:s'.
+     * @param int|null $limit
+     *
+     * @return array<int, array{id:int,id_job:int,password:string,source_page:int,recorded_penalty_points:float,actual_penalty_points:float}>
      * @throws PDOException
      */
-    public function countPenaltyPointsMismatches(?int $minJobId = null): int
+    public function findPenaltyPointsMismatchesByDateRange(string $from, string $to, ?int $limit = null): array
     {
-        [$inner, $parameters] = $this->penaltyPointsMismatchesQuery($minJobId);
-
-        $conn = $this->database->getConnection();
-        $stmt = $conn->prepare("SELECT COUNT(*) FROM ( " . $inner . " ) mismatches");
-        $stmt->execute($parameters);
-
-        return (int)$stmt->fetchColumn();
+        return $this->queryPenaltyPointsMismatches(
+            "WHERE j.create_date >= :from AND j.create_date < :to",
+            ['from' => $from, 'to' => $to],
+            $limit
+        );
     }
 
     /**
-     * The shared body of the drift query: every qa_chunk_reviews row whose recorded penalty_points
-     * disagrees with the live SUM(qa_entries.penalty_points) for the same chunk and source_page.
+     * The shared body of the drift query: every qa_chunk_reviews row in the window whose recorded
+     * penalty_points disagrees with the live SUM(qa_entries.penalty_points) for the same chunk and
+     * source_page.
      *
-     * @param int|null $minJobId Only consider jobs above this id. A starting watermark, not a cap.
+     * @param string                    $where      The window predicate, including the WHERE keyword.
+     * @param array<string, int|string> $parameters Its bound values.
+     * @param int|null                  $limit
      *
-     * @return array{0: string, 1: array<string, int>}
+     * @return array<int, array{id:int,id_job:int,password:string,source_page:int,recorded_penalty_points:float,actual_penalty_points:float}>
+     * @throws PDOException
      */
-    private function penaltyPointsMismatchesQuery(?int $minJobId): array
+    private function queryPenaltyPointsMismatches(string $where, array $parameters, ?int $limit): array
     {
         // ABS(difference) rather than ROUND(a,2) != ROUND(b,2): penalty_points is double(20,2) in
         // production, one side accumulates incrementally while the other comes from a single SUM(),
@@ -272,11 +274,26 @@ class ChunkReviewDao extends AbstractDao
                 AND e.id_segment <= j.job_last_segment
                 AND e.source_page = r.source_page
                 AND e.deleted_at IS NULL
-            " . ($minJobId !== null ? "WHERE r.id_job > :min_job_id " : "") . "
+            " . $where . "
             GROUP BY r.id
-            HAVING ABS(actual_penalty_points - recorded_penalty_points) > 0.005";
+            HAVING ABS(actual_penalty_points - recorded_penalty_points) > 0.005
+            ORDER BY r.id_job, r.source_page";
 
-        return [$sql, $minJobId !== null ? ['min_job_id' => $minJobId] : []];
+        // Interpolated, not bound: execute() with an array binds every value as a string, which turns
+        // LIMIT into LIMIT '50' and a syntax error. The int cast is the injection guard. Same shape as
+        // ProjectDao::getProjectsByUser().
+        if ($limit !== null) {
+            $sql .= " LIMIT " . (int)$limit;
+        }
+
+        $conn = $this->database->getConnection();
+        $stmt = $conn->prepare($sql);
+        $stmt->execute($parameters);
+
+        /** @var array<int, array{id:int,id_job:int,password:string,source_page:int,recorded_penalty_points:float,actual_penalty_points:float}> $rows */
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return $rows;
     }
 
     /**

--- a/lib/Plugins/Features/ReviewExtended/ChunkReviewModel.php
+++ b/lib/Plugins/Features/ReviewExtended/ChunkReviewModel.php
@@ -203,11 +203,54 @@ class ChunkReviewModel implements IChunkReviewModel
         // caller of the recount — BatchReviewProcessor, split/merge, and the repair CLI alike.
         $chunkReviewDao->lockByJobId((int)$this->chunk_review->id_job);
 
+        $this->applyRecount(
+            $chunkReviewDao,
+            $chunkReviewDao->getReviewedWordsCountForSecondPass($this->chunk, $this->chunk_review->source_page),
+            $project,
+            $actingUser
+        );
+    }
+
+    /**
+     * Same recount, deriving reviewed_words_count from the final revision records rather than from the
+     * segments' current status.
+     *
+     * The status derivation used above only answers the question for the top phase of a job, so on a job
+     * with both R1 and R2 it recounts R1 towards zero as R2 approves. This entry point exists for the
+     * repair tasks, which have to be correct for any job shape. The split/merge callers deliberately keep
+     * the older derivation for now, so that re-partitioning a job does not silently change its numbers as
+     * a side effect of this fix; that path needs its own change.
+     *
+     * @throws Exception
+     */
+    public function recountAndUpdatePassFailResultFromFinalRevisions(ProjectStruct $project, UserStruct $actingUser): void
+    {
+        $chunkReviewDao = new ChunkReviewDao($this->database);
+
+        // Same ordering requirement as the recount above: lock before the aggregate reads.
+        $chunkReviewDao->lockByJobId((int)$this->chunk_review->id_job);
+
+        $this->applyRecount(
+            $chunkReviewDao,
+            $chunkReviewDao->getReviewedWordsCountFromFinalRevisions($this->chunk, (int)$this->chunk_review->source_page),
+            $project,
+            $actingUser
+        );
+    }
+
+    /**
+     * The body shared by both recount entry points. Callers must already hold the job's chunk review row
+     * locks and must have computed $reviewedWordsCount while holding them.
+     *
+     * @throws Exception
+     */
+    private function applyRecount(ChunkReviewDao $chunkReviewDao, int $reviewedWordsCount, ProjectStruct $project, UserStruct $actingUser): void
+    {
         /**
          * Count penalty points based on this source_page
          */
         $this->chunk_review->penalty_points = $chunkReviewDao->getPenaltyPointsForChunk($this->chunk, $this->chunk_review->source_page);
-        $this->chunk_review->reviewed_words_count = $chunkReviewDao->getReviewedWordsCountForSecondPass($this->chunk, $this->chunk_review->source_page);
+        $this->chunk_review->reviewed_words_count = $reviewedWordsCount;
         $this->chunk_review->total_tte = $chunkReviewDao->countTimeToEdit($this->chunk, $this->chunk_review->source_page);
 
         // No LQA model means no pass/fail verdict, and NULL is how that third state is already

--- a/lib/Plugins/Features/ReviewExtended/IChunkReviewModel.php
+++ b/lib/Plugins/Features/ReviewExtended/IChunkReviewModel.php
@@ -24,9 +24,9 @@ interface IChunkReviewModel
     /**
      * adds penalty_points and updates pass fail result
      *
-     * @param                         $penalty_points
+     * @param float $penalty_points
      * @param ProjectStruct $projectStruct
-     *
+     * @param UserStruct $actingUser
      * @return void
      */
     public function addPenaltyPoints(float $penalty_points, ProjectStruct $projectStruct, UserStruct $actingUser): void;
@@ -36,7 +36,7 @@ interface IChunkReviewModel
      *
      * @param float $penalty_points
      * @param ProjectStruct $projectStruct
-     *
+     * @param UserStruct $actingUser
      * @return void
      */
     public function subtractPenaltyPoints(float $penalty_points, ProjectStruct $projectStruct, UserStruct $actingUser): void;
@@ -57,8 +57,19 @@ interface IChunkReviewModel
      * penalty_points for the chunk and updates the passfail result.
      *
      * @param ProjectStruct $project
-     *
+     * @param UserStruct $actingUser
      * @return void
      */
     public function recountAndUpdatePassFailResult(ProjectStruct $project, UserStruct $actingUser): void;
+
+    /**
+     * The same recount, but deriving reviewed_words_count from the final revision records rather than from
+     * the segments' current status, which is only correct for the top phase of a job. Repair tasks use this
+     * one because they must hold for any job shape.
+     *
+     * @param ProjectStruct $project
+     * @param UserStruct $actingUser
+     * @return void
+     */
+    public function recountAndUpdatePassFailResultFromFinalRevisions(ProjectStruct $project, UserStruct $actingUser): void;
 }

--- a/lib/Plugins/Features/ReviewExtended/ReviewedWordCountModel.php
+++ b/lib/Plugins/Features/ReviewExtended/ReviewedWordCountModel.php
@@ -141,11 +141,14 @@ class ReviewedWordCountModel implements IReviewedWordCountModel
      */
     private function decreaseCounters(ChunkReviewStruct $chunkReview): void
     {
-        // when downgrading a revision to translation, the issues must be removed (from R1, R2 or both)
-        $this->flagIssuesToBeDeleted($chunkReview->source_page);
-        $chunkReview->penalty_points -= $this->getPenaltyPointsForSourcePage($chunkReview->source_page);
-
+        // A replace-all leaves this phase's review accounting alone entirely. The issues and the
+        // penalty_points cached from them have to move as one unit: dropping the points while the
+        // qa_entries rows survive — or the reverse — is exactly the drift #4690 was merged to stop.
+        // So the guard wraps the whole block rather than individual lines.
         if (!$this->_event->isAReplaceAllEvent()) {
+            // when downgrading a revision to translation, the issues must be removed (from R1, R2 or both)
+            $this->flagIssuesToBeDeleted($chunkReview->source_page);
+            $chunkReview->penalty_points -= $this->getPenaltyPointsForSourcePage($chunkReview->source_page);
             $chunkReview->reviewed_words_count -= $this->_segment->raw_word_count;
             $this->_event->setFinalRevisionToRemove($chunkReview->source_page);
         }
@@ -158,6 +161,19 @@ class ReviewedWordCountModel implements IReviewedWordCountModel
      */
     private function increaseCountersButCheckForFinalRevision(ChunkReviewStruct $chunkReview): void
     {
+        // A replace-all is not review work — nobody read the segment — so neither branch below may run
+        // for it. Both are harmful here. The first credits the words while the final revision they are
+        // meant to represent is not reliably written, which is how the counter drifts above the flagged
+        // truth. The second moves an existing final-revision flag onto the demoting event, so the later
+        // genuine review of that segment finds a flag already present and counts zero. Denying the flag
+        // explicitly keeps that decision here instead of leaving it to whichever path writes it.
+        if ($this->_event->isAReplaceAllEvent()) {
+            $this->_event->setRevisionFlagAllowed(false);
+            $this->_event->setChunkReviewForPassFailUpdate($chunkReview);
+
+            return;
+        }
+
         // There is a change status to this review, we must check if is the first time it happens;
         // in that case, we must add the reviewed word count
         if (!$this->aFinalRevisionExistsForThisChunk($chunkReview)) {

--- a/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php
+++ b/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php
@@ -299,19 +299,19 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
     }
 
     #[Test]
-    public function findPenaltyPointsMismatches_flags_only_the_drifted_source_page(): void
+    public function findPenaltyPointsMismatchesByJobRange_flags_only_the_drifted_source_page(): void
     {
         // The shared fixture already drifted: REVISION's qa_chunk_reviews.penalty_points is the
         // struct default (0) while its qa_entries sum to 5; REVISION_2 has no entries, so 0 == 0.
-        $mismatches = $this->dao->findPenaltyPointsMismatches();
+        $mismatches = $this->dao->findPenaltyPointsMismatchesByJobRange($this->idJob, $this->idJob);
 
         $revisionMismatch = null;
         foreach ($mismatches as $row) {
-            if ($row['id_job'] === $this->idJob && $row['source_page'] === SourcePages::SOURCE_PAGE_REVISION) {
+            if ((int)$row['id_job'] === $this->idJob && (int)$row['source_page'] === SourcePages::SOURCE_PAGE_REVISION) {
                 $revisionMismatch = $row;
             }
             $this->assertFalse(
-                $row['id_job'] === $this->idJob && $row['source_page'] === SourcePages::SOURCE_PAGE_REVISION_2,
+                (int)$row['id_job'] === $this->idJob && (int)$row['source_page'] === SourcePages::SOURCE_PAGE_REVISION_2,
                 'REVISION_2 has no qa_entries and recorded 0, so it must not be reported as a mismatch'
             );
         }
@@ -326,9 +326,9 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
      * Regression: the recount and the detector must agree on fractional penalties.
      *
      * getPenaltyPointsForChunk() used to return int, so a true sum of 5.50 was recomputed as 5.
-     * recountAndUpdatePassFailResult() writes that value as an absolute, while the detector compares
+     * The recount writes that value as an absolute, while the detector compares
      * ABS(actual - recorded) > 0.005 — so the repair wrote 5, the detector immediately re-flagged the
-     * same row, and revision:recount-drifted could never converge.
+     * same row, and no amount of repairing could ever settle it.
      */
     #[Test]
     public function fractional_penalties_recount_and_detector_agree(): void
@@ -346,15 +346,15 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
         $recomputed = $this->dao->getPenaltyPointsForChunk($this->chunk($this->idJob, $this->jobPassword));
         $this->assertSame(10.5, $recomputed, 'the fractional part must survive the recompute');
 
-        // Write it back the way recountAndUpdatePassFailResult() does — as an absolute value.
+        // Write it back the way the recount does — as an absolute value.
         $this->realSqlDb()->getConnection()->exec(
             "UPDATE qa_chunk_reviews SET penalty_points = {$recomputed}
              WHERE id_job = {$this->idJob} AND source_page = " . SourcePages::SOURCE_PAGE_REVISION
         );
 
-        foreach ($this->dao->findPenaltyPointsMismatches() as $row) {
+        foreach ($this->dao->findPenaltyPointsMismatchesByJobRange($this->idJob, $this->idJob) as $row) {
             $this->assertFalse(
-                $row['id_job'] === $this->idJob && $row['source_page'] === SourcePages::SOURCE_PAGE_REVISION,
+                (int)$row['id_job'] === $this->idJob && (int)$row['source_page'] === SourcePages::SOURCE_PAGE_REVISION,
                 'after recomputing, the detector must consider the row settled — it reported '
                 . $row['recorded_penalty_points'] . ' vs ' . $row['actual_penalty_points']
             );
@@ -362,7 +362,7 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
     }
 
     #[Test]
-    public function findPenaltyPointsMismatches_excludes_a_row_once_it_matches(): void
+    public function findPenaltyPointsMismatchesByJobRange_excludes_a_row_once_it_matches(): void
     {
         $job = $this->fixtures->makeJob($this->idProject, [
             'password' => 'match_pwd',
@@ -376,20 +376,26 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
             "UPDATE qa_chunk_reviews SET penalty_points = 0 WHERE id_job = {$job['id']}"
         );
 
-        foreach ($this->dao->findPenaltyPointsMismatches() as $row) {
-            $this->assertNotSame($job['id'], $row['id_job'], 'a row with no drift must not be reported');
+        foreach ($this->dao->findPenaltyPointsMismatchesByJobRange($this->idJob, (int)$job['id']) as $row) {
+            $this->assertNotSame((int)$job['id'], (int)$row['id_job'], 'a row with no drift must not be reported');
         }
     }
 
+    /**
+     * The window is the whole point of the method: it is what turns a full index scan of `jobs` into
+     * a range scan, so a job outside it must not be reachable however drifted it is.
+     */
     #[Test]
-    public function findPenaltyPointsMismatches_respects_the_min_job_id_filter(): void
+    public function findPenaltyPointsMismatchesByJobRange_reports_nothing_outside_the_window(): void
     {
-        $allMismatches = $this->dao->findPenaltyPointsMismatches();
-        $this->assertNotEmpty($allMismatches, 'sanity check: the shared fixture drift must be present');
+        $inside = $this->dao->findPenaltyPointsMismatchesByJobRange($this->idJob, $this->idJob);
+        $this->assertNotEmpty($inside, 'sanity check: the shared fixture drift must be inside its own window');
 
-        $filtered = $this->dao->findPenaltyPointsMismatches($this->idJob);
-        foreach ($filtered as $row) {
-            $this->assertGreaterThan($this->idJob, $row['id_job']);
+        $below = $this->dao->findPenaltyPointsMismatchesByJobRange($this->idJob - 2, $this->idJob - 1);
+        $above = $this->dao->findPenaltyPointsMismatchesByJobRange($this->idJob + 1, $this->idJob + 2);
+
+        foreach (array_merge($below, $above) as $row) {
+            $this->assertNotSame($this->idJob, (int)$row['id_job'], 'the seeded job lies outside both windows');
         }
     }
 
@@ -400,7 +406,7 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
      * decrement that failed to land, which is the more common production shape.
      */
     #[Test]
-    public function findPenaltyPointsMismatches_flags_an_over_recorded_row(): void
+    public function findPenaltyPointsMismatchesByJobRange_flags_an_over_recorded_row(): void
     {
         $job = $this->fixtures->makeJob($this->idProject, [
             'password' => 'over_pwd',
@@ -416,8 +422,8 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
         );
 
         $reported = array_filter(
-            $this->dao->findPenaltyPointsMismatches(),
-            fn(array $row): bool => $row['id_job'] === $job['id']
+            $this->dao->findPenaltyPointsMismatchesByJobRange((int)$job['id'], (int)$job['id']),
+            fn(array $row): bool => (int)$row['id_job'] === (int)$job['id']
         );
 
         $this->assertCount(1, $reported, 'an over-recorded row must be reported');
@@ -427,14 +433,13 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
     }
 
     /**
-     * The page and the total come from the same predicate, so a capped report can state the real
-     * total. Without a cap the first run after deploy renders one table row per drifted chunk review
-     * into an email, unbounded.
+     * Without a cap, a window that has never been checked renders one table row per drifted chunk
+     * review into an email, unbounded.
      */
     #[Test]
-    public function findPenaltyPointsMismatches_caps_the_page_while_the_count_stays_total(): void
+    public function findPenaltyPointsMismatchesByJobRange_caps_the_page(): void
     {
-        // The shared fixture already drifts on two source_pages; add a third drifted chunk.
+        // The shared fixture already drifts on REVISION; add a second drifted chunk in range.
         $job = $this->fixtures->makeJob($this->idProject, [
             'password' => 'limit_pwd',
             'job_first_segment' => $this->idSegment,
@@ -447,21 +452,56 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
             "UPDATE qa_chunk_reviews SET penalty_points = 42 WHERE id_job = {$job['id']}"
         );
 
-        $total = $this->dao->countPenaltyPointsMismatches();
-        $this->assertGreaterThanOrEqual(2, $total);
-        $this->assertSame($total, count($this->dao->findPenaltyPointsMismatches()), 'count and unbounded page must agree');
+        $uncapped = $this->dao->findPenaltyPointsMismatchesByJobRange($this->idJob, (int)$job['id']);
+        $this->assertGreaterThanOrEqual(2, count($uncapped));
 
-        $this->assertCount(1, $this->dao->findPenaltyPointsMismatches(null, 1));
-        $this->assertSame($total, $this->dao->countPenaltyPointsMismatches(), 'the count must ignore the page limit');
+        $this->assertCount(1, $this->dao->findPenaltyPointsMismatchesByJobRange($this->idJob, (int)$job['id'], 1));
     }
 
+    /**
+     * The date window is anchored on jobs.create_date, the only indexed timestamp on the driving
+     * side. What it selects is jobs *created* in the window, not reviews performed in it.
+     */
     #[Test]
-    public function countPenaltyPointsMismatches_respects_the_min_job_id_filter(): void
+    public function findPenaltyPointsMismatchesByDateRange_windows_on_the_job_creation_date(): void
     {
-        $this->assertSame(
-            count($this->dao->findPenaltyPointsMismatches($this->idJob)),
-            $this->dao->countPenaltyPointsMismatches($this->idJob)
+        $this->realSqlDb()->getConnection()->exec(
+            "UPDATE jobs SET create_date = '2024-03-10 12:00:00' WHERE id = {$this->idJob}"
         );
+
+        $inside = $this->dao->findPenaltyPointsMismatchesByDateRange('2024-03-10 00:00:00', '2024-03-11 00:00:00');
+        $this->assertNotEmpty(
+            array_filter($inside, fn(array $row): bool => (int)$row['id_job'] === $this->idJob),
+            'the seeded drift must be reported when its job was created inside the window'
+        );
+
+        $after = $this->dao->findPenaltyPointsMismatchesByDateRange('2024-03-11 00:00:00', '2024-03-12 00:00:00');
+        foreach ($after as $row) {
+            $this->assertNotSame($this->idJob, (int)$row['id_job'], 'a job created before the window must not be reported');
+        }
+    }
+
+    /**
+     * The bounds are half-open, [from, to), so a run over Monday and a run over Tuesday neither
+     * report the midnight job twice nor skip it.
+     */
+    #[Test]
+    public function findPenaltyPointsMismatchesByDateRange_bounds_are_half_open(): void
+    {
+        $this->realSqlDb()->getConnection()->exec(
+            "UPDATE jobs SET create_date = '2024-03-10 00:00:00' WHERE id = {$this->idJob}"
+        );
+
+        $startsOnIt = $this->dao->findPenaltyPointsMismatchesByDateRange('2024-03-10 00:00:00', '2024-03-11 00:00:00');
+        $this->assertNotEmpty(
+            array_filter($startsOnIt, fn(array $row): bool => (int)$row['id_job'] === $this->idJob),
+            'a job created exactly at --from is inside the window'
+        );
+
+        $endsOnIt = $this->dao->findPenaltyPointsMismatchesByDateRange('2024-03-09 00:00:00', '2024-03-10 00:00:00');
+        foreach ($endsOnIt as $row) {
+            $this->assertNotSame($this->idJob, (int)$row['id_job'], 'a job created exactly at --to is outside the window');
+        }
     }
 
     #[Test]

--- a/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php
+++ b/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php
@@ -1087,6 +1087,108 @@ class ChunkReviewDaoRealSqlTest extends AbstractTest
     }
 
     /**
+     * The case that motivates the method. Once R2 approves a segment its status is APPROVED2, so the status
+     * derivation stops seeing it for R1 — and a job fully approved through R2 recounts R1 to zero. The final
+     * revision record is unaffected: R1 did finish reviewing this segment, and that stays true afterwards.
+     */
+    #[Test]
+    public function getReviewedWordsCountFromFinalRevisions_stillCountsASegmentR2HasSincePromoted(): void
+    {
+        $this->setSegmentTranslation(['status' => TranslationStatus::STATUS_APPROVED2]);
+        $this->flagFinalRevision(SourcePages::SOURCE_PAGE_REVISION);
+
+        $chunk = $this->chunk($this->idJob, $this->jobPassword);
+
+        $this->assertSame(10, $this->dao->getReviewedWordsCountFromFinalRevisions($chunk, SourcePages::SOURCE_PAGE_REVISION));
+        $this->assertSame(0, $this->dao->getReviewedWordsCountForSecondPass($chunk, SourcePages::SOURCE_PAGE_REVISION));
+    }
+
+    /**
+     * A reviewer who reads a pretranslated segment and approves it without changing anything leaves
+     * version_number at 0. That is ordinary review work, but `version_number != 0` filters it out.
+     */
+    #[Test]
+    public function getReviewedWordsCountFromFinalRevisions_countsASegmentApprovedWithoutAnEdit(): void
+    {
+        $this->setSegmentTranslation(['version_number' => 0]);
+        $this->flagFinalRevision(SourcePages::SOURCE_PAGE_REVISION);
+
+        $chunk = $this->chunk($this->idJob, $this->jobPassword);
+
+        $this->assertSame(10, $this->dao->getReviewedWordsCountFromFinalRevisions($chunk, SourcePages::SOURCE_PAGE_REVISION));
+        $this->assertSame(0, $this->dao->getReviewedWordsCountForSecondPass($chunk, SourcePages::SOURCE_PAGE_REVISION));
+    }
+
+    /**
+     * A replace-all demotes reviewed segments back to TRANSLATED without anyone un-reviewing them. The words
+     * stay reviewed, so the count has to survive the demotion.
+     */
+    #[Test]
+    public function getReviewedWordsCountFromFinalRevisions_survivesADemotionBackToTranslated(): void
+    {
+        $this->setSegmentTranslation(['status' => TranslationStatus::STATUS_TRANSLATED]);
+        $this->flagFinalRevision(SourcePages::SOURCE_PAGE_REVISION);
+
+        $chunk = $this->chunk($this->idJob, $this->jobPassword);
+
+        $this->assertSame(10, $this->dao->getReviewedWordsCountFromFinalRevisions($chunk, SourcePages::SOURCE_PAGE_REVISION));
+        $this->assertSame(0, $this->dao->getReviewedWordsCountForSecondPass($chunk, SourcePages::SOURCE_PAGE_REVISION));
+    }
+
+    /**
+     * The flag is not guaranteed unique per (segment, source_page) — live data carries rows where it is not —
+     * so the query groups by segment before summing. Without that the segment is counted once per flag.
+     */
+    #[Test]
+    public function getReviewedWordsCountFromFinalRevisions_doesNotDoubleCountDuplicateFinalRevisionFlags(): void
+    {
+        $this->flagFinalRevision(SourcePages::SOURCE_PAGE_REVISION, 1);
+        $this->flagFinalRevision(SourcePages::SOURCE_PAGE_REVISION, 2);
+
+        $chunk = $this->chunk($this->idJob, $this->jobPassword);
+
+        $this->assertSame(10, $this->dao->getReviewedWordsCountFromFinalRevisions($chunk, SourcePages::SOURCE_PAGE_REVISION));
+    }
+
+    /**
+     * The negative control. setUp() leaves a REVISION event with final_revision 0, so an unreviewed segment
+     * must count for neither phase however its status reads.
+     */
+    #[Test]
+    public function getReviewedWordsCountFromFinalRevisions_ignoresAPhaseWithNoFinalRevision(): void
+    {
+        $chunk = $this->chunk($this->idJob, $this->jobPassword);
+
+        $this->assertSame(0, $this->dao->getReviewedWordsCountFromFinalRevisions($chunk, SourcePages::SOURCE_PAGE_REVISION));
+        $this->assertSame(0, $this->dao->getReviewedWordsCountFromFinalRevisions($chunk, SourcePages::SOURCE_PAGE_REVISION_2));
+    }
+
+    /**
+     * @param array<string, string|int> $columns
+     */
+    private function setSegmentTranslation(array $columns): void
+    {
+        $assignments = [];
+        foreach ($columns as $column => $value) {
+            $assignments[] = $column . ' = ' . (is_int($value) ? $value : "'" . $value . "'");
+        }
+
+        $this->realSqlDb()->getConnection()->exec(
+            'UPDATE segment_translations SET ' . implode(', ', $assignments) .
+            ' WHERE id_segment = ' . $this->idSegment . ' AND id_job = ' . $this->idJob
+        );
+    }
+
+    private function flagFinalRevision(int $sourcePage, int $versionNumber = 1): void
+    {
+        $this->fixtures->makeSegmentTranslationEvent($this->idJob, $this->idSegment, [
+            'source_page'    => $sourcePage,
+            'final_revision' => 1,
+            'version_number' => $versionNumber,
+        ]);
+    }
+
+    /**
      * Both fixture rows share the review password, and updateReviewPassword() rotates one phase at
      * a time, so a job-wide rotation needs one call per phase.
      */

--- a/tests/unit/Core/Features/ReviewExtended/ReviewedWordCountModelTest.php
+++ b/tests/unit/Core/Features/ReviewExtended/ReviewedWordCountModelTest.php
@@ -380,12 +380,16 @@ class ReviewedWordCountModelTest extends AbstractTest
      * A replace-all rewrites many segments at once without anyone opening them in the editor, so no reviewer
      * un-reviewed anything: the reviewed word count must survive the event untouched.
      *
-     * The penalty points are a different matter. flagIssuesToBeDeleted() runs outside the guard and
-     * BatchReviewProcessor deletes those issue rows regardless, so their points must still come off the
-     * counter — otherwise qa_chunk_reviews.penalty_points drifts away from qa_entries.
+     * The penalty points and the issues they are cached from move as one unit, so they have to survive
+     * too. Deleting them here destroys review work silently: the qa_entries rows are only soft-deleted,
+     * their comments are left orphaned, nothing in the codebase ever clears deleted_at, and the
+     * notification that would have told the reviewer is skipped for replace-all events.
+     *
+     * An issue is stubbed in deliberately. The point is that a deduction is available and still is not
+     * taken, which tests the guard rather than an absence of data.
      */
     #[Test]
-    public function evaluateChunkReviewEventTransitions_lowerTransitionOnAReplaceAllKeepsTheReviewedWordCountButStillDropsThePenaltyPoints(): void
+    public function evaluateChunkReviewEventTransitions_aReplaceAllLeavesTheReviewedWordCountAndThePenaltyPointsUntouched(): void
     {
         $issue                 = $this->createStub(EntryWithCategoryStruct::class);
         $issue->source_page    = 2;
@@ -416,7 +420,133 @@ class ReviewedWordCountModelTest extends AbstractTest
 
         $this->assertNotNull($partial);
         $this->assertSame(0, $partial->reviewed_words_count);
-        $this->assertSame(-5.0, (float)$partial->penalty_points);
+        $this->assertSame(0.0, (float)$partial->penalty_points);
+    }
+
+    /**
+     * The acting phase's own row goes through increaseCountersButCheckForFinalRevision(), which the reviewed
+     * word count guard never covered. Measured on a real job, that is where the counter drifts above the
+     * flagged truth: the words are credited while the final revision they are meant to represent is not
+     * reliably written. A replace-all must add nothing here and must deny the flag outright.
+     */
+    #[Test]
+    public function evaluateChunkReviewEventTransitions_aReplaceAllOnTheActingPhaseAddsNothingAndDeniesTheFinalRevisionFlag(): void
+    {
+        $partial = null;
+
+        $event = $this->createMock(TranslationEvent::class);
+        $event->method('isAReplaceAllEvent')->willReturn(true);
+        $event->expects($this->once())->method('setRevisionFlagAllowed')->with(false);
+        $event->expects($this->never())->method('setFinalRevisionToRemove');
+        $event->expects($this->once())
+            ->method('setChunkReviewForPassFailUpdate')
+            ->willReturnCallback(function (ChunkReviewStruct $chunkReview) use (&$partial) {
+                $partial = clone $chunkReview;
+            });
+
+        $model = $this->buildModel(
+            isChangingStatus: true,
+            currentEventOnChunk: true,
+            event: $event,
+            sourcePagesWithFinalRevisions: [],
+        );
+
+        $model->evaluateChunkReviewEventTransitions();
+
+        $this->assertNotNull($partial);
+        $this->assertSame(0, $partial->reviewed_words_count);
+        $this->assertSame(0, (int)$partial->total_tte);
+    }
+
+    /**
+     * The other half of the same branch. With a final revision already recorded for the acting phase, the
+     * unguarded code moved that flag onto the demoting event, so a later genuine review of the segment found
+     * a flag already present and counted zero words for real work.
+     */
+    #[Test]
+    public function evaluateChunkReviewEventTransitions_aReplaceAllDoesNotMoveAnExistingFinalRevisionFlag(): void
+    {
+        $event = $this->createMock(TranslationEvent::class);
+        $event->method('isAReplaceAllEvent')->willReturn(true);
+        $event->expects($this->once())->method('setRevisionFlagAllowed')->with(false);
+        $event->expects($this->never())->method('setFinalRevisionToRemove');
+
+        $model = $this->buildModel(
+            isChangingStatus: true,
+            currentEventOnChunk: true,
+            event: $event,
+            sourcePagesWithFinalRevisions: [2],
+        );
+
+        $model->evaluateChunkReviewEventTransitions();
+    }
+
+    /**
+     * increaseCountersButCheckForFinalRevision() has three call sites — the changing-status branch covered
+     * above, the ICE branch, and the no-status-change fallthrough. The guard lives inside the method rather
+     * than at one call site so that all three are covered; these two tests are what pin that placement.
+     *
+     * A replace-all rewrites the text, so an ICE segment stops being unmodified and reaches the increase
+     * branch whenever the substitution does not also change the status.
+     */
+    #[Test]
+    public function evaluateChunkReviewEventTransitions_aReplaceAllOnAModifiedIceAddsNothing(): void
+    {
+        $partial = null;
+
+        $event = $this->createMock(TranslationEvent::class);
+        $event->method('isAReplaceAllEvent')->willReturn(true);
+        $event->expects($this->once())->method('setRevisionFlagAllowed')->with(false);
+        $event->expects($this->never())->method('setFinalRevisionToRemove');
+        $event->expects($this->once())
+            ->method('setChunkReviewForPassFailUpdate')
+            ->willReturnCallback(function (ChunkReviewStruct $chunkReview) use (&$partial) {
+                $partial = clone $chunkReview;
+            });
+
+        $model = $this->buildModel(
+            isIce: true,
+            isUnModifiedIce: false,
+            currentEventOnChunk: true,
+            event: $event,
+            sourcePagesWithFinalRevisions: [],
+        );
+
+        $model->evaluateChunkReviewEventTransitions();
+
+        $this->assertNotNull($partial);
+        $this->assertSame(0, $partial->reviewed_words_count);
+    }
+
+    /**
+     * The third call site: a reviewer editing a segment already in their own phase's status, which is what a
+     * replace-all produces once the segment has nothing left to demote to.
+     */
+    #[Test]
+    public function evaluateChunkReviewEventTransitions_aReplaceAllWithNoStatusChangeAddsNothing(): void
+    {
+        $partial = null;
+
+        $event = $this->createMock(TranslationEvent::class);
+        $event->method('isAReplaceAllEvent')->willReturn(true);
+        $event->expects($this->once())->method('setRevisionFlagAllowed')->with(false);
+        $event->expects($this->never())->method('setFinalRevisionToRemove');
+        $event->expects($this->once())
+            ->method('setChunkReviewForPassFailUpdate')
+            ->willReturnCallback(function (ChunkReviewStruct $chunkReview) use (&$partial) {
+                $partial = clone $chunkReview;
+            });
+
+        $model = $this->buildModel(
+            currentEventOnChunk: true,
+            event: $event,
+            sourcePagesWithFinalRevisions: [],
+        );
+
+        $model->evaluateChunkReviewEventTransitions();
+
+        $this->assertNotNull($partial);
+        $this->assertSame(0, $partial->reviewed_words_count);
     }
 
     /**

--- a/tests/unit/Core/Plugins/Features/ReviewExtended/ChunkReviewModelTest.php
+++ b/tests/unit/Core/Plugins/Features/ReviewExtended/ChunkReviewModelTest.php
@@ -375,4 +375,160 @@ class ChunkReviewModelTest extends AbstractTest
 
         $this->assertTrue($this->chunkReviewStruct->is_pass);
     }
+
+    // -----------------------------------------------------------------------
+    // recountAndUpdatePassFailResultFromFinalRevisions
+    // -----------------------------------------------------------------------
+
+    /**
+     * The pass/fail half of the recount is shared between both entry points, so the no-model case
+     * has to hold here too: NULL is how "no verdict was computed" is represented, and a stale true
+     * must be cleared rather than left standing.
+     */
+    #[Test]
+    public function recountFromFinalRevisionsLeavesIsPassNullWhenProjectHasNoLqaModel(): void
+    {
+        $this->stmtStub->method('execute')->willReturn(true);
+        $this->stmtStub->method('rowCount')->willReturn(1);
+        $this->stmtStub->method('fetchAll')->willReturn([]);
+        $this->stmtStub->method('fetch')->willReturn([0 => null]);
+
+        $this->chunkReviewStruct->is_pass = true;
+
+        $model = new ChunkReviewModel($this->chunkReviewStruct, $this->dbStub);
+        $model->recountAndUpdatePassFailResultFromFinalRevisions($this->nullLqaProject, $this->operator());
+
+        $this->assertNull($this->chunkReviewStruct->is_pass);
+    }
+
+    #[Test]
+    public function recountFromFinalRevisionsWithLqaModelSetsIsPassWhenScoreBelowLimit(): void
+    {
+        $lqaModel = new ModelStruct([
+            'pass_options' => json_encode(['limit' => [8, 5]]),
+            'pass_type'    => 'combined',
+            'label'        => 'test',
+            'create_date'  => '2024-01-01',
+            'hash'         => 'abc',
+        ]);
+
+        $this->stmtStub->method('execute')->willReturn(true);
+        $this->stmtStub->method('rowCount')->willReturn(1);
+        $this->stmtStub->method('fetchAll')->willReturnOnConsecutiveCalls([], [$lqaModel], [], [], []);
+        $this->stmtStub->method('fetch')->willReturn([0 => null]);
+
+        $project = new ProjectStruct();
+        $project->id = 10;
+        $project->id_qa_model = 1;
+
+        $model = new ChunkReviewModel($this->chunkReviewStruct, $this->dbStub);
+        $model->recountAndUpdatePassFailResultFromFinalRevisions($project, $this->operator());
+
+        $this->assertTrue($this->chunkReviewStruct->is_pass);
+    }
+
+    /**
+     * The one property that distinguishes this entry point, and the one an is_pass assertion cannot
+     * see: it must derive the reviewed words from the phase's own final-revision records, not from
+     * the segments' current status. The status derivation only answers for the top phase of a job
+     * and recounts R1 towards zero as R2 approves — a repair tool writing a wrong value over a right
+     * one. Swapping the derivation back would leave every other assertion in this file green, so the
+     * query itself is what gets pinned.
+     */
+    #[Test]
+    public function recountFromFinalRevisionsDerivesTheWordsFromTheFinalRevisionRecords(): void
+    {
+        $captured = $this->captureSqlWhile(
+            fn(IDatabase $database) => (new ChunkReviewModel($this->chunkReviewStruct, $database))
+                ->recountAndUpdatePassFailResultFromFinalRevisions($this->nullLqaProject, $this->operator())
+        );
+
+        $this->assertTrue(
+            $this->anyStatementContains($captured, 'ste.final_revision = 1'),
+            'the recount must read the phase\'s final revision records'
+        );
+        $this->assertFalse(
+            $this->anyStatementContains($captured, 'st.status = :translation_status'),
+            'the recount must not fall back to the segment-status derivation'
+        );
+    }
+
+    /**
+     * The companion guard. The split and merge callers deliberately keep the status derivation, so
+     * that re-partitioning a job does not silently change its numbers as a side effect of the fix
+     * that added the entry point above. That "unchanged" claim is only worth anything if something
+     * fails when it stops being true.
+     */
+    #[Test]
+    public function recountAndUpdatePassFailResultStillDerivesTheWordsFromTheSegmentStatus(): void
+    {
+        $captured = $this->captureSqlWhile(
+            fn(IDatabase $database) => (new ChunkReviewModel($this->chunkReviewStruct, $database))
+                ->recountAndUpdatePassFailResult($this->nullLqaProject, $this->operator())
+        );
+
+        $this->assertTrue(
+            $this->anyStatementContains($captured, 'st.status = :translation_status'),
+            'the original recount must still read the segments\' current status'
+        );
+        $this->assertFalse(
+            $this->anyStatementContains($captured, 'ste.final_revision = 1'),
+            'the original recount must not have been switched to the final revision derivation'
+        );
+    }
+
+    private function operator(): UserStruct
+    {
+        return new UserStruct(['uid' => 987, 'email' => 'actor@example.org']);
+    }
+
+    /**
+     * Runs $exercise against a database stub that records the SQL of every statement prepared, and
+     * returns what it saw. Built here rather than reconfiguring the shared pdoStub, whose prepare()
+     * is already stubbed in setUp.
+     *
+     * @param callable(IDatabase): void $exercise
+     *
+     * @return string[]
+     */
+    private function captureSqlWhile(callable $exercise): array
+    {
+        $captured = [];
+
+        $this->stmtStub->method('execute')->willReturn(true);
+        $this->stmtStub->method('rowCount')->willReturn(1);
+        $this->stmtStub->method('fetchAll')->willReturn([]);
+        $this->stmtStub->method('fetch')->willReturn([0 => null]);
+
+        $pdo = $this->createStub(\PDO::class);
+        // lockByJobId() refuses to run outside a transaction; both entry points take it.
+        $pdo->method('inTransaction')->willReturn(true);
+        $pdo->method('prepare')->willReturnCallback(function (string $sql) use (&$captured): \PDOStatement {
+            $captured[] = $sql;
+
+            return $this->stmtStub;
+        });
+
+        $database = $this->createStub(IDatabase::class);
+        $database->method('getConnection')->willReturn($pdo);
+        $database->method('onCommit')->willReturnCallback(static fn(callable $callback) => $callback());
+
+        $exercise($database);
+
+        return $captured;
+    }
+
+    /**
+     * @param string[] $statements
+     */
+    private function anyStatementContains(array $statements, string $needle): bool
+    {
+        foreach ($statements as $sql) {
+            if (str_contains($sql, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary

A replace-all credited reviewed words for segments nobody read, and moved existing final-revision
flags onto the demoting event. The phase counter then sat above the truth its own flags record, and a
later genuine review of the same segment counted zero because a flag was already there. Measured on a
purpose-built job on dev: 71 words credited that no final revision accounts for, decomposing exactly
into the three segments the replace-all touched (23 + 24 + 24).

It also adds the derivation the repair tooling needs. The existing recount reads the segments'
*current status*, which only answers the question for a job's top phase — on a job with both R1 and
R2 it walks R1 towards zero as R2 approves, i.e. the repair tool writing a wrong value over a right
one. The new entry point reads each phase's own final-revision records instead.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Plugins/Features/ReviewExtended/ReviewedWordCountModel.php` | Guard `increaseCountersButCheckForFinalRevision()` against replace-all events and deny the revision flag explicitly. Guarding the method rather than one call site, because it is reached from the changing-status branch, the ICE branch and the no-status-change fallthrough. `decreaseCounters()` now wraps the issue flagging and the `penalty_points` subtraction in the same guard as the word count — those move as one unit or they drift. |
| `lib/Model/LQA/ChunkReviewDao.php` | New `getReviewedWordsCountFromFinalRevisions()`, deriving the phase's reviewed words from its `final_revision` records: grouped by segment so a phase counts a segment once however often it was revised, and bounded to the chunk's segment range so split jobs do not each count the whole job. The penalty drift query is now windowed — `findPenaltyPointsMismatchesByJobRange()` / `...ByDateRange()` replace the unbounded `findPenaltyPointsMismatches()`, and `countPenaltyPointsMismatches()` is deleted. |
| `lib/Plugins/Features/ReviewExtended/ChunkReviewModel.php` | Both recount entry points now share a private `applyRecount()`. `recountAndUpdatePassFailResult()` is behaviourally unchanged; the new `recountAndUpdatePassFailResultFromFinalRevisions()` takes the same lock and feeds it the final-revision derivation. |
| `lib/Plugins/Features/ReviewExtended/IChunkReviewModel.php` | Declares the new method (one implementer), plus `@param` docblock corrections. |
| `tests/unit/Core/Features/ReviewExtended/ReviewedWordCountModelTest.php` | Regression coverage for the fix: replace-all adds nothing and denies the flag on the acting phase, does not move an existing flag, adds nothing on a modified ICE, adds nothing with no status change, and leaves both the word count and the penalty points untouched on a demotion. |
| `tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoRealSqlTest.php` | Real-SQL coverage for the new derivation, each asserting new-vs-old side by side, and for the windowed drift query — bounds respected, half-open date window, page cap, and drift in both directions. |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

```
PHPUnit: OK (9686 tests, 31529 assertions)
PHPStan: level 8, [OK] No errors
```

Note: this project has no `phpstan-baseline.neon` — level 8 is clean without one.

**Manual testing.** A clean job was built on dev specifically to avoid historical pollution, with
segments in known states across all three phases, and driven through the UI:

- Baseline before any replace-all: `reviewed_words_count` equals
  `SUM(raw_word_count WHERE final_revision = 1 AND source_page = P)` **exactly** for both phases
  (R1 123 = 123, R2 126 = 126) — establishing the invariant the fix protects.
- Pre-fix, a replace-all broke it by exactly 71 words, decomposing into the three touched segments.
- Post-fix, replace-all leaves every counter frozen while statuses still demote and versions still
  bump (verified with a `di` → `dì` replacement).
- The approve path self-corrects: 12 R1 and 14 R2 approvals landed both phases on exactly 305, the
  job's total word count, with R2's invariant exact — each phase counts each segment at most once.
- `MarkAllSegmentStatusController` and `SetTranslationController` were confirmed equivalent.
- The new DAO derivation returns 362/328 on that job against a live database.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**Follow-up in `internal_scripts`, required before the new entry point has a caller.**
`recountAndUpdatePassFailResultFromFinalRevisions()` is added here but consumed by the CLI tasks,
which live in the submodule and land in their own PR. That branch consolidates three overlapping
repair scripts into one `revision:recount` (targeted by `--job`/`--password` or `--project`, dry-run
by default with a before/after diff) and makes `revision:check-penalty-drift` windowed and
replica-served. This PR is safe to merge first — nothing here changes existing behaviour on its own.

**Why `recountAndUpdatePassFailResult()` was left alone.** The split/merge path still uses the
status derivation, deliberately: re-partitioning a job should not silently change its numbers as a
side effect of this fix. That path needs its own change.

**Known gap, not addressed here.** The drift detector still has a predicate for `penalty_points`
only. `reviewed_words_count` and `total_tte` have none, so a job can be wrong and absent from every
report at the same time — demonstrated on the dev job above, whose word drift the detector does not
see. Reaching it requires naming the job directly.

**Separate tickets found along the way, not fixed here.**
`JobDao::getReviewedWordsCountGroupedByFileParts()` is missing the segment-range filter and
overcounts 16× on a split job (measured on job 737); its only caller is the V3 `QualitySummary`
endpoint, which touches neither counters nor score.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217794098162666