### PR TITLE
✨ feat(icu): subfilter ICU segments with the ICU-compliant handlers in analysis and contribution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "matecat/cwh": "^3.1",
         "matecat/klein": "^3.2",
         "matecat/simple-s3": "^v2.0.0",
-        "matecat/subfiltering": "^4.1",
+        "matecat/subfiltering": "^4.1.1",
         "matecat/whole-text-finder": "^2.0",
         "matecat/xliff-parser": "~v3.0",
         "matecat/icu-intl": "^v1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22b2b2e05824fd2109a5f88fdeca63c4",
+    "content-hash": "4e99adbcc833cdc5ce0a69c2c91e9315",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -1929,16 +1929,16 @@
         },
         {
             "name": "matecat/subfiltering",
-            "version": "v4.1.0",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matecat/subfiltering.git",
-                "reference": "f005df702444c8b87c16223f61bd9eaadbeda08b"
+                "reference": "fc8274f1f477a9b58ebaf375cc48fd48a2143010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/f005df702444c8b87c16223f61bd9eaadbeda08b",
-                "reference": "f005df702444c8b87c16223f61bd9eaadbeda08b",
+                "url": "https://api.github.com/repos/matecat/subfiltering/zipball/fc8274f1f477a9b58ebaf375cc48fd48a2143010",
+                "reference": "fc8274f1f477a9b58ebaf375cc48fd48a2143010",
                 "shasum": ""
             },
             "require": {
@@ -1986,9 +1986,9 @@
             ],
             "support": {
                 "issues": "https://github.com/matecat/subfiltering/issues",
-                "source": "https://github.com/matecat/subfiltering/tree/v4.1.0"
+                "source": "https://github.com/matecat/subfiltering/tree/v4.1.1"
             },
-            "time": "2026-05-15T21:40:36+00:00"
+            "time": "2026-08-25T17:17:00+00:00"
         },
         {
             "name": "matecat/whole-text-finder",

--- a/lib/Controller/API/App/GetContributionController.php
+++ b/lib/Controller/API/App/GetContributionController.php
@@ -3,11 +3,13 @@
 namespace Controller\API\App;
 
 use Controller\Abstracts\KleinController;
+use DomainException;
 use Controller\API\Commons\Exceptions\AuthenticationError;
 use Controller\API\Commons\Validators\ChunkPasswordValidator;
 use Controller\API\Commons\Validators\LoginValidator;
 use Exception;
 use InvalidArgumentException;
+use Matecat\ICU\MessagePatternValidator;
 use Matecat\SubFiltering\MateCatFilter;
 use Model\Exceptions\NotFoundException;
 use Model\Exceptions\ValidationError;
@@ -20,6 +22,7 @@ use Model\Projects\MetadataDao as ProjectMetadataDao;
 use Model\MTQE\Templates\DTO\MTQEWorkflowParams;
 use Model\Projects\ProjectsMetadataMarshaller;
 use Model\Segments\SegmentDao;
+use Model\Segments\SegmentStruct;
 use Model\Segments\SegmentOriginalDataDao;
 use Model\Users\UserDao;
 use ReflectionException;
@@ -28,10 +31,12 @@ use Utils\Contribution\Get;
 use Utils\Contribution\GetContributionRequest;
 use Utils\Constants\SourcePages;
 use Utils\Engines\Lara;
+use Utils\LQA\ICUSourceSegmentDetector;
 use Utils\Registry\AppConfig;
 use Model\Projects\ProjectDao;
 use Utils\TaskRunner\Exceptions\EndQueueException;
 use Utils\TaskRunner\Exceptions\ReQueueException;
+use Utils\Subfiltering\IcuCompliantHandlers;
 use Utils\TmKeyManagement\Filter;
 
 class GetContributionController extends KleinController
@@ -106,12 +111,26 @@ class GetContributionController extends KleinController
         $jobId = $jobStruct->id ?? throw new TypeError('Job ID must not be null');
         $jobPassword = $jobStruct->password ?? throw new TypeError('Job password must not be null');
         $subfiltering_handlers = (new MetadataDao($this->getDatabase()))->getSubfilteringCustomHandlers($jobId, $jobPassword);
-        /** @var MateCatFilter $Filter */
-        $Filter = MateCatFilter::getInstance($this->featureSet, $jobStruct->source, $jobStruct->target, $dataRefMap, $subfiltering_handlers);
 
         $context_list_before = [];
         $context_list_after = [];
+
+        // A concordance search has no stored segment behind it, so no source can be inspected and
+        // the project handlers travel untouched. Everything else takes the decision below.
+        $wire_handlers = $this->contributionHandlers($subfiltering_handlers, false);
+
         if (!$concordance_search) {
+            // The stored contexts are read before the filter exists, because the stored source is
+            // what decides the handler set: a segment carrying valid complex ICU is converted with
+            // the ICU-compliant handlers only, and the same reduced list is what the TM is told,
+            // so the matches come back encoded the way they were sent.
+            $segmentsList = $this->fetchContributionContexts($request);
+            $icuEnabled = (bool)(new ProjectMetadataDao($this->getDatabase()))->setCacheTTL(3600)->getValue((int)$projectStruct->id, ProjectsMetadataMarshaller::ICU_ENABLED->value);
+            $sourceContainsIcu = $this->segmentSourceContainsIcu($icuEnabled, $jobStruct, $segmentsList);
+
+            /** @var MateCatFilter $Filter */
+            $Filter = MateCatFilter::getInstance($this->featureSet, $jobStruct->source, $jobStruct->target, $dataRefMap, $subfiltering_handlers, $sourceContainsIcu);
+
             $context_list_before = array_values(array_map(function (string $context) use ($Filter) {
                 return $Filter->fromLayer2ToLayer1($context);
             }, $request['context_list_before'] ?? []));
@@ -120,7 +139,8 @@ class GetContributionController extends KleinController
                 return $Filter->fromLayer2ToLayer1($context);
             }, $request['context_list_after'] ?? []));
 
-            $this->rewriteContributionContexts($request, $Filter);
+            $this->subfilterContributionContexts($request, $Filter, $segmentsList);
+            $wire_handlers = $this->contributionHandlers($subfiltering_handlers, $sourceContainsIcu);
 
             $mtEvaluation = (new ProjectMetadataDao($this->getDatabase()))->setCacheTTL(3600)->getValue((int)$projectStruct->id, ProjectsMetadataMarshaller::MT_EVALUATION->value);
             if ($mtEvaluation === null) {
@@ -169,7 +189,7 @@ class GetContributionController extends KleinController
 
         $mtQeParams = $projectMetadataDao->setCacheTTL(3600)->getValue((int)$projectStruct->id, ProjectsMetadataMarshaller::MT_QE_WORKFLOW_PARAMETERS->value);
         $contributionRequest->mt_qe_workflow_parameters = $mtQeParams instanceof MTQEWorkflowParams ? $mtQeParams->toArray() : null;
-        $contributionRequest->subfiltering_handlers = $subfiltering_handlers !== null ? array_values($subfiltering_handlers) : null;
+        $contributionRequest->subfiltering_handlers = $wire_handlers;
 
         if ($this->isRevision()) {
             $contributionRequest->userRole = Filter::ROLE_REVISOR;
@@ -352,8 +372,12 @@ class GetContributionController extends KleinController
     }
 
     /**
+     * Reads the stored contexts and lets the features rewrite them. Nothing is converted here:
+     * the Layer 0 source this returns is what decides the handler set the conversion runs with.
+     *
      * @param array<string, mixed> $request
-     * @param MateCatFilter $Filter
+     *
+     * @return object{id_before: ?SegmentStruct, id_segment: ?SegmentStruct, id_after: ?SegmentStruct}
      *
      * @throws AuthenticationError
      * @throws EndQueueException
@@ -363,7 +387,7 @@ class GetContributionController extends KleinController
      * @throws ValidationError
      * @throws Exception
      */
-    private function rewriteContributionContexts(array &$request, MateCatFilter $Filter): void
+    private function fetchContributionContexts(array &$request): object
     {
         //Get contexts
         $segmentsList = (new SegmentDao($this->getDatabase()))->setCacheTTL(60 * 60 * 24)->getContextAndSegmentByIDs(
@@ -376,9 +400,19 @@ class GetContributionController extends KleinController
 
         $rewriteContributionContextsEvent = new RewriteContributionContextsEvent($segmentsList, $request);
         $this->featureSet->dispatch($rewriteContributionContextsEvent);
-        $segmentsList = $rewriteContributionContextsEvent->getSegmentsList();
         $request = $rewriteContributionContextsEvent->getRequestData();
 
+        return $rewriteContributionContextsEvent->getSegmentsList();
+    }
+
+    /**
+     * @param array<string, mixed> $request
+     * @param object{id_before: ?SegmentStruct, id_segment: ?SegmentStruct, id_after: ?SegmentStruct} $segmentsList
+     *
+     * @throws Exception
+     */
+    private function subfilterContributionContexts(array &$request, MateCatFilter $Filter, object $segmentsList): void
+    {
         if ($segmentsList->id_before) {
             $request['context_before'] = $Filter->fromLayer0ToLayer1($segmentsList->id_before->segment);
         }
@@ -390,6 +424,47 @@ class GetContributionController extends KleinController
         if ($segmentsList->id_after) {
             $request['context_after'] = $Filter->fromLayer0ToLayer1($segmentsList->id_after->segment);
         }
+    }
+
+    /**
+     * ICU presence is a property of the single segment, not of the project, so the segment the
+     * editor asked matches for is the one that answers. A concordance search has no stored
+     * segment behind it and never gets here.
+     *
+     * @param object{id_before: ?SegmentStruct, id_segment: ?SegmentStruct, id_after: ?SegmentStruct} $segmentsList
+     *
+     * @throws DomainException
+     */
+    private function segmentSourceContainsIcu(bool $icuEnabled, JobStruct $chunk, object $segmentsList): bool
+    {
+        if (empty($segmentsList->id_segment)) {
+            return false;
+        }
+
+        return ICUSourceSegmentDetector::sourceContainsIcu(
+            new MessagePatternValidator((string)$chunk->source, (string)$segmentsList->id_segment->segment),
+            $icuEnabled
+        );
+    }
+
+    /**
+     * The list travels with the request because MyMemory decodes what it receives back to Layer 0
+     * with the very same handlers, and re-encodes its matches with them. Sending the project list
+     * for a segment converted with the ICU-compliant one would have the matches come back with the
+     * ICU arguments wrapped in PH tags, and the Layer 1 to Layer 2 transition has no PH restore to
+     * undo it.
+     *
+     * @param array<int|string, mixed>|null $subfilteringHandlers
+     *
+     * @return list<mixed>|null
+     */
+    private function contributionHandlers(?array $subfilteringHandlers, bool $sourceContainsIcu): ?array
+    {
+        if ($sourceContainsIcu) {
+            return IcuCompliantHandlers::reduceToIcuCompliant($subfilteringHandlers);
+        }
+
+        return $subfilteringHandlers !== null ? array_values($subfilteringHandlers) : null;
     }
 
     /**

--- a/lib/Model/ProjectCreation/ProjectManager.php
+++ b/lib/Model/ProjectCreation/ProjectManager.php
@@ -4,6 +4,7 @@ namespace Model\ProjectCreation;
 
 use Controller\API\Commons\Exceptions\AuthenticationError;
 use Exception;
+use Matecat\ICU\MessagePatternValidator;
 use Matecat\SubFiltering\MateCatFilter;
 use Model\ActivityLog\ActivityLogStruct;
 use Model\Concerns\LogsMessages;
@@ -43,6 +44,7 @@ use Utils\ActiveMQ\WorkerClient;
 use Utils\AsyncTasks\Workers\ActivityLogWorker;
 use Utils\Constants\ProjectStatus;
 use Utils\Logger\LoggerFactory;
+use Utils\LQA\ICUSourceSegmentDetector;
 use Utils\Registry\AppConfig;
 use Utils\TaskRunner\Exceptions\EndQueueException;
 use Utils\TaskRunner\Exceptions\ReQueueException;
@@ -84,6 +86,12 @@ class ProjectManager
     protected IDatabase $dbHandler;
 
     protected MateCatFilter $filter;
+
+    /**
+     * Sibling of $filter carrying only the ICU-compliant handlers. Built on first use,
+     * because most projects never hit an ICU segment.
+     */
+    protected ?MateCatFilter $icuFilter = null;
 
     protected MetadataDao $filesMetadataDao;
 
@@ -417,7 +425,7 @@ class ProjectManager
     /**
      * Initialize a Google Drive session if a UID is present in the session data.
      * @throws Exception
-     * @throws \TypeError
+     * @throws TypeError
      */
     private function initGdriveSession(): void
     {
@@ -500,7 +508,7 @@ class ProjectManager
      *
      * @throws EndQueueException
      * @throws \DomainException
-     * @throws \TypeError
+     * @throws TypeError
      * @throws \Psr\Log\InvalidArgumentException
      */
     private function setPrivateTmKeysOrFail(string $firstTMXFileName): void
@@ -554,7 +562,7 @@ class ProjectManager
      *
      * @throws EndQueueException
      * @throws \Psr\Log\InvalidArgumentException
-     * @throws \TypeError
+     * @throws TypeError
      */
     private function handleZipFiles(array $linkFiles): void
     {
@@ -662,7 +670,7 @@ class ProjectManager
      * @param array<int, array<string, mixed>> $totalFilesStructure
      *
      * @throws Exception
-     * @throws \TypeError
+     * @throws TypeError
      */
     private function extractSegmentsFromFiles(array &$totalFilesStructure): void
     {
@@ -836,7 +844,7 @@ class ProjectManager
      * @param string $fileName
      *
      * @throws Exception
-     * @throws \TypeError
+     * @throws TypeError
      */
     public function getSingleS3QueueFile(string $fileName): void
     {
@@ -882,8 +890,64 @@ class ProjectManager
     }
 
     /**
+     * Layer 0 to Layer 1 for the fast-analysis payload.
+     *
+     * The payload written here is what every MT/TM call of the analysis eventually
+     * receives, so the handler set must be chosen the same way the editor chooses it
+     * when it renders the same segment: a source carrying valid complex ICU syntax is
+     * converted with the ICU-compliant handlers only, otherwise the project handlers
+     * would wrap ICU arguments in PH tags and the pattern would stop parsing as ICU.
+     *
+     * ICU presence is a property of the single segment, not of the project, hence the
+     * per-segment decision.
+     *
      * @throws Exception
-     * @throws \TypeError
+     * @throws TypeError
+     */
+    protected function subfilterForAnalysis(string $segment): string
+    {
+        return $this->analysisFilter($segment)->fromLayer0ToLayer1($segment);
+    }
+
+    /**
+     * @throws Exception
+     * @throws TypeError
+     */
+    private function analysisFilter(string $rawSource): MateCatFilter
+    {
+        $icuEnabled = (bool)($this->projectStructure->metadata[ProjectsMetadataMarshaller::ICU_ENABLED->value] ?? false);
+        if (!$icuEnabled) {
+            return $this->filter;
+        }
+
+        $containsIcu = ICUSourceSegmentDetector::sourceContainsIcu(
+            new MessagePatternValidator((string)$this->projectStructure->source_language, $rawSource),
+            true
+        );
+
+        if (!$containsIcu) {
+            return $this->filter;
+        }
+
+        if ($this->icuFilter === null) {
+            /** @var MateCatFilter $icuFilter */
+            $icuFilter = MateCatFilter::getInstance(
+                $this->features,
+                $this->projectStructure->source_language,
+                (string)json_encode($this->projectStructure->target_language),
+                [],
+                json_decode($this->projectStructure->subfiltering_handlers ?? 'null'),
+                true
+            );
+            $this->icuFilter = $icuFilter;
+        }
+
+        return $this->icuFilter;
+    }
+
+    /**
+     * @throws Exception
+     * @throws TypeError
      */
     private function writeFastAnalysisData(): void
     {
@@ -909,7 +973,7 @@ class ProjectManager
             $segmentElement['source'] = $this->projectStructure->source_language;
             $segmentElement['target'] = implode(",", $this->projectStructure->array_jobs['job_languages']);
             $segmentElement['payable_rates'] = $this->projectStructure->array_jobs['payable_rates'];
-            $segmentElement['segment'] = $this->filter->fromLayer0ToLayer1($segmentElement['segment']);
+            $segmentElement['segment'] = $this->subfilterForAnalysis($segmentElement['segment']);
         }
         unset($segmentElement); // break the reference to the last array element to avoid accidental overwrites
 
@@ -974,7 +1038,7 @@ class ProjectManager
      * @param array<string, mixed> $linkFiles
      *
      * @throws Exception
-     * @throws \TypeError
+     * @throws TypeError
      */
     protected function zipFileHandling(array $linkFiles): void
     {
@@ -1000,7 +1064,7 @@ class ProjectManager
     /**
      * @return list<JobStruct>
      * @throws Exception
-     * @throws \TypeError
+     * @throws TypeError
      */
     protected function createJobs(): array
     {
@@ -1016,7 +1080,7 @@ class ProjectManager
      *
      * @param list<JobStruct> $jobs
      * @throws Exception
-     * @throws \TypeError
+     * @throws TypeError
      */
     private function linkFilesAndInsertPreTranslations(array $jobs): void
     {
@@ -1035,7 +1099,7 @@ class ProjectManager
      * @param array<string, mixed> $file_info
      *
      * @throws Exception
-     * @throws \TypeError
+     * @throws TypeError
      */
     protected function extractSegments(int $fid, array $file_info): void
     {
@@ -1077,7 +1141,7 @@ class ProjectManager
     /**
      * Store segments for a file — delegates to SegmentStorageService.
      * @throws Exception
-     * @throws \TypeError
+     * @throws TypeError
      */
     protected function storeSegments(int $fid): void
     {

--- a/lib/Model/ProjectCreation/ProjectManager.php
+++ b/lib/Model/ProjectCreation/ProjectManager.php
@@ -3,6 +3,7 @@
 namespace Model\ProjectCreation;
 
 use Controller\API\Commons\Exceptions\AuthenticationError;
+use DomainException;
 use Exception;
 use Matecat\ICU\MessagePatternValidator;
 use Matecat\SubFiltering\MateCatFilter;
@@ -507,7 +508,7 @@ class ProjectManager
      * Validate and insert private TM keys. Aborts if validation errors occur.
      *
      * @throws EndQueueException
-     * @throws \DomainException
+     * @throws DomainException
      * @throws TypeError
      * @throws \Psr\Log\InvalidArgumentException
      */
@@ -898,37 +899,42 @@ class ProjectManager
      * converted with the ICU-compliant handlers only, otherwise the project handlers
      * would wrap ICU arguments in PH tags and the pattern would stop parsing as ICU.
      *
-     * ICU presence is a property of the single segment, not of the project, hence the
-     * per-segment decision.
-     *
      * @throws Exception
      * @throws TypeError
      */
-    protected function subfilterForAnalysis(string $segment): string
+    protected function subfilterForAnalysis(string $segment, bool $isIcuSource): string
     {
-        return $this->analysisFilter($segment)->fromLayer0ToLayer1($segment);
+        return ($isIcuSource ? $this->icuCompliantFilter() : $this->filter)->fromLayer0ToLayer1($segment);
+    }
+
+    /**
+     * Whether the raw source is an ICU message, by the same rule the editor applies:
+     * ICU is enabled on the project and the pattern carries valid complex syntax.
+     *
+     * ICU presence is a property of the single segment, not of the project, hence the
+     * per-segment decision.
+     *
+     * @throws DomainException
+     */
+    protected function sourceIsIcuMessage(string $rawSource): bool
+    {
+        $icuEnabled = (bool)($this->projectStructure->metadata[ProjectsMetadataMarshaller::ICU_ENABLED->value] ?? false);
+        if (!$icuEnabled) {
+            return false;
+        }
+
+        return ICUSourceSegmentDetector::sourceContainsIcu(
+            new MessagePatternValidator((string)$this->projectStructure->source_language, $rawSource),
+            true
+        );
     }
 
     /**
      * @throws Exception
      * @throws TypeError
      */
-    private function analysisFilter(string $rawSource): MateCatFilter
+    private function icuCompliantFilter(): MateCatFilter
     {
-        $icuEnabled = (bool)($this->projectStructure->metadata[ProjectsMetadataMarshaller::ICU_ENABLED->value] ?? false);
-        if (!$icuEnabled) {
-            return $this->filter;
-        }
-
-        $containsIcu = ICUSourceSegmentDetector::sourceContainsIcu(
-            new MessagePatternValidator((string)$this->projectStructure->source_language, $rawSource),
-            true
-        );
-
-        if (!$containsIcu) {
-            return $this->filter;
-        }
-
         if ($this->icuFilter === null) {
             /** @var MateCatFilter $icuFilter */
             $icuFilter = MateCatFilter::getInstance(
@@ -946,6 +952,42 @@ class ProjectManager
     }
 
     /**
+     * Fills in the per-segment fields of one fast-analysis row.
+     *
+     * `icu_source` records the decision taken here so the TM query can ship the same
+     * reduced handler list the text was built with: MyMemory decodes what we send and
+     * re-encodes the matches with the handlers it is given, and it has no ICU flag of
+     * its own, so the full project list would bring the arguments back wrapped in PH
+     * tags.
+     *
+     * @param array<string, mixed> $segmentElement
+     *
+     * @return array<string, mixed>
+     *
+     * @throws DomainException
+     * @throws Exception
+     * @throws TypeError
+     */
+    protected function decorateFastAnalysisSegment(array $segmentElement, string $job_id_passes): array
+    {
+        unset($segmentElement['internal_id']);
+        unset($segmentElement['xliff_mrk_id']);
+        unset($segmentElement['show_in_cattool']);
+
+        $isIcuSource = $this->sourceIsIcuMessage((string)$segmentElement['segment']);
+
+        $segmentElement['jsid'] = $segmentElement['id'] . "-" . $job_id_passes;
+        $segmentElement['source'] = $this->projectStructure->source_language;
+        $segmentElement['target'] = implode(",", $this->projectStructure->array_jobs['job_languages']);
+        $segmentElement['payable_rates'] = $this->projectStructure->array_jobs['payable_rates'];
+        $segmentElement['icu_source'] = $isIcuSource;
+        $segmentElement['segment'] = $this->subfilterForAnalysis((string)$segmentElement['segment'], $isIcuSource);
+
+        return $segmentElement;
+    }
+
+    /**
+     * @throws DomainException
      * @throws Exception
      * @throws TypeError
      */
@@ -965,15 +1007,7 @@ class ProjectManager
         );
 
         foreach ($this->projectStructure->segments_metadata as &$segmentElement) {
-            unset($segmentElement['internal_id']);
-            unset($segmentElement['xliff_mrk_id']);
-            unset($segmentElement['show_in_cattool']);
-
-            $segmentElement['jsid'] = $segmentElement['id'] . "-" . $job_id_passes;
-            $segmentElement['source'] = $this->projectStructure->source_language;
-            $segmentElement['target'] = implode(",", $this->projectStructure->array_jobs['job_languages']);
-            $segmentElement['payable_rates'] = $this->projectStructure->array_jobs['payable_rates'];
-            $segmentElement['segment'] = $this->subfilterForAnalysis($segmentElement['segment']);
+            $segmentElement = $this->decorateFastAnalysisSegment($segmentElement, $job_id_passes);
         }
         unset($segmentElement); // break the reference to the last array element to avoid accidental overwrites
 

--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysisWorker.php
@@ -34,6 +34,7 @@ use Utils\Engines\EnginesFactory;
 use Utils\Engines\MyMemory;
 use Utils\Registry\AppConfig;
 use Utils\TaskRunner\Commons\AbstractElement;
+use Utils\Subfiltering\IcuCompliantHandlers;
 use Utils\TaskRunner\Commons\AbstractWorker;
 use Utils\TaskRunner\Commons\QueueElement;
 use Utils\TaskRunner\Exceptions\EmptyElementException;
@@ -413,9 +414,19 @@ class TMAnalysisWorker extends AbstractWorker
         $_config['additional_params'] = $params->additional_params ?? null;
         $_config['priority_key'] = $params->tm_prioritization ?? null;
         $_config['job_id'] = $params->id_job ?? null;
-        $_config[JobsMetadataMarshaller::SUBFILTERING_HANDLERS->value] = isset($params->subfiltering_handlers)
+        $subfilteringHandlers = isset($params->subfiltering_handlers)
             ? $params->subfiltering_handlers->toArray()
             : null;
+
+        // The payload text of an ICU segment was built with the ICU-compliant handlers only
+        // (see ProjectManager::decorateFastAnalysisSegment). MyMemory re-encodes the matches
+        // with the handlers this list names and knows nothing about ICU, so the full project
+        // list would hand the matches back with the ICU arguments wrapped in PH tags.
+        if (!empty($params->icu_source)) {
+            $subfilteringHandlers = IcuCompliantHandlers::reduceToIcuCompliant($subfilteringHandlers);
+        }
+
+        $_config[JobsMetadataMarshaller::SUBFILTERING_HANDLERS->value] = $subfilteringHandlers;
 
         if ($params->dialect_strict ?? false) {
             $_config['dialect_strict'] = $params->dialect_strict;

--- a/lib/Utils/Subfiltering/IcuCompliantHandlers.php
+++ b/lib/Utils/Subfiltering/IcuCompliantHandlers.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Utils\Subfiltering;
+
+use Matecat\SubFiltering\Enum\InjectableFiltersTags;
+use Matecat\SubFiltering\HandlersSorter;
+
+/**
+ * Reduces a subfiltering handler list to the handlers that leave ICU syntax intact.
+ *
+ * MateCat builds the Layer 1 text of an ICU segment with the ICU-compliant handlers only,
+ * but the list that travels to MyMemory next to that text carries no ICU flag: MyMemory
+ * decodes what it receives, queries its index and re-encodes the matches with whatever
+ * handlers it was given. Handed the full project list it would bring the matches back with
+ * the ICU arguments wrapped in PH tags, so the list itself has to be reduced before it
+ * leaves.
+ *
+ * Both sentinel values of that field are preserved: `null` asks for no handlers at all,
+ * an empty array asks for the default set.
+ */
+class IcuCompliantHandlers
+{
+    /**
+     * @param array<int|string, mixed>|null $tagNames Handler tag names as they travel on the wire.
+     *
+     * @return array<int, string>|null The reduced list, or null when no handler survives.
+     */
+    public static function reduceToIcuCompliant(?array $tagNames): ?array
+    {
+        if ($tagNames === null) {
+            // No handlers are loaded on either side, so there is nothing to keep in step.
+            return null;
+        }
+
+        $classNames = InjectableFiltersTags::classesForArrayTagNames(
+            array_values(array_filter($tagNames, 'is_string'))
+        );
+
+        if (empty($classNames)) {
+            // Same fallback AbstractFilter::getInstance() applies to a list that maps to
+            // nothing: the default set. Reducing it here is what keeps the two sides equal.
+            $classNames = array_keys(HandlersSorter::getDefaultInjectedHandlers());
+        }
+
+        // The literal is HandlersSorter's $icu_enabled, and it is the reduction itself: with
+        // false the sorter hands back the same list, so this method would return its own input.
+        // Whether a segment needs the reduction is the caller's question, answered against a
+        // flag that may be missing, false or true; by the time we are here it is settled.
+        $reduced = InjectableFiltersTags::tagNamesForArrayClasses(
+            (new HandlersSorter($classNames, true))->getOrderedHandlersClassNames()
+        );
+
+        // An empty array would be read as "load the defaults", which is the opposite of
+        // what an empty reduction means, so it has to travel as null instead.
+        return empty($reduced) ? null : $reduced;
+    }
+}

--- a/lib/Utils/Subfiltering/IcuCompliantHandlers.php
+++ b/lib/Utils/Subfiltering/IcuCompliantHandlers.php
@@ -23,7 +23,7 @@ class IcuCompliantHandlers
     /**
      * @param array<int|string, mixed>|null $tagNames Handler tag names as they travel on the wire.
      *
-     * @return array<int, string>|null The reduced list, or null when no handler survives.
+     * @return list<string>|null The reduced list, or null when no handler survives.
      */
     public static function reduceToIcuCompliant(?array $tagNames): ?array
     {
@@ -40,8 +40,12 @@ class IcuCompliantHandlers
         // resolveClassNames() is the same entry point AbstractFilter::getInstance() resolves
         // its own handlers through, down to the fallback to the default set for a list that
         // maps to nothing. Going through it is what keeps the two sides equal.
-        $reduced = InjectableFiltersTags::tagNamesForArrayClasses(
-            HandlersSorter::resolveClassNames(array_values(array_filter($tagNames, 'is_string')), true)
+        // array_values() because the list travels as JSON: the library documents the mapping as an
+        // array of tag names, and only a sequential one encodes as a JSON array.
+        $reduced = array_values(
+            InjectableFiltersTags::tagNamesForArrayClasses(
+                HandlersSorter::resolveClassNames(array_values(array_filter($tagNames, 'is_string')), true)
+            )
         );
 
         // An empty array would be read as "load the defaults", which is the opposite of

--- a/lib/Utils/Subfiltering/IcuCompliantHandlers.php
+++ b/lib/Utils/Subfiltering/IcuCompliantHandlers.php
@@ -32,22 +32,16 @@ class IcuCompliantHandlers
             return null;
         }
 
-        $classNames = InjectableFiltersTags::classesForArrayTagNames(
-            array_values(array_filter($tagNames, 'is_string'))
-        );
-
-        if (empty($classNames)) {
-            // Same fallback AbstractFilter::getInstance() applies to a list that maps to
-            // nothing: the default set. Reducing it here is what keeps the two sides equal.
-            $classNames = array_keys(HandlersSorter::getDefaultInjectedHandlers());
-        }
-
         // The literal is HandlersSorter's $icu_enabled, and it is the reduction itself: with
         // false the sorter hands back the same list, so this method would return its own input.
         // Whether a segment needs the reduction is the caller's question, answered against a
         // flag that may be missing, false or true; by the time we are here it is settled.
+        //
+        // resolveClassNames() is the same entry point AbstractFilter::getInstance() resolves
+        // its own handlers through, down to the fallback to the default set for a list that
+        // maps to nothing. Going through it is what keeps the two sides equal.
         $reduced = InjectableFiltersTags::tagNamesForArrayClasses(
-            (new HandlersSorter($classNames, true))->getOrderedHandlersClassNames()
+            HandlersSorter::resolveClassNames(array_values(array_filter($tagNames, 'is_string')), true)
         );
 
         // An empty array would be read as "load the defaults", which is the opposite of

--- a/tests/unit/Core/Controllers/GetContributionControllerTest.php
+++ b/tests/unit/Core/Controllers/GetContributionControllerTest.php
@@ -15,6 +15,11 @@ use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
 use Utils\Constants\SourcePages;
 use Utils\Contribution\GetContributionRequest;
+use Matecat\SubFiltering\Enum\InjectableFiltersTags;
+use Matecat\SubFiltering\MateCatFilter;
+use Model\Jobs\JobStruct;
+use Model\Segments\SegmentStruct;
+use Model\Jobs\MetadataDao;
 
 class TestableGetContributionController extends GetContributionController
 {
@@ -507,6 +512,12 @@ class GetContributionControllerTest extends AbstractTest
         $this->assertSame('test-client-1', $testable->capturedRequest->id_client);
         $this->assertTrue($testable->capturedRequest->concordanceSearch);
         $this->assertSame(10, $testable->capturedRequest->resultNum);
+        // No stored segment is read on this branch, so no source can be inspected and the
+        // project handlers must reach the TM exactly as the job declares them.
+        $this->assertSame(
+            (new MetadataDao(obtainTestDatabase()))->getSubfilteringCustomHandlers(1886428338, 'a90acf203402'),
+            $testable->capturedRequest->subfiltering_handlers
+        );
     }
 
     #[Test]
@@ -571,5 +582,225 @@ class GetContributionControllerTest extends AbstractTest
         $this->assertNotEmpty($testable->capturedRequest->context_list_before);
         $this->assertNotEmpty($testable->capturedRequest->context_list_after);
         $this->assertInstanceOf(GetContributionRequest::class, $testable->capturedRequest);
+        // The stored source of this segment carries no complex ICU, so the reduction must not
+        // fire: the job handlers travel untouched.
+        $this->assertSame(
+            (new MetadataDao(obtainTestDatabase()))->getSubfilteringCustomHandlers(1886428338, 'a90acf203402'),
+            $testable->capturedRequest->subfiltering_handlers
+        );
     }
+
+    // ──────────────────────────────────────────────────────────────────
+    // ICU: the stored source decides the handler set, and the TM is told
+    // ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Complex ICU plural block plus a simple argument. The simple argument is the
+     * discriminating part: the single-curly handler cannot match the plural block but it
+     * does match {SEARCH_TERM}.
+     */
+    private const ICU_SEGMENT = 'You have {NUM_RESULTS, plural, one {1 result} other {# results}} for "{SEARCH_TERM}".';
+
+    private function segmentsList(?string $segment, ?string $before = null, ?string $after = null): object
+    {
+        $wrap = static function (?string $text): ?SegmentStruct {
+            if ($text === null) {
+                return null;
+            }
+            $struct = new SegmentStruct();
+            $struct->segment = $text;
+
+            return $struct;
+        };
+
+        return (object)[
+            'id_before' => $wrap($before),
+            'id_segment' => $wrap($segment),
+            'id_after' => $wrap($after),
+        ];
+    }
+
+    private function chunk(): JobStruct
+    {
+        $chunk = new JobStruct();
+        $chunk->source = 'en-US';
+        $chunk->target = 'it-IT';
+
+        return $chunk;
+    }
+
+    #[Test]
+    public function segmentSourceContainsIcu_true_for_a_valid_complex_pattern(): void
+    {
+        $result = $this->invokeMethod('segmentSourceContainsIcu', [
+            true, $this->chunk(), $this->segmentsList(self::ICU_SEGMENT)
+        ]);
+
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function segmentSourceContainsIcu_false_for_a_bare_placeholder(): void
+    {
+        $result = $this->invokeMethod('segmentSourceContainsIcu', [
+            true, $this->chunk(), $this->segmentsList('Hello {NAME}, welcome.')
+        ]);
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function segmentSourceContainsIcu_false_when_the_project_flag_is_off(): void
+    {
+        $result = $this->invokeMethod('segmentSourceContainsIcu', [
+            false, $this->chunk(), $this->segmentsList(self::ICU_SEGMENT)
+        ]);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * A concordance search reaches the dispatch with no stored segment behind it.
+     */
+    #[Test]
+    public function segmentSourceContainsIcu_false_without_a_stored_segment(): void
+    {
+        $result = $this->invokeMethod('segmentSourceContainsIcu', [
+            true, $this->chunk(), $this->segmentsList(null)
+        ]);
+
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    public function contributionHandlers_reduces_the_wire_list_for_an_icu_segment(): void
+    {
+        $handlers = [
+            InjectableFiltersTags::single_curly->value,
+            InjectableFiltersTags::markup->value,
+            InjectableFiltersTags::sprintf->value,
+        ];
+
+        $result = $this->invokeMethod('contributionHandlers', [$handlers, true]);
+
+        $this->assertSame([InjectableFiltersTags::markup->value], $result);
+    }
+
+    /**
+     * An empty reduction has to travel as null: an empty array is read as a request for the
+     * default handlers, which is the opposite of keeping none.
+     */
+    #[Test]
+    public function contributionHandlers_sends_null_when_no_handler_survives(): void
+    {
+        $result = $this->invokeMethod('contributionHandlers', [[InjectableFiltersTags::single_curly->value], true]);
+
+        $this->assertNull($result);
+    }
+
+    #[Test]
+    public function contributionHandlers_keeps_the_project_list_for_a_plain_segment(): void
+    {
+        $handlers = [InjectableFiltersTags::single_curly->value, InjectableFiltersTags::markup->value];
+
+        $result = $this->invokeMethod('contributionHandlers', [$handlers, false]);
+
+        $this->assertSame($handlers, $result);
+    }
+
+    #[Test]
+    public function contributionHandlers_passes_the_no_handlers_sentinel_through(): void
+    {
+        $this->assertNull($this->invokeMethod('contributionHandlers', [null, false]));
+        $this->assertNull($this->invokeMethod('contributionHandlers', [null, true]));
+    }
+
+    #[Test]
+    public function subfilterContributionContexts_keeps_icu_when_the_filter_is_icu_compliant(): void
+    {
+        $request = ['text' => 'client sent this'];
+        $filter = $this->filter(true);
+
+        $this->invokeMethodByReference('subfilterContributionContexts', $request, [
+            $filter, $this->segmentsList(self::ICU_SEGMENT, 'Before {TOKEN}', 'After')
+        ]);
+
+        $this->assertSame(self::ICU_SEGMENT, $request['text']);
+        $this->assertStringNotContainsString('<ph ', $request['text']);
+        // The contexts travel with the same reduced handler set, or the TM would decode them
+        // with a list it was never given.
+        $this->assertStringContainsString('{TOKEN}', $request['context_before']);
+    }
+
+    #[Test]
+    public function subfilterContributionContexts_wraps_placeholders_for_a_plain_segment(): void
+    {
+        $request = ['text' => 'client sent this'];
+        $filter = $this->filter(false);
+
+        $this->invokeMethodByReference('subfilterContributionContexts', $request, [
+            $filter, $this->segmentsList('Hello {NAME}, welcome.')
+        ]);
+
+        $this->assertStringContainsString('ctype="x-curly-brackets"', $request['text']);
+        $this->assertStringNotContainsString('{NAME}', $request['text']);
+    }
+
+    /**
+     * The invariant the whole wiring exists for: the list the TM is told must be the list the
+     * text was actually built with. MyMemory decodes what it receives with the handlers it is
+     * given and re-encodes its matches with them, so any drift between the two comes back as
+     * ICU arguments wrapped in PH tags, and the Layer 1 to Layer 2 transition has no PH restore
+     * to undo it. Reading the set back off the filter is what makes the two comparable.
+     */
+    #[Test]
+    public function theWireListIsTheSetTheFilterActuallyResolved(): void
+    {
+        $handlers = [
+            InjectableFiltersTags::single_curly->value,
+            InjectableFiltersTags::markup->value,
+            InjectableFiltersTags::sprintf->value,
+        ];
+
+        foreach ([true, false] as $sourceContainsIcu) {
+            $filter = $this->filter($sourceContainsIcu);
+            $wire = $this->invokeMethod('contributionHandlers', [$handlers, $sourceContainsIcu]);
+
+            $this->assertEqualsCanonicalizing(
+                $filter->getOrderedHandlerTagNames(),
+                $wire ?? [],
+                sprintf('handler set drifted from the filter (icu: %s)', var_export($sourceContainsIcu, true))
+            );
+        }
+    }
+
+    private function filter(bool $icuEnabled): MateCatFilter
+    {
+        /** @var MateCatFilter $filter */
+        $filter = MateCatFilter::getInstance(
+            null,
+            'en-US',
+            (string)json_encode(['it-IT']),
+            [],
+            [
+                InjectableFiltersTags::single_curly->value,
+                InjectableFiltersTags::markup->value,
+                InjectableFiltersTags::sprintf->value,
+            ],
+            $icuEnabled
+        );
+
+        return $filter;
+    }
+
+    /**
+     * @param array<string, mixed> $request
+     * @param array<int, mixed> $args
+     */
+    private function invokeMethodByReference(string $name, array &$request, array $args): void
+    {
+        $method = $this->reflector->getMethod($name);
+        $method->invokeArgs($this->controller, [&$request, ...$args]);
+    }
+
 }

--- a/tests/unit/Core/Model/ProjectCreation/FastAnalysisIcuSubfilteringTest.php
+++ b/tests/unit/Core/Model/ProjectCreation/FastAnalysisIcuSubfilteringTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Matecat\Core\Model\ProjectCreation;
+
+use Matecat\SubFiltering\Enum\InjectableFiltersTags;
+use Matecat\SubFiltering\MateCatFilter;
+use Matecat\TestHelpers\AbstractTest;
+use Model\FeaturesBase\FeatureSet;
+use Model\Files\MetadataDao;
+use Model\Projects\ProjectsMetadataMarshaller;
+use PHPUnit\Framework\Attributes\Test;
+use Utils\Logger\MatecatLogger;
+
+/**
+ * The fast-analysis payload is the Layer 1 text every MT/TM call in the analysis
+ * eventually sees: ProjectManager converts it once at creation time and persists it,
+ * FastAnalysis reads it back and TMAnalysisWorker forwards it to the engines.
+ *
+ * A source segment carrying valid complex ICU syntax must therefore be converted with
+ * the ICU-compliant handler set only, exactly as the editor does when it renders the
+ * same segment. Segments without complex ICU keep the project handlers, so a bare
+ * {placeholder} is still wrapped in a PH tag.
+ */
+class FastAnalysisIcuSubfilteringTest extends AbstractTest
+{
+    private const SOURCE_LANG = 'en-US';
+
+    /**
+     * Complex ICU plural block plus a simple argument. The simple argument is the
+     * discriminating part: the single-curly handler cannot match the plural block
+     * (its regex rejects spaces and nesting) but it does match {SEARCH_TERM}.
+     */
+    private const ICU_SEGMENT = 'You have {NUM_RESULTS, plural, one {1 result} other {# results}} for "{SEARCH_TERM}".';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string> $handlers
+     */
+    private function projectManager(bool $icuEnabled, array $handlers): TestableProjectManager
+    {
+        $filter = MateCatFilter::getInstance(
+            null,
+            self::SOURCE_LANG,
+            (string)json_encode(['it-IT']),
+            [],
+            $handlers
+        );
+
+        $pm = new TestableProjectManager();
+        $pm->initForTest(
+            $filter,
+            $this->createStub(FeatureSet::class),
+            $this->createStub(MetadataDao::class),
+            $this->createStub(MatecatLogger::class)
+        );
+
+        $pm->setProjectStructureValue('source_language', self::SOURCE_LANG);
+        $pm->setProjectStructureValue('target_language', ['it-IT']);
+        $pm->setProjectStructureValue('subfiltering_handlers', (string)json_encode($handlers));
+        $pm->setProjectStructureValue('metadata', [
+            ProjectsMetadataMarshaller::ICU_ENABLED->value => $icuEnabled,
+        ]);
+
+        return $pm;
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function handlersWithSingleCurly(): array
+    {
+        return [
+            InjectableFiltersTags::single_curly->value,
+            InjectableFiltersTags::markup->value,
+            InjectableFiltersTags::sprintf->value,
+        ];
+    }
+
+    #[Test]
+    public function complexIcuSourceIsNotSubfilteredWithNonIcuCompliantHandlers(): void
+    {
+        $pm = $this->projectManager(true, $this->handlersWithSingleCurly());
+
+        $layer1 = $pm->callSubfilterForAnalysis(self::ICU_SEGMENT);
+
+        $this->assertSame(
+            self::ICU_SEGMENT,
+            $layer1,
+            'A valid complex ICU source must reach the engines as ICU, not as PH tags'
+        );
+        $this->assertStringNotContainsString('<ph ', $layer1);
+    }
+
+    #[Test]
+    public function simpleCurlyWithoutComplexIcuIsStillWrappedInPh(): void
+    {
+        $pm = $this->projectManager(true, $this->handlersWithSingleCurly());
+
+        $layer1 = $pm->callSubfilterForAnalysis('Hello {NAME}, welcome.');
+
+        $this->assertStringContainsString('<ph ', $layer1);
+        $this->assertStringContainsString('ctype="x-curly-brackets"', $layer1);
+        $this->assertStringNotContainsString('{NAME}', $layer1);
+    }
+
+    #[Test]
+    public function icuDisabledLeavesTheProjectHandlersInPlace(): void
+    {
+        $pm = $this->projectManager(false, $this->handlersWithSingleCurly());
+
+        $layer1 = $pm->callSubfilterForAnalysis(self::ICU_SEGMENT);
+
+        // The plural block is skipped by the handler regex, the simple argument is not.
+        $this->assertStringContainsString('{NUM_RESULTS, plural,', $layer1);
+        $this->assertStringContainsString('ctype="x-curly-brackets"', $layer1);
+        $this->assertStringNotContainsString('{SEARCH_TERM}', $layer1);
+    }
+
+    #[Test]
+    public function invalidComplexIcuFallsBackToTheProjectHandlers(): void
+    {
+        $pm = $this->projectManager(true, $this->handlersWithSingleCurly());
+
+        // Unbalanced braces: complex syntax is present but the pattern does not parse,
+        // so it is not an ICU segment and must keep the ordinary project handlers.
+        $layer1 = $pm->callSubfilterForAnalysis('Broken {NUM, plural, one {x} for "{TOKEN}".');
+
+        $this->assertStringContainsString('ctype="x-curly-brackets"', $layer1);
+        $this->assertStringNotContainsString('{TOKEN}', $layer1);
+    }
+
+    #[Test]
+    public function withoutSingleCurlyTheIcuSegmentIsUntouchedEitherWay(): void
+    {
+        $handlers = [InjectableFiltersTags::markup->value, InjectableFiltersTags::sprintf->value];
+
+        $icuOn = $this->projectManager(true, $handlers)->callSubfilterForAnalysis(self::ICU_SEGMENT);
+        $icuOff = $this->projectManager(false, $handlers)->callSubfilterForAnalysis(self::ICU_SEGMENT);
+
+        $this->assertSame(self::ICU_SEGMENT, $icuOn);
+        $this->assertSame($icuOn, $icuOff);
+    }
+}

--- a/tests/unit/Core/Model/ProjectCreation/FastAnalysisIcuSubfilteringTest.php
+++ b/tests/unit/Core/Model/ProjectCreation/FastAnalysisIcuSubfilteringTest.php
@@ -20,6 +20,9 @@ use Utils\Logger\MatecatLogger;
  * the ICU-compliant handler set only, exactly as the editor does when it renders the
  * same segment. Segments without complex ICU keep the project handlers, so a bare
  * {placeholder} is still wrapped in a PH tag.
+ *
+ * The row also carries the decision as `icu_source`, because the TM query has to ship
+ * the same handler list the text was built with.
  */
 class FastAnalysisIcuSubfilteringTest extends AbstractTest
 {
@@ -69,8 +72,21 @@ class FastAnalysisIcuSubfilteringTest extends AbstractTest
         $pm->setProjectStructureValue('metadata', [
             ProjectsMetadataMarshaller::ICU_ENABLED->value => $icuEnabled,
         ]);
+        $pm->setProjectStructureValue('array_jobs', [
+            'job_languages' => ['80415:it-IT'],
+            'payable_rates' => ['80415' => '{"NEW":100}'],
+        ]);
 
         return $pm;
+    }
+
+    /**
+     * Detection and conversion always travel together in the payload loop, so the tests
+     * exercise the same pair.
+     */
+    private function layer1(TestableProjectManager $pm, string $segment): string
+    {
+        return $pm->callSubfilterForAnalysis($segment, $pm->callSourceIsIcuMessage($segment));
     }
 
     /**
@@ -90,7 +106,7 @@ class FastAnalysisIcuSubfilteringTest extends AbstractTest
     {
         $pm = $this->projectManager(true, $this->handlersWithSingleCurly());
 
-        $layer1 = $pm->callSubfilterForAnalysis(self::ICU_SEGMENT);
+        $layer1 = $this->layer1($pm, self::ICU_SEGMENT);
 
         $this->assertSame(
             self::ICU_SEGMENT,
@@ -105,7 +121,7 @@ class FastAnalysisIcuSubfilteringTest extends AbstractTest
     {
         $pm = $this->projectManager(true, $this->handlersWithSingleCurly());
 
-        $layer1 = $pm->callSubfilterForAnalysis('Hello {NAME}, welcome.');
+        $layer1 = $this->layer1($pm, 'Hello {NAME}, welcome.');
 
         $this->assertStringContainsString('<ph ', $layer1);
         $this->assertStringContainsString('ctype="x-curly-brackets"', $layer1);
@@ -117,7 +133,7 @@ class FastAnalysisIcuSubfilteringTest extends AbstractTest
     {
         $pm = $this->projectManager(false, $this->handlersWithSingleCurly());
 
-        $layer1 = $pm->callSubfilterForAnalysis(self::ICU_SEGMENT);
+        $layer1 = $this->layer1($pm, self::ICU_SEGMENT);
 
         // The plural block is skipped by the handler regex, the simple argument is not.
         $this->assertStringContainsString('{NUM_RESULTS, plural,', $layer1);
@@ -132,7 +148,7 @@ class FastAnalysisIcuSubfilteringTest extends AbstractTest
 
         // Unbalanced braces: complex syntax is present but the pattern does not parse,
         // so it is not an ICU segment and must keep the ordinary project handlers.
-        $layer1 = $pm->callSubfilterForAnalysis('Broken {NUM, plural, one {x} for "{TOKEN}".');
+        $layer1 = $this->layer1($pm, 'Broken {NUM, plural, one {x} for "{TOKEN}".');
 
         $this->assertStringContainsString('ctype="x-curly-brackets"', $layer1);
         $this->assertStringNotContainsString('{TOKEN}', $layer1);
@@ -143,10 +159,58 @@ class FastAnalysisIcuSubfilteringTest extends AbstractTest
     {
         $handlers = [InjectableFiltersTags::markup->value, InjectableFiltersTags::sprintf->value];
 
-        $icuOn = $this->projectManager(true, $handlers)->callSubfilterForAnalysis(self::ICU_SEGMENT);
-        $icuOff = $this->projectManager(false, $handlers)->callSubfilterForAnalysis(self::ICU_SEGMENT);
+        $icuOn = $this->layer1($this->projectManager(true, $handlers), self::ICU_SEGMENT);
+        $icuOff = $this->layer1($this->projectManager(false, $handlers), self::ICU_SEGMENT);
 
         $this->assertSame(self::ICU_SEGMENT, $icuOn);
         $this->assertSame($icuOn, $icuOff);
+    }
+
+    #[Test]
+    public function theIcuDecisionIsCarriedByThePayloadRow(): void
+    {
+        $pm = $this->projectManager(true, $this->handlersWithSingleCurly());
+
+        $row = $pm->callDecorateFastAnalysisSegment(
+            [
+                'id' => 4711,
+                'segment' => self::ICU_SEGMENT,
+                'segment_hash' => 'abc',
+                'raw_word_count' => 9,
+                'internal_id' => 'u1',
+                'xliff_mrk_id' => null,
+                'show_in_cattool' => 1,
+            ],
+            '4711:7acfb82b8168'
+        );
+
+        $this->assertTrue($row['icu_source'], 'The row must tell the worker which handler set built the text');
+        $this->assertSame(self::ICU_SEGMENT, $row['segment']);
+        $this->assertSame('4711-4711:7acfb82b8168', $row['jsid']);
+        $this->assertSame(self::SOURCE_LANG, $row['source']);
+        $this->assertSame('80415:it-IT', $row['target']);
+        // Fields the payload must not carry any more.
+        $this->assertArrayNotHasKey('internal_id', $row);
+        $this->assertArrayNotHasKey('xliff_mrk_id', $row);
+        $this->assertArrayNotHasKey('show_in_cattool', $row);
+    }
+
+    #[Test]
+    public function aNonIcuRowIsFlaggedFalseAndKeepsThePhTags(): void
+    {
+        $pm = $this->projectManager(true, $this->handlersWithSingleCurly());
+
+        $row = $pm->callDecorateFastAnalysisSegment(
+            [
+                'id' => 12,
+                'segment' => 'Hello {NAME}, welcome.',
+                'segment_hash' => 'def',
+                'raw_word_count' => 3,
+            ],
+            '12:7acfb82b8168'
+        );
+
+        $this->assertFalse($row['icu_source']);
+        $this->assertStringContainsString('ctype="x-curly-brackets"', $row['segment']);
     }
 }

--- a/tests/unit/Core/Model/ProjectCreation/TestableProjectManager.php
+++ b/tests/unit/Core/Model/ProjectCreation/TestableProjectManager.php
@@ -3,6 +3,7 @@
 namespace Matecat\Core\Model\ProjectCreation;
 
 use Controller\API\Commons\Exceptions\AuthenticationError;
+use DomainException;
 use Exception;
 use Matecat\SubFiltering\MateCatFilter;
 use Model\Exceptions\NotFoundException;
@@ -137,9 +138,34 @@ class TestableProjectManager extends ProjectManager
      *
      * @throws Exception
      */
-    public function callSubfilterForAnalysis(string $segment): string
+    public function callSubfilterForAnalysis(string $segment, bool $isIcuSource): string
     {
-        return $this->subfilterForAnalysis($segment);
+        return $this->subfilterForAnalysis($segment, $isIcuSource);
+    }
+
+    /**
+     * Expose the per-segment ICU detection.
+     *
+     * @throws DomainException
+     */
+    public function callSourceIsIcuMessage(string $rawSource): bool
+    {
+        return $this->sourceIsIcuMessage($rawSource);
+    }
+
+    /**
+     * Expose the assembly of one fast-analysis payload row.
+     *
+     * @param array<string, mixed> $segmentElement
+     *
+     * @return array<string, mixed>
+     *
+     * @throws DomainException
+     * @throws Exception
+     */
+    public function callDecorateFastAnalysisSegment(array $segmentElement, string $job_id_passes): array
+    {
+        return $this->decorateFastAnalysisSegment($segmentElement, $job_id_passes);
     }
 
     /**

--- a/tests/unit/Core/Model/ProjectCreation/TestableProjectManager.php
+++ b/tests/unit/Core/Model/ProjectCreation/TestableProjectManager.php
@@ -133,6 +133,16 @@ class TestableProjectManager extends ProjectManager
     }
 
     /**
+     * Expose the per-segment fast-analysis subfiltering.
+     *
+     * @throws Exception
+     */
+    public function callSubfilterForAnalysis(string $segment): string
+    {
+        return $this->subfilterForAnalysis($segment);
+    }
+
+    /**
      * Set a specific key in the projectStructure for testing.
      */
     public function setProjectStructureValue(string $key, mixed $value): void

--- a/tests/unit/Core/Utils/IcuCompliantHandlersTest.php
+++ b/tests/unit/Core/Utils/IcuCompliantHandlersTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Matecat\Core\Utils;
+
+use Matecat\SubFiltering\Enum\InjectableFiltersTags;
+use Matecat\TestHelpers\AbstractTest;
+use PHPUnit\Framework\Attributes\Test;
+use Utils\Subfiltering\IcuCompliantHandlers;
+
+/**
+ * The handler list travels to MyMemory next to the Layer 1 text: MyMemory decodes what it
+ * receives, queries its index and re-encodes the matches with the handlers it was given.
+ * It has no ICU flag of its own, so for an ICU segment MateCat must send the list already
+ * reduced to the ICU-compliant handlers — the same set that produced the text.
+ *
+ * The two sentinel values of that wire field drive the whole reduction: `null` means "load
+ * no handlers", an empty array means "load your defaults".
+ */
+class IcuCompliantHandlersTest extends AbstractTest
+{
+    #[Test]
+    public function nullIsLeftAloneBecauseNoHandlersAreLoadedOnEitherSide(): void
+    {
+        $this->assertNull(IcuCompliantHandlers::reduceToIcuCompliant(null));
+    }
+
+    #[Test]
+    public function theDefaultSetIsSentExplicitlyInsteadOfAsAnEmptyArray(): void
+    {
+        // An empty array would make MyMemory reload its full default set, four members of
+        // which are not ICU-compliant.
+        $this->assertSame(
+            [InjectableFiltersTags::markup->value],
+            IcuCompliantHandlers::reduceToIcuCompliant([])
+        );
+    }
+
+    #[Test]
+    public function nonCompliantHandlersAreDroppedFromAnExplicitList(): void
+    {
+        $reduced = IcuCompliantHandlers::reduceToIcuCompliant([
+            InjectableFiltersTags::single_curly->value,
+            InjectableFiltersTags::markup->value,
+            InjectableFiltersTags::sprintf->value,
+        ]);
+
+        $this->assertSame([InjectableFiltersTags::markup->value], $reduced);
+    }
+
+    #[Test]
+    public function aListThatReducesToNothingBecomesNullNotAnEmptyArray(): void
+    {
+        // `[]` on the wire means "defaults", so an empty result must be expressed as null
+        // or MyMemory would load every default handler back.
+        $this->assertNull(IcuCompliantHandlers::reduceToIcuCompliant([
+            InjectableFiltersTags::single_curly->value,
+            InjectableFiltersTags::twig->value,
+        ]));
+    }
+
+    #[Test]
+    public function anAlreadyCompliantListIsUnchanged(): void
+    {
+        $this->assertSame(
+            [InjectableFiltersTags::markup->value],
+            IcuCompliantHandlers::reduceToIcuCompliant([InjectableFiltersTags::markup->value])
+        );
+    }
+
+    #[Test]
+    public function unknownTagNamesResolveTheSameWayTheFilterResolvesThem(): void
+    {
+        // AbstractFilter::getInstance() maps tag names to handler classes and falls back to
+        // the default set when nothing maps, so MyMemory would do the same with this list.
+        // The reduction has to mirror that, not invent a stricter rule.
+        $this->assertSame(
+            [InjectableFiltersTags::markup->value],
+            IcuCompliantHandlers::reduceToIcuCompliant(['not_a_handler'])
+        );
+    }
+}

--- a/tests/unit/Core/Workers/TMAnalysisV2/TMAnalysisWorkerIntegrationTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/TMAnalysisWorkerIntegrationTest.php
@@ -4,6 +4,8 @@ namespace Matecat\Core\Workers\TMAnalysisV2;
 
 use Matecat\TestHelpers\AbstractTest;
 use Model\Analysis\Constants\InternalMatchesConstants;
+use Matecat\SubFiltering\Enum\InjectableFiltersTags;
+use Model\Jobs\JobsMetadataMarshaller;
 use Model\DataAccess\Database;
 use Model\MTQE\Templates\DTO\MTQEWorkflowParams;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -904,5 +906,144 @@ class TMAnalysisWorkerIntegrationTest extends AbstractTest
         $this->assertTrue($config['onlyprivate']);
         // only_private + no id_user + !get_mt → id_tms = 0
         $this->assertEquals(0, $config['id_tms']);
+    }
+    // ── ICU handler-list reduction ──────────────────────────────────────
+
+    #[Test]
+    public function buildEngineConfig_reduces_the_handler_list_for_an_icu_segment(): void
+    {
+        $this->ensureFakeEnginesExist();
+
+        $worker = new class($this->createStub(AMQHandler::class), obtainTestDatabase()) extends TMAnalysisWorker {
+            /**
+             * @return array<string, mixed>
+             * @throws Exception
+             */
+            public function exposedBuildEngineConfig(QueueElement $queueElement): array
+            {
+                return $this->buildEngineConfig($queueElement);
+            }
+        };
+
+        $element = $this->makeQueueElement([
+            'id_tms' => 900,
+            'id_mt_engine' => 901,
+            'tm_keys' => '[]',
+            'icu_source' => true,
+            'subfiltering_handlers' => new Params([
+                InjectableFiltersTags::single_curly->value,
+                InjectableFiltersTags::markup->value,
+                InjectableFiltersTags::sprintf->value,
+            ]),
+        ]);
+
+        $config = $worker->exposedBuildEngineConfig($element);
+
+        // MyMemory re-encodes the matches with the handlers it is given and has no ICU flag,
+        // so only the ICU-compliant ones may travel with an ICU segment.
+        $this->assertSame(
+            [InjectableFiltersTags::markup->value],
+            $config[JobsMetadataMarshaller::SUBFILTERING_HANDLERS->value]
+        );
+    }
+
+    #[Test]
+    public function buildEngineConfig_keeps_the_full_handler_list_for_a_non_icu_segment(): void
+    {
+        $this->ensureFakeEnginesExist();
+
+        $worker = new class($this->createStub(AMQHandler::class), obtainTestDatabase()) extends TMAnalysisWorker {
+            /**
+             * @return array<string, mixed>
+             * @throws Exception
+             */
+            public function exposedBuildEngineConfig(QueueElement $queueElement): array
+            {
+                return $this->buildEngineConfig($queueElement);
+            }
+        };
+
+        $handlers = [
+            InjectableFiltersTags::single_curly->value,
+            InjectableFiltersTags::markup->value,
+        ];
+
+        $element = $this->makeQueueElement([
+            'id_tms' => 900,
+            'id_mt_engine' => 901,
+            'tm_keys' => '[]',
+            'icu_source' => false,
+            'subfiltering_handlers' => new Params($handlers),
+        ]);
+
+        $config = $worker->exposedBuildEngineConfig($element);
+
+        $this->assertSame($handlers, $config[JobsMetadataMarshaller::SUBFILTERING_HANDLERS->value]);
+    }
+
+    #[Test]
+    public function buildEngineConfig_keeps_the_full_handler_list_when_the_icu_flag_is_absent(): void
+    {
+        $this->ensureFakeEnginesExist();
+
+        // Rows rebuilt by FastAnalysis::_getSegmentsForFastVolumeAnalysis carry no icu_source,
+        // so a missing flag must behave exactly like a non-ICU segment.
+        $worker = new class($this->createStub(AMQHandler::class), obtainTestDatabase()) extends TMAnalysisWorker {
+            /**
+             * @return array<string, mixed>
+             * @throws Exception
+             */
+            public function exposedBuildEngineConfig(QueueElement $queueElement): array
+            {
+                return $this->buildEngineConfig($queueElement);
+            }
+        };
+
+        $handlers = [InjectableFiltersTags::single_curly->value];
+
+        $element = $this->makeQueueElement([
+            'id_tms' => 900,
+            'id_mt_engine' => 901,
+            'tm_keys' => '[]',
+            'subfiltering_handlers' => new Params($handlers),
+        ]);
+
+        $config = $worker->exposedBuildEngineConfig($element);
+
+        $this->assertSame($handlers, $config[JobsMetadataMarshaller::SUBFILTERING_HANDLERS->value]);
+    }
+
+    #[Test]
+    public function buildEngineConfig_sends_the_default_set_explicitly_for_an_icu_segment(): void
+    {
+        $this->ensureFakeEnginesExist();
+
+        $worker = new class($this->createStub(AMQHandler::class), obtainTestDatabase()) extends TMAnalysisWorker {
+            /**
+             * @return array<string, mixed>
+             * @throws Exception
+             */
+            public function exposedBuildEngineConfig(QueueElement $queueElement): array
+            {
+                return $this->buildEngineConfig($queueElement);
+            }
+        };
+
+        // An empty list means "use your defaults", four of which are not ICU-compliant, so it
+        // must leave as the explicit reduced set instead.
+        $element = $this->makeQueueElement([
+            'id_tms' => 900,
+            'id_mt_engine' => 901,
+            'tm_keys' => '[]',
+            'icu_source' => true,
+            'subfiltering_handlers' => new Params([]),
+        ]);
+
+        $config = $worker->exposedBuildEngineConfig($element);
+
+        $this->assertSame(
+            [InjectableFiltersTags::markup->value],
+            $config[JobsMetadataMarshaller::SUBFILTERING_HANDLERS->value]
+        );
     }
 }


### PR DESCRIPTION
## Summary

A source segment carrying valid complex ICU syntax must be subfiltered with the ICU-compliant
handlers only, otherwise the ICU arguments come back wrapped in PH tags. The decision is a
property of the single segment, not of the project, so it is taken per segment on the stored
Layer 0 source — never on anything the client declares — and the resulting handler list travels
with every request that leaves for MyMemory, because MyMemory decodes what it receives with the
handlers it is given and re-encodes its matches with them.

This wires that decision through both paths that reach the engines: the analysis payload built
at project creation, and the editor contribution lookup.

## Type

- [x] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Model/ProjectCreation/ProjectManager.php` | Picks the handler set per segment when building the fast-analysis payload, and carries the verdict on the row as `icu_source` so the worker ships the list the text was built with |
| `lib/Controller/API/App/GetContributionController.php` | Reads the stored contexts before the filter exists, takes the ICU decision on that source, builds the filter with it, and sends the same reduced list to the TM. The verdict is scoped to the branch that takes it, so PHPStan rejects any future reorder that would build the filter first |
| `lib/Utils/Subfiltering/IcuCompliantHandlers.php` | Reduction delegated to the library's new `HandlersSorter::resolveClassNames()`; result normalised to a list, since a non-sequential array would encode as a JSON object on the wire |
| `composer.json` / `composer.lock` | `matecat/subfiltering` `^4.1.1`, which exposes `resolveClassNames()` and `getOrderedHandlerTagNames()` |
| `tests/unit/Core/Controllers/GetContributionControllerTest.php` | ICU detection, the four wire-list cases, both context-conversion directions, and the no-drift invariant: the list the TM is told is the set the filter actually resolved |
| `tests/unit/Core/Model/ProjectCreation/FastAnalysisIcuSubfilteringTest.php` | Analysis payload: ICU kept as ICU, bare `{placeholder}` still PH-wrapped, flag off and invalid patterns fall back to the project handlers |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

```
OK (9718 tests, 31585 assertions)
[OK] No errors
```

PHPStan is run whole-tree; this repository has no baseline, so every reported error is a failure.
Diff coverage on the changed `lib/` lines measured at 22/22 = 100% against the 80% gate.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

`GetContributionWorker` deliberately needs no change: it forwards the
`subfiltering_handlers` it is given into both the TM and MT configs, so shipping the reduced
list from the controller is the whole fix.

The empty reduction travels as `null`, not `[]`: on the receiving side `[]` means "load the
default handlers" while `null` means "load none", so the two are opposite instructions.

Depends on `matecat/subfiltering` v4.1.1, already released and on Packagist.

Follow-up work, not in this PR:

- `SetContributionWorker` / `SetContributionMTWorker` have not been examined for the same
  handler-set question.
- The DB fallback `_getSegmentsForFastVolumeAnalysis` still sends raw Layer 0 with no flag.
