### PR TITLE
🔧 chore(docs): document the segment-analysis endpoints in the Swagger spec

### DIFF
--- a/public/api/swagger-source.json
+++ b/public/api/swagger-source.json
@@ -1854,6 +1854,144 @@
         }
       }
     },
+    "/api/v3/jobs/{id_job}/{password}/segment-analysis": {
+      "get": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Segment analysis",
+        "description": "Returns a paginated, segment by segment analysis of a job: source and target text, word counts, match type, revision status, LQA issues and notes. Access is granted by the id/password pair itself, so the exact pair must be presented: either the translate password of the job or the password of one of its revision steps.",
+        "parameters": [
+          {
+            "name": "id_job",
+            "in": "path",
+            "description": "The id of the job",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "password",
+            "in": "path",
+            "description": "The password of the job. Either the translate password or the password of a revision step.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "The page of segments to retrieve. Defaults to 1. Asking for a page beyond the last one is an error.",
+            "required": false,
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "Number of segments per page. Defaults to 50. Values above 200 are silently reduced to 200.",
+            "required": false,
+            "type": "integer",
+            "default": 50,
+            "maximum": 200
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of analysed segments.",
+            "schema": {
+              "$ref": "#/definitions/SegmentAnalysis"
+            }
+          },
+          "401": {
+            "description": "The caller is not authenticated.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "No job matches the supplied id and password.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/projects/{id_project}/{password}/segment-analysis": {
+      "get": {
+        "tags": [
+          "Project"
+        ],
+        "summary": "Segment analysis",
+        "description": "Returns a paginated, segment by segment analysis of every job in a project: source and target text, word counts, match type, revision status, LQA issues and notes. Each item carries the id and password of the chunk it belongs to. Access is granted by the id/password pair itself, so the exact pair must be presented.",
+        "parameters": [
+          {
+            "name": "id_project",
+            "in": "path",
+            "description": "The id of the project",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "password",
+            "in": "path",
+            "description": "The password of the project",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "The page of segments to retrieve. Defaults to 1. Asking for a page beyond the last one is an error, and so is asking for page 1 of a project that has no segments.",
+            "required": false,
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "Number of segments per page. Defaults to 50. Values above 200 are silently reduced to 200.",
+            "required": false,
+            "type": "integer",
+            "default": 50,
+            "maximum": 200
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of analysed segments.",
+            "schema": {
+              "$ref": "#/definitions/SegmentAnalysis"
+            }
+          },
+          "401": {
+            "description": "The caller is not authenticated.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "404": {
+            "description": "No project matches the supplied id and password.",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/api/v3/teams": {
       "get": {
         "tags": [
@@ -8004,6 +8142,253 @@
         },
         "review_password": {
           "type": "string"
+        }
+      }
+    },
+    "SegmentAnalysis": {
+      "type": "object",
+      "properties": {
+        "workflow_type": {
+          "type": "string",
+          "description": "The analysis workflow the project runs on. It decides which set of values match_type can take.",
+          "enum": [
+            "standard",
+            "mtqe"
+          ]
+        },
+        "_links": {
+          "type": "object",
+          "properties": {
+            "page": {
+              "type": "integer",
+              "description": "The page returned by this call"
+            },
+            "per_page": {
+              "type": "integer",
+              "description": "Number of segments in a full page, after the 200 cap has been applied"
+            },
+            "total_pages": {
+              "type": "number",
+              "description": "Number of pages the result set is split into. Serialized as a number, not necessarily an integer."
+            },
+            "total_items": {
+              "type": "integer",
+              "description": "Total number of segments available"
+            },
+            "next_page": {
+              "type": "string",
+              "description": "Path of the next page, or null on the last page. Note that this path is built with the /api/app prefix rather than /api/v3: use the page and per_page values instead of following it verbatim.",
+              "x-nullable": true
+            },
+            "prev_page": {
+              "type": "string",
+              "description": "Path of the previous page, or null on the first page. The same /api/app prefix caveat as next_page applies.",
+              "x-nullable": true
+            }
+          }
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SegmentAnalysisItem"
+          }
+        }
+      }
+    },
+    "SegmentAnalysisItem": {
+      "type": "object",
+      "properties": {
+        "id_segment": {
+          "type": "integer"
+        },
+        "id_chunk": {
+          "type": "integer",
+          "description": "The id of the job (chunk) this segment belongs to"
+        },
+        "chunk_password": {
+          "type": "string",
+          "description": "The translate password of the job (chunk) this segment belongs to"
+        },
+        "urls": {
+          "type": "object",
+          "description": "Editor links to this segment, one per phase. A key is present only when the corresponding phase exists on the job, so the object can be empty.",
+          "properties": {
+            "t": {
+              "type": "string",
+              "description": "Link to the segment in the translation phase"
+            },
+            "r1": {
+              "type": "string",
+              "description": "Link to the segment in the first revision phase"
+            },
+            "r2": {
+              "type": "string",
+              "description": "Link to the segment in the second revision phase"
+            }
+          }
+        },
+        "id_request": {
+          "type": "string",
+          "description": "The external request id stored against this segment, or null when none was set",
+          "x-nullable": true
+        },
+        "filename": {
+          "type": "string",
+          "description": "The name of the file the segment was extracted from",
+          "x-nullable": true
+        },
+        "original_filename": {
+          "type": "string",
+          "description": "The name of the file as originally uploaded, before any conversion. Falls back to filename.",
+          "x-nullable": true
+        },
+        "source": {
+          "type": "string",
+          "description": "The source text of the segment",
+          "x-nullable": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The current translation of the segment, or null when it has never been translated",
+          "x-nullable": true
+        },
+        "source_lang": {
+          "type": "string",
+          "description": "RFC 5646 language+region code of the source, e.g. en-US"
+        },
+        "target_lang": {
+          "type": "string",
+          "description": "RFC 5646 language+region code of the target, e.g. it-IT"
+        },
+        "stored_source_raw_word_count": {
+          "type": "string",
+          "description": "The source raw word count recorded at analysis time. It comes straight from storage as a decimal string, e.g. \"12.00\".",
+          "x-nullable": true
+        },
+        "source_raw_word_count": {
+          "type": "integer",
+          "description": "The source raw word count recomputed on this request, using the subfiltering handlers the project was created with"
+        },
+        "target_raw_word_count": {
+          "type": "integer",
+          "description": "The target raw word count recomputed on this request, using the subfiltering handlers the project was created with"
+        },
+        "match_type": {
+          "type": "string",
+          "description": "How the segment was matched during analysis. On a standard workflow: new, tm_50_74, tm_75_84, tm_85_94, tm_95_99, tm_100, tm_100_public, ice, MT, ice_mt, repetitions, internal, numbers_only. On an mtqe workflow: tm_100, tm_100_public, ice, ice_mt, repetitions, top_quality_mt, higher_quality_mt, standard_quality_mt. Read workflow_type to know which set applies."
+        },
+        "revision_number": {
+          "type": "integer",
+          "description": "The revision step the segment last moved through: 1 for the first revision, 2 for the second. Null when the segment has never left the translation phase.",
+          "x-nullable": true
+        },
+        "issues": {
+          "type": "array",
+          "description": "The LQA issues open on this segment, across every phase. Empty when there are none.",
+          "items": {
+            "$ref": "#/definitions/SegmentAnalysisIssue"
+          }
+        },
+        "notes": {
+          "type": "array",
+          "description": "The notes carried by the segment in the source file. Empty when there are none.",
+          "items": {
+            "type": "string",
+            "x-nullable": true
+          }
+        },
+        "status": {
+          "type": "object",
+          "properties": {
+            "translation_status": {
+              "type": "string",
+              "description": "The status of the segment translation",
+              "enum": [
+                "NEW",
+                "DRAFT",
+                "TRANSLATED",
+                "APPROVED",
+                "APPROVED2",
+                "REJECTED",
+                "FIXED"
+              ]
+            },
+            "final_version": {
+              "type": "string",
+              "description": "The phase that produced the current version of the translation. Null when the segment has no recorded event.",
+              "enum": [
+                "t",
+                "r1",
+                "r2"
+              ],
+              "x-nullable": true
+            },
+            "counts": {
+              "type": "object",
+              "description": "Raw word count attributed to each revision phase. A phase reports the count as a decimal string when the segment passed through it, the number 0 when it did not, and null when the phase does not apply to this segment.",
+              "properties": {
+                "r1": {
+                  "type": "string",
+                  "x-nullable": true
+                },
+                "r2": {
+                  "type": "string",
+                  "x-nullable": true
+                }
+              }
+            }
+          }
+        },
+        "last_edit": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of the last recorded event on the segment, or null when there is none",
+          "x-nullable": true
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "True when the segment has been disabled and is excluded from translation"
+        }
+      }
+    },
+    "SegmentAnalysisIssue": {
+      "type": "object",
+      "properties": {
+        "source_page": {
+          "type": "string",
+          "description": "The phase the issue was raised in",
+          "enum": [
+            "t",
+            "r1",
+            "r2"
+          ],
+          "x-nullable": true
+        },
+        "id_category": {
+          "type": "integer",
+          "description": "The id of the QA category the issue belongs to"
+        },
+        "category": {
+          "type": "string",
+          "description": "The label of the QA category, as defined in the quality framework of the project",
+          "x-nullable": true
+        },
+        "severity": {
+          "type": "string",
+          "description": "The severity assigned to the issue, as defined in the quality framework of the project"
+        },
+        "translation_version": {
+          "type": "integer",
+          "description": "The version of the translation the issue was raised against"
+        },
+        "penalty_points": {
+          "type": "number",
+          "description": "The penalty points the issue carries"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp of when the issue was raised"
         }
       }
     },


### PR DESCRIPTION
## Summary

Publishes the `segment-analysis` endpoints in the public API reference. They have existed for a long
time and are used by external integrators, but they have never appeared in the Swagger spec —
customers could only discover them by being told. Documentation only: no PHP is touched and no
behaviour changes.

The PM asked for the job route; the same controller serves an identical project-level route, so both
are documented and share one set of definitions.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/api/swagger-source.json` | `paths`: added `GET /api/v3/jobs/{id_job}/{password}/segment-analysis` (tag *Job*) and `GET /api/v3/projects/{id_project}/{password}/segment-analysis` (tag *Project*), each with the `page` / `per_page` query parameters and 200/401/404/default responses |
| `public/api/swagger-source.json` | `definitions`: added `SegmentAnalysis` (the `workflow_type` + `_links` + `items` envelope), `SegmentAnalysisItem` (the 21 fields returned per segment) and `SegmentAnalysisIssue` |

The spec is served verbatim to Swagger UI by `lib/View/templates/_APIDoc.php`, so there is no build
step and no generated artifact to regenerate.

A new `SegmentAnalysisIssue` definition was needed rather than reusing `#/definitions/Issue`: the
existing one has a different key set (`id`, `comment`, `start_node`, …, all typed `string`) and does
not describe this payload.

`match_type` is documented as a description listing both value sets instead of a single `enum`,
because which set applies depends on `workflow_type` (`standard` vs `mtqe`).

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

No PHP, JS or SQL is touched, so phpunit and phpstan are unaffected — there is nothing for them to
exercise in a JSON documentation file. The spec was validated statically instead:

- The file parses; 97 paths and 96 definitions load.
- Every `#/definitions/...` `$ref` in the file resolves. This matters because Swagger UI renders a
  typo'd ref as a silently empty model rather than an error.
- The new operations were checked against the Swagger 2.0 rules that a hand-written entry gets wrong:
  every parameter has `name` and `in`, path parameters are `required` and match their URL template,
  every response has a `description`, and no non-2.0 keywords appear in the new schemas.
- **The documented fields were diffed programmatically against the controller.** The property names
  of `SegmentAnalysisItem`, of its nested `status` object, of `SegmentAnalysisIssue` and of the
  `SegmentAnalysis` envelope were extracted from the `return [...]` blocks of `formatSegment()`,
  `getStatusObject()`, `getIssuesNotesAndIdRequests()` and `getSegmentsForAJob()` in
  `lib/Controller/API/V3/SegmentAnalysisController.php` and compared with the spec: exact match in
  all four, nothing undocumented and nothing invented.
- `prettier --check` already fails on this file on `develop` (verified against a stashed tree), so
  that pre-existing warning is untouched — reformatting would have produced a large unrelated diff.

One typing decision could not be confirmed against a live response, because no MateCat container is
running locally: `stored_source_raw_word_count` and `status.counts.r1` / `.r2` are documented as
strings. `Database::getConnection()` sets neither `PDO::ATTR_EMULATE_PREPARES` nor
`ATTR_STRINGIFY_FETCHES`, so MySQL prepare emulation is on and those uncast `double(20,2)` columns
serialize as e.g. `"12.00"`. Worth a glance at a real response before merging. Note that the existing
`QualityReportSegment.raw_word_count` types the same column as `number`, so one of the two is wrong.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

The spec describes the endpoints exactly as they behave today, including two pre-existing defects
that are **deliberately not fixed here** to keep this a documentation-only change. Both deserve their
own ticket:

1. **`next_page` / `prev_page` point at a route that 404s.** The links are built with an `/api/app/`
   prefix rather than `/api/v3/` (`SegmentAnalysisController` lines 101-102 and 206-207). For the job
   variant that target does not exist at all: `lib/Routes/app_routes.php:51` registers
   `route(' /segment-analysis', …)` with a **leading space**, so the effective path is
   `/api/app/jobs/{id}/{password} /segment-analysis`. An integrator who follows `next_page` gets a
   404. The project alias (`app_routes.php:71`) has no typo and resolves. Until it is fixed, the
   `next_page` / `prev_page` descriptions in the spec tell clients to use the `page` and `per_page`
   values instead of following the link verbatim.

2. **Pagination errors are 500s, and the two branches disagree on an empty result.** Both guards
   throw a bare `Exception`, which `router.php` maps to **500** rather than the 400 a client would
   expect for a bad `page`. The job guard (line 97) is
   `($page > $totalPages && $totalPages > 0) || $page <= 0` and returns an empty page for a job with
   no segments, while the project guard (line 202) is `$page > $totalPages or $page <= 0` and throws.
   Related: `?per_page=0.5` reaches `ceil($count / 0)` → `DivisionByZeroError` → 500, and
   `?per_page=-10` reaches SQL as `LIMIT -10` → `PDOException` → 503 with no response body.

Also worth a decision separately from this PR: `public/api/swagger-source.js` is a hand-maintained
twin of the JSON that nothing loads, and the two have already drifted (`7d793551e8` updated
`ProjectList` in the `.js` only). It is left untouched here. It should probably be deleted or
re-synced deliberately.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213397249913878