### PR TITLE
🐛 fix(lqa): enter the transaction scope unconditionally in createRecord

### DIFF
--- a/inc/version.ini
+++ b/inc/version.ini
@@ -1,2 +1,2 @@
 [MATECAT_VERSION]
-version = "v4.1.2"
+version = "v4.1.3"

--- a/lib/Model/LQA/ChunkReviewDao.php
+++ b/lib/Model/LQA/ChunkReviewDao.php
@@ -14,6 +14,7 @@ use PDOException;
 use Plugins\Features\ReviewExtended\ReviewUtils;
 use ReflectionException;
 use RuntimeException;
+use Throwable;
 use TypeError;
 use Utils\Constants\SourcePages;
 
@@ -833,6 +834,8 @@ class ChunkReviewDao extends AbstractDao
      * @throws ReflectionException
      * @throws RuntimeException if the row cannot be read back after the write
      * @throws TypeError
+     * @throws Throwable the write runs inside a transaction scope, which aborts the transaction on
+     *                   any throw and re-throws the original, whatever its type
      */
     public function createRecord(array $data): ChunkReviewStruct
     {
@@ -865,24 +868,39 @@ class ChunkReviewDao extends AbstractDao
 
                 ";
 
-        $conn = $this->database->getConnection();
+        $write = function () use ($sql, $attrs, $struct): ChunkReviewStruct {
+            $stmt = $this->database->getConnection()->prepare($sql);
+            $stmt->execute($attrs);
 
-        $stmt = $conn->prepare($sql);
-        $stmt->execute($attrs);
+            // Not lastInsertId(): when ON DUPLICATE KEY UPDATE takes the *update* branch MySQL leaves
+            // LAST_INSERT_ID() at 0 (or at a value left by an earlier statement on this connection), so
+            // the caller got id 0 or someone else's id for an existing chunk review. That id then flows
+            // into recountAndUpdatePassFailResult() — whose updateStruct keys on the primary key and so
+            // silently updates nothing — and into passFailCountsAtomicUpdate(), where an unmatched id
+            // takes the insert branch and creates a duplicate row. Both branches leave exactly one row
+            // identified by job_pw_source_page, so read it back; the lookup is uncached, so it sees the
+            // row this statement just wrote.
+            return $this->findByIdJobAndPasswordAndSourcePage(
+                $struct->id_job,
+                $struct->password,
+                $struct->source_page
+            ) ?? throw new RuntimeException('qa_chunk_reviews row not found after createRecord for job ' . $struct->id_job);
+        };
 
-        // Not lastInsertId(): when ON DUPLICATE KEY UPDATE takes the *update* branch MySQL leaves
-        // LAST_INSERT_ID() at 0 (or at a value left by an earlier statement on this connection), so
-        // the caller got id 0 or someone else's id for an existing chunk review. That id then flows
-        // into recountAndUpdatePassFailResult() — whose updateStruct keys on the primary key and so
-        // silently updates nothing — and into passFailCountsAtomicUpdate(), where an unmatched id
-        // takes the insert branch and creates a duplicate row. Both branches leave exactly one row
-        // identified by job_pw_source_page, so read it back; the lookup is uncached, so it sees the
-        // row this statement just wrote inside the caller's transaction.
-        $struct = $this->findByIdJobAndPasswordAndSourcePage(
-            $struct->id_job,
-            $struct->password,
-            $struct->source_page
-        ) ?? throw new RuntimeException('qa_chunk_reviews row not found after createRecord for job ' . $struct->id_job);
+        // The INSERT and the read-back have to reach the same server. ProxySQL routes a bare SELECT to
+        // the reader hostgroup and an INSERT to the writer, so with nothing open the two statements
+        // land on different machines: the read arrives at a replica that has not received the row yet
+        // and the ?? above throws on a write that in fact succeeded, leaving a committed row the
+        // caller never learns about. A transaction keeps them together, because transaction_persistent
+        // pins every statement of one to the writer.
+        //
+        // Only when there is nothing open, though. transaction() here begins and commits
+        // unconditionally, with no notion of a nested scope, so opening one inside a caller that has
+        // already begun would commit that caller's work early. A caller holding a transaction has
+        // pinned the connection to the writer for us anyway, which is the whole point of the wrap.
+        $struct = $this->database->getConnection()->inTransaction()
+            ? $write()
+            : $this->database->transaction($write);
 
         // A new row changes what findChunkReviews()/getByProjectId() should return.
         $this->database->onCommit(fn() => $this->destroyCachesFor($struct));

--- a/lib/Model/LQA/ChunkReviewDao.php
+++ b/lib/Model/LQA/ChunkReviewDao.php
@@ -867,7 +867,14 @@ class ChunkReviewDao extends AbstractDao
 
                 ";
 
-        $write = function () use ($sql, $attrs, $struct): ChunkReviewStruct {
+        // The INSERT and the read-back have to reach the same server. ProxySQL routes a bare SELECT to
+        // the reader hostgroup and an INSERT to the writer, so with nothing open the two statements
+        // land on different machines: the read arrives at a replica that has not received the row yet
+        // and the ?? below throws on a write that in fact succeeded, leaving a committed row the
+        // caller never learns about. A transaction keeps them together, because transaction_persistent
+        // pins every statement of one to the writer. A caller that already holds one enters here as a
+        // guest — the scope opens and commits nothing, and that caller's transaction does the pinning.
+        $struct = $this->database->transaction(function () use ($sql, $attrs, $struct): ChunkReviewStruct {
             $stmt = $this->database->getConnection()->prepare($sql);
             $stmt->execute($attrs);
 
@@ -884,25 +891,12 @@ class ChunkReviewDao extends AbstractDao
                 $struct->password,
                 $struct->source_page
             ) ?? throw new RuntimeException('qa_chunk_reviews row not found after createRecord for job ' . $struct->id_job);
-        };
+        });
 
-        // The INSERT and the read-back have to reach the same server. ProxySQL routes a bare SELECT to
-        // the reader hostgroup and an INSERT to the writer, so with nothing open the two statements
-        // land on different machines: the read arrives at a replica that has not received the row yet
-        // and the ?? above throws on a write that in fact succeeded, leaving a committed row the
-        // caller never learns about. A transaction keeps them together, because transaction_persistent
-        // pins every statement of one to the writer.
-        //
-        // Only when there is nothing open, though. transaction() here begins and commits
-        // unconditionally, with no notion of a nested scope, so opening one inside a caller that has
-        // already begun would commit that caller's work early. A caller holding a transaction has
-        // pinned the connection to the writer for us anyway, which is the whole point of the wrap.
-        $struct = $this->database->getConnection()->inTransaction()
-            ? $write()
-            : $this->database->transaction($write);
-
-        // A new row changes what findChunkReviews()/getByProjectId() should return.
-        $this->destroyCachesFor($struct);
+        // A new row changes what findChunkReviews()/getByProjectId() should return. After the commit,
+        // not before: a guest scope returns with the caller's transaction still open, and a bust
+        // issued there lets a concurrent reader repopulate the cache from the pre-commit row.
+        $this->database->onCommit(fn() => $this->destroyCachesFor($struct));
 
         return $struct;
     }

--- a/package.json
+++ b/package.json
@@ -98,5 +98,5 @@
   "resolutions": {
     "wrap-ansi": "^7.0.0"
   },
-  "version": "4.1.2"
+  "version": "4.1.3"
 }

--- a/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php
+++ b/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php
@@ -32,6 +32,13 @@ class ChunkReviewDaoTest extends AbstractTest
         AppConfig::$SKIP_SQL_CACHE = true;
 
         [$this->dbStub, $this->pdoStub, $this->stmtStub] = $this->createDatabaseMock();
+
+        // createRecord() runs its write inside a transaction scope. An unstubbed transaction() returns
+        // null without ever calling back, which would make the method look as though it produced
+        // nothing. Run it inline here rather than in the shared harness: on this branch other
+        // controllers still drive their transactions by hand, and stubbing it globally would start
+        // executing scopes those tests deliberately leave inert.
+        $this->dbStub->method('transaction')->willReturnCallback(static fn(callable $callback) => $callback());
     }
 
     protected function tearDown(): void
@@ -806,6 +813,131 @@ class ChunkReviewDaoTest extends AbstractTest
         $this->assertSame(2, $result->id_job);
         $this->assertSame('test_pw', $result->password);
         $this->assertSame('rev_pw', $result->review_password);
+    }
+
+    /**
+     * The INSERT and its read-back have to run inside one transaction scope.
+     *
+     * ProxySQL routes a bare SELECT to the reader hostgroup and an INSERT to the writer, so a
+     * read-back issued with no transaction open can reach a replica that has not received the row
+     * yet. createRecord then throws on a write that in fact succeeded, leaving a committed row its
+     * caller never learns about. Only a transaction keeps both statements on the writer.
+     */
+    #[Test]
+    public function instanceCreateRecordWritesInsideATransactionScope(): void
+    {
+        $insideScope      = false;
+        $scopesOpened     = 0;
+        $statementsOutside = 0;
+
+        $this->stmtStub->method('execute')->willReturnCallback(
+            function () use (&$insideScope, &$statementsOutside): bool {
+                if (!$insideScope) {
+                    $statementsOutside++;
+                }
+
+                return true;
+            }
+        );
+
+        $this->stmtStub->method('fetchAll')->willReturnCallback(
+            function () use (&$insideScope, &$statementsOutside): array {
+                if (!$insideScope) {
+                    $statementsOutside++;
+                }
+
+                return [
+                    new ChunkReviewStruct([
+                        'id'              => 44,
+                        'id_project'      => 1,
+                        'id_job'          => 2,
+                        'password'        => 'test_pw',
+                        'review_password' => 'rev_pw',
+                        'source_page'     => 2,
+                    ])
+                ];
+            }
+        );
+
+        $database = $this->createStub(IDatabase::class);
+        $database->method('getConnection')->willReturn($this->pdoStub);
+        $database->method('transaction')->willReturnCallback(
+            function (callable $callback) use (&$insideScope, &$scopesOpened) {
+                $scopesOpened++;
+                $insideScope = true;
+
+                try {
+                    return $callback();
+                } finally {
+                    $insideScope = false;
+                }
+            }
+        );
+
+        $result = (new ChunkReviewDao($database))->createRecord([
+            'id_project'      => 1,
+            'id_job'          => 2,
+            'password'        => 'test_pw',
+            'review_password' => 'rev_pw',
+            'source_page'     => 2,
+        ]);
+
+        $this->assertSame(1, $scopesOpened, 'createRecord must open exactly one transaction scope');
+        $this->assertSame(0, $statementsOutside, 'the write and its read-back must not leave the scope');
+        $this->assertSame(44, $result->id);
+    }
+
+    /**
+     * A caller that has already begun a transaction must not have one opened underneath it.
+     *
+     * transaction() on this branch begins and commits unconditionally - there is no nested scope - so
+     * opening one here would commit the caller's work early and leave its later commit with nothing to
+     * close. The caller's transaction has already pinned the connection to the writer, which is the
+     * only thing the wrap is there to achieve.
+     */
+    #[Test]
+    public function instanceCreateRecordDoesNotOpenATransactionInsideAnOpenOne(): void
+    {
+        $this->stmtStub->method('execute')->willReturn(true);
+        $this->stmtStub->method('fetchAll')->willReturn([
+            new ChunkReviewStruct([
+                'id'              => 45,
+                'id_project'      => 1,
+                'id_job'          => 2,
+                'password'        => 'test_pw',
+                'review_password' => 'rev_pw',
+                'source_page'     => 2,
+            ])
+        ]);
+
+        // A connection of its own: the shared harness already stubs inTransaction() on $this->pdoStub,
+        // and the first matcher registered for a method is the one that answers.
+        $connection = $this->createStub(PDO::class);
+        $connection->method('inTransaction')->willReturn(true);
+        $connection->method('prepare')->willReturn($this->stmtStub);
+
+        $scopesOpened = 0;
+
+        $database = $this->createStub(IDatabase::class);
+        $database->method('getConnection')->willReturn($connection);
+        $database->method('transaction')->willReturnCallback(
+            function (callable $callback) use (&$scopesOpened) {
+                $scopesOpened++;
+
+                return $callback();
+            }
+        );
+
+        $result = (new ChunkReviewDao($database))->createRecord([
+            'id_project'      => 1,
+            'id_job'          => 2,
+            'password'        => 'test_pw',
+            'review_password' => 'rev_pw',
+            'source_page'     => 2,
+        ]);
+
+        $this->assertSame(0, $scopesOpened, 'createRecord must not open a transaction inside an open one');
+        $this->assertSame(45, $result->id);
     }
 
     #[Test]

--- a/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php
+++ b/tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php
@@ -14,6 +14,8 @@ use PDO;
 use PDOStatement;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Stub;
+use RuntimeException;
+use Throwable;
 use Utils\Constants\SourcePages;
 use Utils\Registry\AppConfig;
 
@@ -32,13 +34,6 @@ class ChunkReviewDaoTest extends AbstractTest
         AppConfig::$SKIP_SQL_CACHE = true;
 
         [$this->dbStub, $this->pdoStub, $this->stmtStub] = $this->createDatabaseMock();
-
-        // createRecord() runs its write inside a transaction scope. An unstubbed transaction() returns
-        // null without ever calling back, which would make the method look as though it produced
-        // nothing. Run it inline here rather than in the shared harness: on this branch other
-        // controllers still drive their transactions by hand, and stubbing it globally would start
-        // executing scopes those tests deliberately leave inert.
-        $this->dbStub->method('transaction')->willReturnCallback(static fn(callable $callback) => $callback());
     }
 
     protected function tearDown(): void
@@ -888,15 +883,17 @@ class ChunkReviewDaoTest extends AbstractTest
     }
 
     /**
-     * A caller that has already begun a transaction must not have one opened underneath it.
+     * A caller that already holds a transaction still goes through transaction().
      *
-     * transaction() on this branch begins and commits unconditionally - there is no nested scope - so
-     * opening one here would commit the caller's work early and leave its later commit with nothing to
-     * close. The caller's transaction has already pinned the connection to the writer, which is the
-     * only thing the wrap is there to achieve.
+     * Guest handling belongs to Database: an inner scope opens nothing and commits nothing, and the
+     * caller's own transaction is what pins the connection to the writer. So there is nothing for the
+     * DAO to decide, and deciding anyway - skipping the scope when a transaction is already open - is
+     * the shape this fix carried on the release branch, where transaction() had no guest semantics. It
+     * must not come back here: it would leave the read-back unpinned on any path that reached
+     * createRecord outside a transaction after the check.
      */
     #[Test]
-    public function instanceCreateRecordDoesNotOpenATransactionInsideAnOpenOne(): void
+    public function instanceCreateRecordEntersTheScopeEvenInsideAnOpenTransaction(): void
     {
         $this->stmtStub->method('execute')->willReturn(true);
         $this->stmtStub->method('fetchAll')->willReturn([
@@ -916,13 +913,13 @@ class ChunkReviewDaoTest extends AbstractTest
         $connection->method('inTransaction')->willReturn(true);
         $connection->method('prepare')->willReturn($this->stmtStub);
 
-        $scopesOpened = 0;
+        $scopesEntered = 0;
 
         $database = $this->createStub(IDatabase::class);
         $database->method('getConnection')->willReturn($connection);
         $database->method('transaction')->willReturnCallback(
-            function (callable $callback) use (&$scopesOpened) {
-                $scopesOpened++;
+            function (callable $callback) use (&$scopesEntered) {
+                $scopesEntered++;
 
                 return $callback();
             }
@@ -936,8 +933,109 @@ class ChunkReviewDaoTest extends AbstractTest
             'source_page'     => 2,
         ]);
 
-        $this->assertSame(0, $scopesOpened, 'createRecord must not open a transaction inside an open one');
+        $this->assertSame(1, $scopesEntered, 'createRecord must always enter a transaction scope');
         $this->assertSame(45, $result->id);
+    }
+
+    /**
+     * A read-back that finds nothing has to fail inside the scope.
+     *
+     * The row is unreadable either because the write did not happen or because it is not visible from
+     * here, and neither is a state to commit: throwing from within the scope is what makes the
+     * transaction abort. Thrown after the commit instead, it would leave exactly the row-exists-but-
+     * caller-was-told-otherwise state that made a second revision pass impossible to create.
+     */
+    #[Test]
+    public function instanceCreateRecordFailsInsideTheScopeWhenTheReadBackFindsNothing(): void
+    {
+        $this->stmtStub->method('execute')->willReturn(true);
+        $this->stmtStub->method('fetchAll')->willReturn([]);
+
+        $insideScope = false;
+        $failedInsideScope = null;
+
+        $database = $this->createStub(IDatabase::class);
+        $database->method('getConnection')->willReturn($this->pdoStub);
+        $database->method('transaction')->willReturnCallback(
+            function (callable $callback) use (&$insideScope, &$failedInsideScope) {
+                $insideScope = true;
+
+                try {
+                    return $callback();
+                } catch (Throwable $e) {
+                    $failedInsideScope = $insideScope;
+
+                    throw $e;
+                } finally {
+                    $insideScope = false;
+                }
+            }
+        );
+
+        $dao = new ChunkReviewDao($database);
+
+        try {
+            $dao->createRecord([
+                'id_project'      => 1,
+                'id_job'          => 2,
+                'password'        => 'test_pw',
+                'review_password' => 'rev_pw',
+                'source_page'     => 2,
+            ]);
+
+            $this->fail('createRecord must throw when the row it wrote cannot be read back');
+        } catch (RuntimeException $e) {
+            $this->assertStringContainsString('qa_chunk_reviews row not found after createRecord', $e->getMessage());
+        }
+
+        $this->assertTrue($failedInsideScope, 'the failure must reach the scope, so that it aborts');
+    }
+
+    /**
+     * The cache bust waits for the commit.
+     *
+     * createRecord returns with the transaction still open whenever its caller owns one. A bust issued
+     * there is a window in which a concurrent reader repopulates the cache from the pre-commit row, and
+     * that stale value then outlives the commit for the whole TTL.
+     */
+    #[Test]
+    public function instanceCreateRecordDefersTheCacheBustUntilCommit(): void
+    {
+        $this->stmtStub->method('execute')->willReturn(true);
+        $this->stmtStub->method('fetchAll')->willReturn([
+            new ChunkReviewStruct([
+                'id'              => 46,
+                'id_project'      => 1,
+                'id_job'          => 2,
+                'password'        => 'test_pw',
+                'review_password' => 'rev_pw',
+                'source_page'     => 2,
+            ])
+        ]);
+
+        /** @var list<callable> $deferred */
+        $deferred = [];
+
+        $database = $this->createStub(IDatabase::class);
+        $database->method('getConnection')->willReturn($this->pdoStub);
+        $database->method('transaction')->willReturnCallback(static fn(callable $callback) => $callback());
+        // Hold the callbacks instead of running them, which is what a real open transaction does.
+        $database->method('onCommit')->willReturnCallback(
+            function (callable $callback) use (&$deferred): void {
+                $deferred[] = $callback;
+            }
+        );
+
+        $result = (new ChunkReviewDao($database))->createRecord([
+            'id_project'      => 1,
+            'id_job'          => 2,
+            'password'        => 'test_pw',
+            'review_password' => 'rev_pw',
+            'source_page'     => 2,
+        ]);
+
+        $this->assertCount(1, $deferred, 'the cache bust must be scheduled through onCommit');
+        $this->assertSame(46, $result->id);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Back-merge of `master` (up to `v4.1.3`, which carries the r2 fix from #4792) into `develop`, plus the
adjustment that fix needs on this branch.

`ChunkReviewDao::createRecord()` inserts the row and then re-reads it to recover its id. ProxySQL
routes an `INSERT` to the writer hostgroup and a bare `SELECT` to the readers, so with no transaction
open the two statements reach different servers and the read can land on a replica that has not
received the row yet — `createRecord()` then throws on a write that in fact succeeded, which is what
made a second revision pass impossible to create in production.

The fix shipped on `master` guards the wrap with `getConnection()->inTransaction()`. That guard exists
only because `Database::transaction()` there begins and commits unconditionally, so a scope opened
inside a caller that had already begun would have committed the caller's work early. `transaction()`
on `develop` has guest semantics — an inner scope opens nothing and commits nothing — so the guard
buys nothing here and costs the scope on the path that needs it most.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
| --- | --- |
| `lib/Model/LQA/ChunkReviewDao.php` | `createRecord()` always enters `transaction()`, with the write and its read-back written inline in the scope. The cache bust moves to `onCommit()`: a guest scope returns with the caller's transaction still open, and a bust issued there lets a concurrent reader repopulate the cache from the pre-commit row, where the stale value then outlives the commit for the whole TTL. |
| `tests/unit/Core/DAO/TestChunkReviewDAO/ChunkReviewDaoTest.php` | Replaces the nesting-guard regression test with one asserting the scope is entered even inside an open transaction; adds one asserting a failed read-back reaches the scope so it aborts, and one asserting the cache bust is deferred. Drops the local `transaction()` stub — the shared harness already runs scopes inline on this branch. |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite: OK (10129 tests, 32434 assertions). PHPStan: 0 errors on both changed files.

Manual testing: the original production failure was reproduced and traced through the `fatal_errors`
CloudWatch stream (`RuntimeException: qa_chunk_reviews row not found after createRecord for job
12666438`), and the affected `qa_chunk_reviews` rows were read back directly to confirm the write had
committed. That diagnosis is what #4792 shipped; this PR only changes the shape of the wrap.

Each new test was run against the code it guards and fails there:

- `instanceCreateRecordEntersTheScopeEvenInsideAnOpenTransaction` — fails against the `master`-shaped
  guard, which skips the scope.
- `instanceCreateRecordFailsInsideTheScopeWhenTheReadBackFindsNothing` — fails with no wrap at all.
- `instanceCreateRecordDefersTheCacheBustUntilCommit` — fails against the inline cache bust.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5). Diagnosis, code and tests reviewed by me before opening.

## Notes

The merge itself was clean — `git merge origin/master` auto-merged `lib/Model/LQA/ChunkReviewDao.php`
with no conflicts, and touched `inc/version.ini`, `package.json` and the test file besides.

The `onCommit()` move is the one change here that is not strictly about the guard. It is a one-liner
in the same function and is easy to drop if it should travel separately.
