### PR TITLE
📝 docs(api): document lara_style, drop stale v1/new params

### DIFF
--- a/public/api/swagger-source.json
+++ b/public/api/swagger-source.json
@@ -139,13 +139,6 @@
             "default": "anonymous"
           },
           {
-            "name": "due_date",
-            "in": "formData",
-            "description": "If you want to set a due date for your project, send this param with a timestamp",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "id_team",
             "in": "formData",
             "description": "The team you want to assign this project",
@@ -155,16 +148,9 @@
           {
             "name": "payable_rate_template_id",
             "in": "formData",
-            "description": "The id of the billing model you want to use in the project you are creating (if you want to use a custom billing model in a project, both relevant parameters must be included in the API call)",
+            "description": "The id of the billing model you want to use in the project you are creating.",
             "required": false,
             "type": "integer"
-          },
-          {
-            "name": "payable_rate_template_name",
-            "in": "formData",
-            "description": "The name of the billing model you want to use in the project you are creating (if you want to use a custom billing model in a project, both relevant parameters must be included in the API call)",
-            "required": false,
-            "type": "string"
           },
           {
             "name": "get_public_matches",
@@ -209,6 +195,26 @@
             "required": false,
             "type": "string",
             "example": "[\"gls_xyz123\"]"
+          },
+          {
+            "name": "lara_style",
+            "in": "formData",
+            "description": "The translation style applied to Lara's suggestions for every segment in the project. Only works if a Lara engine is used.",
+            "required": false,
+            "type": "string",
+            "default": "faithful",
+            "enum": [
+              "faithful",
+              "fluid",
+              "creative"
+            ]
+          },
+          {
+            "name": "lara_style_guideline_id",
+            "in": "formData",
+            "description": "The ID of the Lara style guide to apply to the project's translations (activates Lara Prose). Only works if a Lara engine is used.",
+            "required": false,
+            "type": "string"
           },
           {
             "name": "mmt_glossaries",
@@ -371,13 +377,6 @@
             "description": "Enable project completion feature",
             "required": false,
             "type": "boolean"
-          },
-          {
-            "name": "qa_model_template_id",
-            "in": "formData",
-            "description": "The id of the QA model you want to use in the project you are creating (if you want to use a custom QA model in a project, both relevant parameters must be included in the API call)",
-            "required": false,
-            "type": "integer"
           },
           {
             "name": "enable_mt_analysis",


### PR DESCRIPTION
## Summary

Documents the `lara_style` and `lara_style_guideline_id` parameters of `POST /api/v1/new`, and removes three entries from the same parameter list that no longer describe what the endpoint does.

`lara_style` has been accepted since the Lara Prosa integration (#4588) but was never added to the reference, so there was no documented way to discover that the project's Lara translation style is settable at creation time, nor which values are legal.

Documentation only — no PHP is touched.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/api/swagger-source.json` | Added `lara_style` — `enum: [faithful, fluid, creative]`, `default: faithful`, mirroring the field shape of the existing `deepl_formality` entry |
| `public/api/swagger-source.json` | Added `lara_style_guideline_id` — opaque Lara-issued ID, so no `example` is given |
| `public/api/swagger-source.json` | Removed `qa_model_template_id` from `/api/v1/new` — validated then dropped, it has no effect |
| `public/api/swagger-source.json` | Removed `payable_rate_template_name` from `/api/v1/new`, and dropped the now-dangling "both relevant parameters" clause from `payable_rate_template_id`'s description |
| `public/api/swagger-source.json` | Removed `due_date` from `/api/v1/new` — the dedicated project `due_date` endpoint stays documented |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

No PHP file is touched, so `phpstan` has nothing to analyse and no test needed changing. The spec is served verbatim to Swagger UI with no build step, so verification was structural:

- `jq empty public/api/swagger-source.json` — still valid JSON. A syntax error here blanks the whole API doc page.
- The three removed names now return 0 hits in the `/api/v1/new` operation; `id_qa_model_template`, `id_qa_model`, `payable_rate_template_id`, `lara_style` and `lara_style_guideline_id` return 1 each. 44 parameters, no duplicates.
- `/api/v3/projects/{id_project}/{password}/due_date` still exposes `post`, `put` and `delete` — only the `/api/v1/new` form field was removed.
- 95 paths before and after, so no other operation was disturbed.
- The documented enum and default were cross-checked against the engine by reflection: they match `Lara::ALLOWED_STYLES` and `Lara::DEFAULT_STYLE` exactly, in the same order, and the two documented names match `Lara::getConfigurationParameters()`.

`prettier --check` already failed on this file before this branch and there is no prettier gate in CI, so the file was edited by hand at its existing indentation rather than reformatted — running `--write` would have buried a small change under a whole-file diff.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**Follow-up required — `payable_rate_template_name`.** This PR removes it from the reference, but `NewController::validatePayableRateTemplate()` still throws on all three of: name without id, **id without name**, and name not matching the stored template's name. A caller following the spec as it now reads — passing `payable_rate_template_id` alone — therefore still gets `` `payable_rate_template_name` param is missing`` and project creation fails. Making the name optional is a deliberate follow-up, kept out of this PR because the task was scoped to documentation. `Controller\API\App\CreateProjectController` (the UI creation path) already resolves the template from the id alone and is the shape to converge on; two tests in `NewControllerValidationMethodsTest` pin the current throws.

**Why `id_qa_model_template` stays.** It looked like the dead parameter, but it is fully wired: read in `NewController`, validated by `validateQaModelTemplate()`, then applied as `$projectStructure->qa_model_template`. The near-identically named `qa_model_template_id` is the one with no effect — it is returned by `validateTheRequest()` and never read again, since `$request` reaches only `buildProjectStructure()`, whose sole dynamic access is restricted to the selected engine's configuration parameters. Its dead PHP read is left in place here; only the documentation entry is gone.

**Separate suspected spec bug, not addressed.** The reference documents `legacy_icu` for `/api/v1/new`, but the controller reads `icu_enabled`. If nothing maps the two, the documented name has no effect and the working one is undocumented. Left alone pending confirmation.

Also still accepted by `/api/v1/new` but undocumented: `mandatory_issues`, `metadata`, `icu_enabled` and four `mt_qe_workflow_*` parameters.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213296649189485
  - https://app.asana.com/0/0/1213829449444529