### PR TITLE
🔧 chore(plugins): add the fedex plugin submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,3 +30,6 @@
 [submodule "MateCat-docs"]
 	path = MateCat-docs
 	url = git@github.com:matecat/MateCat-docs.git
+[submodule "plugins/fedex"]
+	path = plugins/fedex
+	url = git@github.com:matecat/fedex_plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,13 +17,6 @@
 	path = internal_scripts
 	url = git@github.com:matecat/internal_scripts.git
 	ignore = untracked
-[submodule "plugins/familysearch"]
-	path = plugins/familysearch
-	url = git@github.com:matecat/familysearch_plugin.git
-[submodule "plugins/roblox"]
-        path = plugins/roblox
-        url = git@github.com:matecat/roblox_plugin.git
-
 [submodule "plugins/vite"]
 	path = plugins/vite
 	url = git@github.com:matecat/vite_plugin.git


### PR DESCRIPTION
## Summary

Adds `matecat/fedex_plugin` as a submodule at `plugins/fedex`. The plugin carries a single
hook, `filterMyMemoryGetParameters`, which sets `cid=fedex` on every MyMemory lookup so
MyMemory can scope TM results to the FedEx account — the same mechanism Airbnb and Uber
already use, minus their spice/context rewriting.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [x] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `.gitmodules` | new `[submodule "plugins/fedex"]` stanza → `git@github.com:matecat/fedex_plugin.git` |
| `.gitmodules` | drop the stale `plugins/familysearch` and `plugins/roblox` stanzas (no gitlink since #4309) |
| `plugins/fedex` | new `160000` gitlink at `8de7d53` (`master` of `fedex_plugin`) |

No core file is touched. `PluginsLoader::getInstance()` discovers plugins by scanning
`plugins/*/manifest.php`, `phpunit.xml` already globs `plugins/*/tests/unit`, and
`phpstan.neon` already has `plugins` in `paths` — so registration, test collection and
static analysis all pick the new directory up with no edit.

Contents of the submodule, for reviewers who would rather not switch repos:

| File | Purpose |
|------|---------|
| `manifest.php` | `FEATURE_CODE => 'fedex'`, `PLUGIN_CLASS => '\Features\Fedex'` |
| `lib/Features/Fedex.php` | the whole feature: one hook, four statements |
| `tests/unit/FedexTest.php` | 6 tests, 11 assertions, full coverage of the class |
| `composer.json`, `phpunit-coverage.xml`, `.gitignore`, `README.md` | scaffolding, copied from `plugins/vite` |

```php
public function filterMyMemoryGetParameters(FilterMyMemoryGetParametersEvent $event): void
{
    $parameters = $event->getParameters();
    $parameters['cid'] = Fedex::FEATURE_CODE;

    $event->setParameters($parameters);
}
```

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

**PHPUnit** — full suite: 10225 tests, 32645 assertions, 8 failures, 0 errors. All 8 are
pre-existing and unrelated (ActiveMQ broker unavailable in `CommentControllerTest`, plus
confirmation-token tests in `SignupModelUnitTest` / `UserDaoRealSqlTest`). Verified by
removing `plugins/fedex` entirely and re-running those three classes: the same 8 fail.

New plugin suite in isolation:

```
Matecat\Plugins\Fedex\FedexTest
  ✓ featureCodeIsFedex
  ✓ manifestMatchesTheFeatureCode
  ✓ filterMyMemoryGetParameters_addsCidAndKeepsExistingParameters
  ✓ filterMyMemoryGetParameters_addsCidToAnEmptyParameterSet
  ✓ filterMyMemoryGetParameters_overwritesACallerSuppliedCid
  ✓ filterMyMemoryGetParameters_ignoresTheConfig

OK (6 tests, 11 assertions)
```

`--testsuite "Plugins Unit tests"`: 217 tests, 1 pre-existing failure
(`Translated\FraudDetectionTest`, DB-dependent).

**PHPStan** — `plugins/fedex/lib/Features/Fedex.php` at level 8 with the repo config:
`[OK] No errors`. Worth stating explicitly because `phpstan.neon` has `plugins` in `paths`
with no baseline and `phpstan.yml` checks out `submodules: recursive`, so this file really
is analysed on CI.

**Manual** — booted the real bootstrap and exercised discovery end-to-end rather than
trusting the loader by inspection:

```
fedex registered: YES
plugin class    : \Features\Fedex
params          : {"q":"hello","cid":"fedex"}
```

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

Merging this registers the plugin but does not switch it on for anyone. `fedex` becomes a
valid feature code; activation is a per-owner `owner_features` row, resolved at runtime by
`FeatureSet::forProject()`. A global switch would be `AppConfig::$AUTOLOAD_PLUGINS`, which
this PR deliberately does not touch.

The plugin has no `config.ini`: `getConfig()` is never called, so there is nothing to
provision on deploy.

The second commit prunes the `plugins/familysearch` and `plugins/roblox` stanzas from
`.gitmodules`. #4309 removed both gitlinks in January but left the stanzas, so the file has
described two submodules that neither `develop` nor `master` has tracked since. Nothing had
broken because `git submodule init` iterates the index rather than `.gitmodules`. Both repos
still exist and are untouched — only the dead config goes, and `.gitmodules` now has exactly
one stanza per gitlink in both directions.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217937527392057