### PR TITLE
🐛 fix(context-url): size the rate limit for 5 requests per second

### DIFF
--- a/lib/Controller/API/App/ContextUrlController.php
+++ b/lib/Controller/API/App/ContextUrlController.php
@@ -33,6 +33,16 @@ use TypeError;
 
 class ContextUrlController extends KleinController
 {
+    /**
+     * Sustained budget of 5 requests/second per identifier.
+     *
+     * RateLimiterService uses a fixed window whose TTL is the end of the current minute plus one
+     * more (see RateLimiterService::getTtl()), so a window lasts 61-120 seconds rather than 60.
+     * The budget is sized on the 120-second worst case - 5 * 120 - so the floor holds wherever the
+     * window happens to open; a window opening near a minute boundary allows up to ~9.8/s.
+     */
+    private const int RATE_LIMIT_MAX_RETRIES = 600;
+
     protected ?ProjectStruct $project = null;
     protected ProjectsMetadataDao $projectsMetadataDao;
     protected FilesMetadataDao $filesMetadataDao;
@@ -108,7 +118,7 @@ class ContextUrlController extends KleinController
 
         foreach ($identifiers as $identifier) {
             $response = $this->rateLimiterService->checkAndIncrement(
-                $this->response, $identifier, $route, 5
+                $this->response, $identifier, $route, self::RATE_LIMIT_MAX_RETRIES
             );
             if ($response instanceof Response) {
                 $this->response = $response;

--- a/public/api/swagger-source.json
+++ b/public/api/swagger-source.json
@@ -4926,7 +4926,7 @@
           "Context URL"
         ],
         "summary": "Set context URL for a project",
-        "description": "Sets the context URL at the project level. Requires authentication, project access, and passes rate limiting (max 10 requests per route).",
+        "description": "Sets the context URL at the project level. Requires authentication, project access, and passes rate limiting (max 600 requests per ~2 minute window, roughly 5 requests/second).",
         "consumes": [
           "application/json"
         ],
@@ -5000,7 +5000,7 @@
           "Context URL"
         ],
         "summary": "Set context URL for a file",
-        "description": "Sets the context URL at the file level. The file must belong to the specified project. Requires authentication, project access, and passes rate limiting (max 10 requests per route).",
+        "description": "Sets the context URL at the file level. The file must belong to the specified project. Requires authentication, project access, and passes rate limiting (max 600 requests per ~2 minute window, roughly 5 requests/second).",
         "consumes": [
           "application/json"
         ],
@@ -5080,7 +5080,7 @@
           "Context URL"
         ],
         "summary": "Set context URL for a segment",
-        "description": "Sets the context URL at the segment level. The segment must belong to a file in the specified project. Requires authentication, project access, and passes rate limiting (max 10 requests per route).",
+        "description": "Sets the context URL at the segment level. The segment must belong to a file in the specified project. Requires authentication, project access, and passes rate limiting (max 600 requests per ~2 minute window, roughly 5 requests/second).",
         "consumes": [
           "application/json"
         ],

--- a/tests/unit/Core/Controllers/ContextUrlControllerTest.php
+++ b/tests/unit/Core/Controllers/ContextUrlControllerTest.php
@@ -218,6 +218,46 @@ class ContextUrlControllerTest extends AbstractTest
         $this->controller->setForSegment();
     }
 
+    /**
+     * The budget was introduced as 10 and silently became 5 inside a Swagger-only commit
+     * (7156d439c5), because nothing pinned it. Pin the derived value, the shared route key and the
+     * fact that both identifiers are charged, so the next drift fails here.
+     */
+    #[Test]
+    public function checkRateLimit_charges_600_per_window_on_the_shared_context_url_route(): void
+    {
+        $responseMock = $this->injectResponseMock();
+
+        $seen = [];
+
+        $rateLimiter = $this->createMock(RateLimiterService::class);
+        $rateLimiter->expects(self::exactly(2))
+            ->method('checkAndIncrement')
+            ->with(
+                self::anything(),
+                self::anything(),
+                '/api/v3/context-url',
+                600
+            )
+            ->willReturnCallback(function ($response, $identifier) use (&$seen) {
+                $seen[] = $identifier;
+
+                return null;
+            });
+        $this->reflector->getProperty('rateLimiterService')->setValue($this->controller, $rateLimiter);
+
+        $this->setRequestBody('{"context_url": "https://example.com"}');
+
+        // under the limit the request goes through to its normal response
+        $responseMock->expects(self::once())->method('json');
+
+        $this->controller->setForProject();
+
+        // the IP is charged first, then the logged-in user
+        self::assertCount(2, $seen);
+        self::assertSame('test@example.org', $seen[1]);
+    }
+
     // ── Authorization ────────────────────────────────────────────────────
 
     #[Test]


### PR DESCRIPTION
## Summary

The three `ContextUrlController` write endpoints enforce a rate limit of `5`, which works out to
roughly 5 requests per **minute**. The intended budget is 5 requests per **second**. This sizes the
limit correctly, names it, and pins it so it cannot drift again.

Two findings shaped the fix:

**The `5` was never a deliberate choice.** The limit shipped as `10` in `8295ef6255`, the
IDOR-hardening commit. It became `5` in `7156d439c5` — a Swagger-only commit whose entire PHP diff
is that one line and whose message never mentions it. Nothing pinned the value, so it went
unnoticed, and the spec has documented the pre-change `10` ever since. Code said 5, docs said 10,
and neither was a throughput decision.

**The window is 61–120 seconds, not 60.** `RateLimiterService::getTtl()` returns
`60 + (60 - current_second)` — the end of the current minute plus a full extra minute —
as `RateLimiterServiceTest::ttlValueIsBetween61And120` pins. So the naive conversion
"5/min → 300 for 5/sec" does not hold:

| limit | slowest window (120s) | fastest window (61s) |
|-------|----------------------|----------------------|
| `5` (today) | 2.5 req/min | 4.9 req/min |
| `300` | 2.5 req/s | 4.9 req/s |
| **`600`** | **5.0 req/s** | 9.8 req/s |

`300` never reaches 5 req/s in any window. Sizing on the 120s worst case — `5 * 120` — is the only
value that delivers the requirement as a guaranteed floor.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Controller/API/App/ContextUrlController.php` | Replace the magic `5` with `private const int RATE_LIMIT_MAX_RETRIES = 600`, carrying its derivation in the docblock so it cannot be misread as a per-minute figure. Follows the `AIAssistantController` pattern. |
| `public/api/swagger-source.json` | Correct the three context-url descriptions from "max 10 requests per route" to "max 600 requests per ~2 minute window, roughly 5 requests/second". The window is now stated, because the house wording gives no time unit at all — the ambiguity behind this whole report. |
| `tests/unit/Core/Controllers/ContextUrlControllerTest.php` | Add the missing regression guard: assert the limit, the shared route key, and that both identifiers are charged. |

The single shared bucket is deliberate and unchanged — the route key stays the literal
`/api/v3/context-url` for all three actions, matching the "static route pattern" contract in
`RateLimiterService`'s docblock.

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

`ContextUrlControllerTest` 27/27, `RateLimiterServiceTest` + `RateLimiterTraitTest` 16/16.
Full PHPStan run across the codebase: `[OK] No errors`.

The phpunit box is left unchecked deliberately rather than claimed falsely. The full suite reports
**8 failures**, all pre-existing and unrelated (`CommentControllerTest` broker-unavailable,
`SignupModelUnitTest` and `UserDaoRealSqlTest` token lookups). Verified by stashing this branch's
changes and re-running those three classes on a clean tree: the same 8 fail. Nothing in this diff
touches them.

Manual verification that the new guard actually bites — the failure mode here was an unpinned
value, so a test that passes either way would be worthless. Temporarily setting the constant to
`300`:

```
Parameter 3 for invocation RateLimiterService::checkAndIncrement(..., '/api/v3/context-url', 300, 1)
Failed asserting that 300 matches expected 600.
```

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

Three things surfaced while sizing this limit that I deliberately did **not** change, because each
lives in the shared `RateLimiterService` alongside the auth endpoints, where the current behaviour
is correct. They matter more now that this endpoint carries machine traffic, so flagging them for a
separate discussion:

1. **Every 429 re-arms the TTL** (`RateLimiterService:68`), so a client retrying *before*
   `Retry-After` extends its own lockout indefinitely. Right for brute-force defence on login; a
   trap for an integration. A client honouring `Retry-After` recovers normally.
2. **The IP check short-circuits before the email check**, so once a shared-NAT IP bucket is
   exhausted the per-user email bucket is never incremented — under contention the limit is
   effectively IP-only.
3. **Redis keys are a bare `md5($identifier . $route)`** with no namespace prefix, sharing the
   keyspace with everything else in that database.

Separately: `ForgotPasswordController.php:123` silently relies on the service default of `10` while
its two siblings at lines 51–52 pass an explicit `5`. Possibly intentional, possibly the same class
of drift as this one.
