### PR TITLE
🐛 fix(lqa): escape the tag names in QA warning messages

### DIFF
--- a/lib/Utils/LQA/QA/ErrObject.php
+++ b/lib/Utils/LQA/QA/ErrObject.php
@@ -24,7 +24,17 @@ class ErrObject implements Stringable
 {
 
     public ?int $outcome = null;
+
+    /**
+     * The message, as an HTML fragment: the editor injects it with `dangerouslySetInnerHTML`
+     * (public/js/components/segments/SegmentWarnings.js). Literal angle brackets must arrive escaped.
+     */
     public ?string $debug = null;
+
+    /**
+     * The suggestion, as plain text: the editor renders it as a JSX child, so an entity here would be
+     * shown to the user verbatim. Write angle brackets raw.
+     */
     public string $tip = "";
 
     protected string $orig_debug;

--- a/lib/Utils/LQA/QA/ErrorManager.php
+++ b/lib/Utils/LQA/QA/ErrorManager.php
@@ -84,7 +84,17 @@ class ErrorManager
     public const string WARNING = 'WARNING';
     public const string INFO = 'INFO';
 
-    /** @var array<int, string|null> */
+    /**
+     * Messages shown next to the segment in the editor.
+     *
+     * These reach the browser as {@see ErrObject::$debug} and the editor injects them as raw HTML
+     * (`dangerouslySetInnerHTML` in public/js/components/segments/SegmentWarnings.js), so a value here
+     * is an HTML fragment: write a literal angle bracket as `&lt;`/`&gt;` or the browser eats the word
+     * as a tag, and add markup only where it is meant to render. {@see ICUChecker} is the one place
+     * that does the latter, joining its parts with `<br/>`.
+     *
+     * @var array<int, string|null>
+     */
     protected array $errorMap = [
         0 => '',
         1 => 'Tag count mismatch',
@@ -99,7 +109,7 @@ class ErrorManager
         10 => 'Tail carriage return mismatch',
         11 => 'Char mismatch between tags',
         12 => 'End line char mismatch',
-        13 => 'Wrong format for x tag. Should be < x .... />',
+        13 => 'Wrong format for x tag. Should be &lt;x ... /&gt;',
         14 => 'Char mismatch before a tag',
         15 => 'Tag order mismatch',
         16 => 'New line mismatch',
@@ -125,18 +135,25 @@ class ErrorManager
         1104 => 'Whitespace(s) mismatch after a tag.',
         1105 => 'Whitespace(s) mismatch before a tag.',
         1200 => 'Symbol mismatch',
-        1300 => 'Found nested <ex> and/or <bx> tag(s) inside a <g> tag',
-        1301 => 'Wrong <ex> and/or <bx> placement',
-        1302 => '<ex>, <bx> and/or <g> total count mismatch',
+        1300 => 'Found nested &lt;ex&gt; and/or &lt;bx&gt; tag(s) inside a &lt;g&gt; tag',
+        1301 => 'Wrong &lt;ex&gt; and/or &lt;bx&gt; placement',
+        1302 => '&lt;ex&gt;, &lt;bx&gt; and/or &lt;g&gt; total count mismatch',
         2000 => 'Smart count plural forms mismatch',
         2001 => '%smartcount tag count mismatch',
         3000 => 'Characters limit exceeded',
         4000 => 'Unedited fuzzy match confirmed',
     ];
 
-    /** @var array<int, string|null> */
+    /**
+     * Suggestions shown under the message.
+     *
+     * The mirror image of {@see self::$errorMap}: the editor renders {@see ErrObject::$tip} as plain
+     * text, so write angle brackets raw. An entity here would be shown to the user verbatim.
+     *
+     * @var array<int, string|null>
+     */
     protected array $tipMap = [
-        29 => "Should be < g ... > ... < /g >",
+        29 => 'Should be <g>...</g>',
         1000 => "Press 'alt + t' shortcut to add tags or delete extra tags.",
         3000 => 'Maximum characters limit exceeded.',
         4000 => 'This segment was confirmed without making any changes, despite being a fuzzy match.',

--- a/lib/Utils/LQA/QA/ICUChecker.php
+++ b/lib/Utils/LQA/QA/ICUChecker.php
@@ -91,11 +91,20 @@ class ICUChecker
             return;
         }
 
+        // The message ends up in ErrObject::$debug, which the editor injects as HTML. These parts are
+        // built from the translator's own segment (argument names, plural selectors), so they are
+        // escaped here and the <br/> separators stay the only markup that reaches the browser.
+        $escape = static fn(string $text): string => htmlspecialchars(
+            $text,
+            ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5,
+            'UTF-8'
+        );
+
         try {
             $errorMessage = [];
             $complaints = $this->icuPatternComparator->validate(validateTarget: true);
             foreach ($complaints->targetWarnings?->getArgumentWarnings() ?? [] as $complaint) {
-                $errorMessage[] = implode('<br/><br/>', $complaint->getMessages());
+                $errorMessage[] = implode('<br/><br/>', array_map($escape, $complaint->getMessages()));
             }
 
             if ($errorMessage) {
@@ -106,7 +115,7 @@ class ICUChecker
                 $this->errorManager->addError(ErrorManager::ERR_ICU_VALIDATION);
             }
         } catch (Exception $e) {
-            $this->errorManager->setErrorMessage(ErrorManager::ERR_ICU_VALIDATION, $e->getMessage());
+            $this->errorManager->setErrorMessage(ErrorManager::ERR_ICU_VALIDATION, $escape($e->getMessage()));
             $this->errorManager->addError(ErrorManager::ERR_ICU_VALIDATION);
         }
     }

--- a/public/js/components/segments/SegmentWarnings.js
+++ b/public/js/components/segments/SegmentWarnings.js
@@ -87,10 +87,9 @@ class SegmentWarnings extends React.Component {
               <ul>
                 <li className="icon-column">{icon}</li>
                 <li className="content-column">
+                  {/* `debug` is an HTML fragment: ErrorManager escapes its literal angle
+                      brackets and ICUChecker joins its parts with <br/>. */}
                   <p dangerouslySetInnerHTML={{__html: el.debug}} />
-                  {/*  {el.debug}*/}
-                  {/*  /!*<b>({warnings_count[el.outcome]})</b>*!/*/}
-                  {/*</p>*/}
                   {el.tip !== '' ? (
                     <p className="error-solution">
                       <b>{el.tip}</b>

--- a/public/js/components/segments/SegmentWarnings.test.js
+++ b/public/js/components/segments/SegmentWarnings.test.js
@@ -68,6 +68,68 @@ describe('SegmentWarnings', () => {
     expect(container.textContent).toContain('first')
   })
 
+  test('renders escaped tag names in debug as visible text', () => {
+    // `debug` is injected as HTML, so the backend escapes the tag names it mentions.
+    // Written raw they would be parsed as markup and vanish from the warning.
+    const warnings = {
+      ERROR: {
+        Categories: {
+          cat1: [
+            {
+              outcome: 1302,
+              debug:
+                '&lt;ex&gt;, &lt;bx&gt; and/or &lt;g&gt; total count mismatch',
+              tip: '',
+            },
+          ],
+        },
+      },
+    }
+    const {container} = render(<SegmentWarnings warnings={warnings} />)
+
+    expect(container.textContent).toContain(
+      '<ex>, <bx> and/or <g> total count mismatch',
+    )
+  })
+
+  test('keeps intentional markup in debug, such as the ICU line breaks', () => {
+    const warnings = {
+      ERROR: {
+        Categories: {
+          cat1: [
+            {outcome: 30, debug: 'first line<br/><br/>second line', tip: ''},
+          ],
+        },
+      },
+    }
+    const {container} = render(<SegmentWarnings warnings={warnings} />)
+
+    expect(container.querySelectorAll('br')).toHaveLength(2)
+    expect(container.textContent).toContain('first line')
+    expect(container.textContent).toContain('second line')
+  })
+
+  test('renders a tip as plain text, so raw tag names survive', () => {
+    const warnings = {
+      ERROR: {
+        Categories: {
+          cat1: [
+            {
+              outcome: 29,
+              debug: 'File-breaking tag issue',
+              tip: 'Should be <g>...</g>',
+            },
+          ],
+        },
+      },
+    }
+    const {container} = render(<SegmentWarnings warnings={warnings} />)
+
+    expect(container.querySelector('.error-solution')).toHaveTextContent(
+      'Should be <g>...</g>',
+    )
+  })
+
   test('shouldComponentUpdate re-renders when warnings prop changes', () => {
     const initial = {
       ERROR: {Categories: {cat1: [{outcome: 'e1', debug: 'first', tip: ''}]}},

--- a/tests/unit/Core/LQA/ErrObjectTest.php
+++ b/tests/unit/Core/LQA/ErrObjectTest.php
@@ -147,5 +147,22 @@ class ErrObjectTest extends AbstractTest
         $this->assertNull($errObj->outcome);
         $this->assertEquals('', (string)$errObj);
     }
+
+    #[Test]
+    public function carriesDebugAndTipVerbatim(): void
+    {
+        // The editor renders $debug as HTML and $tip as text, so escaping belongs to whoever
+        // writes the message. ErrObject is a plain carrier and must not transform either field:
+        // escaping here would double-encode the map, and unescaping would undo it.
+        $errObj = ErrObject::get([
+            'outcome' => 1302,
+            'debug'   => '&lt;ex&gt;, &lt;bx&gt; and/or &lt;g&gt; total count mismatch',
+            'tip'     => 'Should be <g>...</g>',
+        ]);
+
+        $this->assertEquals('&lt;ex&gt;, &lt;bx&gt; and/or &lt;g&gt; total count mismatch', $errObj->debug);
+        $this->assertEquals('&lt;ex&gt;, &lt;bx&gt; and/or &lt;g&gt; total count mismatch', $errObj->getOrigDebug());
+        $this->assertEquals('Should be <g>...</g>', $errObj->getTip());
+    }
 }
 

--- a/tests/unit/Core/LQA/ErrorManagerTest.php
+++ b/tests/unit/Core/LQA/ErrorManagerTest.php
@@ -3,7 +3,9 @@
 namespace Matecat\Core\LQA;
 
 use Matecat\TestHelpers\AbstractTest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
 use Utils\LQA\QA\ErrorManager;
 
 class ErrorManagerTest extends AbstractTest
@@ -639,6 +641,76 @@ class ErrorManagerTest extends AbstractTest
 
         $notices = $this->errorManager->getNotices();
         $this->assertCount(3, $notices);
+    }
+
+    // ========== HTML/text sink contract ==========
+    // ErrObject::$debug is injected with dangerouslySetInnerHTML by
+    // public/js/components/segments/SegmentWarnings.js, while $tip is rendered as a JSX child.
+    // A tag name written raw in a message is therefore swallowed by the browser, which is how
+    // '<ex>, <bx> and/or <g> total count mismatch' used to reach the user as ', and/or total
+    // count mismatch'. These tests pin the two opposite treatments.
+
+    /**
+     * @return list<array{int, list<string>}>
+     */
+    public static function messagesNamingTagsProvider(): array
+    {
+        return [
+            [ErrorManager::ERR_UNCLOSED_X_TAG, ['&lt;x']],
+            [ErrorManager::ERR_EX_BX_NESTED_IN_G, ['&lt;ex&gt;', '&lt;bx&gt;', '&lt;g&gt;']],
+            [ErrorManager::ERR_EX_BX_WRONG_POSITION, ['&lt;ex&gt;', '&lt;bx&gt;']],
+            [ErrorManager::ERR_EX_BX_COUNT_MISMATCH, ['&lt;ex&gt;', '&lt;bx&gt;', '&lt;g&gt;']],
+        ];
+    }
+
+    /**
+     * @param list<string> $expectedEntities
+     */
+    #[Test]
+    #[DataProvider('messagesNamingTagsProvider')]
+    public function messagesNamingTagsUseEntities(int $errorCode, array $expectedEntities): void
+    {
+        $message = $this->errorManager->getErrorMessage($errorCode);
+
+        foreach ($expectedEntities as $entity) {
+            $this->assertStringContainsString($entity, $message);
+        }
+
+        $this->assertStringNotContainsString('<', $message);
+        $this->assertStringNotContainsString('>', $message);
+    }
+
+    #[Test]
+    public function noStaticMessageCarriesUnescapedMarkup(): void
+    {
+        $errorMap = (new ReflectionProperty(ErrorManager::class, 'errorMap'))
+            ->getValue($this->errorManager);
+
+        foreach ($errorMap as $code => $message) {
+            $this->assertDoesNotMatchRegularExpression(
+                '#<[a-zA-Z/]#',
+                (string)$message,
+                "Message for code $code reaches an HTML sink: escape its angle brackets."
+            );
+        }
+    }
+
+    #[Test]
+    public function tipsAreWrittenAsPlainText(): void
+    {
+        $tipMap = (new ReflectionProperty(ErrorManager::class, 'tipMap'))
+            ->getValue($this->errorManager);
+
+        // The mirror of the check above: an entity in a tip would be shown to the user verbatim.
+        foreach ($tipMap as $code => $tip) {
+            $this->assertStringNotContainsString(
+                '&lt;',
+                (string)$tip,
+                "Tip for code $code is rendered as text: write its angle brackets raw."
+            );
+        }
+
+        $this->assertStringContainsString('<g>', (string)$tipMap[ErrorManager::ERR_UNCLOSED_G_TAG]);
     }
 }
 

--- a/tests/unit/Core/LQA/ICUCheckerTest.php
+++ b/tests/unit/Core/LQA/ICUCheckerTest.php
@@ -136,6 +136,50 @@ class ICUCheckerTest extends AbstractTest
         $this->assertTrue($this->errorManager->thereAreErrors());
     }
 
+    // ========== HTML escaping ==========
+    // The message ends up in ErrObject::$debug, which the editor injects with
+    // dangerouslySetInnerHTML. A malformed selector makes the ICU validator echo the
+    // translator's own target text back inside the exception message, so it must arrive escaped.
+
+    #[Test]
+    public function checkICUMessageConsistencyEscapesTargetTextEchoedByTheValidator(): void
+    {
+        $comparator = new MessagePatternComparator(
+            'en',
+            'it',
+            'You have {n, plural, one{a car} other{# cars}}',
+            'You have {n, plural, o<b>ne{a car} other{# cars}}',
+        );
+
+        $this->icuChecker->setIcuPatternComparator($comparator);
+        $this->icuChecker->checkICUMessageConsistency();
+
+        $message = $this->errorManager->getErrorMessage(ErrorManager::ERR_ICU_VALIDATION);
+
+        $this->assertStringContainsString('o&lt;b&gt;ne', $message);
+        $this->assertStringNotContainsString('<b>', $message);
+    }
+
+    #[Test]
+    public function checkICUMessageConsistencyKeepsTheLineBreakSeparators(): void
+    {
+        // Escaping the parts must not escape the <br/> the checker joins them with.
+        $comparator = new MessagePatternComparator(
+            'en',
+            'it',
+            'You have {select, plural, one{a car} other{# cars}}',
+            'You have {select, plural, one{a car} other{# cars}}',
+        );
+
+        $this->icuChecker->setIcuPatternComparator($comparator);
+        $this->icuChecker->checkICUMessageConsistency();
+
+        $message = $this->errorManager->getErrorMessage(ErrorManager::ERR_ICU_VALIDATION);
+
+        $this->assertStringNotContainsString('&lt;br', $message);
+        $this->assertStringNotContainsString('&amp;', $message);
+    }
+
     // ========== Edge Cases ==========
 
     #[Test]


### PR DESCRIPTION
## Summary

Three QA warning messages name the XLIFF tags they are about — `<ex>`, `<bx>`, `<g>` — and the
editor injects `ErrObject::$debug` with `dangerouslySetInnerHTML`. The browser parsed the tag names
as markup, so the translator read `, and/or total count mismatch` instead of
`<ex>, <bx> and/or <g> total count mismatch`. The messages are now escaped at the source.

`$debug` stays an HTML sink on purpose: `ICUChecker` joins its parts with `<br/>`. `$tip` is the
opposite — the editor renders it as a JSX child — so its angle brackets stay raw. Both contracts are
now documented and pinned by tests.

While tracing the sink: `ICUChecker` also feeds it with text built from the translator's own target.
A malformed plural selector makes the ICU validator quote the raw pattern back inside its exception
message, which reached `dangerouslySetInnerHTML` unescaped. Each part is escaped before the `<br/>`
join, leaving the separators as the only markup that reaches the browser.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Utils/LQA/QA/ErrorManager.php` | Escape the tag names in `$errorMap` codes 13, 1300, 1301, 1302; rewrite tip 29 as raw text; document which sink each array feeds |
| `lib/Utils/LQA/QA/ICUChecker.php` | `htmlspecialchars()` each ICU message part before the `<br/>` join, and the caught exception message |
| `lib/Utils/LQA/QA/ErrObject.php` | Document `$debug` as an HTML fragment and `$tip` as plain text |
| `public/js/components/segments/SegmentWarnings.js` | Replace the commented-out `{el.debug}` with a note on why the HTML sink is deliberate |
| `tests/unit/Core/LQA/ErrorManagerTest.php` | Entity assertions for the four messages, a sweep over the whole static map, and the mirrored raw-text check for tips |
| `tests/unit/Core/LQA/ICUCheckerTest.php` | A malformed target selector arrives escaped, with the `<br/>` separators intact |
| `tests/unit/Core/LQA/ErrObjectTest.php` | `ErrObject` carries both fields verbatim and transforms neither |
| `public/js/components/segments/SegmentWarnings.test.js` | Escaped tag names render as visible text, intentional `<br/>` still renders, tips keep raw brackets |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

`tests/unit/Core/LQA` — 482 tests, 825 assertions, green. PHPStan reports 0 errors on the five
changed source files. `npx jest public/js/components/segments/SegmentWarnings.test.js` — 8/8.

The full suite leaves 8 failures, all pre-existing and unrelated: `CommentControllerTest` cases that
assert a throw *when the broker is unavailable* (the local ActiveMQ container is up, so they do not
throw), plus `UserDaoRealSqlTest` / `SignupModelUnitTest` confirmation-token lookups.

The ICU vector is reproducible: target `You have {n, plural, o<b>ne{a car} other{# cars}}` against a
well-formed source makes `validate()` throw `Bad argument syntax ... "o<b>ne{a car} other{ ..."`,
which is exactly what used to land in the DOM.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

Historical `segment_translations.serialized_errors_list` rows keep the old text and need no
migration: every reader goes through `QA::JSONtoExceptionList()`, which discards the stored message
and re-derives it from the `outcome` code against the live map.

Not verified end-to-end in the editor against a real job — the behaviour is covered by the unit and
component tests only.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216456913874835