### PR TITLE
🐛 fix(filters): trim the extraction parameter names and show the JSON and YAML key padding

### DIFF
--- a/lib/Model/Filters/DTO/Dita.php
+++ b/lib/Model/Filters/DTO/Dita.php
@@ -5,6 +5,8 @@ namespace Model\Filters\DTO;
 class Dita implements IDto
 {
 
+    use NormalizesNamesTrait;
+
     /** @var list<string> */
     private array $do_not_translate_elements = [];
 
@@ -13,7 +15,7 @@ class Dita implements IDto
      */
     public function setDoNotTranslateElements(array $do_not_translate_elements): void
     {
-        $this->do_not_translate_elements = $do_not_translate_elements;
+        $this->do_not_translate_elements = $this->normalizeNames($do_not_translate_elements);
     }
 
     /**

--- a/lib/Model/Filters/DTO/MSExcel.php
+++ b/lib/Model/Filters/DTO/MSExcel.php
@@ -5,6 +5,8 @@ namespace Model\Filters\DTO;
 class MSExcel implements IDto
 {
 
+    use NormalizesNamesTrait;
+
     private bool $extract_doc_properties = false;
     private bool $extract_hidden_cells = false;
     private bool $extract_diagrams = false;
@@ -43,7 +45,7 @@ class MSExcel implements IDto
      */
     public function setExcludeColumns(array $exclude_columns): void
     {
-        $this->exclude_columns = $exclude_columns;
+        $this->exclude_columns = $this->normalizeNames($exclude_columns);
     }
 
     /**

--- a/lib/Model/Filters/DTO/MSPowerpoint.php
+++ b/lib/Model/Filters/DTO/MSPowerpoint.php
@@ -27,6 +27,11 @@ class MSPowerpoint implements IDto
     }
 
     /**
+     * Slide numbers, not names: the frontend converts a pill list to integers before it saves
+     * (convertTranslateSlidesToServer in MsPowerpoint.js), so they are stored and returned as
+     * numbers. They are left verbatim — casting them to strings would change the stored type,
+     * and NumbersDashBadge already refuses whitespace on the way in.
+     *
      * @param list<string> $translate_slides
      */
     public function setTranslateSlides(array $translate_slides): void

--- a/lib/Model/Filters/DTO/MSWord.php
+++ b/lib/Model/Filters/DTO/MSWord.php
@@ -5,6 +5,8 @@ namespace Model\Filters\DTO;
 class MSWord implements IDto
 {
 
+    use NormalizesNamesTrait;
+
     private bool $extract_doc_properties = false;
     private bool $extract_comments = false;
     private bool $extract_headers_footers = false;
@@ -45,7 +47,7 @@ class MSWord implements IDto
      */
     public function setExcludeStyles(array $exclude_styles): void
     {
-        $this->exclude_styles = $exclude_styles;
+        $this->exclude_styles = $this->normalizeNames($exclude_styles);
     }
 
     /**
@@ -53,7 +55,7 @@ class MSWord implements IDto
      */
     public function setExcludeHighlightColors(array $exclude_highlight_colors): void
     {
-        $this->exclude_highlight_colors = $exclude_highlight_colors;
+        $this->exclude_highlight_colors = $this->normalizeNames($exclude_highlight_colors);
     }
 
     /**

--- a/lib/Model/Filters/DTO/NormalizesNamesTrait.php
+++ b/lib/Model/Filters/DTO/NormalizesNamesTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Model\Filters\DTO;
+
+/**
+ * Normalises the element/key name lists of the filters whose names cannot carry padding.
+ *
+ * XML and DITA element names, MS Word style and highlight colour names, MS Excel columns and
+ * MS PowerPoint slide numbers are all tokens in which a leading or trailing space is never
+ * meaningful: the remote filters would simply fail to match them. Users type that padding by
+ * accident and cannot see it afterwards, because a pill collapses whitespace when it renders.
+ *
+ * JSON object keys and YAML mapping keys are arbitrary strings, so " label " is a legitimate
+ * key distinct from "label". Json and Yaml deliberately do not use this trait.
+ *
+ * The extraction parameters schema declares every list as a bare array with no `items`
+ * constraint, so a member may arrive as a number as well as a string.
+ */
+trait NormalizesNamesTrait
+{
+
+    /**
+     * Trim every name and drop the ones left empty.
+     *
+     * @param array<array-key, mixed> $names
+     *
+     * @return list<string>
+     */
+    private function normalizeNames(array $names): array
+    {
+        $normalized = [];
+
+        foreach ($names as $name) {
+            if (!is_scalar($name)) {
+                continue;
+            }
+
+            $trimmed = trim((string)$name);
+
+            if ($trimmed !== '') {
+                $normalized[] = $trimmed;
+            }
+        }
+
+        return $normalized;
+    }
+
+}

--- a/lib/Model/Filters/DTO/Xml.php
+++ b/lib/Model/Filters/DTO/Xml.php
@@ -5,6 +5,8 @@ namespace Model\Filters\DTO;
 class Xml implements IDto
 {
 
+    use NormalizesNamesTrait;
+
     private bool $preserve_whitespace = false;
     /** @var list<string> */
     private array $translate_elements = [];
@@ -23,7 +25,7 @@ class Xml implements IDto
      */
     public function setTranslateElements(array $translate_elements): void
     {
-        $this->translate_elements = $translate_elements;
+        $this->translate_elements = $this->normalizeNames($translate_elements);
     }
 
     /**
@@ -31,7 +33,7 @@ class Xml implements IDto
      */
     public function setDoNotTranslateElements(array $do_not_translate_elements): void
     {
-        $this->do_not_translate_elements = $do_not_translate_elements;
+        $this->do_not_translate_elements = $this->normalizeNames($do_not_translate_elements);
     }
 
     /**
@@ -39,7 +41,7 @@ class Xml implements IDto
      */
     public function setTranslateAttributes(array $translate_attributes): void
     {
-        $this->translate_attributes = $translate_attributes;
+        $this->translate_attributes = $this->normalizeNames($translate_attributes);
     }
 
     /**

--- a/lib/Model/Filters/Readme.md
+++ b/lib/Model/Filters/Readme.md
@@ -324,6 +324,24 @@ Response example:
 
 ## Filters params endpoints documentation
 
+### Value normalization
+
+The element and key name lists are normalized on the way in, and the same normalization runs when a
+template is read back, so an older row is returned clean too.
+
+`xml.translate_elements`, `xml.do_not_translate_elements`, `xml.translate_attributes`,
+`dita.do_not_translate_elements`, `ms_word.exclude_styles`, `ms_word.exclude_highlight_colors` and
+`ms_excel.exclude_columns` hold tokens in which a leading or trailing space is never meaningful, so
+each member is trimmed and the ones left empty are dropped. Internal spaces are kept:
+`" Heading 1 "` becomes `"Heading 1"`.
+
+`json` and `yaml` are the exception. Their `translate_keys`, `do_not_translate_keys`, `context_keys`
+and `character_limit` hold JSON object keys and YAML mapping keys, which are arbitrary strings:
+`" label "` is a legitimate key distinct from `"label"` and is stored verbatim.
+
+`ms_powerpoint.translate_slides` holds slide numbers rather than names and is stored as it arrives,
+so an integer list stays an integer list.
+
 ### Schema
 
 This endpoint returns the JSON schema used to validate QAModels:

--- a/public/js/components/common/EmailsBadge/EmailsBadge.js
+++ b/public/js/components/common/EmailsBadge/EmailsBadge.js
@@ -27,6 +27,15 @@ const splitEmailsBySeparators = (value, separators) => {
     [cleanValue],
   )
 }
+/**
+ * Splits a value into its leading whitespace, its core and its trailing whitespace.
+ * Everything is optional, so a value made only of spaces lands entirely in the first group.
+ */
+const EDGE_WHITESPACE_PATTERN = /^(\s*)([\s\S]*?)(\s*)$/
+const WHITESPACE_MARKER = '·'
+
+const isMeaningful = (value) => value.trim() !== ''
+
 const stringIncludesSeparator = (text, separators) => {
   const lastChar = text.slice(-1)
   return separators.some((separator) => lastChar === separator)
@@ -43,6 +52,8 @@ export const EmailsBadge = ({
   validateUserTyping,
   validateChip = EMAIL_PATTERN,
   separators = EMAIL_SEPARATORS,
+  trimChips = true,
+  revealEdgeWhitespace = false,
   placeholder,
   disabled,
   error,
@@ -79,17 +90,20 @@ export const EmailsBadge = ({
       const hasSeparator = stringIncludesSeparator(newValue, filteredSeparators)
       const emails = splitEmailsBySeparators(newValue, filteredSeparators)
       const lastEmail = emails.pop()
+      const normalize = (email) => (trimChips ? email.trim() : email)
       setEmails((prevState) => {
-        const updatedState = [
-          ...prevState,
-          ...emails.map((email) => email.trim()),
-          ...(hasSeparator && lastEmail ? [lastEmail.trim()] : []),
-        ]
+        // an entry left empty once trimmed matches nothing: drop it instead of
+        // committing a chip the user cannot see
+        const committed = [
+          ...emails.map(normalize),
+          ...(hasSeparator && lastEmail ? [normalize(lastEmail)] : []),
+        ].filter(isMeaningful)
+        const updatedState = [...prevState, ...committed]
         return hasSeparator ? removeDuplicates(updatedState) : updatedState
       })
       setInputValue(hasSeparator ? '' : lastEmail)
     },
-    [separators],
+    [separators, trimChips],
   )
 
   const handleInputChange = (e) => {
@@ -205,6 +219,32 @@ export const EmailsBadge = ({
   }, [emails, onChange])
 
   // RENDER
+  /**
+   * Leading and trailing spaces collapse when the browser renders them, so a chip whose value
+   * keeps them verbatim (JSON and YAML keys) has to spell them out.
+   */
+  const renderChipLabel = (email) => {
+    if (!revealEdgeWhitespace) return email
+
+    const [, leading, core, trailing] = email.match(EDGE_WHITESPACE_PATTERN)
+
+    return (
+      <span className={styles['email-badge-tag-label']}>
+        {leading && (
+          <span className={styles['email-badge-tag-whitespace']}>
+            {WHITESPACE_MARKER.repeat(leading.length)}
+          </span>
+        )}
+        {core}
+        {trailing && (
+          <span className={styles['email-badge-tag-whitespace']}>
+            {WHITESPACE_MARKER.repeat(trailing.length)}
+          </span>
+        )}
+      </span>
+    )
+  }
+
   const renderChip = (email, index) => {
     const isValid =
       typeof validateChipRef.current === 'object'
@@ -216,6 +256,7 @@ export const EmailsBadge = ({
         key={index}
         className={styles['email-badge-item']}
         onClick={(e) => handleClickOnChip(e, index)}
+        title={revealEdgeWhitespace ? email : undefined}
       >
         <Tag
           status={
@@ -227,7 +268,7 @@ export const EmailsBadge = ({
           }
           onRemove={() => removeEmail(index)}
         >
-          {email}
+          {renderChipLabel(email)}
         </Tag>
       </div>
     )
@@ -279,6 +320,8 @@ EmailsBadge.propTypes = {
   value: PropTypes.arrayOf(PropTypes.string),
   validateUserTyping: PropTypes.func,
   validateChip: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  trimChips: PropTypes.bool,
+  revealEdgeWhitespace: PropTypes.bool,
   placeholder: PropTypes.string,
   disabled: PropTypes.bool,
   error: PropTypes.object,

--- a/public/js/components/common/EmailsBadge/EmailsBadge.module.scss
+++ b/public/js/components/common/EmailsBadge/EmailsBadge.module.scss
@@ -94,6 +94,16 @@
   }
 }
 
+// only rendered when the chip has to reveal its edge whitespace: `pre` keeps repeated
+// internal spaces at their real width too
+.email-badge-tag-label {
+  white-space: pre;
+}
+
+.email-badge-tag-whitespace {
+  opacity: 0.55;
+}
+
 .email-badge-tag-remove {
   flex-shrink: 0;
   margin: -2px -4px -2px 0 !important;

--- a/public/js/components/common/EmailsBadge/EmailsBadge.test.js
+++ b/public/js/components/common/EmailsBadge/EmailsBadge.test.js
@@ -219,6 +219,121 @@ describe('EmailsBadge additional behaviors', () => {
     expect(screen.getByText('b@mail.com')).toBeInTheDocument()
   })
 
+  it('drops an entry that is only whitespace instead of committing an empty chip', async () => {
+    const user = userEvent.setup()
+    let emails = []
+    const setEmails = (data) => (emails = data)
+
+    render(
+      <EmailsBadge
+        name="invite"
+        value={emails}
+        onChange={setEmails}
+        separators={[',', SPECIALS_SEPARATORS.EnterKey]}
+      />,
+    )
+
+    const inputElement = screen.getByTestId('email-input')
+    await user.type(inputElement, '   ')
+    await user.keyboard('{Enter}')
+
+    expect(emails).toEqual([])
+  })
+
+  it('keeps the padding when trimChips is false', async () => {
+    const user = userEvent.setup()
+    let emails = []
+    const setEmails = (data) => (emails = data)
+
+    render(
+      <EmailsBadge
+        name="invite"
+        value={emails}
+        onChange={setEmails}
+        separators={[',', SPECIALS_SEPARATORS.EnterKey]}
+        trimChips={false}
+      />,
+    )
+
+    const inputElement = screen.getByTestId('email-input')
+    await user.type(inputElement, ' my key ')
+    await user.keyboard('{Enter}')
+
+    expect(emails).toEqual([' my key '])
+  })
+
+  it('trims the padding by default', async () => {
+    const user = userEvent.setup()
+    let emails = []
+    const setEmails = (data) => (emails = data)
+
+    render(
+      <EmailsBadge
+        name="invite"
+        value={emails}
+        onChange={setEmails}
+        separators={[',', SPECIALS_SEPARATORS.EnterKey]}
+      />,
+    )
+
+    const inputElement = screen.getByTestId('email-input')
+    await user.type(inputElement, ' my-key ')
+    await user.keyboard('{Enter}')
+
+    expect(emails).toEqual(['my-key'])
+  })
+
+  it('closes a chip on the space bar when the space is a configured separator', async () => {
+    const user = userEvent.setup()
+    let emails = []
+    const setEmails = (data) => (emails = data)
+
+    render(
+      <EmailsBadge
+        name="invite"
+        value={emails}
+        onChange={setEmails}
+        separators={[',', ' ', SPECIALS_SEPARATORS.EnterKey]}
+      />,
+    )
+
+    const inputElement = screen.getByTestId('email-input')
+    await user.type(inputElement, 'div span,p')
+    await user.keyboard('{Enter}')
+
+    expect(emails).toEqual(['div', 'span', 'p'])
+  })
+
+  it('spells out the edge whitespace when revealEdgeWhitespace is set', () => {
+    render(
+      <EmailsBadge
+        name="invite"
+        value={[' my key  ']}
+        onChange={() => {}}
+        revealEdgeWhitespace
+      />,
+    )
+
+    // one dot per edge space, the internal space untouched
+    expect(screen.getByText('·')).toBeInTheDocument()
+    expect(screen.getByText('··')).toBeInTheDocument()
+    expect(screen.getByText('my key')).toBeInTheDocument()
+    // getByTitle normalizes whitespace, so assert on the raw attribute
+    expect(document.querySelector('[title]')).toHaveAttribute(
+      'title',
+      ' my key  ',
+    )
+  })
+
+  it('renders the value as-is when revealEdgeWhitespace is not set', () => {
+    render(
+      <EmailsBadge name="invite" value={[' my key  ']} onChange={() => {}} />,
+    )
+
+    expect(screen.queryByText('·')).not.toBeInTheDocument()
+    expect(document.querySelector('[title]')).toBeNull()
+  })
+
   it('supports a RegExp validateChip prop for marking invalid chips', () => {
     render(
       <EmailsBadge

--- a/public/js/components/common/KeysBadge/KeysBadge.js
+++ b/public/js/components/common/KeysBadge/KeysBadge.js
@@ -2,7 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {EmailsBadge, SPECIALS_SEPARATORS} from '../EmailsBadge/EmailsBadge'
 
-export const WordsBadge = ({
+/**
+ * Pill input for the JSON and YAML extraction parameters.
+ *
+ * A JSON object key and a YAML mapping key are arbitrary strings, so " label " is a legitimate
+ * key distinct from "label": the value is kept verbatim and the pill spells out the padding.
+ * The space bar therefore cannot close a pill here, unlike in {@link WordsBadge}.
+ */
+export const KeysBadge = ({
   name,
   onChange,
   value = [],
@@ -17,9 +24,9 @@ export const WordsBadge = ({
         onChange,
         value,
         validateChip: /./,
-        // none of these formats allows whitespace inside a name, so the space bar
-        // closes a pill just like the comma does
-        separators: [',', ' ', SPECIALS_SEPARATORS.EnterKey],
+        separators: [',', SPECIALS_SEPARATORS.EnterKey],
+        trimChips: false,
+        revealEdgeWhitespace: true,
         placeholder,
         disabled,
         error,
@@ -28,10 +35,11 @@ export const WordsBadge = ({
   )
 }
 
-WordsBadge.propTypes = {
+KeysBadge.propTypes = {
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.arrayOf(PropTypes.string),
   placeholder: PropTypes.string,
+  disabled: PropTypes.bool,
   error: PropTypes.object,
 }

--- a/public/js/components/common/KeysBadge/index.js
+++ b/public/js/components/common/KeysBadge/index.js
@@ -1,0 +1,1 @@
+export * from './KeysBadge'

--- a/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Json.js
+++ b/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Json.js
@@ -1,7 +1,7 @@
 import React, {useContext, useEffect, useRef, useState} from 'react'
 import Switch from '../../../../common/Switch'
 import {SegmentedControl} from '../../../../common/SegmentedControl'
-import {WordsBadge} from '../../../../common/WordsBadge/WordsBadge'
+import {KeysBadge} from '../../../../common/KeysBadge/KeysBadge'
 import {FiltersParamsContext} from './FiltersParamsContext'
 import {Controller, useForm} from 'react-hook-form'
 import {isEqual} from 'lodash'
@@ -100,7 +100,7 @@ export const Json = () => {
             control={control}
             name={id}
             render={({field: {onChange, value, name}}) => (
-              <WordsBadge
+              <KeysBadge
                 name={name}
                 value={value}
                 onChange={onChange}
@@ -197,7 +197,7 @@ export const Json = () => {
           control={control}
           name="context_keys"
           render={({field: {onChange, value, name}}) => (
-            <WordsBadge
+            <KeysBadge
               name={name}
               value={value}
               onChange={onChange}
@@ -226,7 +226,7 @@ export const Json = () => {
           control={control}
           name="character_limit"
           render={({field: {onChange, value, name}}) => (
-            <WordsBadge
+            <KeysBadge
               name={name}
               value={value}
               onChange={onChange}

--- a/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Json.test.js
+++ b/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Json.test.js
@@ -121,6 +121,27 @@ describe('Json', () => {
     expect(updated.json.context_keys).toEqual(['note'])
   })
 
+  test('a key keeps its padding and the pill spells it out', async () => {
+    const user = userEvent.setup()
+    const {modifyingCurrentTemplate, currentTemplate} = setup()
+
+    const contextKeysInput = screen.getAllByTestId('email-input')[1]
+
+    await user.type(contextKeysInput, ' my key ')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(modifyingCurrentTemplate).toHaveBeenCalled())
+
+    const updater =
+      modifyingCurrentTemplate.mock.calls[
+        modifyingCurrentTemplate.mock.calls.length - 1
+      ][0]
+    const updated = updater(currentTemplate)
+    // the space bar must not split a JSON key
+    expect(updated.json.context_keys).toEqual([' my key '])
+    expect(screen.getAllByText('·')).toHaveLength(2)
+  })
+
   test('does not call modifyingCurrentTemplate when nothing changed', () => {
     const {modifyingCurrentTemplate} = setup()
 

--- a/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/MsPowerpoint.test.js
+++ b/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/MsPowerpoint.test.js
@@ -127,6 +127,24 @@ describe('MsPowerpoint', () => {
     expect(updated.msPowerpoint.extract_notes).toBe(false)
   })
 
+  test('the space bar closes a slide pill', async () => {
+    const user = userEvent.setup()
+    const {modifyingCurrentTemplate, currentTemplate} = setup()
+
+    await user.type(screen.getByTestId('email-input'), '1 3 5')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(modifyingCurrentTemplate).toHaveBeenCalled())
+
+    const updater =
+      modifyingCurrentTemplate.mock.calls[
+        modifyingCurrentTemplate.mock.calls.length - 1
+      ][0]
+    const updated = updater(currentTemplate)
+    // the panel converts the pills to slide numbers before it saves
+    expect(updated.msPowerpoint.translate_slides).toEqual([1, 3, 5])
+  })
+
   test('does not call modifyingCurrentTemplate when nothing changed', () => {
     const {modifyingCurrentTemplate} = setup()
 

--- a/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/MsWord.test.js
+++ b/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/MsWord.test.js
@@ -135,6 +135,27 @@ describe('MsWord', () => {
     expect(updated.msWord.exclude_highlight_colors).toEqual(['yellow'])
   })
 
+  test('a style name loses its padding but keeps its internal space', async () => {
+    const user = userEvent.setup()
+    const {modifyingCurrentTemplate, currentTemplate} = setup()
+
+    const excludeStylesInput = screen.getAllByTestId('email-input')[0]
+
+    // the panel tells users to strip the spaces from a style name, so the space bar
+    // closing the pill is what they want; only the padding is dropped
+    await user.type(excludeStylesInput, ' testStyle ')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(modifyingCurrentTemplate).toHaveBeenCalled())
+
+    const updater =
+      modifyingCurrentTemplate.mock.calls[
+        modifyingCurrentTemplate.mock.calls.length - 1
+      ][0]
+    const updated = updater(currentTemplate)
+    expect(updated.msWord.exclude_styles).toEqual(['testStyle'])
+  })
+
   test('does not call modifyingCurrentTemplate when nothing changed', () => {
     const {modifyingCurrentTemplate} = setup()
 

--- a/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/NumbersDashBadge.js
+++ b/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/NumbersDashBadge.js
@@ -15,8 +15,10 @@ export const NumbersDashBadge = ({
   disabled,
   error,
 }) => {
+  // the space has to get through the keystroke filter, otherwise the space bar could
+  // never close a pill here
   const validateUserTypingCallback = useCallback(
-    (value) => /^[0-9-,]*$/.test(value),
+    (value) => /^[0-9-, ]*$/.test(value),
     [],
   )
 
@@ -36,7 +38,7 @@ export const NumbersDashBadge = ({
         value,
         validateUserTyping: validateUserTypingCallback,
         validateChip: validateChipCallback,
-        separators: [',', SPECIALS_SEPARATORS.EnterKey],
+        separators: [',', ' ', SPECIALS_SEPARATORS.EnterKey],
         placeholder,
         disabled,
         error,

--- a/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Xml.test.js
+++ b/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Xml.test.js
@@ -104,6 +104,25 @@ describe('Xml', () => {
     expect(updated.xml.translate_attributes).toEqual(['p@class'])
   })
 
+  test('the space bar and the comma both close a pill, without the padding', async () => {
+    const user = userEvent.setup()
+    const {modifyingCurrentTemplate, currentTemplate} = setup()
+
+    const elementsInput = screen.getAllByTestId('email-input')[0]
+
+    await user.type(elementsInput, ' div span,p ')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(modifyingCurrentTemplate).toHaveBeenCalled())
+
+    const updater =
+      modifyingCurrentTemplate.mock.calls[
+        modifyingCurrentTemplate.mock.calls.length - 1
+      ][0]
+    const updated = updater(currentTemplate)
+    expect(updated.xml.translate_elements).toEqual(['div', 'span', 'p'])
+  })
+
   test('does not call modifyingCurrentTemplate when nothing changed', () => {
     const {modifyingCurrentTemplate} = setup()
 

--- a/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Yaml.js
+++ b/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Yaml.js
@@ -1,6 +1,6 @@
 import React, {useContext, useEffect, useRef, useState} from 'react'
 import {SegmentedControl} from '../../../../common/SegmentedControl'
-import {WordsBadge} from '../../../../common/WordsBadge/WordsBadge'
+import {KeysBadge} from '../../../../common/KeysBadge/KeysBadge'
 import {FiltersParamsContext} from './FiltersParamsContext'
 import {Controller, useForm} from 'react-hook-form'
 import {isEqual} from 'lodash'
@@ -106,7 +106,7 @@ export const Yaml = () => {
             control={control}
             name={id}
             render={({field: {onChange, value, name}}) => (
-              <WordsBadge
+              <KeysBadge
                 name={name}
                 value={value}
                 onChange={onChange}
@@ -172,7 +172,7 @@ export const Yaml = () => {
           control={control}
           name="context_keys"
           render={({field: {onChange, value, name}}) => (
-            <WordsBadge
+            <KeysBadge
               name={name}
               value={value}
               onChange={onChange}
@@ -201,7 +201,7 @@ export const Yaml = () => {
           control={control}
           name="character_limit"
           render={({field: {onChange, value, name}}) => (
-            <WordsBadge
+            <KeysBadge
               name={name}
               value={value}
               onChange={onChange}

--- a/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Yaml.test.js
+++ b/public/js/components/settingsPanel/Contents/FileImportTab/FiltersParams/Yaml.test.js
@@ -102,6 +102,27 @@ describe('Yaml', () => {
     expect(updated.yaml.character_limit).toEqual(['limitKey'])
   })
 
+  test('a key keeps its padding and the pill spells it out', async () => {
+    const user = userEvent.setup()
+    const {modifyingCurrentTemplate, currentTemplate} = setup()
+
+    const contextKeysInput = screen.getAllByTestId('email-input')[1]
+
+    await user.type(contextKeysInput, ' my key ')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(modifyingCurrentTemplate).toHaveBeenCalled())
+
+    const updater =
+      modifyingCurrentTemplate.mock.calls[
+        modifyingCurrentTemplate.mock.calls.length - 1
+      ][0]
+    const updated = updater(currentTemplate)
+    // the space bar must not split a YAML key
+    expect(updated.yaml.context_keys).toEqual([' my key '])
+    expect(screen.getAllByText('·')).toHaveLength(2)
+  })
+
   test('does not call modifyingCurrentTemplate when nothing changed', () => {
     const {modifyingCurrentTemplate} = setup()
 

--- a/tests/unit/Core/Filters/DTO/DitaTest.php
+++ b/tests/unit/Core/Filters/DTO/DitaTest.php
@@ -45,4 +45,22 @@ class DitaTest extends AbstractTest
         $dto = new Dita();
         $this->assertInstanceOf(\JsonSerializable::class, $dto);
     }
+
+    #[Test]
+    public function setterTrimsNamesAndDropsTheEmptyOnes(): void
+    {
+        $dto = new Dita();
+        $dto->setDoNotTranslateElements([' topic ', "note\t", '  ']);
+
+        $this->assertSame(['topic', 'note'], $dto->jsonSerialize()['do_not_translate_elements']);
+    }
+
+    #[Test]
+    public function fromArrayTrimsNames(): void
+    {
+        $dto = new Dita();
+        $dto->fromArray(['do_not_translate_elements' => [' keyword ']]);
+
+        $this->assertSame(['keyword'], $dto->jsonSerialize()['do_not_translate_elements']);
+    }
 }

--- a/tests/unit/Core/Filters/DTO/JsonTest.php
+++ b/tests/unit/Core/Filters/DTO/JsonTest.php
@@ -150,4 +150,29 @@ class JsonTest extends AbstractTest
         $dto = new Json();
         $dto->fromArray(['inner_content_type' => 'invalid/type']);
     }
+
+    #[Test]
+    public function keysKeepTheirLeadingAndTrailingSpaces(): void
+    {
+        // a JSON object key is an arbitrary string, so " label " is a legitimate key
+        // distinct from "label" and must survive untouched
+        $dto = new Json();
+        $dto->setTranslateKeys([' label ']);
+        $dto->setContextKeys(['  note']);
+        $dto->setCharacterLimit(['limit  ']);
+
+        $result = $dto->jsonSerialize();
+        $this->assertSame([' label '], $result['translate_keys']);
+        $this->assertSame(['  note'], $result['context_keys']);
+        $this->assertSame(['limit  '], $result['character_limit']);
+    }
+
+    #[Test]
+    public function fromArrayKeepsKeyPadding(): void
+    {
+        $dto = new Json();
+        $dto->fromArray(['do_not_translate_keys' => [' label ', '   ']]);
+
+        $this->assertSame([' label ', '   '], $dto->jsonSerialize()['do_not_translate_keys']);
+    }
 }

--- a/tests/unit/Core/Filters/DTO/MSExcelTest.php
+++ b/tests/unit/Core/Filters/DTO/MSExcelTest.php
@@ -71,4 +71,22 @@ class MSExcelTest extends AbstractTest
         $dto->fromArray(['unknown' => true]);
         $this->assertFalse($dto->jsonSerialize()['extract_doc_properties']);
     }
+
+    #[Test]
+    public function setterTrimsColumnsAndDropsTheEmptyOnes(): void
+    {
+        $dto = new MSExcel();
+        $dto->setExcludeColumns([' A ', "B\t", ' ', '']);
+
+        $this->assertSame(['A', 'B'], $dto->jsonSerialize()['exclude_columns']);
+    }
+
+    #[Test]
+    public function fromArrayTrimsColumns(): void
+    {
+        $dto = new MSExcel();
+        $dto->fromArray(['exclude_columns' => [' AA ']]);
+
+        $this->assertSame(['AA'], $dto->jsonSerialize()['exclude_columns']);
+    }
 }

--- a/tests/unit/Core/Filters/DTO/MSPowerpointTest.php
+++ b/tests/unit/Core/Filters/DTO/MSPowerpointTest.php
@@ -70,4 +70,15 @@ class MSPowerpointTest extends AbstractTest
         $dto->fromArray(['unknown' => true]);
         $this->assertFalse($dto->jsonSerialize()['extract_doc_properties']);
     }
+
+    #[Test]
+    public function setterKeepsTheSlideNumbersAsTheyArrive(): void
+    {
+        // the frontend converts the pills to integers before it saves, so the stored type
+        // has to survive untouched
+        $dto = new MSPowerpoint();
+        $dto->setTranslateSlides([1, 3, 5]);
+
+        $this->assertSame([1, 3, 5], $dto->jsonSerialize()['translate_slides']);
+    }
 }

--- a/tests/unit/Core/Filters/DTO/MSWordTest.php
+++ b/tests/unit/Core/Filters/DTO/MSWordTest.php
@@ -76,4 +76,25 @@ class MSWordTest extends AbstractTest
         $dto->fromArray(['unknown' => true]);
         $this->assertFalse($dto->jsonSerialize()['extract_doc_properties']);
     }
+
+    #[Test]
+    public function settersTrimTheEdgesAndKeepInternalSpaces(): void
+    {
+        $dto = new MSWord();
+        $dto->setExcludeStyles([' Heading 1 ', '  ', 'Body Text']);
+        $dto->setExcludeHighlightColors([" yellow\n", '']);
+
+        $result = $dto->jsonSerialize();
+        $this->assertSame(['Heading 1', 'Body Text'], $result['exclude_styles']);
+        $this->assertSame(['yellow'], $result['exclude_highlight_colors']);
+    }
+
+    #[Test]
+    public function fromArrayTrimsNames(): void
+    {
+        $dto = new MSWord();
+        $dto->fromArray(['exclude_styles' => [' Normal ', ' ']]);
+
+        $this->assertSame(['Normal'], $dto->jsonSerialize()['exclude_styles']);
+    }
 }

--- a/tests/unit/Core/Filters/DTO/XmlTest.php
+++ b/tests/unit/Core/Filters/DTO/XmlTest.php
@@ -70,4 +70,25 @@ class XmlTest extends AbstractTest
         $dto->fromArray(['unknown' => true]);
         $this->assertFalse($dto->jsonSerialize()['preserve_whitespace']);
     }
+
+    #[Test]
+    public function settersTrimNamesAndDropTheEmptyOnes(): void
+    {
+        $dto = new Xml();
+        $dto->setTranslateElements([' p ', "span\t", '  ', '']);
+        $dto->setTranslateAttributes(["  div@alt\n", ' ']);
+
+        $result = $dto->jsonSerialize();
+        $this->assertSame(['p', 'span'], $result['translate_elements']);
+        $this->assertSame(['div@alt'], $result['translate_attributes']);
+    }
+
+    #[Test]
+    public function fromArrayTrimsNames(): void
+    {
+        $dto = new Xml();
+        $dto->fromArray(['do_not_translate_elements' => [' script ', '   ']]);
+
+        $this->assertSame(['script'], $dto->jsonSerialize()['do_not_translate_elements']);
+    }
 }

--- a/tests/unit/Core/Filters/DTO/YamlTest.php
+++ b/tests/unit/Core/Filters/DTO/YamlTest.php
@@ -128,4 +128,29 @@ class YamlTest extends AbstractTest
             $this->assertSame($type, $dto->jsonSerialize()['inner_content_type']);
         }
     }
+
+    #[Test]
+    public function keysKeepTheirLeadingAndTrailingSpaces(): void
+    {
+        // a YAML mapping key is an arbitrary string, so " label " is a legitimate key
+        // distinct from "label" and must survive untouched
+        $dto = new Yaml();
+        $dto->setTranslateKeys([' label ']);
+        $dto->setContextKeys(['  note']);
+        $dto->setCharacterLimit(['limit  ']);
+
+        $result = $dto->jsonSerialize();
+        $this->assertSame([' label '], $result['translate_keys']);
+        $this->assertSame(['  note'], $result['context_keys']);
+        $this->assertSame(['limit  '], $result['character_limit']);
+    }
+
+    #[Test]
+    public function fromArrayKeepsKeyPadding(): void
+    {
+        $dto = new Yaml();
+        $dto->fromArray(['do_not_translate_keys' => [' label ', '   ']]);
+
+        $this->assertSame([' label ', '   '], $dto->jsonSerialize()['do_not_translate_keys']);
+    }
 }

--- a/tests/unit/Core/Model/Filters/FiltersConfigTemplateStructTest.php
+++ b/tests/unit/Core/Model/Filters/FiltersConfigTemplateStructTest.php
@@ -13,6 +13,8 @@ use Model\Filters\DTO\Xml;
 use Model\Filters\DTO\Yaml;
 use Model\Filters\FiltersConfigTemplateStruct;
 use PHPUnit\Framework\Attributes\Test;
+use Utils\Validator\JSONSchema\JSONValidator;
+use Utils\Validator\JSONSchema\JSONValidatorObject;
 
 class FiltersConfigTemplateStructTest extends AbstractTest
 {
@@ -146,6 +148,73 @@ class FiltersConfigTemplateStructTest extends AbstractTest
         $this->assertInstanceOf(MSWord::class, $struct->getMsWord());
         $this->assertInstanceOf(MSPowerpoint::class, $struct->getMsPowerpoint());
         $this->assertInstanceOf(Dita::class, $struct->getDita());
+    }
+
+    #[Test]
+    public function hydrateAllDto_normalizes_the_names_that_cannot_carry_padding(): void
+    {
+        // hydrateAllDto() runs on the read path too (FiltersConfigTemplateDao::hydrateTemplateStruct),
+        // so a row stored with padding before the names were normalized comes back clean
+        $struct = new FiltersConfigTemplateStruct();
+        $struct->hydrateAllDto([
+            'xml'           => ['translate_elements' => [' div ', '  ']],
+            'ms_word'       => ['exclude_styles' => [' Heading 1 ']],
+            'ms_excel'      => ['exclude_columns' => [' A ']],
+            'dita'          => ['do_not_translate_elements' => [' topic ']],
+        ]);
+
+        $this->assertSame(['div'], $struct->getXml()->jsonSerialize()['translate_elements']);
+        $this->assertSame(['Heading 1'], $struct->getMsWord()->jsonSerialize()['exclude_styles']);
+        $this->assertSame(['A'], $struct->getMsExcel()->jsonSerialize()['exclude_columns']);
+        $this->assertSame(['topic'], $struct->getDita()->jsonSerialize()['do_not_translate_elements']);
+    }
+
+    #[Test]
+    public function hydrateAllDto_preserves_json_and_yaml_key_padding(): void
+    {
+        $struct = new FiltersConfigTemplateStruct();
+        $struct->hydrateAllDto([
+            'json' => '{"translate_keys":[" label "]}',
+            'yaml' => ['context_keys' => ['  note']],
+        ]);
+
+        $this->assertSame([' label '], $struct->getJson()->jsonSerialize()['translate_keys']);
+        $this->assertSame(['  note'], $struct->getYaml()->jsonSerialize()['context_keys']);
+    }
+
+    #[Test]
+    public function the_whole_write_path_normalizes_the_names_and_keeps_the_keys(): void
+    {
+        // the payload a client POSTs to /api/v3/filters-config-template: the schema declares the
+        // lists without an `items` constraint, so the padding passes validation and the DTOs are
+        // the only place that can strip it
+        $payload = json_encode([
+            'name'     => 'padded',
+            'uid'      => 1,
+            'xml'      => ['translate_elements' => [' div ', '  ']],
+            'ms_word'  => ['exclude_styles' => [' Heading 1 ']],
+            'ms_excel' => ['exclude_columns' => [' A ']],
+            'dita'     => ['do_not_translate_elements' => [' topic ']],
+            'json'     => ['translate_keys' => [' label ']],
+            'yaml'     => ['context_keys' => ['  note']],
+        ], JSON_THROW_ON_ERROR);
+
+        $validatorObject = new JSONValidatorObject($payload);
+        (new JSONValidator('filters_extraction_parameters.json', true))->validate($validatorObject);
+
+        $struct = (new FiltersConfigTemplateStruct())->hydrateFromJSON($payload);
+        $serialized = $struct->jsonSerialize();
+
+        $this->assertSame(['div'], $serialized['xml']->jsonSerialize()['translate_elements']);
+        $this->assertSame(['Heading 1'], $serialized['ms_word']->jsonSerialize()['exclude_styles']);
+        $this->assertSame(['A'], $serialized['ms_excel']->jsonSerialize()['exclude_columns']);
+        $this->assertSame(
+            ['topic'],
+            $serialized['dita']->jsonSerialize()['do_not_translate_elements']
+        );
+        // JSON and YAML keys are arbitrary strings: the padding is part of the identifier
+        $this->assertSame([' label '], $serialized['json']->jsonSerialize()['translate_keys']);
+        $this->assertSame(['  note'], $serialized['yaml']->jsonSerialize()['context_keys']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

In Settings panel → File import → **Extraction parameters**, a name typed with a leading or
trailing space rendered identically to one without it, because a pill collapses whitespace. Users
could not tell what had actually been saved.

Names are now normalised for the formats where padding is meaningless, and kept verbatim — and
shown — for the two where it is part of the identifier. Entering a value is also quicker: the space
bar closes a pill wherever a name cannot contain a space.

No schema change is involved.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Model/Filters/DTO/NormalizesNamesTrait.php` | New. Trims each member, drops the ones left empty, tolerates the non-string members the schema still permits |
| `lib/Model/Filters/DTO/{Xml,Dita,MSWord,MSExcel}.php` | Apply the trait in the seven list setters whose names cannot carry padding |
| `lib/Model/Filters/DTO/{Json,Yaml}.php` | Untouched — their four key lists stay verbatim |
| `lib/Model/Filters/DTO/MSPowerpoint.php` | Comment only, documenting why `translate_slides` is excluded |
| `lib/Model/Filters/Readme.md` | Document the normalisation for API consumers |
| `public/js/components/common/EmailsBadge/EmailsBadge.js` | New `trimChips` / `revealEdgeWhitespace` props, both defaulting to the old behaviour; an all-whitespace entry no longer becomes a pill |
| `public/js/components/common/EmailsBadge/EmailsBadge.module.scss` | Styles for the chip label and the whitespace markers |
| `public/js/components/common/KeysBadge/` | New wrapper for JSON and YAML: verbatim values, edge whitespace shown, no space separator |
| `public/js/components/common/WordsBadge/WordsBadge.js` | Add the space as a separator |
| `public/js/components/settingsPanel/.../FiltersParams/{Json,Yaml}.js` | Swap `WordsBadge` for `KeysBadge` at the six call sites |
| `public/js/components/settingsPanel/.../FiltersParams/NumbersDashBadge.js` | Let a space through the keystroke filter so the space bar can close a slide pill |
| `tests/unit/Core/Filters/DTO/*Test.php`, `tests/unit/Core/Model/Filters/FiltersConfigTemplateStructTest.php` | Per-setter trim and verbatim cases, plus a full write-path test through the real JSON schema validator |
| `public/js/**/*.test.js` | Space separator, trim, verbatim keys, whitespace markers, slide pills |

### Which lists trim, and why

| Lists | Behaviour |
|---|---|
| `xml.translate_elements`, `xml.do_not_translate_elements`, `xml.translate_attributes`, `dita.do_not_translate_elements`, `ms_word.exclude_styles`, `ms_word.exclude_highlight_colors`, `ms_excel.exclude_columns` | **Trimmed.** These are tokens in which a leading or trailing space is never meaningful — an XML `NCName` cannot contain whitespace, and the MS Word panel copy already tells users to strip spaces from style names. Internal spaces survive: `" Heading 1 "` → `"Heading 1"` |
| `json.*` and `yaml.*` — `translate_keys`, `do_not_translate_keys`, `context_keys`, `character_limit` | **Verbatim.** All four hold *key names*. A JSON object key and a YAML mapping key are arbitrary strings, so `" label "` is a legitimate key distinct from `"label"`. The pill spells the padding out as a muted dot per space, with the raw value on the chip's `title` |
| `ms_powerpoint.translate_slides` | **Untouched.** These are slide numbers, not names: `convertTranslateSlidesToServer()` parseInts the pills, so the column persists integers, and casting them to strings would change the stored and returned JSON type. `NumbersDashBadge` already refuses whitespace on the way in |

### Why the DTO setters

`FiltersConfigTemplateDao::hydrateTemplateStruct()` runs `hydrateAllDto()` on the **read** path as
well as the write path, so normalising in the setters also cleans rows that were stored with
padding before this change — no migration, no backfill. It is also the only choke point that
covers `GDriveController`, which hydrates with no schema validation at all.

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

**PHPStan** — full run, `[OK] No errors`.

**PHPUnit** — 10318 tests. 8 failures, all pre-existing on `develop` and unrelated
(`SignupControllerTest`, `CommentControllerTest`, `SignupModelUnitTest`, `UserDaoRealSqlTest`);
verified by re-running those four files with the DTO changes reverted and getting the same 8.

**Jest** — full suite green: 427 suites, 4409 tests.

**Write path** — `the_whole_write_path_normalizes_the_names_and_keeps_the_keys` runs a real
`POST /api/v3/filters-config-template` payload through `JSONValidator` →
`hydrateFromJSON()` → `jsonSerialize()` and asserts `[" div ", "  "]` → `["div"]` alongside
`[" label "]` → `[" label "]`.

**Manual** — Settings panel → File import → Extraction parameters:

- XML: typing `div span,p` gives three pills, none padded; space and comma both close one.
- MS Word: `" testStyle "` + Enter gives `testStyle`.
- JSON / YAML: `" my key "` + Enter gives one pill rendered `·my key·`, and the space bar does not
  split the key.
- PowerPoint: `1 3 5` gives three pills.
- Team invite modals (`CreateTeam`, `ModifyTeam`) unchanged — they use `EmailsBadge` directly and
  both new props default to the previous behaviour.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

Two things found on the way that are **not** addressed here:

1. `CreateProjectController::validateFiltersExtractionParameters()` returns a raw array that
   bypasses the DTOs, so padding typed there survives. It is only `json_encode`d into project
   metadata and never reaches the conversion service, which always goes through the struct — so it
   is cosmetic, but it is the one remaining gap.
2. `migrations/20250110104800_add_dita_to_filters_config_table.php` writes
   `ADD COLUMN \`dita\` TEXT DEFAULT "{}"`, which MySQL rejects with error 1101 (a `TEXT` column
   cannot carry a default). It presumably ran on MariaDB. Worth a separate fix — and note
   `INSTALL/matecat.sql` does not ship `filters_config_templates` or `xliff_config_templates` at
   all, so a fresh install depends on that migration succeeding.

Trimming changes the conversion cache key (`ConversionHandler` hashes
`json_encode($extraction_parameters)`), so files under a template that currently holds padded
values will re-convert once. No action needed.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209289320047006