### PR TITLE
🐛 fix(contribution): reserve a result slot for the MT suggestion

### DIFF
--- a/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/MatchProcessorService.php
+++ b/lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/MatchProcessorService.php
@@ -40,12 +40,13 @@ class MatchProcessorService implements MatchProcessorServiceInterface
     /**
      * @param array<string, mixed>              $mtResult
      * @param array<int, array<string, mixed>>  $tmMatches
+     * @param int|null                          $limit
      *
      * @return list<array<string, mixed>>
      */
-    public function sortMatches(array $mtResult, array $tmMatches): array
+    public function sortMatches(array $mtResult, array $tmMatches, ?int $limit = null): array
     {
-        return $this->matchSorter->sortMatches($mtResult, $tmMatches);
+        return $this->matchSorter->sortMatches($mtResult, $tmMatches, $limit);
     }
 
     /**

--- a/lib/Utils/AsyncTasks/Workers/GetContributionWorker.php
+++ b/lib/Utils/AsyncTasks/Workers/GetContributionWorker.php
@@ -83,7 +83,10 @@ class GetContributionWorker extends AbstractWorker
 
         [$mt_result, $matches] = $this->_getMatches($contributionStruct, $jobStruct, $jobStruct->target, $featureSet);
 
-        $matches = $this->matchSorter->sortMatches($mt_result, $matches);
+        // The limit is applied by the sorter, which reserves a slot for the MT suggestion:
+        // the TM is asked for resultNum matches and the MT row is appended to them, so cutting
+        // the tail here would drop the MT row whenever every TM match outscores it.
+        $matches = $this->matchSorter->sortMatches($mt_result, $matches, $contributionStruct->resultNum);
 
         if (!$contributionStruct->concordanceSearch) {
             //execute these lines only in segment contribution search,
@@ -91,7 +94,6 @@ class GetContributionWorker extends AbstractWorker
             $this->updateAnalysisSuggestion($matches, $contributionStruct);
         }
 
-        $matches = array_slice($matches, 0, $contributionStruct->resultNum);
         $this->normalizeMTMatches($matches, $contributionStruct, $featureSet);
 
         $this->_publishPayload($matches, $contributionStruct, $featureSet, $jobStruct->target);
@@ -467,7 +469,7 @@ class GetContributionWorker extends AbstractWorker
             !$contributionStruct->concordanceSearch &&
             !$isCrossLang
         ) {
-            if ($contributionStruct->mt_quality_value_in_editor > 99 || empty($tms_match) || (int)str_replace("%", "", $tms_match[0]['match']) < 100) {
+            if ($contributionStruct->mt_quality_value_in_editor > 99 || empty($tms_match) || $this->bestTmScore($tms_match) < 100) {
                 /**
                  * Call The MT EnginesFactory IF
                  * - The user has set an MT Quality value in the editor > 99
@@ -531,6 +533,23 @@ class GetContributionWorker extends AbstractWorker
         }
 
         return [$mt_result, $tms_match];
+    }
+
+    /**
+     * Highest score among the TM matches. The list is not assumed to be ordered: the worker
+     * re-sorts it with the MatchSorter, so the TM engine's own ordering is not relied upon.
+     *
+     * @param array<int, array<string, mixed>> $tms_match
+     */
+    private function bestTmScore(array $tms_match): int
+    {
+        $best = 0;
+
+        foreach ($tms_match as $match) {
+            $best = max($best, (int)str_replace("%", "", (string)($match['match'] ?? 0)));
+        }
+
+        return $best;
     }
 
     /**

--- a/lib/Utils/AsyncTasks/Workers/Interface/MatchSorterInterface.php
+++ b/lib/Utils/AsyncTasks/Workers/Interface/MatchSorterInterface.php
@@ -13,10 +13,14 @@ interface MatchSorterInterface
      * Appends the MT result (if non-empty) to the TM matches and sorts
      * them descending by score, with ICE and MT tiebreakers.
      *
+     * When $limit is given, at most $limit matches are returned and one slot is reserved for
+     * the MT result, so that it survives the cut even when every TM match outscores it.
+     *
      * @param array<string, mixed>              $mtResult
      * @param array<int, array<string, mixed>>  $tmMatches
+     * @param int|null                          $limit
      *
      * @return list<array<string, mixed>>
      */
-    public function sortMatches(array $mtResult, array $tmMatches): array;
+    public function sortMatches(array $mtResult, array $tmMatches, ?int $limit = null): array;
 }

--- a/lib/Utils/AsyncTasks/Workers/Service/MatchSorter.php
+++ b/lib/Utils/AsyncTasks/Workers/Service/MatchSorter.php
@@ -18,16 +18,32 @@ class MatchSorter implements MatchSorterInterface
     /**
      * @param array<string, mixed>              $mtResult
      * @param array<int, array<string, mixed>>  $tmMatches
+     * @param int|null                          $limit
      *
      * @return list<array<string, mixed>>
      */
-    public function sortMatches(array $mtResult, array $tmMatches): array
+    public function sortMatches(array $mtResult, array $tmMatches, ?int $limit = null): array
     {
+        $tmMatches = array_values($tmMatches);
+
+        if ($limit !== null) {
+            // The TM is asked for $limit matches and the MT suggestion is appended to that
+            // already full list, so the merged array overflows by one. Cutting the tail after
+            // the merge would discard the MT row every time each TM match outscores the MT
+            // application threshold, so the slot is reserved before merging instead.
+            usort($tmMatches, $this->compareScoreDesc(...));
+            $tmMatches = array_slice($tmMatches, 0, max(0, $limit - (empty($mtResult) ? 0 : 1)));
+        }
+
         if (!empty($mtResult)) {
             $tmMatches[] = $mtResult;
         }
 
         usort($tmMatches, $this->compareScoreDesc(...));
+
+        if ($limit !== null) {
+            $tmMatches = array_slice($tmMatches, 0, max(0, $limit));
+        }
 
         return $tmMatches;
     }

--- a/tests/unit/Core/TestContribution/GetContributionWorkerTest.php
+++ b/tests/unit/Core/TestContribution/GetContributionWorkerTest.php
@@ -624,6 +624,145 @@ class GetContributionWorkerTest extends AbstractTest
     }
 
     #[Test]
+    public function test_execGetContribution_keeps_the_mt_suggestion_when_the_tm_fills_the_result_budget(): void
+    {
+        $worker = new WorkerHarnessGetContributionWorker(self::getStubBuilder(AMQHandler::class)->getStub(), obtainTestDatabase());
+        $worker->queueMatchResult(
+            [
+                'match' => '76%',
+                'created_by' => EngineConstants::MT,
+                'memory_key' => '',
+                'segment' => 'Hello world',
+                'translation' => 'Ciao mondo MT',
+                'raw_translation' => 'Ciao mondo MT',
+            ],
+            [
+                [
+                    'match' => '100%',
+                    'created_by' => 'MyMemory',
+                    'memory_key' => 'k1',
+                    'segment' => 'Hello world',
+                    'translation' => 'Ciao mondo',
+                    'raw_translation' => 'Ciao mondo',
+                ],
+                [
+                    'match' => '99%',
+                    'created_by' => 'MyMemory',
+                    'memory_key' => 'k2',
+                    'segment' => 'Hello world',
+                    'translation' => 'Ciao mondo!',
+                    'raw_translation' => 'Ciao mondo!',
+                ],
+                [
+                    'match' => '98%',
+                    'created_by' => 'MyMemory',
+                    'memory_key' => 'k3',
+                    'segment' => 'Hello world',
+                    'translation' => 'Salve mondo',
+                    'raw_translation' => 'Salve mondo',
+                ],
+            ]
+        );
+
+        $request = $this->makeBaseRequest([
+            'concordanceSearch' => false,
+            'segmentId' => null,
+            'crossLangTargets' => [],
+            'resultNum' => 3,
+        ]);
+
+        $method = new ReflectionMethod($worker, '_execGetContribution');
+        $method->invoke($worker, $request);
+
+        $this->assertCount(1, $worker->publishedPayloads);
+        $published = $worker->publishedPayloads[0]['data']['payload']['matches'];
+
+        // The TM was asked for resultNum matches and the MT row is appended to them, so the
+        // budget must reserve a slot for the MT suggestion instead of cutting it off the tail.
+        $this->assertCount(3, $published);
+        $this->assertSame(EngineConstants::MT, $published[2]['match']);
+        $this->assertSame('100%', $published[0]['match']);
+        $this->assertSame('99%', $published[1]['match']);
+    }
+
+    #[Test]
+    public function test_getMatches_skips_the_mt_engine_when_the_best_tm_match_is_not_first(): void
+    {
+        $request = $this->makeBaseRequest([
+            'mt_quality_value_in_editor' => 99,
+        ]);
+        $request->setJobStruct(new JobStruct([
+            'id' => self::TEST_JOB_ID,
+            'id_project' => self::TEST_PROJECT_ID,
+            'password' => 'pw',
+            'source' => 'en-US',
+            'target' => 'it-IT',
+            'job_first_segment' => self::TEST_SEGMENT_ID,
+            'job_last_segment' => self::TEST_SEGMENT_ID,
+            'id_tms' => 1,
+            'id_mt_engine' => 2,
+            'tm_keys' => '[]',
+            'only_private_tm' => 0,
+        ]));
+
+        $featureSet = new FeatureSet($this->createStub(\Model\DataAccess\IDatabase::class));
+
+        // The 100% match is deliberately not the first element: the worker re-sorts the list
+        // itself, so the suppression must key off the best score, not the TM engine's order.
+        $tmResponse = new GetMemoryResponse([
+            'responseStatus' => 200,
+            'matches' => [
+                [
+                    'id' => 1,
+                    'segment' => 'Hello world',
+                    'translation' => 'Ciao mondo quasi',
+                    'match' => 0.95,
+                    'created-by' => 'MyMemory',
+                    'last-update-date' => '2025-01-01 10:00:00',
+                    'create-date' => '2025-01-01 10:00:00',
+                    'tm_properties' => '[]',
+                    'target_note' => '',
+                ],
+                [
+                    'id' => 2,
+                    'segment' => 'Hello world',
+                    'translation' => 'Ciao mondo',
+                    'match' => 1,
+                    'created-by' => 'MyMemory',
+                    'last-update-date' => '2025-01-01 10:00:00',
+                    'create-date' => '2025-01-01 10:00:00',
+                    'tm_properties' => '[]',
+                    'target_note' => '',
+                ],
+            ],
+        ]);
+        $tmResponse->featureSet($featureSet);
+
+        $tmEngine = $this->getMockBuilder(MyMemory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getConfigStruct', 'setMTPenalty', 'get'])
+            ->getMock();
+        $tmEngine->method('getConfigStruct')->willReturn([]);
+        $tmEngine->method('setMTPenalty')->willReturnSelf();
+        $tmEngine->expects($this->once())->method('get')->willReturn($tmResponse);
+
+        $mtEngine = $this->getMockBuilder(MyMemory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getConfigStruct', 'setMTPenalty', 'get'])
+            ->getMock();
+        $mtEngine->expects($this->never())->method('get');
+
+        $request->forcedTMEngine = $tmEngine;
+        $request->forcedMTEngine = $mtEngine;
+
+        $method = new ReflectionMethod($this->worker, '_getMatches');
+        [$mt, $matches] = $method->invoke($this->worker, $request, $request->getJobStruct(), 'it-IT', $featureSet, false);
+
+        $this->assertSame([], $mt);
+        $this->assertCount(2, $matches);
+    }
+
+    #[Test]
     public function test_normalizeMTMatches_applies_concordance_format_and_rewrites_high_score(): void
     {
         $request = $this->makeBaseRequest([

--- a/tests/unit/Core/Workers/TMAnalysisV2/MatchProcessorServiceTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/MatchProcessorServiceTest.php
@@ -157,6 +157,20 @@ class MatchProcessorServiceTest extends AbstractTest
     }
 
     #[Test]
+    public function sortMatches_forwards_the_limit_to_the_sorter(): void
+    {
+        $mt76  = ['match' => '76%',  'ICE' => false, 'created_by' => 'MT'];
+        $tm100 = ['match' => '100%', 'ICE' => false, 'created_by' => 'TM'];
+        $tm99  = ['match' => '99%',  'ICE' => false, 'created_by' => 'TM'];
+        $tm98  = ['match' => '98%',  'ICE' => false, 'created_by' => 'TM'];
+
+        $result = $this->service->sortMatches($mt76, [$tm100, $tm99, $tm98], 3);
+
+        $this->assertCount(3, $result);
+        $this->assertSame('MT', $result[2]['created_by']);
+    }
+
+    #[Test]
     public function calculateWordDiscount_returns_zero_eq_and_std_for_ice_at_zero_rate(): void
     {
         $payableRates = [

--- a/tests/unit/Core/Workers/TMAnalysisV2/MatchSorterTest.php
+++ b/tests/unit/Core/Workers/TMAnalysisV2/MatchSorterTest.php
@@ -130,6 +130,66 @@ class MatchSorterTest extends AbstractTest
     }
 
     #[Test]
+    public function sortMatches_keeps_the_mt_result_when_the_tm_fills_the_whole_limit(): void
+    {
+        $mt76  = ['match' => '76%',  'ICE' => false, 'created_by' => 'MT'];
+        $tm100 = ['match' => '100%', 'ICE' => false, 'created_by' => 'TM'];
+        $tm99  = ['match' => '99%',  'ICE' => false, 'created_by' => 'TM'];
+        $tm98  = ['match' => '98%',  'ICE' => false, 'created_by' => 'TM'];
+
+        $result = $this->sorter->sortMatches($mt76, [$tm100, $tm99, $tm98], 3);
+
+        $this->assertCount(3, $result);
+        $this->assertSame('100%', $result[0]['match']);
+        $this->assertSame('99%', $result[1]['match']);
+        $this->assertSame('MT', $result[2]['created_by']);
+        $this->assertSame('76%', $result[2]['match']);
+    }
+
+    #[Test]
+    public function sortMatches_does_not_reserve_a_slot_without_an_mt_result(): void
+    {
+        $tm100 = ['match' => '100%', 'ICE' => false, 'created_by' => 'TM'];
+        $tm99  = ['match' => '99%',  'ICE' => false, 'created_by' => 'TM'];
+        $tm98  = ['match' => '98%',  'ICE' => false, 'created_by' => 'TM'];
+        $tm97  = ['match' => '97%',  'ICE' => false, 'created_by' => 'TM'];
+
+        $result = $this->sorter->sortMatches([], [$tm98, $tm100, $tm97, $tm99], 3);
+
+        $this->assertCount(3, $result);
+        $this->assertSame('100%', $result[0]['match']);
+        $this->assertSame('99%', $result[1]['match']);
+        $this->assertSame('98%', $result[2]['match']);
+    }
+
+    #[Test]
+    public function sortMatches_without_a_limit_drops_nothing(): void
+    {
+        $mt76  = ['match' => '76%',  'ICE' => false, 'created_by' => 'MT'];
+        $tm100 = ['match' => '100%', 'ICE' => false, 'created_by' => 'TM'];
+        $tm99  = ['match' => '99%',  'ICE' => false, 'created_by' => 'TM'];
+        $tm98  = ['match' => '98%',  'ICE' => false, 'created_by' => 'TM'];
+
+        $result = $this->sorter->sortMatches($mt76, [$tm100, $tm99, $tm98]);
+
+        $this->assertCount(4, $result);
+        $this->assertSame('MT', $result[3]['created_by']);
+    }
+
+    #[Test]
+    public function sortMatches_limit_wider_than_the_input_returns_everything(): void
+    {
+        $mt85  = ['match' => '85%',  'ICE' => false, 'created_by' => 'MT'];
+        $tm100 = ['match' => '100%', 'ICE' => false, 'created_by' => 'TM'];
+
+        $result = $this->sorter->sortMatches($mt85, [$tm100], 10);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('100%', $result[0]['match']);
+        $this->assertSame('MT', $result[1]['created_by']);
+    }
+
+    #[Test]
     public function sortMatches_equal_scores_no_ice_no_mt_returns_zero(): void
     {
         $a = ['match' => '80%', 'ICE' => false, 'created_by' => 'TM1'];


### PR DESCRIPTION
## Summary

The MT suggestion disappeared from the editor's match list as soon as the TM returned a full set
of matches. MyMemory is asked for exactly `resultNum` matches and the MT row is then *appended*
to that already full list, so the merged array overflowed by one and the post-merge
`array_slice(0, resultNum)` always discarded the tail — the MT row, whenever every TM match
outscored the MT application threshold. The limit now lives in the sorter, which reserves one
slot for the MT suggestion before merging.

Reported as "MT at 99% is not shown when there are three public TM matches": at the time the
budget was 3 end-to-end, so three TM matches were enough to evict MT. `dc80a3cf61` ("Show more
matches") later raised the budget to 10, which only widened the trigger from 3 matches to 10.

Note on what is **not** changed: the direct-MT engine is deliberately not called when the best TM
match is 100% and the MT application threshold is 99 or below. That gate stays as designed — a
`100%` → `MT` → `99%` list is not a state the product produces. Only the way the gate reads the
best TM score is corrected: it used to read element zero of the TM list, while the worker
re-sorts that list itself and therefore does not rely on the engine's ordering.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Utils/AsyncTasks/Workers/Service/MatchSorter.php` | `sortMatches()` takes an optional `$limit` and reserves one slot for the MT row before merging, so the MT suggestion survives the cut |
| `lib/Utils/AsyncTasks/Workers/Interface/MatchSorterInterface.php` | New optional `$limit` parameter, documented |
| `lib/Utils/AsyncTasks/Workers/Analysis/TMAnalysis/Service/MatchProcessorService.php` | Forwards `$limit` to the delegate |
| `lib/Utils/AsyncTasks/Workers/GetContributionWorker.php` | Passes `resultNum` to the sorter, drops the standalone `array_slice`, and adds `bestTmScore()` so the direct-MT gate reads the highest TM score instead of element zero |
| `tests/unit/Core/Workers/TMAnalysisV2/MatchSorterTest.php` | 4 cases for the reserved slot: MT kept when the TM fills the limit, no slot reserved without an MT row, no limit drops nothing, limit wider than the input |
| `tests/unit/Core/Workers/TMAnalysisV2/MatchProcessorServiceTest.php` | Asserts the delegate forwards the limit |
| `tests/unit/Core/TestContribution/GetContributionWorkerTest.php` | Regression test on the published payload (3 TM matches + MT with `resultNum` 3), and a test that the MT engine is still skipped when the best TM match is 100% but not first in the list |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

Full suite: `10309 tests, 8 failures`, all 8 pre-existing on `develop` in this local environment
(4 `CommentControllerTest::*broker_unavailable*` cases, which assert a throw when ActiveMQ is
unreachable while it is reachable locally, plus `SignupModelUnitTest::testResendingAConfirmation
MintsAToken` and the 3 `UserDaoRealSqlTest::testScopedConfirmationTokenLookup*` cases). PHPStan
reports 0 errors on the four changed `lib/` files.

Both new `GetContributionWorkerTest` cases were confirmed to fail against the unpatched code:
the payload regression test reports `'MT'` replaced by `'98%'` — the reported symptom — and the
gate test fails because the MT engine is called.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

Two follow-ups deliberately left out of this PR:

- The editor still renders only the first 3 of the delivered matches until "More" is clicked
  (`SegmentFooterTabMatches.js`, `MAX_ITEMS_TO_DISPLAY_NOT_EXTENDED = 3`), and `CTRL+1/2/3` are
  the only suggestion shortcuts, so an MT ranked 4th or lower is delivered but not visible at a
  glance.
- The "Application threshold" help text describes only pre-population, so the 100%-suppresses-MT
  behaviour is not discoverable from the UI.

The other half of the original report — a freshly created 100% match not appearing — is not
explicable from this codebase: there is no deduplication, no result cache, and the truncation runs
after the descending sort, so a 100% cannot be cut. That needs a live reproduction against
MyMemory (indexing latency, a penalty on the key it was written to, or key visibility in the job).

The cross-language branch still slices per language with no aggregate cap, so N target languages
yield up to N × `resultNum` rows. Untouched here: `get_mt` is forced off for cross-language, so
there is no MT row to protect on that path.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211674479765150