### PR TITLE
💄 style(segments): fix horizontal alignment filename project bar

### DIFF
--- a/public/css/sass/style.scss
+++ b/public/css/sass/style.scss
@@ -180,7 +180,7 @@ section.opened .warnings {
   color: colors.$grey500;
   display: flex;
   justify-content: flex-start;
-  padding: 10px 115px 10px 4.5%;
+  padding: 10px 115px 10px 5%;
   align-items: center;
   span.fileFormat {
     padding: 10px;

--- a/public/js/components/common/Popover/Popover.module.scss
+++ b/public/js/components/common/Popover/Popover.module.scss
@@ -30,8 +30,8 @@
 
 .popover-component-popover {
   position: absolute;
-
   z-index: 4;
+  width: max-content;
   border-radius: variables.$border-radius-default;
   box-shadow: 0 0 24px rgba(colors.$black, 0.15);
   overflow: hidden;


### PR DESCRIPTION
## Summary

Fixes horizontal misalignment of the file name in the project bar and sizes the popover
component to its content instead of a fixed width.

## Type

- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [x] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/css/sass/style.scss` | change `.projectbar` left padding from 4.5% to 5% to align the file name |
| `public/js/components/common/Popover/Popover.module.scss` | add `width: max-content` to the popover so it sizes to its content |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

Verified visually in the browser that the project bar file name aligns correctly and the
popover no longer stretches to a fixed width.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-sonnet-5)

## Notes

None.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218244268839864