### PR TITLE
🐛 fix(glossary): treat MyMemory HTTP 202 as an acknowledgement, not an error

### DIFF
--- a/lib/Utils/AsyncTasks/Workers/GlossaryWorker.php
+++ b/lib/Utils/AsyncTasks/Workers/GlossaryWorker.php
@@ -426,11 +426,8 @@ class GlossaryWorker extends AbstractWorker
             'payload' => null,
         ];
 
-        if ($response->responseStatus === 202 || $response->responseStatus >= 300) {
-            $errMessage = match ($response->responseStatus) {
-                202 => "MyMemory is busy, please try later",
-                default => "Error, please try later",
-            };
+        if ($response->responseStatus >= 300) {
+            $errMessage = "Error, please try later";
 
             $message['error'] = [
                 'code' => $response->responseStatus,
@@ -439,7 +436,7 @@ class GlossaryWorker extends AbstractWorker
             ];
         }
 
-        if ($response->responseStatus < 300 && $response->responseStatus !== 202) {
+        if ($response->responseStatus < 300) {
             $matchingWords = $payload['term']['matching_words'];
             $matchingWordsAsArray = [];
 

--- a/tests/unit/Core/Workers/GlossaryWorkerTest.php
+++ b/tests/unit/Core/Workers/GlossaryWorkerTest.php
@@ -179,6 +179,36 @@ class GlossaryWorkerTest extends AbstractTest
     }
 
     #[Test]
+    public function deletePublishesPayloadWhenResponseStatus202(): void
+    {
+        $mock = $this->createMock(MyMemory::class);
+        $response = new DeleteGlossaryResponse([
+            'responseStatus' => 202,
+            'responseDetails' => '',
+        ]);
+
+        $mock->expects($this->once())
+            ->method('glossaryDelete')
+            ->willReturn($response);
+
+        $this->withMock($mock);
+
+        $this->processAction('delete', [
+            'id_segment' => 'seg-1',
+            'id_job' => 42,
+            'password' => 'pwd',
+            'term' => ['term1'],
+            'id_client' => 'client-1',
+            'jobData' => $this->jobData(),
+        ]);
+
+        $msg = $this->worker->publishedMessages[0];
+        $payload = $msg['data']['payload'];
+        $this->assertArrayNotHasKey('error', $payload);
+        $this->assertNotNull($payload['payload']);
+    }
+
+    #[Test]
     public function deletePublishesErrorWhenResponseStatusGte300(): void
     {
         $mock = $this->createMock(MyMemory::class);
@@ -392,6 +422,40 @@ class GlossaryWorkerTest extends AbstractTest
     }
 
     #[Test]
+    public function setPublishesPayloadWhenResponseStatus202(): void
+    {
+        $mock = $this->createMock(MyMemory::class);
+        $response = new SetGlossaryResponse([
+            'responseStatus' => 202,
+            'responseDetails' => 'req-202',
+        ]);
+
+        $mock->expects($this->once())
+            ->method('glossarySet')
+            ->willReturn($response);
+
+        $this->withMock($mock);
+
+        $this->processAction('set', [
+            'id_segment' => 'seg-1',
+            'id_job' => 42,
+            'password' => 'pwd',
+            'term' => [
+                'matching_words' => ['foo', 'bar'],
+                'metadata' => ['keys' => ['k1', 'k2']],
+            ],
+            'id_client' => 'client-1',
+            'jobData' => $this->jobData(),
+        ]);
+
+        $msg = $this->worker->publishedMessages[0];
+        $payload = $msg['data']['payload'];
+        $this->assertArrayNotHasKey('error', $payload);
+        $this->assertNotNull($payload['payload']);
+        $this->assertSame('req-202', $payload['payload']['request_id']);
+    }
+
+    #[Test]
     public function setPublishesErrorOnFailure(): void
     {
         $mock = $this->createMock(MyMemory::class);
@@ -456,13 +520,17 @@ class GlossaryWorkerTest extends AbstractTest
         $this->assertArrayNotHasKey('error', $payload);
     }
 
+    /**
+     * MyMemory answers 202 to acknowledge receipt of the request. It is not an error and carries
+     * no message for the user, so it must publish a payload exactly like a 200 does.
+     */
     #[Test]
-    public function updatePublishesBusyErrorWhenResponseStatus202(): void
+    public function updatePublishesPayloadWhenResponseStatus202(): void
     {
         $mock = $this->createMock(MyMemory::class);
         $response = new UpdateGlossaryResponse([
             'responseStatus' => 202,
-            'responseDetails' => '',
+            'responseDetails' => 'req-202',
         ]);
 
         $mock->expects($this->once())
@@ -482,10 +550,10 @@ class GlossaryWorkerTest extends AbstractTest
 
         $msg = $this->worker->publishedMessages[0];
         $payload = $msg['data']['payload'];
-        $this->assertArrayHasKey('error', $payload);
-        $this->assertSame(202, $payload['error']['code']);
-        $this->assertSame('MyMemory is busy, please try later', $payload['error']['message']);
-        $this->assertNull($payload['payload']);
+        $this->assertArrayNotHasKey('error', $payload);
+        $this->assertSame('seg-1', $payload['id_segment']);
+        $this->assertNotNull($payload['payload']);
+        $this->assertSame('req-202', $payload['payload']['request_id']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

MyMemory answers a glossary write with `202` to say **it received the request**. It is an
acknowledgement — not an error, and not a message for the user. `GlossaryWorker::update()` turned it
into an `error` payload reading *"MyMemory is busy, please try later"*, so a glossary edit that
actually succeeded surfaced in the editor as a failure.

`05a18485f7` ("Fixed Glossary set on HTTP 202") already dropped that arm from `delete()` and
`set()`, but missed `update()`. A later cleanup pass then widened `update()`'s guard from `>= 300`
to `=== 202 || >= 300` so the unreachable `match` arm became reachable, entrenching the wrong
contract instead of deleting it. This finishes the job: `update()` branches on the status range
alone, exactly like `set()`.

## Type

- [ ] `feat` — new user-facing feature
- [x] `fix` — bug fix
- [ ] `refactor` — restructure without behavior change
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `lib/Utils/AsyncTasks/Workers/GlossaryWorker.php` | `update()` error guard is `>= 300` and the payload guard `< 300`, mirroring `set()`. A 202 now publishes the normal payload with `request_id`. |
| `lib/Utils/AsyncTasks/Workers/GlossaryWorker.php` | Removed the dead `match` on `responseStatus` — its `202 => "MyMemory is busy, please try later"` arm was unreachable under a `>= 300` guard. `$errMessage` is now the same plain string `set()` and `delete()` use. |
| `tests/unit/Core/Workers/GlossaryWorkerTest.php` | `updatePublishesBusyErrorWhenResponseStatus202` → `updatePublishesPayloadWhenResponseStatus202`: asserts no `error` key and `request_id` echoed from `responseDetails`. |
| `tests/unit/Core/Workers/GlossaryWorkerTest.php` | Added `setPublishesPayloadWhenResponseStatus202` and `deletePublishesPayloadWhenResponseStatus202` — `05a18485f7` fixed those two paths with no test, which is how the arm survived in `update()`. |

## Testing

- [x] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [x] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [x] Regression tests added for bug fixes

`GlossaryWorkerTest` goes from 16 tests (1 failing against the fixed worker) to 18 tests, 79
assertions, all green:

```
$ vendor/bin/phpunit tests/unit/Core/Workers/GlossaryWorkerTest.php --no-coverage
OK (18 tests, 79 assertions)
```

PHPStan is clean on both changed files (level 8, no baseline in this repo):

```
$ vendor/bin/phpstan analyse lib/Utils/AsyncTasks/Workers/GlossaryWorker.php \
    tests/unit/Core/Workers/GlossaryWorkerTest.php \
    --configuration=phpstan.neon --no-progress --error-format=table
 [OK] No errors
```

Also grepped `tests/` for the removed string — no assertion anywhere pins `MyMemory is busy`, nor
the `is busy` fragment that a substring matcher would catch.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (claude-opus-5)

## Notes

**Why not leave 202 between the two guards.** An intermediate form of this fix had `>= 300` on the
error branch but `!== 202` on the payload branch, which publishes `{id_segment, payload: null}` with
no `error` key. That is worse than the bug it replaces: `public/js/sse/SocketListener.js` only tests
`if (data.error)`, so the null reaches `normalizeSetUpdateGlossary(action.payload.term)` in
`public/js/stores/SegmentStore.js` and throws a `TypeError` inside the Flux dispatch. 202 must take
the success branch outright.

**Deliberately not touched.** `set()` normalizes `term.metadata.keys` and `update()` does not. That
asymmetry is correct, not drift: `inc/validation/schema/glossary/update.json` is
`additionalProperties: false` with a singular `metadata.key` and no `keys` property, so the frontend
cannot send it on update.

**Follow-up, separate repo.** `MateCat-docs/backend/completed/phpstan-baseline-reduction-progression.md:1587`
still records the widened guard as a fix — *"so 202 is correctly treated as error"*. That line is how
the behaviour came back after `05a18485f7`, and it is now wrong. `MateCat-docs` is a submodule, so
correcting it needs its own commit there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1218319084129293