### PR TITLE
♻️ refactor(languageSelector): convert to function components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,7 +87,10 @@ module.exports = {
     // Migrated to function components; ban the class form here so it can't return.
     // Grows with the migration one directory at a time instead of gating it.
     {
-      files: ['public/js/components/modals/**/*.js'],
+      files: [
+        'public/js/components/modals/**/*.js',
+        'public/js/components/languageSelector/**/*.js',
+      ],
       rules: {
         'no-restricted-syntax': [
           'error',

--- a/public/js/components/languageSelector/LanguageSelector.js
+++ b/public/js/components/languageSelector/LanguageSelector.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useState, useRef, useEffect} from 'react'
 
 import LanguageSelectorList from './LanguageSelectorList'
 import LanguageSelectorSearch from './LanguageSelectorSearch'
@@ -48,252 +48,93 @@ export const setRecentlyUsedLanguages = (languages) => {
   )
 }
 
-class LanguageSelector extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      selectedLanguages: null,
-      initialLanguages: null,
-      fromLanguage: null,
-      querySearch: '',
-      filteredLanguages: [],
+const LanguageSelector = (props) => {
+  const {
+    languagesList,
+    onClose,
+    selectedLanguagesFromDropdown,
+    fromLanguage: fromLanguageProp,
+  } = props
+
+  const [selectedLanguages, setSelectedLanguages] = useState(null)
+  // `initialLanguages` is write-only dead state, preserved verbatim from the
+  // class component (set once at mount, never read anywhere).
+  const [, setInitialLanguages] = useState(null)
+  const [fromLanguage, setFromLanguage] = useState(null)
+  const [querySearch, setQuerySearch] = useState('')
+  const [filteredLanguages, setFilteredLanguages] = useState([])
+
+  const containerRef = useRef(null)
+  const listRef = useRef(null)
+
+  const latestRef = useRef({})
+  latestRef.current = {onClose: props.onClose, querySearch, onConfirm}
+
+  useEffect(() => {
+    const container = containerRef.current
+    const navigateLanguagesList = listRef.current.navigateLanguagesList
+    container.addEventListener('keydown', navigateLanguagesList)
+
+    const handleDocumentKeyDown = (event) => {
+      const keyCode = event.keyCode
+      if (keyCode === 27) {
+        latestRef.current.onClose()
+      }
+      if (event.key === 'Enter' && !latestRef.current.querySearch) {
+        latestRef.current.onConfirm()
+      }
     }
+    document.addEventListener('keydown', handleDocumentKeyDown)
 
-    this.listRef = React.createRef()
-  }
-
-  componentDidMount() {
-    const {selectedLanguagesFromDropdown, languagesList, fromLanguage} =
-      this.props
-    this.container.addEventListener(
-      'keydown',
-      this.listRef.current.navigateLanguagesList,
-    )
-    document.addEventListener('keydown', this.keyHandler)
-
-    this.setState({
-      fromLanguage: languagesList.filter((i) => i.code === fromLanguage)[0],
-      selectedLanguages: selectedLanguagesFromDropdown.map(
+    setFromLanguage(languagesList.filter((i) => i.code === fromLanguageProp)[0])
+    setSelectedLanguages(
+      selectedLanguagesFromDropdown.map(
         (e) => languagesList.filter((i) => i.code === e)[0],
       ),
-      initialLanguages: selectedLanguagesFromDropdown.map(
+    )
+    setInitialLanguages(
+      selectedLanguagesFromDropdown.map(
         (e) => languagesList.filter((i) => i.code === e)[0],
       ),
-    })
-  }
-
-  componentWillUnmount() {
-    this.container.removeEventListener(
-      'keydown',
-      this.listRef.current.navigateLanguagesList,
     )
-    document.removeEventListener('keydown', this.keyHandler)
-  }
 
-  componentDidUpdate(prevProps, prevState) {
-    if (prevState.querySearch !== this.state.querySearch) {
-      const filteredLanguages = this.state.querySearch
-        ? this.props.languagesList.filter(
+    return () => {
+      container.removeEventListener('keydown', navigateLanguagesList)
+      document.removeEventListener('keydown', handleDocumentKeyDown)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const isFirstRender = useRef(true)
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    setFilteredLanguages(
+      querySearch
+        ? languagesList.filter(
             (e) =>
-              e.name
-                .toLowerCase()
-                .indexOf(this.state.querySearch.toLowerCase()) === 0,
+              e.name.toLowerCase().indexOf(querySearch.toLowerCase()) === 0,
           )
-        : []
-      this.setState({filteredLanguages})
-    }
-  }
-
-  setSelectLanguagesFromRecentlyUsed = (list) => {
-    this.setState({selectedLanguages: list})
-  }
-
-  render() {
-    const {
-      onQueryChange,
-      onToggleLanguage,
-      onConfirm,
-      preventDismiss,
-      onReset,
-      onResetResults,
-    } = this
-    const {languagesList, onClose} = this.props
-    const {selectedLanguages, querySearch, fromLanguage, filteredLanguages} =
-      this.state
-
-    const recentyUsedLanguages = getRecentyUsedLanguages().reverse()
-
-    return (
-      <div
-        id="matecat-modal-languages"
-        className="matecat-modal"
-        ref={(el) => {
-          this.container = el
-        }}
-        onClick={onClose}
-      >
-        <div className="matecat-modal-content" onClick={preventDismiss}>
-          <div className="matecat-modal-header">
-            <span className={'modal-title'}>Target languages</span>
-            <Button
-              type={BUTTON_TYPE.ICON}
-              size={BUTTON_SIZE.ICON_STANDARD}
-              mode={BUTTON_MODE.GHOST}
-              onClick={onClose}
-            >
-              <Close size={20} />
-            </Button>
-          </div>
-
-          <div className="matecat-modal-body">
-            <div className="matecat-modal-subheader">
-              <div className={'language-from'}>
-                <div className={'first-column'}>
-                  <span className={'label'}>From:</span>
-                </div>
-                <div>
-                  <span>{fromLanguage && fromLanguage.name}</span>
-                </div>
-              </div>
-              <div className={'language-to'}>
-                <div className={'first-column'}>
-                  <span className={'label'}>To:</span>
-                </div>
-                <div className={'language-search'}>
-                  <LanguageSelectorSearch
-                    languagesList={languagesList}
-                    selectedLanguages={selectedLanguages}
-                    querySearch={querySearch}
-                    onDeleteLanguage={onToggleLanguage}
-                    onQueryChange={onQueryChange}
-                  />
-                </div>
-              </div>
-              {recentyUsedLanguages.length > 0 && (
-                <div className="recently-used">
-                  <div className="first-column">
-                    <span className="label">Recently used:</span>
-                  </div>
-                  <div className="second-column">
-                    {recentyUsedLanguages.map((list, index) => (
-                      <div
-                        className="list-badge"
-                        key={index}
-                        onClick={() =>
-                          this.setSelectLanguagesFromRecentlyUsed(list)
-                        }
-                      >
-                        <LabelWithTooltip>
-                          <span className="language-name">
-                            {list.map(({name}) => name).join(', ')}
-                          </span>
-                        </LabelWithTooltip>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {(filteredLanguages.length > 0 ||
-                (querySearch && !filteredLanguages.length)) && (
-                <div className="button-all-languages">
-                  <Button
-                    type={BUTTON_TYPE.DEFAULT}
-                    mode={BUTTON_MODE.OUTLINE}
-                    onClick={onResetResults}
-                  >
-                    <FlipBackwardIcon />
-                    All languages
-                  </Button>
-                </div>
-              )}
-            </div>
-
-            <LanguageSelectorList
-              ref={this.listRef}
-              languagesList={languagesList}
-              selectedLanguages={selectedLanguages}
-              querySearch={querySearch}
-              onToggleLanguage={onToggleLanguage}
-              onResetResults={onResetResults}
-            />
-          </div>
-
-          <div className="matecat-modal-footer">
-            <div className="selected-counter">
-              {selectedLanguages && selectedLanguages.length > 0 ? (
-                <span className={'uncheck-all'} onClick={onReset}>
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="12"
-                    height="12"
-                    viewBox="0 0 12 12"
-                  >
-                    <g
-                      fill="#00AEE4"
-                      fillRule="nonzero"
-                      stroke="#00AEE4"
-                      strokeWidth="1"
-                      transform="translate(-5 -5) translate(5 5)"
-                    >
-                      <rect
-                        width="13"
-                        height="1"
-                        x="-0.5"
-                        y="5.5"
-                        rx="0.5"
-                        transform="rotate(45 6 6)"
-                      >
-                        {' '}
-                      </rect>
-                      <rect
-                        width="13"
-                        height="1"
-                        x="-0.5"
-                        y="5.5"
-                        rx="0.5"
-                        transform="rotate(-45 6 6)"
-                      >
-                        {' '}
-                      </rect>
-                    </g>
-                  </svg>
-                </span>
-              ) : null}
-              <span className={'badge'}>
-                {selectedLanguages && selectedLanguages.length}
-              </span>
-              <span className={'label'}>
-                {`Language${selectedLanguages?.length === 0 || selectedLanguages?.length > 1 ? 's' : ''}`}{' '}
-                selected
-              </span>
-            </div>
-            <div className="">
-              <Button type={BUTTON_TYPE.PRIMARY} onClick={onConfirm}>
-                Confirm
-              </Button>
-            </div>
-          </div>
-        </div>
-      </div>
+        : [],
     )
-  }
+  }, [querySearch])
 
-  preventDismiss = (event) => {
+  const preventDismiss = (event) => {
     event.stopPropagation()
   }
-  onConfirm = () => {
+
+  function onConfirm() {
     //confirm must have 1 language selected
-    const {selectedLanguages} = this.state
-    this.props.onConfirm(selectedLanguages)
+    props.onConfirm(selectedLanguages)
   }
 
-  onQueryChange = (querySearch) => {
-    this.setState({querySearch})
+  const onQueryChange = (querySearch) => {
+    setQuerySearch(querySearch)
   }
 
-  onToggleLanguage = (language) => {
-    const {selectedLanguages} = this.state
+  const onToggleLanguage = (language) => {
     let newSelectedLanguages = [...selectedLanguages]
     const indexSearch = selectedLanguages
       .map((e) => e.code)
@@ -305,44 +146,182 @@ class LanguageSelector extends React.Component {
     }
 
     const areAllResultsSelected =
-      this.state.filteredLanguages.filter(({code}) =>
+      filteredLanguages.filter(({code}) =>
         newSelectedLanguages.find((selected) => selected.code === code),
-      ).length === this.state.filteredLanguages.length
+      ).length === filteredLanguages.length
 
     const shouldResetQuery =
-      this.state.filteredLanguages.length < 2 || areAllResultsSelected
+      filteredLanguages.length < 2 || areAllResultsSelected
 
-    this.setState({
-      selectedLanguages: newSelectedLanguages,
-      ...(shouldResetQuery && {querySearch: ''}),
-    })
+    setSelectedLanguages(newSelectedLanguages)
+    if (shouldResetQuery) setQuerySearch('')
     //when add a language, restore query search.
   }
 
-  onReset = () => {
-    this.setState({
-      selectedLanguages: [],
-      querySearch: '',
-    })
+  const onReset = () => {
+    setSelectedLanguages([])
+    setQuerySearch('')
   }
-  onResetResults = () => {
-    this.setState({querySearch: ''})
+  const onResetResults = () => {
+    setQuerySearch('')
   }
 
-  keyHandler = (event) => {
-    const {onClose} = this.props
-    const keyCode = event.keyCode
-
-    if (keyCode === 27) {
-      onClose()
-    }
-
-    if (event.key === 'Enter' && !this.state.querySearch) {
-      this.onConfirm()
-    }
-
-    //27
+  const setSelectLanguagesFromRecentlyUsed = (list) => {
+    setSelectedLanguages(list)
   }
+
+  const recentyUsedLanguages = getRecentyUsedLanguages().reverse()
+
+  return (
+    <div
+      id="matecat-modal-languages"
+      className="matecat-modal"
+      ref={containerRef}
+      onClick={onClose}
+    >
+      <div className="matecat-modal-content" onClick={preventDismiss}>
+        <div className="matecat-modal-header">
+          <span className={'modal-title'}>Target languages</span>
+          <Button
+            type={BUTTON_TYPE.ICON}
+            size={BUTTON_SIZE.ICON_STANDARD}
+            mode={BUTTON_MODE.GHOST}
+            onClick={onClose}
+          >
+            <Close size={20} />
+          </Button>
+        </div>
+
+        <div className="matecat-modal-body">
+          <div className="matecat-modal-subheader">
+            <div className={'language-from'}>
+              <div className={'first-column'}>
+                <span className={'label'}>From:</span>
+              </div>
+              <div>
+                <span>{fromLanguage && fromLanguage.name}</span>
+              </div>
+            </div>
+            <div className={'language-to'}>
+              <div className={'first-column'}>
+                <span className={'label'}>To:</span>
+              </div>
+              <div className={'language-search'}>
+                <LanguageSelectorSearch
+                  languagesList={languagesList}
+                  selectedLanguages={selectedLanguages}
+                  querySearch={querySearch}
+                  onDeleteLanguage={onToggleLanguage}
+                  onQueryChange={onQueryChange}
+                />
+              </div>
+            </div>
+            {recentyUsedLanguages.length > 0 && (
+              <div className="recently-used">
+                <div className="first-column">
+                  <span className="label">Recently used:</span>
+                </div>
+                <div className="second-column">
+                  {recentyUsedLanguages.map((list, index) => (
+                    <div
+                      className="list-badge"
+                      key={index}
+                      onClick={() => setSelectLanguagesFromRecentlyUsed(list)}
+                    >
+                      <LabelWithTooltip>
+                        <span className="language-name">
+                          {list.map(({name}) => name).join(', ')}
+                        </span>
+                      </LabelWithTooltip>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {(filteredLanguages.length > 0 ||
+              (querySearch && !filteredLanguages.length)) && (
+              <div className="button-all-languages">
+                <Button
+                  type={BUTTON_TYPE.DEFAULT}
+                  mode={BUTTON_MODE.OUTLINE}
+                  onClick={onResetResults}
+                >
+                  <FlipBackwardIcon />
+                  All languages
+                </Button>
+              </div>
+            )}
+          </div>
+
+          <LanguageSelectorList
+            ref={listRef}
+            languagesList={languagesList}
+            selectedLanguages={selectedLanguages}
+            querySearch={querySearch}
+            onToggleLanguage={onToggleLanguage}
+            onResetResults={onResetResults}
+          />
+        </div>
+
+        <div className="matecat-modal-footer">
+          <div className="selected-counter">
+            {selectedLanguages && selectedLanguages.length > 0 ? (
+              <span className={'uncheck-all'} onClick={onReset}>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="12"
+                  height="12"
+                  viewBox="0 0 12 12"
+                >
+                  <g
+                    fill="#00AEE4"
+                    fillRule="nonzero"
+                    stroke="#00AEE4"
+                    strokeWidth="1"
+                    transform="translate(-5 -5) translate(5 5)"
+                  >
+                    <rect
+                      width="13"
+                      height="1"
+                      x="-0.5"
+                      y="5.5"
+                      rx="0.5"
+                      transform="rotate(45 6 6)"
+                    >
+                      {' '}
+                    </rect>
+                    <rect
+                      width="13"
+                      height="1"
+                      x="-0.5"
+                      y="5.5"
+                      rx="0.5"
+                      transform="rotate(-45 6 6)"
+                    >
+                      {' '}
+                    </rect>
+                  </g>
+                </svg>
+              </span>
+            ) : null}
+            <span className={'badge'}>
+              {selectedLanguages && selectedLanguages.length}
+            </span>
+            <span className={'label'}>
+              {`Language${selectedLanguages?.length === 0 || selectedLanguages?.length > 1 ? 's' : ''}`}{' '}
+              selected
+            </span>
+          </div>
+          <div className="">
+            <Button type={BUTTON_TYPE.PRIMARY} onClick={onConfirm}>
+              Confirm
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 LanguageSelector.defaultProps = {

--- a/public/js/components/languageSelector/LanguageSelectorList.js
+++ b/public/js/components/languageSelector/LanguageSelectorList.js
@@ -1,113 +1,31 @@
-import React from 'react'
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
 import TEXT_UTILS from '../../utils/textUtils'
 
-class LanguageSelectorList extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      position: 0,
-    }
-  }
+const LanguageSelectorList = forwardRef((props, ref) => {
+  const {
+    querySearch,
+    selectedLanguages,
+    languagesList,
+    onToggleLanguage,
+    onResetResults,
+  } = props
+  const [position, setPosition] = useState(0)
 
-  currentSelectedElementRef = null
-  wrapperScrollRef = null
+  const currentSelectedElementRef = useRef(null)
+  const wrapperScrollRef = useRef(null)
 
-  componentDidUpdate(prevProps) {
-    const {scrollIfTagNavigationIsOverflow} = this
-    scrollIfTagNavigationIsOverflow()
-
-    if (prevProps.querySearch !== this.props.querySearch) {
-      this.setState({
-        position: 0,
-      })
-    }
-  }
-
-  render() {
-    let counterItem = -1
-    const languages = this.getLanguagesInColumns()
-    const {onClickElement} = this
-    const {querySearch, selectedLanguages} = this.props
-    const {position} = this.state
-    this.currentSelectedElementRef = null
-
-    return (
-      <div
-        className="languages-columns"
-        ref={(el) => {
-          this.wrapperScrollRef = el
-        }}
-      >
-        {languages.map((languagesColumn, key) => {
-          return (
-            <ul key={key} className={'dropdown__list'}>
-              {languagesColumn.map((e) => {
-                counterItem++
-                let elementClass = ''
-                const isHover = querySearch && counterItem === position
-                if (
-                  selectedLanguages &&
-                  selectedLanguages.map((e) => e.code).indexOf(e.code) > -1
-                ) {
-                  elementClass = `selected ${isHover ? 'hover' : ''}`
-                } else if (isHover) {
-                  elementClass = 'hover'
-                }
-                return (
-                  <li
-                    key={`${counterItem}`}
-                    ref={(el) => {
-                      if (isHover) {
-                        this.currentSelectedElementRef = el
-                      }
-                    }}
-                    className={`lang-item ${elementClass}`}
-                    onClick={onClickElement(e)}
-                  >
-                    <div className="language-dropdown-item-container">
-                      <div className="code-badge">
-                        <span className={`code-badge-${elementClass}`}>
-                          {e.code}
-                        </span>
-                      </div>
-                      <span>{e.name}</span>
-                    </div>
-                    <span className={'check'}>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="16"
-                        height="12"
-                        viewBox="0 0 16 12"
-                      >
-                        <path
-                          fill="#FFF"
-                          fillRule="evenodd"
-                          stroke="none"
-                          strokeWidth="1"
-                          d="M15.735.265a.798.798 0 00-1.13 0L5.04 9.831 1.363 6.154a.798.798 0 00-1.13 1.13l4.242 4.24a.799.799 0 001.13 0l10.13-10.13a.798.798 0 000-1.129z"
-                          transform="translate(-266 -10) translate(266 8) translate(0 2)"
-                        >
-                          {' '}
-                        </path>
-                      </svg>
-                    </span>
-                  </li>
-                )
-              })}
-            </ul>
-          )
-        })}
-      </div>
-    )
-  }
-
-  onClickElement = (language) => () => {
-    const {onToggleLanguage} = this.props
+  const onClickElement = (language) => () => {
     onToggleLanguage(language)
   }
 
-  getFilteredLanguages = () => {
-    const {languagesList, querySearch} = this.props
+  const getFilteredLanguages = () => {
     // const querySplitted = TEXT_UTILS.escapeRegExp(querySearch)
     //   .split(' ')
     //   .join('|')
@@ -157,9 +75,7 @@ class LanguageSelectorList extends React.Component {
     return sortInputFirst(querySearch, langs)
   }
 
-  getLanguagesInColumns = () => {
-    const {getFilteredLanguages} = this
-    const {languagesList} = this.props
+  const getLanguagesInColumns = () => {
     const languagesPerColumn = Math.ceil(languagesList.length / 4)
     const filteredLanguagesInColumns = chunk(
       getFilteredLanguages(),
@@ -176,35 +92,66 @@ class LanguageSelectorList extends React.Component {
       )
     }
   }
-  scrollIfTagNavigationIsOverflow = () => {
-    const {currentSelectedElementRef, wrapperScrollRef} = this
 
-    if (currentSelectedElementRef) {
+  const scrollIfTagNavigationIsOverflow = () => {
+    if (currentSelectedElementRef.current) {
       const relativePositionOfTag =
-        currentSelectedElementRef.offsetTop -
-        wrapperScrollRef.offsetTop +
-        currentSelectedElementRef.clientHeight
+        currentSelectedElementRef.current.offsetTop -
+        wrapperScrollRef.current.offsetTop +
+        currentSelectedElementRef.current.clientHeight
       const bottomPositionOfWrapper =
-        wrapperScrollRef.clientHeight + wrapperScrollRef.scrollTop
+        wrapperScrollRef.current.clientHeight +
+        wrapperScrollRef.current.scrollTop
       if (relativePositionOfTag > bottomPositionOfWrapper) {
         //check if element is overflowBottom of parent
-        wrapperScrollRef.scrollTop =
-          relativePositionOfTag + 10 - wrapperScrollRef.clientHeight
+        wrapperScrollRef.current.scrollTop =
+          relativePositionOfTag + 10 - wrapperScrollRef.current.clientHeight
       } else if (
-        wrapperScrollRef.scrollTop >
-        relativePositionOfTag - currentSelectedElementRef.clientHeight
+        wrapperScrollRef.current.scrollTop >
+        relativePositionOfTag - currentSelectedElementRef.current.clientHeight
       ) {
         //check if element is overflowTop of parent
-        wrapperScrollRef.scrollTop =
-          relativePositionOfTag - currentSelectedElementRef.clientHeight - 10
+        wrapperScrollRef.current.scrollTop =
+          relativePositionOfTag -
+          currentSelectedElementRef.current.clientHeight -
+          10
       }
     }
   }
 
-  navigateLanguagesList = (event) => {
-    const {getFilteredLanguages} = this
-    const {position} = this.state
-    const {querySearch, onToggleLanguage, onResetResults} = this.props
+  const isFirstRender = useRef(true)
+  const prevQuerySearchRef = useRef(querySearch)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      prevQuerySearchRef.current = querySearch
+      return
+    }
+    scrollIfTagNavigationIsOverflow()
+    if (prevQuerySearchRef.current !== querySearch) {
+      setPosition(0)
+    }
+    prevQuerySearchRef.current = querySearch
+  })
+
+  const latestRef = useRef(null)
+  latestRef.current = {
+    position,
+    querySearch,
+    onToggleLanguage,
+    onResetResults,
+    getFilteredLanguages,
+  }
+
+  const navigateLanguagesList = useCallback((event) => {
+    const {
+      position,
+      querySearch,
+      onToggleLanguage,
+      onResetResults,
+      getFilteredLanguages,
+    } = latestRef.current
     const keyCode = event.keyCode
     if (keyCode === 38 || keyCode === 40) {
       event.preventDefault()
@@ -215,16 +162,12 @@ class LanguageSelectorList extends React.Component {
       if (keyCode === 38) {
         // up key
         if (position !== 0) {
-          this.setState({
-            position: position - 1,
-          })
+          setPosition(position - 1)
         }
       } else if (keyCode === 40) {
         // down key
         if (position + 1 < filteredLanguages.length) {
-          this.setState({
-            position: position + 1,
-          })
+          setPosition(position + 1)
         }
       } else if (keyCode === 13 && filteredLanguages.length) {
         //enter with 1 language filtered
@@ -233,8 +176,82 @@ class LanguageSelectorList extends React.Component {
         event.stopPropagation()
       }
     }
-  }
-}
+  }, [])
+
+  useImperativeHandle(ref, () => ({navigateLanguagesList}), [
+    navigateLanguagesList,
+  ])
+
+  let counterItem = -1
+  const languages = getLanguagesInColumns()
+  currentSelectedElementRef.current = null
+
+  return (
+    <div className="languages-columns" ref={wrapperScrollRef}>
+      {languages.map((languagesColumn, key) => {
+        return (
+          <ul key={key} className={'dropdown__list'}>
+            {languagesColumn.map((e) => {
+              counterItem++
+              let elementClass = ''
+              const isHover = querySearch && counterItem === position
+              if (
+                selectedLanguages &&
+                selectedLanguages.map((e) => e.code).indexOf(e.code) > -1
+              ) {
+                elementClass = `selected ${isHover ? 'hover' : ''}`
+              } else if (isHover) {
+                elementClass = 'hover'
+              }
+              return (
+                <li
+                  key={`${counterItem}`}
+                  ref={(el) => {
+                    if (isHover) {
+                      currentSelectedElementRef.current = el
+                    }
+                  }}
+                  className={`lang-item ${elementClass}`}
+                  onClick={onClickElement(e)}
+                >
+                  <div className="language-dropdown-item-container">
+                    <div className="code-badge">
+                      <span className={`code-badge-${elementClass}`}>
+                        {e.code}
+                      </span>
+                    </div>
+                    <span>{e.name}</span>
+                  </div>
+                  <span className={'check'}>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="12"
+                      viewBox="0 0 16 12"
+                    >
+                      <path
+                        fill="#FFF"
+                        fillRule="evenodd"
+                        stroke="none"
+                        strokeWidth="1"
+                        d="M15.735.265a.798.798 0 00-1.13 0L5.04 9.831 1.363 6.154a.798.798 0 00-1.13 1.13l4.242 4.24a.799.799 0 001.13 0l10.13-10.13a.798.798 0 000-1.129z"
+                        transform="translate(-266 -10) translate(266 8) translate(0 2)"
+                      >
+                        {' '}
+                      </path>
+                    </svg>
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        )
+      })}
+    </div>
+  )
+})
+
+LanguageSelectorList.displayName = 'LanguageSelectorList'
 
 LanguageSelectorList.defaultProps = {
   selectedLanguages: false,

--- a/public/js/components/languageSelector/LanguageSelectorSearch.js
+++ b/public/js/components/languageSelector/LanguageSelectorSearch.js
@@ -1,79 +1,52 @@
-import React from 'react'
+import React, {useEffect, useRef, useState} from 'react'
 import TagsInput from 'react-tagsinput'
 
-class LanguageSelectorSearch extends React.Component {
-  constructor(props) {
-    super(props)
-  }
+const LanguageSelectorSearch = ({
+  onQueryChange,
+  querySearch,
+  selectedLanguages,
+  onDeleteLanguage,
+}) => {
+  const [highlightDelete, setHighlightDelete] = useState(false)
+  const tagsInputRef = useRef(null)
 
-  state = {
-    highlightDelete: false,
-  }
-
-  componentDidMount() {
-    document.addEventListener('mousedown', () => {
-      this.setState({highlightDelete: false})
-    })
-
-    this.tagsInput.focus()
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', () => {
-      this.setState({highlightDelete: false})
-    })
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.querySearch !== this.props.querySearch) {
-      this.setState({
-        highlightDelete: false,
-      })
+  useEffect(() => {
+    const handleMouseDown = () => {
+      setHighlightDelete(false)
     }
-  }
 
-  handleChange = () => {
-    const {onDeleteLanguage, selectedLanguages} = this.props
-    const {highlightDelete} = this.state
+    document.addEventListener('mousedown', handleMouseDown)
 
+    tagsInputRef.current.focus()
+
+    return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
+    }
+  }, [])
+
+  const isFirstRender = useRef(true)
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    setHighlightDelete(false)
+  }, [querySearch])
+
+  const handleChange = () => {
     if (highlightDelete) {
       onDeleteLanguage(selectedLanguages[selectedLanguages.length - 1])
-      this.setState({
-        highlightDelete: false,
-      })
+      setHighlightDelete(false)
     } else {
-      this.setState({
-        highlightDelete: true,
-      })
+      setHighlightDelete(true)
     }
   }
-  removeLanguageWithIconTag = (tagIndex) => {
-    const {onDeleteLanguage, selectedLanguages} = this.props
+
+  const removeLanguageWithIconTag = (tagIndex) => {
     onDeleteLanguage(selectedLanguages[tagIndex])
   }
 
-  render() {
-    const {defaultRenderTag} = this
-    const {onQueryChange, querySearch, selectedLanguages} = this.props
-    return (
-      <TagsInput
-        inputValue={querySearch}
-        addKeys={[]}
-        inputProps={{placeholder: 'Search...'}}
-        onChangeInput={onQueryChange}
-        renderTag={defaultRenderTag}
-        value={selectedLanguages ? selectedLanguages.map((e) => e.name) : []}
-        onChange={this.handleChange}
-        autofocus={true}
-        ref={(tagsInput) => (this.tagsInput = tagsInput)}
-      />
-    )
-  }
-
-  defaultRenderTag = (props) => {
-    const {removeLanguageWithIconTag} = this
-    const {highlightDelete} = this.state
-    const {selectedLanguages} = this.props
+  const defaultRenderTag = (props) => {
     let {
       tag,
       key,
@@ -102,6 +75,20 @@ class LanguageSelectorSearch extends React.Component {
       </span>
     )
   }
+
+  return (
+    <TagsInput
+      inputValue={querySearch}
+      addKeys={[]}
+      inputProps={{placeholder: 'Search...'}}
+      onChangeInput={onQueryChange}
+      renderTag={defaultRenderTag}
+      value={selectedLanguages ? selectedLanguages.map((e) => e.name) : []}
+      onChange={handleChange}
+      autofocus={true}
+      ref={tagsInputRef}
+    />
+  )
 }
 
 LanguageSelectorSearch.defaultProps = {


### PR DESCRIPTION
## Summary

Step 03 of the PR #4768 split plan (wave 1, independent): migrates the three
`languageSelector` components to function components with hooks, porting the
final state from the `react-class-to-functional-migration` branch. Extends
the per-directory eslint ratchet started in #4814 to this directory.

Note: the split proposal's write-up for this step describes an "XSS
sanitisation change" in `LanguageSelectorSearch` — I diffed this file in full
against the migration branch and found no such change, only a
mousedown-listener-leak fix (matches that branch's own commit message,
`fix(languageSelector): convert LanguageSelectorSearch to a function
component and fix mousedown listener leak`). Flagging the discrepancy rather
than repeating an inaccurate claim; happy to dig further if a reviewer knows
of a sanitisation concern this missed.

## Type

- [x] `refactor` — restructure without behavior change
- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/languageSelector/LanguageSelector.js` | Convert to function component with hooks |
| `public/js/components/languageSelector/LanguageSelectorList.js` | Convert to function component with hooks |
| `public/js/components/languageSelector/LanguageSelectorSearch.js` | Convert to function component; fixes a mousedown-listener leak (listener referenced by closure identity couldn't be removed) |
| `.eslintrc.js` | Extend the class-component-ban override's `files` list to `public/js/components/languageSelector/**/*.js` |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

No new tests were added — existing tests are unchanged (they exercise the
public interface and already covered the converted components) and still
pass: `yarn test --watchAll=false public/js/components/languageSelector/` —
3 suites, 38 tests, all passing. Full suite `yarn test --watchAll=false` —
426 suites, 4387 tests, all passing, no regressions. Scoped `npx eslint
public/js/components/languageSelector/` diffed against the pre-change
ruleset: the ratchet extension introduces zero new errors (61 pre-existing
errors, unchanged, all in files outside this PR's scope).

No browser-based manual verification (opening the language selector,
searching, selecting, confirming, keyboard nav) was performed in this
session — background job, no interactive browser available — so treat the
"manual testing" box above as automated-verification-only and give it an
actual click-through pass before merge.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (Sonnet 5)

## Notes

Part of the split of #4768 (wave 1, step 03 of 14) — see #4814 for the
first step in this series and the full merge-order plan. Independent of
the other wave-1 PRs; can merge in any order.

