### PR TITLE
♻️ refactor(review-extended): convert to function components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,8 @@ module.exports = {
       files: [
         'public/js/components/modals/**/*.js',
         'public/js/components/languageSelector/**/*.js',
+        'public/js/components/review_extended/**/*.js',
+        'public/js/components/common/WrapperLoader.js',
       ],
       rules: {
         'no-restricted-syntax': [

--- a/public/js/components/common/WrapperLoader.js
+++ b/public/js/components/common/WrapperLoader.js
@@ -1,32 +1,26 @@
 import React from 'react'
-class WrapperLoader extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {}
-  }
 
-  render() {
-    let overlayLoaderStyle = {
-      position: 'absolute',
-      left: 0,
-      top: 0,
-      background: 'rgba(255,255,255,0.6)',
-      width: '100%',
-      height: '100%',
-      zIndex: 999,
-    }
-    let loaderStyle = {
-      left: '50%',
-      top: '50%',
-      transform: 'translate(-50%)',
-      display: 'block',
-    }
-    return (
-      <div className="overlayLoader" style={overlayLoaderStyle}>
-        <div className="loader" style={loaderStyle}></div>
-      </div>
-    )
+const WrapperLoader = () => {
+  const overlayLoaderStyle = {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    background: 'rgba(255,255,255,0.6)',
+    width: '100%',
+    height: '100%',
+    zIndex: 999,
   }
+  const loaderStyle = {
+    left: '50%',
+    top: '50%',
+    transform: 'translate(-50%)',
+    display: 'block',
+  }
+  return (
+    <div className="overlayLoader" style={overlayLoaderStyle}>
+      <div className="loader" style={loaderStyle}></div>
+    </div>
+  )
 }
 
 export default WrapperLoader

--- a/public/js/components/common/WrapperLoader.test.js
+++ b/public/js/components/common/WrapperLoader.test.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import {render} from '@testing-library/react'
+import WrapperLoader from './WrapperLoader'
+
+test('renders overlay and loader elements', () => {
+  // decorative positioning divs with no accessible role — no semantic Testing Library
+  // query applies, so container access is the only way to assert they render
+  const {container} = render(<WrapperLoader />)
+  // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+  expect(container.querySelector('.overlayLoader')).toBeInTheDocument()
+  // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+  expect(container.querySelector('.loader')).toBeInTheDocument()
+})

--- a/public/js/components/review_extended/ReviewExtendedIssuePanel.js
+++ b/public/js/components/review_extended/ReviewExtendedIssuePanel.js
@@ -1,4 +1,10 @@
-import React from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import ReviewExtendedCategorySelector from './ReviewExtendedCategorySelector'
 import CommonUtils from '../../utils/commonUtils'
 import SegmentActions from '../../actions/SegmentActions'
@@ -11,39 +17,80 @@ import CatToolActions from '../../actions/CatToolActions'
 import {editSegmentIssue} from '../../api/editSegmentIssue/editSegmentIssue'
 import {sendSegmentVersionIssue} from '../../api/sendSegmentVersionIssue'
 
-class ReviewExtendedIssuePanel extends React.Component {
-  static contextType = SegmentContext
-
-  constructor(props) {
-    super(props)
-    this.issueCategoriesFlat = config.lqa_flat_categories
-    this.state = {
-      submitDisabled: false,
-      categorySelectedIndex: 0,
-      categorySelectedId: this.issueCategoriesFlat[0].id,
-      enableArrows: false,
-      severityIndex: 0,
-    }
-    this.issueCategories = orderBy(config.lqa_nested_categories.categories, [
-      'id',
-    ])
-
-    this.handleShortcutsKeyDown = this.handleShortcutsKeyDown.bind(this)
-    this.handleShortcutsKeyUp = this.handleShortcutsKeyUp.bind(this)
+const getNextCategoryIndex = (direction, currentIndex, length) => {
+  switch (direction) {
+    case 'next':
+      return (currentIndex + 1) % length
+    case 'prev':
+      return (currentIndex === 0 && length - 1) || currentIndex - 1
+    default:
+      return currentIndex
   }
-  sendIssue(category, severity) {
-    if (this.state.submitDisabled) return
-    this.props.setCreationIssueLoader(true)
-    this.setState({
-      submitDisabled: true,
-    })
+}
 
-    const {selection} = this.props
+const getNextSeverityIndex = (direction, currentIndex, length) => {
+  switch (direction) {
+    case 'next':
+      return (currentIndex + 1) % length
+    case 'prev':
+      return (currentIndex === 0 && length - 1) || currentIndex - 1
+    default:
+      return currentIndex
+  }
+}
+
+const ReviewExtendedIssuePanel = ({
+  setCreationIssueLoader,
+  selection,
+  segmentVersion,
+  issueEditing,
+  submitIssueCallback,
+  setIssueEditing,
+  handleFail = () => {},
+}) => {
+  const context = useContext(SegmentContext)
+
+  const issueCategoriesFlatRef = useRef(config.lqa_flat_categories)
+  const issueCategoriesRef = useRef(
+    orderBy(config.lqa_nested_categories.categories, ['id']),
+  )
+  const issueCategoriesFlat = issueCategoriesFlatRef.current
+  const issueCategories = issueCategoriesRef.current
+
+  const listElmRef = useRef(null)
+  const latestRef = useRef({})
+
+  const [submitDisabled, setSubmitDisabled] = useState(false)
+  // eslint-disable-next-line no-unused-vars
+  const [submitDone, setSubmitDone] = useState()
+  const [categorySelected, setCategorySelected] = useState({
+    index: 0,
+    id: issueCategoriesFlat[0].id,
+  })
+  const [severityIndex, setSeverityIndex] = useState(0)
+  const [enableArrows, setEnableArrows] = useState(false)
+
+  const handleSendIssueFail = (response) => {
+    if (response.errors && response.errors[0].code === -2000) {
+      CatToolActions.processErrors(response.errors, 'createIssue')
+    } else {
+      CommonUtils.genericErrorAlertMessage()
+    }
+    setCreationIssueLoader(false)
+    handleFail()
+    setSubmitDone(false)
+    setSubmitDisabled(false)
+  }
+
+  const sendIssue = (category, severity) => {
+    if (submitDisabled) return
+    setCreationIssueLoader(true)
+    setSubmitDisabled(true)
 
     const issue = {
       id_category: category.id,
       severity: severity,
-      version: this.props.segmentVersion,
+      version: segmentVersion,
       ...(selection
         ? {
             target_text: selection.selected_string,
@@ -63,33 +110,29 @@ class ReviewExtendedIssuePanel extends React.Component {
     const deferredSubmit = () => {
       SegmentActions.setStatus(segment.sid, segment.fid, segment.status)
 
-      const {issueEditing} = this.props
-
       const promise = issueEditing ? editSegmentIssue : sendSegmentVersionIssue
 
       promise({
-        idSegment: this.context.segment.sid,
+        idSegment: context.segment.sid,
         issueDetails: issue,
-        issueId: this.props.issueEditing?.id,
+        issueId: issueEditing?.id,
       })
         .then((data) => {
-          SegmentActions.getSegmentVersionsIssues(this.context.segment.sid)
+          SegmentActions.getSegmentVersionsIssues(context.segment.sid)
           CatToolActions.reloadQualityReport()
 
-          this.setState({
-            submitDisabled: false,
-          })
-          this.props.submitIssueCallback()
-          this.props.setCreationIssueLoader(false)
-          if (issueEditing) this.props.setIssueEditing(undefined)
+          setSubmitDisabled(false)
+          submitIssueCallback()
+          setCreationIssueLoader(false)
+          if (issueEditing) setIssueEditing(undefined)
           setTimeout(() => {
-            SegmentActions.issueAdded(this.context.segment.sid, data.issue.id)
+            SegmentActions.issueAdded(context.segment.sid, data.issue.id)
           })
         })
-        .catch(this.handleFail.bind(this))
+        .catch(handleSendIssueFail)
     }
 
-    const segment = this.context.segment
+    const segment = context.segment
     if (
       segment.revision_number !== config.revisionNumber ||
       ![SEGMENTS_STATUS.APPROVED, SEGMENTS_STATUS.APPROVED2].includes(
@@ -108,73 +151,55 @@ class ReviewExtendedIssuePanel extends React.Component {
           SegmentActions.addClassToSegment(segment.sid, 'modified')
           deferredSubmit()
         })
-        .catch(this.handleFail.bind(this))
+        .catch(handleSendIssueFail)
     } else {
       deferredSubmit()
     }
   }
 
-  handleFail(response) {
-    if (response.errors && response.errors[0].code === -2000) {
-      CatToolActions.processErrors(response.errors, 'createIssue')
-    } else {
-      CommonUtils.genericErrorAlertMessage()
-    }
-    this.props.setCreationIssueLoader(false)
-    this.props.handleFail()
-    this.setState({submitDone: false, submitDisabled: false})
-  }
+  const thereAreSubcategories = () =>
+    (issueCategories[0]?.subcategories &&
+      issueCategories[0].subcategories.length > 0) ||
+    (issueCategories[1]?.subcategories &&
+      issueCategories[1].subcategories.length > 0)
 
-  thereAreSubcategories() {
-    return (
-      (this.issueCategories[0]?.subcategories &&
-        this.issueCategories[0].subcategories.length > 0) ||
-      (this.issueCategories[1]?.subcategories &&
-        this.issueCategories[1].subcategories.length > 0)
-    )
-  }
-
-  getCategoriesHtml() {
-    const {issueEditing} = this.props
+  const getCategoriesHtml = () => {
     let categoryComponents = []
-    this.issueCategories.forEach(
-      function (category, i) {
-        let selectedValue = ''
-        categoryComponents.push(
-          <ReviewExtendedCategorySelector
-            key={'category-selector-' + i}
-            sendIssue={this.sendIssue.bind(this)}
-            selectedValue={selectedValue}
-            nested={false}
-            category={category}
-            sid={this.context.segment.sid}
-            active={
-              (this.state.enableArrows &&
-                parseInt(this.state.categorySelectedId) ===
-                  parseInt(category.id)) ||
-              (issueEditing &&
-                parseInt(issueEditing.id_category) === parseInt(category.id))
-            }
-            severityActiveIndex={
-              (this.state.enableArrows &&
-              parseInt(this.state.categorySelectedId) === parseInt(category.id)
-                ? this.state.severityIndex
-                : null) ||
-              (issueEditing &&
-              parseInt(issueEditing.id_category) === parseInt(category.id)
-                ? category.severities.findIndex(
-                    ({label}) => label === issueEditing.severity,
-                  )
-                : null)
-            }
-          />,
-        )
-      }.bind(this),
-    )
+    issueCategories.forEach((category, i) => {
+      let selectedValue = ''
+      categoryComponents.push(
+        <ReviewExtendedCategorySelector
+          key={'category-selector-' + i}
+          sendIssue={sendIssue}
+          selectedValue={selectedValue}
+          nested={false}
+          category={category}
+          sid={context.segment.sid}
+          active={
+            (enableArrows &&
+              parseInt(categorySelected.id) === parseInt(category.id)) ||
+            (issueEditing &&
+              parseInt(issueEditing.id_category) === parseInt(category.id))
+          }
+          severityActiveIndex={
+            (enableArrows &&
+            parseInt(categorySelected.id) === parseInt(category.id)
+              ? severityIndex
+              : null) ||
+            (issueEditing &&
+            parseInt(issueEditing.id_category) === parseInt(category.id)
+              ? category.severities.findIndex(
+                  ({label}) => label === issueEditing.severity,
+                )
+              : null)
+          }
+        />,
+      )
+    })
 
     return (
       <div>
-        {!this.props.issueEditing && (
+        {!issueEditing && (
           <div className="re-item-head pad-left-10">New issue</div>
         )}
         {categoryComponents}
@@ -182,74 +207,36 @@ class ReviewExtendedIssuePanel extends React.Component {
     )
   }
 
-  getSubCategoriesHtml() {
+  const getSubCategoriesHtml = () => {
     let categoryComponents = []
-    this.issueCategories.forEach(
-      function (category, i) {
-        let selectedValue = ''
-        let subcategoriesComponents = []
+    issueCategories.forEach((category, i) => {
+      let selectedValue = ''
+      let subcategoriesComponents = []
 
-        const {issueEditing} = this.props
+      if (category.subcategories.length > 0) {
+        category.subcategories.forEach((category, ii) => {
+          let key = '' + i + '-' + ii
+          let kk = 'category-selector-' + key
+          let selectedValue = ''
 
-        if (category.subcategories.length > 0) {
-          category.subcategories.forEach((category, ii) => {
-            let key = '' + i + '-' + ii
-            let kk = 'category-selector-' + key
-            let selectedValue = ''
-
-            subcategoriesComponents.push(
-              <ReviewExtendedCategorySelector
-                key={kk}
-                selectedValue={selectedValue}
-                sendIssue={this.sendIssue.bind(this)}
-                nested={true}
-                category={category}
-                sid={this.context.segment.sid}
-                active={
-                  (this.state.enableArrows &&
-                    parseInt(this.state.categorySelectedId) ===
-                      parseInt(category.id)) ||
-                  (issueEditing &&
-                    parseInt(issueEditing.id_category) ===
-                      parseInt(category.id))
-                }
-                severityActiveIndex={
-                  (this.state.enableArrows &&
-                  parseInt(this.state.categorySelectedId) ===
-                    parseInt(category.id)
-                    ? this.state.severityIndex
-                    : null) ||
-                  (issueEditing &&
-                  parseInt(issueEditing.id_category) === parseInt(category.id)
-                    ? category.severities.findIndex(
-                        ({label}) => label === issueEditing.severity,
-                      )
-                    : null)
-                }
-              />,
-            )
-          })
-        } else {
           subcategoriesComponents.push(
             <ReviewExtendedCategorySelector
-              key={'default'}
+              key={kk}
               selectedValue={selectedValue}
-              sendIssue={this.sendIssue.bind(this)}
+              sendIssue={sendIssue}
               nested={true}
               category={category}
-              sid={this.context.segment.sid}
+              sid={context.segment.sid}
               active={
-                (this.state.enableArrows &&
-                  parseInt(this.state.categorySelectedId) ===
-                    parseInt(category.id)) ||
+                (enableArrows &&
+                  parseInt(categorySelected.id) === parseInt(category.id)) ||
                 (issueEditing &&
                   parseInt(issueEditing.id_category) === parseInt(category.id))
               }
               severityActiveIndex={
-                (this.state.enableArrows &&
-                parseInt(this.state.categorySelectedId) ===
-                  parseInt(category.id)
-                  ? this.state.severityIndex
+                (enableArrows &&
+                parseInt(categorySelected.id) === parseInt(category.id)
+                  ? severityIndex
                   : null) ||
                 (issueEditing &&
                 parseInt(issueEditing.id_category) === parseInt(category.id)
@@ -260,134 +247,141 @@ class ReviewExtendedIssuePanel extends React.Component {
               }
             />,
           )
-        }
-        let html = (
-          <div key={category.id}>
-            <div className="re-item-head pad-left-10">{category.label}</div>
-            {subcategoriesComponents}
-          </div>
+        })
+      } else {
+        subcategoriesComponents.push(
+          <ReviewExtendedCategorySelector
+            key={'default'}
+            selectedValue={selectedValue}
+            sendIssue={sendIssue}
+            nested={true}
+            category={category}
+            sid={context.segment.sid}
+            active={
+              (enableArrows &&
+                parseInt(categorySelected.id) === parseInt(category.id)) ||
+              (issueEditing &&
+                parseInt(issueEditing.id_category) === parseInt(category.id))
+            }
+            severityActiveIndex={
+              (enableArrows &&
+              parseInt(categorySelected.id) === parseInt(category.id)
+                ? severityIndex
+                : null) ||
+              (issueEditing &&
+              parseInt(issueEditing.id_category) === parseInt(category.id)
+                ? category.severities.findIndex(
+                    ({label}) => label === issueEditing.severity,
+                  )
+                : null)
+            }
+          />,
         )
-        categoryComponents.push(html)
-      }.bind(this),
-    )
+      }
+      let html = (
+        <div key={category.id}>
+          <div className="re-item-head pad-left-10">{category.label}</div>
+          {subcategoriesComponents}
+        </div>
+      )
+      categoryComponents.push(html)
+    })
 
     return categoryComponents
   }
-  getNextCategoryIndex(direction) {
-    let idx = this.state.categorySelectedIndex
-    let length = this.issueCategoriesFlat.length
-    switch (direction) {
-      case 'next':
-        return (idx + 1) % length
-      case 'prev':
-        return (idx === 0 && length - 1) || idx - 1
-      default:
-        return idx
-    }
+
+  latestRef.current = {
+    enableArrows,
+    categorySelected,
+    severityIndex,
+    sendIssue,
   }
-  getNextSeverityIndex(direction) {
-    let idx = this.state.severityIndex
-    let length =
-      this.issueCategoriesFlat[this.state.categorySelectedIndex].severities
-        .length
-    switch (direction) {
-      case 'next':
-        return (idx + 1) % length
-      case 'prev':
-        return (idx === 0 && length - 1) || idx - 1
-      default:
-        return idx
+
+  const handleShortcutsKeyDown = useCallback((e) => {
+    const {enableArrows, categorySelected, severityIndex, sendIssue} =
+      latestRef.current
+    const issueCategoriesFlat = issueCategoriesFlatRef.current
+
+    if (e.ctrlKey && e.altKey && !enableArrows) {
+      setEnableArrows(true)
     }
-  }
-  handleShortcutsKeyDown(e) {
-    if (e.ctrlKey && e.altKey && !this.state.enableArrows) {
-      this.setState({
-        enableArrows: true,
-      })
-    }
-    if (this.state.enableArrows && e.code === 'ArrowDown') {
-      let index = this.getNextCategoryIndex('next')
-      this.setState({
-        categorySelectedIndex: index,
-        categorySelectedId: this.issueCategoriesFlat[index].id,
-        severityIndex: 0,
-      })
-    } else if (this.state.enableArrows && e.code === 'ArrowUp') {
-      let index = this.getNextCategoryIndex('prev')
-      this.setState({
-        categorySelectedIndex: index,
-        categorySelectedId: this.issueCategoriesFlat[index].id,
-        severityIndex: 0,
-      })
-    } else if (this.state.enableArrows && e.code === 'ArrowLeft') {
-      let index = this.getNextSeverityIndex('prev')
-      this.setState({
-        severityIndex: index,
-      })
-    } else if (this.state.enableArrows && e.code === 'ArrowRight') {
-      let index = this.getNextSeverityIndex('next')
-      this.setState({
-        severityIndex: index,
-      })
-    } else if (this.state.enableArrows && e.code === 'Enter') {
-      this.sendIssue(
-        this.issueCategoriesFlat[this.state.categorySelectedIndex],
-        this.issueCategoriesFlat[this.state.categorySelectedIndex].severities[
-          this.state.severityIndex
-        ].label,
+    if (enableArrows && e.code === 'ArrowDown') {
+      const index = getNextCategoryIndex(
+        'next',
+        categorySelected.index,
+        issueCategoriesFlat.length,
+      )
+      setCategorySelected({index, id: issueCategoriesFlat[index].id})
+      setSeverityIndex(0)
+    } else if (enableArrows && e.code === 'ArrowUp') {
+      const index = getNextCategoryIndex(
+        'prev',
+        categorySelected.index,
+        issueCategoriesFlat.length,
+      )
+      setCategorySelected({index, id: issueCategoriesFlat[index].id})
+      setSeverityIndex(0)
+    } else if (enableArrows && e.code === 'ArrowLeft') {
+      const length =
+        issueCategoriesFlat[categorySelected.index].severities.length
+      setSeverityIndex(getNextSeverityIndex('prev', severityIndex, length))
+    } else if (enableArrows && e.code === 'ArrowRight') {
+      const length =
+        issueCategoriesFlat[categorySelected.index].severities.length
+      setSeverityIndex(getNextSeverityIndex('next', severityIndex, length))
+    } else if (enableArrows && e.code === 'Enter') {
+      sendIssue(
+        issueCategoriesFlat[categorySelected.index],
+        issueCategoriesFlat[categorySelected.index].severities[severityIndex]
+          .label,
       )
       setTimeout(() => SegmentActions.setFocusOnEditArea(), 1000)
     }
-  }
+  }, [])
 
-  handleShortcutsKeyUp(e) {
-    if ((!e.ctrlKey || !e.altKey) && this.state.enableArrows) {
-      this.setState({
-        enableArrows: false,
-        categorySelectedIndex: 0,
-        categorySelectedId: this.issueCategoriesFlat[0].id,
-        severityIndex: 0,
+  const handleShortcutsKeyUp = useCallback((e) => {
+    const {enableArrows} = latestRef.current
+    if ((!e.ctrlKey || !e.altKey) && enableArrows) {
+      setEnableArrows(false)
+      setCategorySelected({
+        index: 0,
+        id: issueCategoriesFlatRef.current[0].id,
       })
+      setSeverityIndex(0)
     }
-  }
+  }, [])
 
-  componentDidMount() {
-    document.addEventListener('keydown', this.handleShortcutsKeyDown)
-    document.addEventListener('keyup', this.handleShortcutsKeyUp)
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keyup', this.handleShortcutsKeyUp)
-    document.removeEventListener('keydown', this.handleShortcutsKeyDown)
-  }
-
-  render() {
-    let html = []
-
-    if (this.thereAreSubcategories()) {
-      html = this.getSubCategoriesHtml()
-    } else {
-      html = this.getCategoriesHtml()
+  useEffect(() => {
+    document.addEventListener('keydown', handleShortcutsKeyDown)
+    document.addEventListener('keyup', handleShortcutsKeyUp)
+    return () => {
+      document.removeEventListener('keyup', handleShortcutsKeyUp)
+      document.removeEventListener('keydown', handleShortcutsKeyDown)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-    return (
-      <div className="re-issues-box re-to-create">
-        {/*<h4 className="re-issues-box-title">Error list</h4>*/}
-        {/*<div className="comment-triangle comment-triangle-topleft"></div>*/}
-        <div
-          className="re-list errors"
-          id={'re-category-list-' + this.context.segment.sid}
-          ref={(node) => (this.listElm = node)}
-        >
-          {html}
-        </div>
+  let html = []
+
+  if (thereAreSubcategories()) {
+    html = getSubCategoriesHtml()
+  } else {
+    html = getCategoriesHtml()
+  }
+
+  return (
+    <div className="re-issues-box re-to-create">
+      {/*<h4 className="re-issues-box-title">Error list</h4>*/}
+      {/*<div className="comment-triangle comment-triangle-topleft"></div>*/}
+      <div
+        className="re-list errors"
+        id={'re-category-list-' + context.segment.sid}
+        ref={listElmRef}
+      >
+        {html}
       </div>
-    )
-  }
-}
-
-ReviewExtendedIssuePanel.defaultProps = {
-  handleFail: function () {},
+    </div>
+  )
 }
 
 export default ReviewExtendedIssuePanel

--- a/public/js/components/review_extended/ReviewExtendedIssuesContainer.js
+++ b/public/js/components/review_extended/ReviewExtendedIssuesContainer.js
@@ -1,4 +1,10 @@
-import React from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import WrapperLoader from '../common/WrapperLoader'
 import SegmentConstants from '../../constants/SegmentConstants'
 import SegmentActions from '../../actions/SegmentActions'
@@ -14,27 +20,48 @@ import classnames from 'classnames'
 import ReviewExtendedIssuesTabGroup from './ReviewExtendedIssuesTabGroup'
 import {ReviewExtendedIssue} from './ReviewExtendedIssue'
 
-class ReviewExtendedIssuesContainer extends React.Component {
-  static contextType = SegmentContext
+const ReviewExtendedIssuesContainer = (props) => {
+  const context = useContext(SegmentContext)
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      lastIssueAdded: null,
-      visible: true,
-    }
-    this.issueFlatCategories = config.lqa_flat_categories
-    this.issueNestedCategories = config.lqa_nested_categories.categories
-    this.is2ndPassReviewEnabled =
-      config.secondRevisionsCount && config.secondRevisionsCount > 0
-    this.reviewType = config.revisionNumber
+  const issueFlatCategoriesRef = useRef(config.lqa_flat_categories)
+  const issueNestedCategoriesRef = useRef(
+    config.lqa_nested_categories.categories,
+  )
+  const is2ndPassReviewEnabledRef = useRef(
+    config.secondRevisionsCount && config.secondRevisionsCount > 0,
+  )
+  const reviewTypeRef = useRef(config.revisionNumber)
+
+  const issueFlatCategories = issueFlatCategoriesRef.current
+  const issueNestedCategories = issueNestedCategoriesRef.current
+  const is2ndPassReviewEnabled = is2ndPassReviewEnabledRef.current
+  const reviewType = reviewTypeRef.current
+
+  // eslint-disable-next-line no-unused-vars
+  const [lastIssueAdded] = useState(null)
+  const [visible, setVisible] = useState(true)
+
+  const isFirstRender = useRef(true)
+  const prevIssuesLengthRef = useRef(props.issues.length)
+
+  const latestRef = useRef({context})
+  latestRef.current = {context}
+
+  const findCategory = (id) => {
+    return issueFlatCategories.find((category) => {
+      return id == category.id
+    })
   }
 
-  parseIssues() {
+  const isSubCategory = (category) => {
+    return !isNull(category.id_parent)
+  }
+
+  const parseIssues = () => {
     let issuesObj = {}
-    this.props.issues.forEach((issue) => {
-      let cat = this.findCategory(issue.id_category)
-      let id = this.isSubCategory(cat) ? cat.id_parent : cat.id
+    props.issues.forEach((issue) => {
+      let cat = findCategory(issue.id_category)
+      let id = isSubCategory(cat) ? cat.id_parent : cat.id
 
       if (!issuesObj[id]) {
         issuesObj[id] = []
@@ -44,30 +71,95 @@ class ReviewExtendedIssuesContainer extends React.Component {
     return issuesObj
   }
 
-  findCategory(id) {
-    return this.issueFlatCategories.find((category) => {
-      return id == category.id
-    })
-  }
-
-  isSubCategory(category) {
-    return !isNull(category.id_parent)
-  }
-
-  thereAreSubcategories() {
+  const thereAreSubcategories = () => {
     return (
-      this.issueNestedCategories[0].subcategories &&
-      this.issueNestedCategories[0].subcategories.length > 0
+      issueNestedCategories[0].subcategories &&
+      issueNestedCategories[0].subcategories.length > 0
     )
   }
 
-  getSubCategoriesHtml() {
-    let parsedIssues = this.parseIssues()
+  const changeVisibility = (id, isVisible) => {
+    let issuesList = props.issues.slice()
+    let index = findIndex(issuesList, function (item) {
+      return item.id == id
+    })
+    issuesList[index].visible = isVisible
+
+    let visibleIssues = filter(props.issues, function (item) {
+      return isUndefined(item.visible) || item.visible
+    })
+    if (visibleIssues.length === 0) {
+      setVisible(false)
+    } else {
+      setVisible(true)
+    }
+  }
+
+  const getIssuesSortedComponentList = (list) => {
+    let issuesR1 = [],
+      issuesR2 = []
+    let sorted_issues = list.sort(function (a, b) {
+      a = new Date(a.created_at)
+      b = new Date(b.created_at)
+      return a > b ? -1 : a < b ? 1 : 0
+    })
+
+    forEach(sorted_issues, (item) => {
+      if (item.revision_number === 2) {
+        issuesR2.push(
+          <ReviewExtendedIssue
+            lastIssueId={lastIssueAdded}
+            sid={context.segment.sid}
+            isReview={props.isReview}
+            currentReview={reviewType}
+            issue={item}
+            key={item.id}
+            changeVisibility={changeVisibility}
+            actions={
+              !SegmentUtils.isIceSegment(context.segment) ||
+              (SegmentUtils.isIceSegment(context.segment) &&
+                context.segment.unlocked)
+            }
+            issueEditing={props.issueEditing}
+            setIssueEditing={props.setIssueEditing}
+            selection={props.selectionObj}
+            segmentVersion={props.versionNumber}
+          />,
+        )
+      } else {
+        issuesR1.push(
+          <ReviewExtendedIssue
+            lastIssueId={lastIssueAdded}
+            sid={context.segment.sid}
+            isReview={props.isReview}
+            currentReview={reviewType}
+            issue={item}
+            key={item.id}
+            changeVisibility={changeVisibility}
+            actions={
+              !SegmentUtils.isIceSegment(context.segment) ||
+              (SegmentUtils.isIceSegment(context.segment) &&
+                context.segment.unlocked)
+            }
+            issueEditing={props.issueEditing}
+            setIssueEditing={props.setIssueEditing}
+            selection={props.selectionObj}
+            segmentVersion={props.versionNumber}
+          />,
+        )
+      }
+    })
+
+    return {r1: issuesR1, r2: issuesR2}
+  }
+
+  const getSubCategoriesHtml = () => {
+    let parsedIssues = parseIssues()
     let htmlR1 = [],
       htmlR2 = []
     each(parsedIssues, (issuesList, id) => {
-      let cat = this.findCategory(id)
-      let issues = this.getIssuesSortedComponentList(issuesList)
+      let cat = findCategory(id)
+      let issues = getIssuesSortedComponentList(issuesList)
       if (issues.r1.length > 0) {
         htmlR1.push(
           <div key={cat.id}>
@@ -85,15 +177,15 @@ class ReviewExtendedIssuesContainer extends React.Component {
         )
       }
     })
-    if (this.is2ndPassReviewEnabled) {
+    if (is2ndPassReviewEnabled) {
       let r1Active =
-        (this.reviewType === 1 && htmlR1.length > 0) ||
+        (reviewType === 1 && htmlR1.length > 0) ||
         (htmlR1.length > 0 && htmlR2.length === 0)
       let r2Active =
-        (this.reviewType === 2 && htmlR2.length > 0) ||
+        (reviewType === 2 && htmlR2.length > 0) ||
         (htmlR2.length > 0 && htmlR1.length === 0)
 
-      const maxHeight = this.props.issueEditing ? '500px' : '200px'
+      const maxHeight = props.issueEditing ? '500px' : '200px'
 
       const tabs = [
         {
@@ -152,21 +244,21 @@ class ReviewExtendedIssuesContainer extends React.Component {
     }
   }
 
-  getCategoriesHtml() {
+  const getCategoriesHtml = () => {
     let issues
 
-    if (this.props.issues.length > 0) {
-      issues = this.getIssuesSortedComponentList(this.props.issues)
+    if (props.issues.length > 0) {
+      issues = getIssuesSortedComponentList(props.issues)
     }
-    if (this.is2ndPassReviewEnabled) {
+    if (is2ndPassReviewEnabled) {
       let r1Active =
-        (this.reviewType === 1 && issues.r1.length > 0) ||
+        (reviewType === 1 && issues.r1.length > 0) ||
         (issues.r1.length > 0 && issues.r2.length === 0)
       let r2Active =
-        (this.reviewType === 2 && issues.r2.length > 0) ||
+        (reviewType === 2 && issues.r2.length > 0) ||
         (issues.r2.length > 0 && issues.r1.length === 0)
 
-      const maxHeight = this.props.issueEditing ? '500px' : '200px'
+      const maxHeight = props.issueEditing ? '500px' : '200px'
 
       const tabs = [
         {
@@ -230,142 +322,59 @@ class ReviewExtendedIssuesContainer extends React.Component {
     }
   }
 
-  getIssuesSortedComponentList(list) {
-    let issuesR1 = [],
-      issuesR2 = []
-    let sorted_issues = list.sort(function (a, b) {
-      a = new Date(a.created_at)
-      b = new Date(b.created_at)
-      return a > b ? -1 : a < b ? 1 : 0
-    })
-
-    forEach(sorted_issues, (item) => {
-      if (item.revision_number === 2) {
-        issuesR2.push(
-          <ReviewExtendedIssue
-            lastIssueId={this.state.lastIssueAdded}
-            sid={this.context.segment.sid}
-            isReview={this.props.isReview}
-            currentReview={this.reviewType}
-            issue={item}
-            key={item.id}
-            changeVisibility={this.changeVisibility.bind(this)}
-            actions={
-              !SegmentUtils.isIceSegment(this.context.segment) ||
-              (SegmentUtils.isIceSegment(this.context.segment) &&
-                this.context.segment.unlocked)
-            }
-            issueEditing={this.props.issueEditing}
-            setIssueEditing={this.props.setIssueEditing}
-            selection={this.props.selectionObj}
-            segmentVersion={this.props.versionNumber}
-          />,
-        )
-      } else {
-        issuesR1.push(
-          <ReviewExtendedIssue
-            lastIssueId={this.state.lastIssueAdded}
-            sid={this.context.segment.sid}
-            isReview={this.props.isReview}
-            currentReview={this.reviewType}
-            issue={item}
-            key={item.id}
-            changeVisibility={this.changeVisibility.bind(this)}
-            actions={
-              !SegmentUtils.isIceSegment(this.context.segment) ||
-              (SegmentUtils.isIceSegment(this.context.segment) &&
-                this.context.segment.unlocked)
-            }
-            issueEditing={this.props.issueEditing}
-            setIssueEditing={this.props.setIssueEditing}
-            selection={this.props.selectionObj}
-            segmentVersion={this.props.versionNumber}
-          />,
-        )
-      }
-    })
-
-    return {r1: issuesR1, r2: issuesR2}
-  }
-
-  changeVisibility(id, visible) {
-    let issues = this.props.issues.slice()
-    let index = findIndex(issues, function (item) {
-      return item.id == id
-    })
-    issues[index].visible = visible
-
-    let visibleIssues = filter(this.props.issues, function (item) {
-      return isUndefined(item.visible) || item.visible
-    })
-    if (visibleIssues.length === 0) {
-      this.setState({
-        visible: false,
-      })
-    } else {
-      this.setState({
-        visible: true,
-      })
-    }
-  }
-
-  setLastIssueAdded(sid, id) {
-    if (sid === this.context.segment.sid) {
+  const setLastIssueAdded = useCallback((sid, id) => {
+    const {context} = latestRef.current
+    if (sid === context.segment.sid) {
       setTimeout(() => {
-        SegmentActions.openIssueComments(this.context.segment.sid, id)
+        SegmentActions.openIssueComments(context.segment.sid, id)
       }, 200)
     }
-  }
+  }, [])
 
-  componentDidMount() {
-    SegmentStore.addListener(
-      SegmentConstants.ISSUE_ADDED,
-      this.setLastIssueAdded.bind(this),
-    )
-  }
-
-  componentWillUnmount() {
-    SegmentStore.removeListener(
-      SegmentConstants.ISSUE_ADDED,
-      this.setLastIssueAdded,
-    )
-    //Undo notification
-    setTimeout(() => CatToolActions.removeAllNotifications())
-  }
-
-  componentDidUpdate(prevProps, prevState) {
-    if (prevProps.issues.length < this.props.issues.length) {
-      this.setState({
-        visible: true,
-      })
-    }
-  }
-
-  render() {
-    if (this.props.issues.length > 0) {
-      let html
-      if (this.thereAreSubcategories()) {
-        html = this.getSubCategoriesHtml()
-      } else {
-        html = this.getCategoriesHtml()
-      }
-      let classNotVisible = !this.state.visible ? 're-issues-box-empty' : ''
-      return (
-        <div className={'re-issues-box re-created ' + classNotVisible}>
-          {this.props.loader ? <WrapperLoader /> : null}
-          <div
-            className={classnames(
-              're-list issues',
-              this.is2ndPassReviewEnabled && 'no-scroll',
-            )}
-          >
-            {html}
-          </div>
-        </div>
+  useEffect(() => {
+    SegmentStore.addListener(SegmentConstants.ISSUE_ADDED, setLastIssueAdded)
+    return () => {
+      SegmentStore.removeListener(
+        SegmentConstants.ISSUE_ADDED,
+        setLastIssueAdded,
       )
+      //Undo notification
+      setTimeout(() => CatToolActions.removeAllNotifications())
     }
-    return ''
+  }, [setLastIssueAdded])
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+    } else if (prevIssuesLengthRef.current < props.issues.length) {
+      setVisible(true)
+    }
+    prevIssuesLengthRef.current = props.issues.length
+  }, [props.issues.length])
+
+  if (props.issues.length > 0) {
+    let html
+    if (thereAreSubcategories()) {
+      html = getSubCategoriesHtml()
+    } else {
+      html = getCategoriesHtml()
+    }
+    let classNotVisible = !visible ? 're-issues-box-empty' : ''
+    return (
+      <div className={'re-issues-box re-created ' + classNotVisible}>
+        {props.loader ? <WrapperLoader /> : null}
+        <div
+          className={classnames(
+            're-list issues',
+            is2ndPassReviewEnabled && 'no-scroll',
+          )}
+        >
+          {html}
+        </div>
+      </div>
+    )
   }
+  return ''
 }
 
 export default ReviewExtendedIssuesContainer

--- a/public/js/components/review_extended/ReviewExtendedPanel.js
+++ b/public/js/components/review_extended/ReviewExtendedPanel.js
@@ -1,5 +1,5 @@
 import {isEmpty} from 'lodash'
-import React from 'react'
+import React, {useCallback, useContext, useEffect, useState} from 'react'
 import classnames from 'classnames'
 
 import ReviewExtendedIssuesContainer from './ReviewExtendedIssuesContainer'
@@ -20,40 +20,30 @@ import {
   BUTTON_TYPE,
 } from '../common/Button/Button'
 
-class ReviewExtendedPanel extends React.Component {
-  static contextType = SegmentContext
+const removeMessageType = 0
+const addIssueToApproveMessageType = 1
+const addIssueToSelectedTextMessageType = 2
 
-  constructor(props) {
-    super(props)
-    this.removeMessageType = 0
-    this.addIssueToApproveMessageType = 1
-    this.addIssueToSelectedTextMessageType = 2
-    this.state = {
-      versionNumber: this.props.segment.versions[0]
-        ? this.props.segment.versions[0].version_number
-        : 0,
-      diffPatch: null,
-      newtranslation: this.props.segment.translation,
-      issueInCreation: false,
-      showAddIssueMessage: false,
-      showAddIssueToSelectedTextMessage: false,
-      issueEditing: undefined,
-    }
-  }
+const ReviewExtendedPanel = (props) => {
+  const context = useContext(SegmentContext)
 
-  removeSelection() {
-    this.setCreationIssueLoader(false)
-    this.context.removeSelection()
-    this.setState({
-      showAddIssueMessage: false,
-      showAddIssueToSelectedTextMessage: false,
-    })
-    SegmentActions.unlockEditArea(this.props.segment.sid)
-  }
+  const versionNumber = props.segment.versions[0]
+    ? props.segment.versions[0].version_number
+    : 0
 
-  getAllIssues() {
+  // eslint-disable-next-line no-unused-vars
+  const [diffPatch, setDiffPatch] = useState(null)
+  const [newtranslation] = useState(props.segment.translation)
+  const [issueInCreation, setIssueInCreation] = useState(false)
+  const [issueEditing, setIssueEditing] = useState(undefined)
+  const [issueMessages, setIssueMessages] = useState({
+    showAddIssueMessage: false,
+    showAddIssueToSelectedTextMessage: false,
+  })
+
+  const getAllIssues = () => {
     let issues = []
-    this.props.segment.versions.forEach(function (version) {
+    props.segment.versions.forEach(function (version) {
       if (!isEmpty(version.issues)) {
         issues = issues.concat(version.issues)
       }
@@ -61,149 +51,136 @@ class ReviewExtendedPanel extends React.Component {
     return issues
   }
 
-  setCreationIssueLoader(inCreation) {
-    this.setState({
-      issueInCreation: inCreation,
+  const removeSelection = () => {
+    setIssueInCreation(false)
+    context.removeSelection()
+    setIssueMessages({
+      showAddIssueMessage: false,
+      showAddIssueToSelectedTextMessage: false,
     })
+    SegmentActions.unlockEditArea(props.segment.sid)
   }
 
-  showIssuesMessage(sid, type) {
+  const showIssuesMessage = useCallback((sid, type) => {
     switch (type) {
-      case this.addIssueToApproveMessageType:
-        this.setState({
+      case addIssueToApproveMessageType:
+        setIssueMessages({
           showAddIssueMessage: true,
           showAddIssueToSelectedTextMessage: false,
         })
         break
-      case this.addIssueToSelectedTextMessageType:
-        this.setState({
+      case addIssueToSelectedTextMessageType:
+        setIssueMessages({
           showAddIssueMessage: false,
           showAddIssueToSelectedTextMessage: true,
         })
         break
-      case this.removeMessageType:
-        this.setState({
+      case removeMessageType:
+        setIssueMessages({
           showAddIssueMessage: false,
           showAddIssueToSelectedTextMessage: false,
         })
         break
     }
+  }, [])
+
+  const closePanel = () => {
+    SegmentActions.closeSegmentIssuePanel(props.segment.sid)
   }
 
-  closePanel() {
-    SegmentActions.closeSegmentIssuePanel(this.props.segment.sid)
-  }
-
-  static getDerivedStateFromProps(props) {
-    return {
-      versionNumber: props.segment.versions[0]
-        ? props.segment.versions[0].version_number
-        : 0,
-    }
-  }
-
-  componentDidMount() {
-    // this.props.setParentLoader(false);
+  useEffect(() => {
     SegmentStore.addListener(
       SegmentConstants.SHOW_ISSUE_MESSAGE,
-      this.showIssuesMessage.bind(this),
+      showIssuesMessage,
     )
-  }
+    return () => {
+      SegmentStore.removeListener(
+        SegmentConstants.SHOW_ISSUE_MESSAGE,
+        showIssuesMessage,
+      )
+    }
+  }, [showIssuesMessage])
 
-  componentWillUnmount() {
-    SegmentStore.removeListener(
-      SegmentConstants.SHOW_ISSUE_MESSAGE,
-      this.showIssuesMessage,
-    )
-  }
+  const issues = getAllIssues()
+  const thereAreIssuesClass = issues.length > 0 ? 'thereAreIssues' : ''
+  const cornerClass = classnames({
+    error: issueMessages.showAddIssueMessage,
+    warning: issueMessages.showAddIssueToSelectedTextMessage,
+    're-open-view re-issues': true,
+  })
 
-  setIssueEditing(issue) {
-    this.setState({issueEditing: issue})
-  }
-  render() {
-    let issues = this.getAllIssues()
-    let thereAreIssuesClass = issues.length > 0 ? 'thereAreIssues' : ''
-    let cornerClass = classnames({
-      error: this.state.showAddIssueMessage,
-      warning: this.state.showAddIssueToSelectedTextMessage,
-      're-open-view re-issues': true,
-    })
-    return (
-      <div className={'re-wrapper shadow-1 ' + thereAreIssuesClass}>
-        <div className={cornerClass} />
-        <Button
-          type={BUTTON_TYPE.ICON}
-          mode={BUTTON_MODE.GHOST}
-          size={BUTTON_SIZE.ICON_XSMALL}
-          className="re-close-balloon"
-          onClick={this.closePanel.bind(this)}
-        >
-          <IconClose />
-        </Button>
-        <ReviewExtendedIssuesContainer
-          loader={this.state.issueInCreation}
-          issues={issues}
-          isReview={this.props.isReview}
-          issueEditing={this.state.issueEditing}
-          setIssueEditing={this.setIssueEditing.bind(this)}
-          selection={this.props.selectionObj}
-          segmentVersion={this.state.versionNumber}
+  return (
+    <div className={'re-wrapper shadow-1 ' + thereAreIssuesClass}>
+      <div className={cornerClass} />
+      <Button
+        type={BUTTON_TYPE.ICON}
+        mode={BUTTON_MODE.GHOST}
+        size={BUTTON_SIZE.ICON_XSMALL}
+        className="re-close-balloon"
+        onClick={closePanel}
+      >
+        <IconClose />
+      </Button>
+      <ReviewExtendedIssuesContainer
+        loader={issueInCreation}
+        issues={issues}
+        isReview={props.isReview}
+        issueEditing={issueEditing}
+        setIssueEditing={setIssueEditing}
+        selection={props.selectionObj}
+        segmentVersion={versionNumber}
+      />
+      {issueMessages.showAddIssueMessage ? (
+        <div className="re-warning-not-added-issue">
+          <p>
+            You must add an issue from the list below before approving this
+            segment.
+            <br />
+            <a
+              onClick={() =>
+                ModalsActions.showModalComponent(
+                  ShortCutsModal,
+                  null,
+                  'Shortcuts',
+                )
+              }
+            >
+              {'Shortcut: ' +
+                Shortcuts.cattol.events.navigateIssues.equivalent[
+                  Shortcuts.shortCutsKeyType
+                ]}
+            </a>
+            <br />
+            <i>
+              Note: the job owner and workspace members can disable this
+              requirement from settings.
+            </i>
+          </p>
+        </div>
+      ) : null}
+
+      {issueMessages.showAddIssueToSelectedTextMessage ? (
+        <div className="re-warning-selected-text-issue">
+          <p>
+            Select an issue from the list below to associate it to the selected
+            text.
+          </p>
+        </div>
+      ) : null}
+
+      {props.isReview &&
+      !(SegmentUtils.isIceSegment(props.segment) && !props.segment.unlocked) ? (
+        <ReviewExtendedIssuePanel
+          selection={props.selectionObj}
+          segmentVersion={versionNumber}
+          submitIssueCallback={removeSelection}
+          newtranslation={newtranslation}
+          setCreationIssueLoader={setIssueInCreation}
+          setIssueEditing={setIssueEditing}
         />
-        {this.state.showAddIssueMessage ? (
-          <div className="re-warning-not-added-issue">
-            <p>
-              You must add an issue from the list below before approving this
-              segment.
-              <br />
-              <a
-                onClick={() =>
-                  ModalsActions.showModalComponent(
-                    ShortCutsModal,
-                    null,
-                    'Shortcuts',
-                  )
-                }
-              >
-                {'Shortcut: ' +
-                  Shortcuts.cattol.events.navigateIssues.equivalent[
-                    Shortcuts.shortCutsKeyType
-                  ]}
-              </a>
-              <br />
-              <i>
-                Note: the job owner and workspace members can disable this
-                requirement from settings.
-              </i>
-            </p>
-          </div>
-        ) : null}
-
-        {this.state.showAddIssueToSelectedTextMessage ? (
-          <div className="re-warning-selected-text-issue">
-            <p>
-              Select an issue from the list below to associate it to the
-              selected text.
-            </p>
-          </div>
-        ) : null}
-
-        {this.props.isReview &&
-        !(
-          SegmentUtils.isIceSegment(this.props.segment) &&
-          !this.props.segment.unlocked
-        ) ? (
-          <ReviewExtendedIssuePanel
-            selection={this.props.selectionObj}
-            segmentVersion={this.state.versionNumber}
-            submitIssueCallback={this.removeSelection.bind(this)}
-            newtranslation={this.state.newtranslation}
-            setCreationIssueLoader={this.setCreationIssueLoader.bind(this)}
-            setIssueEditing={this.setIssueEditing.bind(this)}
-          />
-        ) : null}
-      </div>
-    )
-  }
+      ) : null}
+    </div>
+  )
 }
 
 export default ReviewExtendedPanel

--- a/public/js/components/review_extended/ReviewExtendedTranslationIssuesSideButton.js
+++ b/public/js/components/review_extended/ReviewExtendedTranslationIssuesSideButton.js
@@ -5,11 +5,11 @@ import {Shortcuts} from '../../utils/shortcuts'
 import SegmentUtils from '../../utils/segmentUtils'
 import ReviseIssuesIcon from '../../../img/icons/ReviseIssuesIcon'
 
-class ReviewExtendedTranslationIssuesSideButton extends React.Component {
-  getIssueCount() {
+const ReviewExtendedTranslationIssuesSideButton = ({sid, segment}) => {
+  const getIssueCount = () => {
     let issue_count = 0
-    if (this.props.segment.versions && this.props.segment.versions.length > 0) {
-      this.props.segment.versions.forEach((version) => {
+    if (segment.versions && segment.versions.length > 0) {
+      segment.versions.forEach((version) => {
         issue_count = issue_count + version.issues.length
       })
       return issue_count
@@ -18,42 +18,37 @@ class ReviewExtendedTranslationIssuesSideButton extends React.Component {
     }
   }
 
-  handleClick(e) {
+  const handleClick = (e) => {
     e.preventDefault()
     e.stopPropagation()
-    SegmentActions.openIssuesPanel({sid: this.props.sid}, true)
+    SegmentActions.openIssuesPanel({sid: sid}, true)
   }
 
-  render() {
-    const issuesCount = this.getIssueCount()
-    if (
-      config.isReview &&
-      !(
-        SegmentUtils.isIceSegment(this.props.segment) &&
-        !this.props.segment.unlocked
-      )
-    ) {
-      return (
-        <div
-          className={`revise-button ${issuesCount === 0 && 'no-object'}`}
-          title={
-            issuesCount > 0
-              ? `Show issues ( ${Shortcuts.cattol.events.openIssuesPanel.keystrokes[
-                  Shortcuts.shortCutsKeyType
-                ].toUpperCase()}     )`
-              : 'Add issues'
-          }
-          onClick={this.handleClick.bind(this)}
-        >
-          <ReviseIssuesIcon />
-          <div className="badge-icon badge-red ">
-            {issuesCount > 0 ? issuesCount : '+'}
-          </div>
+  const issuesCount = getIssueCount()
+  if (
+    config.isReview &&
+    !(SegmentUtils.isIceSegment(segment) && !segment.unlocked)
+  ) {
+    return (
+      <div
+        className={`revise-button ${issuesCount === 0 && 'no-object'}`}
+        title={
+          issuesCount > 0
+            ? `Show issues ( ${Shortcuts.cattol.events.openIssuesPanel.keystrokes[
+                Shortcuts.shortCutsKeyType
+              ].toUpperCase()}     )`
+            : 'Add issues'
+        }
+        onClick={handleClick}
+      >
+        <ReviseIssuesIcon />
+        <div className="badge-icon badge-red ">
+          {issuesCount > 0 ? issuesCount : '+'}
         </div>
-      )
-    } else {
-      return ''
-    }
+      </div>
+    )
+  } else {
+    return ''
   }
 }
 


### PR DESCRIPTION
## Summary

Step 04 of the PR #4768 split plan (wave 1, independent): migrates the
review-extended LQA issue panels and `common/WrapperLoader` to function
components with hooks, porting the final state from the
`react-class-to-functional-migration` branch. `WrapperLoader` rides with
this PR because `ReviewExtendedIssuesContainer` is its only consumer
anywhere in core or the four plugin submodules — verified with a grep
across `public/js/` and `plugins/*/static`. Extends the per-directory
eslint ratchet started in #4814 to both directories.

## Type

- [x] `refactor` — restructure without behavior change
- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/review_extended/ReviewExtendedIssuePanel.js` | Convert to function component with hooks |
| `public/js/components/review_extended/ReviewExtendedIssuesContainer.js` | Convert to function component with hooks |
| `public/js/components/review_extended/ReviewExtendedPanel.js` | Convert to function component with hooks |
| `public/js/components/review_extended/ReviewExtendedTranslationIssuesSideButton.js` | Convert to function component with hooks |
| `public/js/components/common/WrapperLoader.js` (+new test) | Convert to function component with hooks |
| `.eslintrc.js` | Extend the class-component-ban override's `files` list to `public/js/components/review_extended/**/*.js` and `public/js/components/common/WrapperLoader.js` |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

`WrapperLoader.test.js` is new (ported from the migration branch); the four
`review_extended` files keep their existing tests unchanged, which already
cover the converted components. `yarn test --watchAll=false
public/js/components/review_extended/ public/js/components/common/WrapperLoader`
— 8 suites, 120 tests, all passing. Full suite `yarn test --watchAll=false`
— 427 suites, 4388 tests, all passing, no regressions (the one added suite
is `WrapperLoader.test.js`). Scoped `npx eslint public/js/components/review_extended/
public/js/components/common/WrapperLoader.js` diffed against the pre-change
ruleset: the ratchet extension introduces zero new errors (117 pre-existing
errors, unchanged, all in files outside this PR's scope).

No browser-based manual verification was performed in this session
(background job, no interactive browser available) — recommend a manual
pass opening a revision job and adding/reviewing an LQA issue before merge.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (Sonnet 5)

## Notes

Part of the split of #4768 (wave 1, step 04 of 14) — see #4814 for the
first step in this series and the full merge-order plan. Independent of
the other wave-1 PRs; can merge in any order.
