### PR TITLE
♻️ refactor(header): convert cattool header to function components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,7 @@ module.exports = {
         'public/js/components/languageSelector/**/*.js',
         'public/js/components/review_extended/**/*.js',
         'public/js/components/common/WrapperLoader.js',
+        'public/js/components/header/cattol/**/*.js',
       ],
       rules: {
         'no-restricted-syntax': [

--- a/public/js/components/header/cattol/QAComponent.js
+++ b/public/js/components/header/cattol/QAComponent.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useCallback, useEffect, useRef, useState} from 'react'
 
 import SegmentActions from '../../../actions/SegmentActions'
 import LXQ from '../../../utils/lxq.main'
@@ -16,60 +16,54 @@ import InfoIcon from '../../../../img/icons/InfoIcon'
 import ChevronLeft from '../../../../img/icons/ChevronLeft'
 import ChevronRight from '../../../../img/icons/ChevronRight'
 
-class QAComponent extends React.Component {
-  constructor(props) {
-    super(props)
+const QAComponent = (props) => {
+  const [navigationList, setNavigationList] = useState([])
+  const [navigationIndex, setNavigationIndex] = useState(0)
+  const [currentPriority, setCurrentPriority] = useState('')
+  const [currentCategory, setCurrentCategory] = useState('')
+  const [labels] = useState({
+    TAG: 'Tag',
+    TAGS: 'Tag',
+    lexiqa: 'Lexiqa',
+    GLOSSARY: 'Glossary',
+    MISMATCH: 'T. Conflicts',
+    FUZZY: 'Unedited fuzzy matches',
+  })
+  const [totalWarnings, setTotalWarnings] = useState(0)
+  const [warnings, setWarnings] = useState({
+    ERROR: {
+      Categories: {},
+      total: 0,
+    },
+    WARNING: {
+      Categories: {},
+      total: 0,
+    },
+    INFO: {
+      Categories: {},
+      total: 0,
+    },
+  })
 
-    this.state = {
-      navigationList: [],
-      navigationIndex: 0,
-      currentPriority: '',
-      currentCategory: '',
-      labels: {
-        TAG: 'Tag',
-        TAGS: 'Tag',
-        lexiqa: 'Lexiqa',
-        GLOSSARY: 'Glossary',
-        MISMATCH: 'T. Conflicts',
-        FUZZY: 'Unedited fuzzy matches'
-      },
-      totalWarnings: 0,
-      warnings: {
-        ERROR: {
-          Categories: {},
-          total: 0,
-        },
-        WARNING: {
-          Categories: {},
-          total: 0,
-        },
-        INFO: {
-          Categories: {},
-          total: 0,
-        },
-      },
-    }
-    this.receiveGlobalWarnings = this.receiveGlobalWarnings.bind(this)
-  }
+  const latestRef = useRef({currentPriority: '', currentCategory: ''})
+  latestRef.current = {currentPriority, currentCategory}
 
-  scrollToSegment(increment) {
-    let newIndex = this.state.navigationIndex + increment
+  const scrollToSegment = (increment) => {
+    let newIndex = navigationIndex + increment
     newIndex =
       newIndex === -1
-        ? this.state.navigationList.length - 1
-        : newIndex % this.state.navigationList.length
+        ? navigationList.length - 1
+        : newIndex % navigationList.length
 
-    let segmentId = this.state.navigationList[newIndex]
+    let segmentId = navigationList[newIndex]
 
     if (segmentId) {
       SegmentActions.openSegment(segmentId)
     }
-    this.setState({
-      navigationIndex: newIndex,
-    })
+    setNavigationIndex(newIndex)
   }
 
-  setCurrentNavigationElements(list, priority, category) {
+  const setCurrentNavigationElements = (list, priority, category) => {
     let segmentId = list[0]
 
     if (segmentId) {
@@ -79,318 +73,295 @@ class QAComponent extends React.Component {
       SegmentActions.openSegment(segmentId)
     }
 
-    this.setState({
-      navigationList: list,
-      navigationIndex: 0,
-      currentPriority: priority,
-      currentCategory: category,
-    })
+    setNavigationList(list)
+    setNavigationIndex(0)
+    setCurrentPriority(priority)
+    setCurrentCategory(category)
   }
 
-  allowHTML(string) {
+  // eslint-disable-next-line no-unused-vars
+  const allowHTML = (string) => {
     return {__html: string}
   }
 
-  componentDidMount() {
-    SegmentStore.addListener(
-      SegmentConstants.UPDATE_GLOBAL_WARNINGS,
-      this.receiveGlobalWarnings,
-    )
-  }
-
-  componentWillUnmount() {
-    SegmentStore.removeListener(
-      SegmentConstants.UPDATE_GLOBAL_WARNINGS,
-      this.receiveGlobalWarnings,
-    )
-  }
-
-  receiveGlobalWarnings(warnings) {
-    const category = warnings.matecat[this.state.currentPriority]
-      ? warnings.matecat[this.state.currentPriority].Categories[
-          this.state.currentCategory
-        ]
+  const receiveGlobalWarnings = useCallback((warnings) => {
+    const {currentPriority, currentCategory} = latestRef.current
+    const category = warnings.matecat[currentPriority]
+      ? warnings.matecat[currentPriority].Categories[currentCategory]
       : null
     if (warnings && category) {
-      this.setState({
-        warnings: warnings.matecat,
-        totalWarnings: warnings.matecat.total,
-        navigationList: category,
-      })
+      setWarnings(warnings.matecat)
+      setTotalWarnings(warnings.matecat.total)
+      setNavigationList(category)
     } else {
-      this.setState({
-        warnings: warnings.matecat,
-        totalWarnings: warnings.matecat.total,
-        navigationList: [],
-      })
+      setWarnings(warnings.matecat)
+      setTotalWarnings(warnings.matecat.total)
+      setNavigationList([])
     }
-  }
+  }, [])
 
-  render() {
-    let mismatch = '',
-      error = [],
-      warning = [],
-      info = []
-    if (this.state.warnings) {
-      if (this.state.warnings.ERROR?.total > 0) {
-        Object.keys(this.state.warnings.ERROR.Categories).map((key, index) => {
-          if (this.state.warnings.ERROR.Categories[key].length > 0) {
-            if (key === 'TAGS') {
-              let activeClass =
-                this.state.currentPriority === 'ERROR' &&
-                this.state.currentCategory === key
-                  ? ' mc-bg-gray'
-                  : ''
-              error.push(
-                <Button
-                  key={index}
-                  type={BUTTON_TYPE.CRITICAL}
-                  mode={BUTTON_MODE.OUTLINE}
-                  className={activeClass}
-                  onClick={this.setCurrentNavigationElements.bind(
-                    this,
-                    this.state.warnings.ERROR.Categories[key],
-                    'ERROR',
-                    key,
-                  )}
-                >
-                  <SegmentQA size={20} />
-                  {this.state.labels[key] ? this.state.labels[key] : key} errors
-                  <b> ({this.state.warnings.ERROR.Categories[key].length})</b>
-                </Button>,
-              )
-            } else {
-              let activeClass =
-                this.state.currentPriority === 'ERROR' &&
-                this.state.currentCategory === key
-                  ? ' mc-bg-gray'
-                  : ''
-              error.push(
-                <Button
-                  key={index}
-                  type={BUTTON_TYPE.CRITICAL}
-                  mode={BUTTON_MODE.OUTLINE}
-                  className={activeClass}
-                  onClick={this.setCurrentNavigationElements.bind(
-                    this,
-                    this.state.warnings.ERROR.Categories[key],
-                    'ERROR',
-                    key,
-                  )}
-                >
-                  <SegmentQA size={20} />
-                  {this.state.labels[key] ? this.state.labels[key] : key}
-                  <b> ({this.state.warnings.ERROR.Categories[key].length})</b>
-                </Button>,
-              )
-            }
-          }
-        })
-      }
-      if (this.state.warnings.WARNING.total > 0) {
-        Object.keys(this.state.warnings.WARNING.Categories).map(
-          (key, index) => {
-            if (this.state.warnings.WARNING.Categories[key].length > 0) {
-              let activeClass =
-                this.state.currentPriority === 'WARNING' &&
-                this.state.currentCategory === key
-                  ? ' mc-bg-gray'
-                  : ''
-              if (key === 'TAGS') {
-                warning.push(
-                  <Button
-                    key={index}
-                    type={BUTTON_TYPE.WARNING}
-                    mode={BUTTON_MODE.OUTLINE}
-                    className={activeClass}
-                    onClick={this.setCurrentNavigationElements.bind(
-                      this,
-                      this.state.warnings.WARNING.Categories[key],
-                      'WARNING',
-                      key,
-                    )}
-                  >
-                    <AlertIcon size={20} />
-                    {this.state.labels[key] ? this.state.labels[key] : key}{' '}
-                    warnings
-                    <b>
-                      {' '}
-                      ({this.state.warnings.WARNING.Categories[key].length}
-                      ){' '}
-                    </b>
-                  </Button>,
-                )
-              } else if (key !== 'MISMATCH') {
-                warning.push(
-                  <Button
-                    key={index}
-                    type={BUTTON_TYPE.WARNING}
-                    mode={BUTTON_MODE.OUTLINE}
-                    className={activeClass}
-                    onClick={this.setCurrentNavigationElements.bind(
-                      this,
-                      this.state.warnings.WARNING.Categories[key],
-                      'WARNING',
-                      key,
-                    )}
-                  >
-                    <AlertIcon size={20} />
-                    {this.state.labels[key] ? this.state.labels[key] : key}
-                    <b>
-                      {' '}
-                      ({this.state.warnings.WARNING.Categories[key].length}
-                      ){' '}
-                    </b>
-                  </Button>,
-                )
-              } else {
-                mismatch = (
-                  <Button
-                    key={index}
-                    type={BUTTON_TYPE.WARNING}
-                    mode={BUTTON_MODE.OUTLINE}
-                    className={activeClass}
-                    onClick={this.setCurrentNavigationElements.bind(
-                      this,
-                      this.state.warnings.WARNING.Categories[key],
-                      'WARNING',
-                      key,
-                    )}
-                  >
-                    <AlertIcon size={20} />
-                    {this.state.labels[key] ? this.state.labels[key] : key}
-                    <b>
-                      {' '}
-                      ({this.state.warnings.WARNING.Categories[key].length}
-                      ){' '}
-                    </b>
-                  </Button>
-                )
-              }
-            }
-          },
-        )
-      }
-      if (this.state.warnings.INFO.total > 0) {
-        Object.keys(this.state.warnings.INFO.Categories).map((key, index) => {
-          if (this.state.warnings.INFO.Categories[key].length > 0) {
+  useEffect(() => {
+    SegmentStore.addListener(
+      SegmentConstants.UPDATE_GLOBAL_WARNINGS,
+      receiveGlobalWarnings,
+    )
+    return () => {
+      SegmentStore.removeListener(
+        SegmentConstants.UPDATE_GLOBAL_WARNINGS,
+        receiveGlobalWarnings,
+      )
+    }
+  }, [])
+
+  let mismatch = '',
+    error = [],
+    warning = [],
+    info = []
+  if (warnings) {
+    if (warnings.ERROR?.total > 0) {
+      Object.keys(warnings.ERROR.Categories).map((key, index) => {
+        if (warnings.ERROR.Categories[key].length > 0) {
+          if (key === 'TAGS') {
             let activeClass =
-              this.state.currentPriority === 'INFO' &&
-              this.state.currentCategory === key
+              currentPriority === 'ERROR' && currentCategory === key
                 ? ' mc-bg-gray'
                 : ''
-            info.push(
+            error.push(
               <Button
                 key={index}
-                className={activeClass}
-                type={BUTTON_TYPE.INFO}
+                type={BUTTON_TYPE.CRITICAL}
                 mode={BUTTON_MODE.OUTLINE}
-                onClick={this.setCurrentNavigationElements.bind(
-                  this,
-                  this.state.warnings.INFO.Categories[key],
-                  'INFO',
-                  key,
-                )}
+                className={activeClass}
+                onClick={() =>
+                  setCurrentNavigationElements(
+                    warnings.ERROR.Categories[key],
+                    'ERROR',
+                    key,
+                  )
+                }
               >
-                <InfoIcon size={20} />
-                {this.state.labels[key] ? this.state.labels[key] : key}{' '}
-                <b> ({this.state.warnings.INFO.Categories[key].length})</b>
+                <SegmentQA size={20} />
+                {labels[key] ? labels[key] : key} errors
+                <b> ({warnings.ERROR.Categories[key].length})</b>
+              </Button>,
+            )
+          } else {
+            let activeClass =
+              currentPriority === 'ERROR' && currentCategory === key
+                ? ' mc-bg-gray'
+                : ''
+            error.push(
+              <Button
+                key={index}
+                type={BUTTON_TYPE.CRITICAL}
+                mode={BUTTON_MODE.OUTLINE}
+                className={activeClass}
+                onClick={() =>
+                  setCurrentNavigationElements(
+                    warnings.ERROR.Categories[key],
+                    'ERROR',
+                    key,
+                  )
+                }
+              >
+                <SegmentQA size={20} />
+                {labels[key] ? labels[key] : key}
+                <b> ({warnings.ERROR.Categories[key].length})</b>
               </Button>,
             )
           }
-        })
-      }
+        }
+      })
     }
-    let segmentsWithActive =
-      error.length > 0 || warning.length > 0 || info.length > 0
-    return this.props.active && this.state.totalWarnings > 0 ? (
-      <div className="qa-wrapper">
-        <div className="qa-container">
-          <div className="qa-container-inside">
-            <div className="qa-issues-list">
-              {segmentsWithActive ? (
-                <div className="label-issues label-issues-segment">
-                  Segments with:
-                </div>
-              ) : null}
-              {segmentsWithActive ? (
-                <div>
-                  {error}
-                  {warning}
-                  {info}
-                </div>
-              ) : null}
-              {this.state.currentPriority === 'INFO' &&
-              this.state.currentCategory === 'lexiqa' ? (
-                <div className="qa-lexiqa-info">
-                  <span>QA:</span>
-                  <a
-                    href={config.lexiqaServer + '/documentation.html'}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Guide
-                  </a>
-                  <a
-                    target="_blank"
-                    rel="noreferrer"
-                    alt="Read the full QA report"
-                    href={
-                      config.lexiqaServer +
-                      '/errorreport?id=' +
-                      LXQ.partnerid +
-                      '-' +
-                      config.id_job +
-                      '-' +
-                      config.password +
-                      '&type=' +
-                      (config.isReview ? 'revise' : 'translate')
-                    }
-                  >
-                    Report
-                  </a>
-                </div>
-              ) : null}
-              {mismatch ? (
-                <div className="label-issues labl">Repetitions with:</div>
-              ) : null}
-              {mismatch ? (
-                <div className="qa-mismatch">
-                  <div>{mismatch}</div>
-                </div>
-              ) : null}
-            </div>
-            {this.state.navigationList.length > 0 ? (
-              <div className="qa-issues-navigator">
-                <div className="qa-actions">
-                  <div className={'qa-arrows qa-arrows-enabled'}>
-                    <Button
-                      size={BUTTON_SIZE.ICON_STANDARD}
-                      mode={BUTTON_MODE.OUTLINE}
-                      onClick={this.scrollToSegment.bind(this, -1)}
-                    >
-                      <ChevronLeft />
-                    </Button>
-                    <div className="info-navigation-issues">
-                      <b>{this.state.navigationIndex + 1} </b> /{' '}
-                      {this.state.navigationList.length} {/*Segments*/}
-                    </div>
-                    <Button
-                      onClick={this.scrollToSegment.bind(this, 1)}
-                      mode={BUTTON_MODE.OUTLINE}
-                      size={BUTTON_SIZE.ICON_STANDARD}
-                    >
-                      <ChevronRight />
-                    </Button>
-                  </div>
-                </div>
+    if (warnings.WARNING.total > 0) {
+      Object.keys(warnings.WARNING.Categories).map((key, index) => {
+        if (warnings.WARNING.Categories[key].length > 0) {
+          let activeClass =
+            currentPriority === 'WARNING' && currentCategory === key
+              ? ' mc-bg-gray'
+              : ''
+          if (key === 'TAGS') {
+            warning.push(
+              <Button
+                key={index}
+                type={BUTTON_TYPE.WARNING}
+                mode={BUTTON_MODE.OUTLINE}
+                className={activeClass}
+                onClick={() =>
+                  setCurrentNavigationElements(
+                    warnings.WARNING.Categories[key],
+                    'WARNING',
+                    key,
+                  )
+                }
+              >
+                <AlertIcon size={20} />
+                {labels[key] ? labels[key] : key} warnings
+                <b> ({warnings.WARNING.Categories[key].length}) </b>
+              </Button>,
+            )
+          } else if (key !== 'MISMATCH') {
+            warning.push(
+              <Button
+                key={index}
+                type={BUTTON_TYPE.WARNING}
+                mode={BUTTON_MODE.OUTLINE}
+                className={activeClass}
+                onClick={() =>
+                  setCurrentNavigationElements(
+                    warnings.WARNING.Categories[key],
+                    'WARNING',
+                    key,
+                  )
+                }
+              >
+                <AlertIcon size={20} />
+                {labels[key] ? labels[key] : key}
+                <b> ({warnings.WARNING.Categories[key].length}) </b>
+              </Button>,
+            )
+          } else {
+            mismatch = (
+              <Button
+                key={index}
+                type={BUTTON_TYPE.WARNING}
+                mode={BUTTON_MODE.OUTLINE}
+                className={activeClass}
+                onClick={() =>
+                  setCurrentNavigationElements(
+                    warnings.WARNING.Categories[key],
+                    'WARNING',
+                    key,
+                  )
+                }
+              >
+                <AlertIcon size={20} />
+                {labels[key] ? labels[key] : key}
+                <b> ({warnings.WARNING.Categories[key].length}) </b>
+              </Button>
+            )
+          }
+        }
+      })
+    }
+    if (warnings.INFO.total > 0) {
+      Object.keys(warnings.INFO.Categories).map((key, index) => {
+        if (warnings.INFO.Categories[key].length > 0) {
+          let activeClass =
+            currentPriority === 'INFO' && currentCategory === key
+              ? ' mc-bg-gray'
+              : ''
+          info.push(
+            <Button
+              key={index}
+              className={activeClass}
+              type={BUTTON_TYPE.INFO}
+              mode={BUTTON_MODE.OUTLINE}
+              onClick={() =>
+                setCurrentNavigationElements(
+                  warnings.INFO.Categories[key],
+                  'INFO',
+                  key,
+                )
+              }
+            >
+              <InfoIcon size={20} />
+              {labels[key] ? labels[key] : key}{' '}
+              <b> ({warnings.INFO.Categories[key].length})</b>
+            </Button>,
+          )
+        }
+      })
+    }
+  }
+  let segmentsWithActive =
+    error.length > 0 || warning.length > 0 || info.length > 0
+  return props.active && totalWarnings > 0 ? (
+    <div className="qa-wrapper">
+      <div className="qa-container">
+        <div className="qa-container-inside">
+          <div className="qa-issues-list">
+            {segmentsWithActive ? (
+              <div className="label-issues label-issues-segment">
+                Segments with:
+              </div>
+            ) : null}
+            {segmentsWithActive ? (
+              <div>
+                {error}
+                {warning}
+                {info}
+              </div>
+            ) : null}
+            {currentPriority === 'INFO' && currentCategory === 'lexiqa' ? (
+              <div className="qa-lexiqa-info">
+                <span>QA:</span>
+                <a
+                  href={config.lexiqaServer + '/documentation.html'}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Guide
+                </a>
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  alt="Read the full QA report"
+                  href={
+                    config.lexiqaServer +
+                    '/errorreport?id=' +
+                    LXQ.partnerid +
+                    '-' +
+                    config.id_job +
+                    '-' +
+                    config.password +
+                    '&type=' +
+                    (config.isReview ? 'revise' : 'translate')
+                  }
+                >
+                  Report
+                </a>
+              </div>
+            ) : null}
+            {mismatch ? (
+              <div className="label-issues labl">Repetitions with:</div>
+            ) : null}
+            {mismatch ? (
+              <div className="qa-mismatch">
+                <div>{mismatch}</div>
               </div>
             ) : null}
           </div>
+          {navigationList.length > 0 ? (
+            <div className="qa-issues-navigator">
+              <div className="qa-actions">
+                <div className={'qa-arrows qa-arrows-enabled'}>
+                  <Button
+                    size={BUTTON_SIZE.ICON_STANDARD}
+                    mode={BUTTON_MODE.OUTLINE}
+                    onClick={() => scrollToSegment(-1)}
+                  >
+                    <ChevronLeft />
+                  </Button>
+                  <div className="info-navigation-issues">
+                    <b>{navigationIndex + 1} </b> / {navigationList.length}{' '}
+                    {/*Segments*/}
+                  </div>
+                  <Button
+                    onClick={() => scrollToSegment(1)}
+                    mode={BUTTON_MODE.OUTLINE}
+                    size={BUTTON_SIZE.ICON_STANDARD}
+                  >
+                    <ChevronRight />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : null}
         </div>
       </div>
-    ) : null
-  }
+    </div>
+  ) : null
 }
 
 export default QAComponent

--- a/public/js/components/header/cattol/SubHeaderContainer.js
+++ b/public/js/components/header/cattol/SubHeaderContainer.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useCallback, useEffect, useState} from 'react'
 
 import CatToolConstants from '../../../constants/CatToolConstants'
 import CatToolStore from '../../../stores/CatToolStore'
@@ -7,133 +7,123 @@ import SegmentsFilter from './segment_filter/SegmentsFilter'
 import Search from './search/Search'
 import QaComponent from './QAComponent'
 
-class SubHeaderContainer extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      selectionBar: true,
-      search: false,
-      segmentFilter: false,
-      qaComponent: false,
-    }
-    this.closeSubHeader = this.closeSubHeader.bind(this)
-    this.toggleContainer = this.toggleContainer.bind(this)
-    this.showContainer = this.showContainer.bind(this)
-  }
-  showContainer(container) {
+const SubHeaderContainer = ({filtersEnabled, userInfo}) => {
+  const [state, setState] = useState({
+    selectionBar: true,
+    search: false,
+    segmentFilter: false,
+    qaComponent: false,
+  })
+
+  const showContainer = useCallback((container) => {
     switch (container) {
       case 'search':
-        this.setState({
+        setState((prev) => ({
+          ...prev,
           search: true,
           segmentFilter: false,
           qaComponent: false,
-        })
+        }))
         break
       case 'segmentFilter':
-        this.setState({
+        setState((prev) => ({
+          ...prev,
           search: false,
           segmentFilter: true,
           qaComponent: false,
-        })
+        }))
         break
       case 'qaComponent':
-        this.setState({
+        setState((prev) => ({
+          ...prev,
           search: false,
           segmentFilter: false,
           qaComponent: true,
-        })
+        }))
         break
     }
-  }
-  toggleContainer(container) {
+  }, [])
+
+  const toggleContainer = useCallback((container) => {
     switch (container) {
       case 'search':
-        this.setState({
-          search: !this.state.search,
+        setState((prev) => ({
+          ...prev,
+          search: !prev.search,
           segmentFilter: false,
           qaComponent: false,
-        })
+        }))
         break
       case 'segmentFilter':
-        this.setState({
+        setState((prev) => ({
+          ...prev,
           search: false,
-          segmentFilter: !this.state.segmentFilter,
+          segmentFilter: !prev.segmentFilter,
           qaComponent: false,
-        })
+        }))
         break
       case 'qaComponent':
-        this.setState({
+        setState((prev) => ({
+          ...prev,
           search: false,
           segmentFilter: false,
-          qaComponent: !this.state.qaComponent,
-        })
+          qaComponent: !prev.qaComponent,
+        }))
         break
     }
-  }
+  }, [])
 
-  closeSubHeader() {
-    this.setState({
+  const closeSubHeader = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
       search: false,
       segmentFilter: false,
       qaComponent: false,
-    })
-  }
-  componentDidMount() {
-    CatToolStore.addListener(
-      CatToolConstants.SHOW_CONTAINER,
-      this.showContainer,
-    )
-    CatToolStore.addListener(
-      CatToolConstants.TOGGLE_CONTAINER,
-      this.toggleContainer,
-    )
-    CatToolStore.addListener(
-      CatToolConstants.CLOSE_SUBHEADER,
-      this.closeSubHeader,
-    )
-  }
+    }))
+  }, [])
 
-  componentWillUnmount() {
-    CatToolStore.removeListener(
-      CatToolConstants.SHOW_CONTAINER,
-      this.showContainer,
-    )
-    CatToolStore.removeListener(
-      CatToolConstants.TOGGLE_CONTAINER,
-      this.toggleContainer,
-    )
-    CatToolStore.removeListener(
-      CatToolConstants.CLOSE_SUBHEADER,
-      this.closeSubHeader,
-    )
-  }
+  useEffect(() => {
+    CatToolStore.addListener(CatToolConstants.SHOW_CONTAINER, showContainer)
+    CatToolStore.addListener(CatToolConstants.TOGGLE_CONTAINER, toggleContainer)
+    CatToolStore.addListener(CatToolConstants.CLOSE_SUBHEADER, closeSubHeader)
 
-  render() {
-    return (
-      <div>
-        <Search
-          active={this.state.search}
+    return () => {
+      CatToolStore.removeListener(
+        CatToolConstants.SHOW_CONTAINER,
+        showContainer,
+      )
+      CatToolStore.removeListener(
+        CatToolConstants.TOGGLE_CONTAINER,
+        toggleContainer,
+      )
+      CatToolStore.removeListener(
+        CatToolConstants.CLOSE_SUBHEADER,
+        closeSubHeader,
+      )
+    }
+  }, [])
+
+  return (
+    <div>
+      <Search
+        active={state.search}
+        isReview={config.isReview}
+        searchable_statuses={config.searchable_statuses}
+        userInfo={userInfo}
+      />
+      {filtersEnabled ? (
+        <SegmentsFilter
+          active={state.segmentFilter}
           isReview={config.isReview}
-          searchable_statuses={config.searchable_statuses}
-          userInfo={this.props.userInfo}
         />
-        {this.props.filtersEnabled ? (
-          <SegmentsFilter
-            active={this.state.segmentFilter}
-            isReview={config.isReview}
-          />
-        ) : null}
-        <QaComponent
-          active={this.state.qaComponent}
-          isReview={config.isReview}
-        />
-        <SegmentSelectionPanel
-          active={this.state.selectionBar}
-          isReview={config.isReview}
-        />
-      </div>
-    )
-  }
+      ) : null}
+      <QaComponent active={state.qaComponent} isReview={config.isReview} />
+      <SegmentSelectionPanel
+        active={state.selectionBar}
+        isReview={config.isReview}
+      />
+    </div>
+  )
 }
 
 export default SubHeaderContainer

--- a/public/js/components/header/cattol/bulk_selection_bar/BulkSelectionBar.js
+++ b/public/js/components/header/cattol/bulk_selection_bar/BulkSelectionBar.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useCallback, useEffect, useRef, useState} from 'react'
 import classnames from 'classnames'
 import SegmentActions from '../../../../actions/SegmentActions'
 import SegmentConstants from '../../../../constants/SegmentConstants'
@@ -32,26 +32,15 @@ const listSegments = (segments) =>
       } more`
     : segments.join(', ')
 
-class BulkSelectionBar extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      count: 0,
-      segmentsArray: [],
-      changingStatus: false,
-    }
+const BulkSelectionBar = ({isReview}) => {
+  const [selection, setSelection] = useState({count: 0, segmentsArray: []})
+  const [changingStatus, setChangingStatus] = useState(false)
 
-    this.countInBulkElements = this.countInBulkElements.bind(this)
-    this.setSegmentsinBulk = this.setSegmentsinBulk.bind(this)
-    this.toggleSegment = this.toggleSegment.bind(this)
-    this.removeAll = this.removeAll.bind(this)
-    this.onClickBulk = this.onClickBulk.bind(this)
-    this.onClickBack = this.onClickBack.bind(this)
-    this.onBulkFailed = this.onBulkFailed.bind(this)
-  }
+  const segmentsArrayRef = useRef(selection.segmentsArray)
+  segmentsArrayRef.current = selection.segmentsArray
 
-  countInBulkElements(segments) {
-    let segmentsArray = this.state.segmentsArray
+  const countInBulkElements = (segments) => {
+    let segmentsArray = selection.segmentsArray
     if (segments && segments.size > 0) {
       segments.map(function (segment) {
         let index = segmentsArray.indexOf(segment.get('sid'))
@@ -62,61 +51,50 @@ class BulkSelectionBar extends React.Component {
         }
       })
     }
-    this.setState({
+    setSelection({
       count: segmentsArray.length,
       segmentsArray: segmentsArray,
     })
   }
-  setSegmentsinBulk(segments) {
-    let segmentsArray = segments
 
-    this.setState({
-      count: segmentsArray.length,
-      segmentsArray: segmentsArray,
+  const setSegmentsinBulk = useCallback((segments) => {
+    setSelection({count: segments.length, segmentsArray: segments})
+  }, [])
+
+  const removeAll = useCallback(() => {
+    setSelection({count: 0, segmentsArray: []})
+  }, [])
+
+  const toggleSegment = useCallback((sid) => {
+    setSelection((prev) => {
+      const index = prev.segmentsArray.indexOf(sid)
+      const array =
+        index > -1
+          ? prev.segmentsArray.filter((_, i) => i !== index)
+          : [...prev.segmentsArray, sid]
+      return {count: array.length, segmentsArray: array}
     })
-  }
-  removeAll() {
-    this.setState({
-      count: 0,
-      segmentsArray: [],
-    })
-  }
-  toggleSegment(sid) {
-    let index = this.state.segmentsArray.indexOf(sid)
-    let array = this.state.segmentsArray.slice(0)
-    if (index > -1) {
-      array.splice(index, 1)
-    } else {
-      array.push(sid)
-    }
-    this.setState({
-      count: array.length,
-      segmentsArray: array,
-    })
-  }
-  onClickBack() {
+  }, [])
+
+  const onClickBack = () => {
     SegmentActions.removeSegmentsOnBulk()
-    this.setState({
-      changingStatus: false,
-    })
+    setChangingStatus(false)
   }
 
-  onBulkFailed(error) {
+  const onBulkFailed = (error) => {
     // Without this the bar keeps the spinner of a change that is not happening, and the selection is
     // silently left as it was. The selection is kept so the user can retry it, and the toast names
     // the segments that stayed behind and stays up until it is closed.
-    this.setState({
-      changingStatus: false,
-    })
-    const segments = this.state.segmentsArray
+    setChangingStatus(false)
+    const segments = segmentsArrayRef.current
     CatToolActions.addNotification({
       title: 'The status of the selected segments was not changed',
       text: (
         <>
           <p>
             {segments.length} segments kept their status: the change to{' '}
-            {this.props.isReview ? 'APPROVED' : 'TRANSLATED'} was refused
-            because {describeBulkFailure(error)}.
+            {isReview ? 'APPROVED' : 'TRANSLATED'} was refused because{' '}
+            {describeBulkFailure(error)}.
           </p>
           <p>
             Job {config.id_job}
@@ -133,119 +111,115 @@ class BulkSelectionBar extends React.Component {
     })
   }
 
-  onClickBulk() {
-    this.setState({
-      changingStatus: true,
-    })
-    if (this.props.isReview) {
-      SegmentActions.approveFilteredSegments(this.state.segmentsArray)
+  const onClickBulk = () => {
+    setChangingStatus(true)
+    if (isReview) {
+      SegmentActions.approveFilteredSegments(selection.segmentsArray)
         .then(() => {
-          this.onClickBack()
-          CatToolActions.onRender({segmentToOpen: this.state.segmentsArray[0]})
+          onClickBack()
+          CatToolActions.onRender({segmentToOpen: segmentsArrayRef.current[0]})
           CatToolActions.reloadQualityReport()
         })
-        .catch((error) => this.onBulkFailed(error))
+        .catch((error) => onBulkFailed(error))
     } else {
-      SegmentActions.translateFilteredSegments(this.state.segmentsArray)
+      SegmentActions.translateFilteredSegments(selection.segmentsArray)
         .then(() => {
-          CatToolActions.onRender({segmentToOpen: this.state.segmentsArray[0]})
-          this.onClickBack()
+          CatToolActions.onRender({segmentToOpen: segmentsArrayRef.current[0]})
+          onClickBack()
         })
-        .catch((error) => this.onBulkFailed(error))
+        .catch((error) => onBulkFailed(error))
     }
     // SegmentActions.closeSegment(SegmentStore.getCurrentSegmentId());
   }
 
-  componentDidMount() {
-    // SegmentStore.addListener(SegmentConstants.RENDER_SEGMENTS, this.countInBulkElements);
+  useEffect(() => {
+    // SegmentStore.addListener(SegmentConstants.RENDER_SEGMENTS, countInBulkElements);
     SegmentStore.addListener(
       SegmentConstants.TOGGLE_SEGMENT_ON_BULK,
-      this.toggleSegment,
+      toggleSegment,
     )
     SegmentStore.addListener(
       SegmentConstants.REMOVE_SEGMENTS_ON_BULK,
-      this.removeAll,
+      removeAll,
     )
     SegmentStore.addListener(
       SegmentConstants.SET_BULK_SELECTION_SEGMENTS,
-      this.setSegmentsinBulk,
+      setSegmentsinBulk,
     )
-  }
 
-  componentWillUnmount() {
-    // SegmentStore.removeListener(SegmentConstants.RENDER_SEGMENTS, this.countInBulkElements);
-    SegmentStore.removeListener(
-      SegmentConstants.TOGGLE_SEGMENT_ON_BULK,
-      this.toggleSegment,
-    )
-    SegmentStore.removeListener(
-      SegmentConstants.REMOVE_SEGMENTS_ON_BULK,
-      this.removeAll,
-    )
-    SegmentStore.removeListener(
-      SegmentConstants.SET_BULK_SELECTION_SEGMENTS,
-      this.setSegmentsinBulk,
-    )
-  }
+    return () => {
+      // SegmentStore.removeListener(SegmentConstants.RENDER_SEGMENTS, countInBulkElements);
+      SegmentStore.removeListener(
+        SegmentConstants.TOGGLE_SEGMENT_ON_BULK,
+        toggleSegment,
+      )
+      SegmentStore.removeListener(
+        SegmentConstants.REMOVE_SEGMENTS_ON_BULK,
+        removeAll,
+      )
+      SegmentStore.removeListener(
+        SegmentConstants.SET_BULK_SELECTION_SEGMENTS,
+        setSegmentsinBulk,
+      )
+    }
+  }, [])
 
-  render() {
-    let buttonClass = classnames({
-      'approve-all-segments': true,
-      'translated-all-bulked': !this.props.isReview,
-      'approved-all-bulked': this.props.isReview,
-      'approved-2nd-pass':
-        config.secondRevisionsCount &&
-        config.revisionNumber &&
-        config.revisionNumber === 2,
-    })
-    return this.state.count > 0 ? (
-      <div className="bulk-approve-bar">
-        <div className="bulk-back-info">
-          <div className="bulk-back">
-            <Button
-              mode={BUTTON_MODE.GHOST}
-              size={BUTTON_SIZE.SMALL}
-              onClick={this.onClickBack}
-            >
-              <IconChevronLeft size={16} /> back
-            </Button>
-          </div>
-          {this.state.count === 1 ? (
-            <div className="bulk-info">
-              <b>{this.state.count} Segment selected</b>
-            </div>
-          ) : (
-            <div className="bulk-info">
-              <b>{this.state.count} Segments selected</b>
-            </div>
-          )}
+  let buttonClass = classnames({
+    'approve-all-segments': true,
+    'translated-all-bulked': !isReview,
+    'approved-all-bulked': isReview,
+    'approved-2nd-pass':
+      config.secondRevisionsCount &&
+      config.revisionNumber &&
+      config.revisionNumber === 2,
+  })
+  return selection.count > 0 ? (
+    <div className="bulk-approve-bar">
+      <div className="bulk-back-info">
+        <div className="bulk-back">
+          <Button
+            mode={BUTTON_MODE.GHOST}
+            size={BUTTON_SIZE.SMALL}
+            onClick={onClickBack}
+          >
+            <IconChevronLeft size={16} /> back
+          </Button>
         </div>
-
-        {this.state.changingStatus ? (
-          <div className="bulk-activity-icons">
-            <div className="label-filters labl">
-              Applying changes
-              <div className="loader" />
-            </div>
+        {selection.count === 1 ? (
+          <div className="bulk-info">
+            <b>{selection.count} Segment selected</b>
           </div>
         ) : (
-          <div className="bulk-activity-icons">
-            <Button
-              className={`mark-button ${buttonClass}`}
-              type={BUTTON_TYPE.PRIMARY}
-              mode={BUTTON_MODE.OUTLINE}
-              onClick={this.onClickBulk}
-            >
-              <div>
-                <Checkmark size={16} />
-              </div>
-              {this.props.isReview ? 'MARK AS APPROVED' : 'MARK AS TRANSLATED'}
-            </Button>
+          <div className="bulk-info">
+            <b>{selection.count} Segments selected</b>
           </div>
         )}
       </div>
-    ) : null
-  }
+
+      {changingStatus ? (
+        <div className="bulk-activity-icons">
+          <div className="label-filters labl">
+            Applying changes
+            <div className="loader" />
+          </div>
+        </div>
+      ) : (
+        <div className="bulk-activity-icons">
+          <Button
+            className={`mark-button ${buttonClass}`}
+            type={BUTTON_TYPE.PRIMARY}
+            mode={BUTTON_MODE.OUTLINE}
+            onClick={onClickBulk}
+          >
+            <div>
+              <Checkmark size={16} />
+            </div>
+            {isReview ? 'MARK AS APPROVED' : 'MARK AS TRANSLATED'}
+          </Button>
+        </div>
+      )}
+    </div>
+  ) : null
 }
 
 export default BulkSelectionBar

--- a/public/js/components/header/cattol/search/Search.js
+++ b/public/js/components/header/cattol/search/Search.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useCallback, useEffect, useRef, useState} from 'react'
 import $ from 'jquery'
 import {isUndefined} from 'lodash'
 import {cloneDeep} from 'lodash/lang'
@@ -16,9 +16,7 @@ import AlertModal from '../../../modals/AlertModal'
 import ModalsActions from '../../../../actions/ModalsActions'
 import {tagSignatures} from '../../../segments/utils/DraftMatecatUtils/tagModel'
 import CommonUtils from '../../../../utils/commonUtils'
-import {
-  REVISE_STEP_NUMBER,
-} from '../../../../constants/Constants'
+import {REVISE_STEP_NUMBER} from '../../../../constants/Constants'
 import {Select} from '../../../common/Select'
 import {segmentTranslation} from '../../../../setTranslationUtil'
 import {Button, BUTTON_MODE, BUTTON_SIZE} from '../../../common/Button/Button'
@@ -26,173 +24,102 @@ import ChevronLeft from '../../../../../img/icons/ChevronLeft'
 import ChevronRight from '../../../../../img/icons/ChevronRight'
 import {MODAL_KEY} from '../../../../constants/ModalKeys'
 
-class Search extends React.Component {
-  constructor(props) {
-    super(props)
-    this.defaultState = {
-      isReview: props.isReview,
-      searchable_statuses: props.searchable_statuses,
-      showReplaceOptionsInSearch: true,
-      search: {
-        enableReplace: false,
-        matchCase: false,
-        exactMatch: false,
-        entireJob: false,
-        replaceTarget: '',
-        selectStatus: 'all',
-        searchTarget: '',
-        searchSource: '',
-        previousIsTagProjectionEnabled: false,
-        isSelectedTag: false,
-      },
-      focus: true,
-      funcFindButton: true, // true=find / false=next
-      total: null,
-      searchReturn: false,
-      searchResults: [],
-      occurrencesList: [],
-      searchResultsDictionary: {},
-      featuredSearchResult: null,
-    }
-    this.state = cloneDeep(this.defaultState)
+// mirrors the class's `defaultState.search` object, used both as the initial
+// value and as the value restored by handleCancelClick/handleClearClick
+const defaultSearch = {
+  enableReplace: false,
+  matchCase: false,
+  exactMatch: false,
+  entireJob: false,
+  replaceTarget: '',
+  selectStatus: 'all',
+  searchTarget: '',
+  searchSource: '',
+  previousIsTagProjectionEnabled: false,
+  isSelectedTag: false,
+}
 
-    this.handleSubmit = this.handleSubmit.bind(this)
-    this.handleCancelClick = this.handleCancelClick.bind(this)
-    this.handleInputChange = this.handleInputChange.bind(this)
-    this.handleReplaceAllClick = this.handleReplaceAllClick.bind(this)
-    this.handleReplaceClick = this.handleReplaceClick.bind(this)
-    this.replaceTargetOnFocus = this.replaceTargetOnFocus.bind(this)
-    this.handelKeydownFunction = this.handelKeydownFunction.bind(this)
-    this.updateSearch = this.updateSearch.bind(this)
-    this.jobIsSplitted = false
+// handling module
+const mod = (n, m) => ((n % m) + m) % m
+
+const Search = (props) => {
+  const [search, setSearch] = useState(() => cloneDeep(defaultSearch))
+  const [focus, setFocus] = useState(true)
+  const [funcFindButton, setFuncFindButton] = useState(true) // true=find / false=next
+  const [total, setTotal] = useState(null)
+  const [searchReturn, setSearchReturn] = useState(false)
+  const [searchResults, setSearchResults] = useState([])
+  const [occurrencesList, setOccurrencesList] = useState([])
+  const [searchResultsDictionary, setSearchResultsDictionary] = useState({})
+  const [featuredSearchResult, setFeaturedSearchResult] = useState(null)
+  const [previousIsTagProjectionEnabled, setPreviousIsTagProjectionEnabled] =
+    useState(false)
+
+  // dead state, preserved verbatim from the class component: `this.state.isReview`
+  // is never read anywhere
+  // eslint-disable-next-line no-unused-vars
+  const [isReview] = useState(props.isReview)
+  // dead state, preserved verbatim from the class component: `this.state.searchable_statuses`
+  // is never read anywhere (render() uses the global `config.searchable_statuses` instead)
+  // eslint-disable-next-line no-unused-vars
+  const [searchableStatuses] = useState(props.searchable_statuses)
+  const [showReplaceOptionsInSearch] = useState(true)
+
+  const sourceElRef = useRef(null)
+  const matchCaseCheckRef = useRef(null)
+  const sourceInputRef = useRef(null)
+  const targetInputRef = useRef(null)
+
+  // mirrors the class's non-reactive instance field: mutating this does not
+  // itself trigger a re-render
+  const jobIsSplittedRef = useRef(false)
+
+  const prevActiveRef = useRef(props.active)
+  const isFirstRender = useRef(true)
+
+  const latestRef = useRef({})
+
+  const resetSearchState = useCallback(() => {
+    setSearch(cloneDeep(defaultSearch))
+    setFocus(true)
+    setFuncFindButton(true)
+    setTotal(null)
+    setSearchReturn(false)
+    setSearchResults([])
+    setOccurrencesList([])
+    setSearchResultsDictionary({})
+    setFeaturedSearchResult(null)
+  }, [])
+
+  const handleStatusChange = (value) => {
+    const nextSearch = cloneDeep(search)
+    nextSearch.selectStatus = value
+    if (value === 'APPROVED-2') {
+      nextSearch.revisionNumber = REVISE_STEP_NUMBER.REVISE2
+      nextSearch.selectStatus = 'APPROVED'
+    } else if (value === 'APPROVED') {
+      nextSearch.revisionNumber = REVISE_STEP_NUMBER.REVISE1
+    }
+    setSearch(nextSearch)
+    setFuncFindButton(true)
   }
 
-  handleSubmit() {
-    if (this.state.funcFindButton) {
-      SearchUtils.execFind(this.state.search)
-    }
-
-    const {guess_tag: guessTag} = this.props.userInfo.metadata
-
-    this.setState({
-      funcFindButton: false,
-      ...(guessTag === 1 && {
-        previousIsTagProjectionEnabled: true,
-      }),
-    })
-    // disable tag projection
-    if (guessTag === 1) {
-      SegmentActions.changeTagProjectionStatus(false)
-    }
+  const resetStatusFilter = () => {
+    handleStatusChange('all')
   }
 
-  setResults(data) {
-    this.setState({
-      total: data.total,
-      searchResults: data.searchResults,
-      occurrencesList: data.occurrencesList,
-      searchResultsDictionary: data.searchResultsDictionary,
-      featuredSearchResult: data.featuredSearchResult,
-      searchReturn: true,
-      isSelectedTag: false,
-    })
+  const handleClearClick = () => {
+    // SearchUtils.clearSearchMarkers();
+    resetStatusFilter()
     setTimeout(() => {
-      !isUndefined(this.state.occurrencesList[data.featuredSearchResult]) &&
-        SegmentActions.openSegment(
-          this.state.occurrencesList[data.featuredSearchResult],
-        )
+      resetSearchState()
+      SegmentActions.removeSearchResultToSegments()
     })
   }
 
-  updateSearch() {
-    if (this.props.active) {
-      setTimeout(() => {
-        const searchObject = SearchUtils.updateSearchObject()
-        this.setState({
-          searchResults: searchObject.searchResults,
-          occurrencesList: searchObject.occurrencesList,
-          searchResultsDictionary: searchObject.searchResultsDictionary,
-          featuredSearchResult: searchObject.featuredSearchResult,
-          isSelectedTag: false,
-        })
-        setTimeout(() =>
-          SegmentActions.addSearchResultToSegments(
-            searchObject.occurrencesList,
-            searchObject.searchResultsDictionary,
-            this.state.featuredSearchResult,
-            searchObject.searchParams,
-          ),
-        )
-      })
-    }
-  }
-
-  updateAfterReplace(sid) {
-    let {searchResults} = this.state
-    let itemReplaced = find(searchResults, (item) => item.id === sid)
-    let total = this.state.total
-    total--
-    if (itemReplaced.occurrences.length === 1) {
-      remove(searchResults, (item) => item.id === sid)
-    }
-    let newResultArray = map(searchResults, (item) => item.id)
-    const searchObject =
-      SearchUtils.updateSearchObjectAfterReplace(newResultArray)
-    this.setState({
-      total: total,
-      searchResults: searchObject.searchResults,
-      occurrencesList: searchObject.occurrencesList,
-      searchResultsDictionary: searchObject.searchResultsDictionary,
-    })
-    CatToolActions.storeSearchResults({
-      total: total,
-      searchResults: searchObject.searchResults,
-      occurrencesList: searchObject.occurrencesList,
-      searchResultsDictionary: searchObject.searchResultsDictionary,
-      featuredSearchResult: this.state.featuredSearchResult,
-    })
-    SegmentActions.addSearchResultToSegments(
-      searchObject.occurrencesList,
-      searchObject.searchResultsDictionary,
-      this.state.featuredSearchResult,
-      searchObject.searchParams,
-    )
-  }
-
-  goToNext() {
-    this.setFeatured(this.state.featuredSearchResult + 1)
-  }
-
-  goToPrev() {
-    this.setFeatured(this.state.featuredSearchResult - 1)
-  }
-
-  setFeatured(value) {
-    if (this.state.occurrencesList.length > 1) {
-      let module = this.state.occurrencesList.length
-      value = this.mod(value, module)
-    } else {
-      value = 0
-    }
-    SearchUtils.updateFeaturedResult(value)
-    CatToolActions.storeSearchResults({
-      total: this.state.total,
-      searchResults: this.state.searchResults,
-      occurrencesList: this.state.occurrencesList,
-      searchResultsDictionary: this.state.searchResultsDictionary,
-      featuredSearchResult: value,
-    })
-    SegmentActions.changeCurrentSearchSegment(value)
-  }
-
-  // handling module
-  mod(n, m) {
-    return ((n % m) + m) % m
-  }
-
-  handleCancelClick() {
+  const handleCancelClick = useCallback(() => {
     SearchUtils.searchOpen = false
-    this.handleClearClick()
+    latestRef.current.handleClearClick()
     if (SegmentStore.getSegmentByIdToJS(SegmentStore.getCurrentSegmentId())) {
       setTimeout(() =>
         SegmentActions.scrollToSegment(SegmentStore.getCurrentSegmentId()),
@@ -204,56 +131,71 @@ class Search extends React.Component {
       })
     }
 
-    this.resetStatusFilter()
+    latestRef.current.resetStatusFilter()
     setTimeout(() => {
       CatToolActions.closeSubHeader()
       SegmentActions.removeSearchResultToSegments()
-      this.setState(cloneDeep(this.defaultState))
+      resetSearchState()
     })
-  }
+  }, [resetSearchState])
 
-  handleClearClick() {
-    // SearchUtils.clearSearchMarkers();
-    this.resetStatusFilter()
-    setTimeout(() => {
-      this.setState(cloneDeep(this.defaultState))
-      SegmentActions.removeSearchResultToSegments()
+  const setFeatured = (value) => {
+    let nextValue = value
+    if (occurrencesList.length > 1) {
+      nextValue = mod(value, occurrencesList.length)
+    } else {
+      nextValue = 0
+    }
+    SearchUtils.updateFeaturedResult(nextValue)
+    CatToolActions.storeSearchResults({
+      total: total,
+      searchResults: searchResults,
+      occurrencesList: occurrencesList,
+      searchResultsDictionary: searchResultsDictionary,
+      featuredSearchResult: nextValue,
     })
+    SegmentActions.changeCurrentSearchSegment(nextValue)
   }
 
-  handleKeyDown(e, name) {
-    if (e.code == 'Space' && e.ctrlKey && e.shiftKey) {
-      let textToInsert = tagSignatures.nbsp.placeholder
-      let cursorPosition = e.target.selectionStart
-      let textBeforeCursorPosition = e.target.value.substring(0, cursorPosition)
-      let textAfterCursorPosition = e.target.value.substring(
-        cursorPosition,
-        e.target.value.length,
-      )
-      e.target.value =
-        textBeforeCursorPosition + textToInsert + textAfterCursorPosition
-      this.handleInputChange(name, e)
+  const goToNext = () => {
+    setFeatured(featuredSearchResult + 1)
+  }
+
+  const goToPrev = () => {
+    setFeatured(featuredSearchResult - 1)
+  }
+
+  const updateAfterReplace = (sid) => {
+    let itemReplaced = find(searchResults, (item) => item.id === sid)
+    let newTotal = total
+    newTotal--
+    if (itemReplaced.occurrences.length === 1) {
+      remove(searchResults, (item) => item.id === sid)
     }
-  }
-
-  resetStatusFilter() {
-    this.handleStatusChange('all')
-  }
-
-  handleReplaceAllClick(event) {
-    event.preventDefault()
-    let props = {
-      search: this.state.search,
-    }
-    ModalsActions.showModalComponent(
-      MODAL_KEY.REPLACE_ALL,
-      props,
-      'Replace text in all results',
+    let newResultArray = map(searchResults, (item) => item.id)
+    const searchObject =
+      SearchUtils.updateSearchObjectAfterReplace(newResultArray)
+    setTotal(newTotal)
+    setSearchResults(searchObject.searchResults)
+    setOccurrencesList(searchObject.occurrencesList)
+    setSearchResultsDictionary(searchObject.searchResultsDictionary)
+    CatToolActions.storeSearchResults({
+      total: newTotal,
+      searchResults: searchObject.searchResults,
+      occurrencesList: searchObject.occurrencesList,
+      searchResultsDictionary: searchObject.searchResultsDictionary,
+      featuredSearchResult: featuredSearchResult,
+    })
+    SegmentActions.addSearchResultToSegments(
+      searchObject.occurrencesList,
+      searchObject.searchResultsDictionary,
+      featuredSearchResult,
+      searchObject.searchParams,
     )
   }
 
-  handleReplaceClick() {
-    if (this.state.search.searchTarget === this.state.search.replaceTarget) {
+  const handleReplaceClick = () => {
+    if (search.searchTarget === search.replaceTarget) {
       ModalsActions.showModalComponent(
         AlertModal,
         {
@@ -264,166 +206,215 @@ class Search extends React.Component {
       return false
     }
 
-    SegmentActions.replaceCurrentSearch(this.state.search.replaceTarget)
+    SegmentActions.replaceCurrentSearch(search.replaceTarget)
 
     setTimeout(() => {
       const segment = SegmentStore.getSegmentByIdToJS(
-        this.state.occurrencesList[this.state.featuredSearchResult],
+        occurrencesList[featuredSearchResult],
       )
       if (segment) {
-        this.updateAfterReplace(segment.original_sid)
+        updateAfterReplace(segment.original_sid)
         segmentTranslation(segment, segment.status, () => {}, false)
       }
     })
   }
 
-  handleStatusChange(value) {
-    let search = cloneDeep(this.state.search)
-    search['selectStatus'] = value
-    if (value === 'APPROVED-2') {
-      search.revisionNumber = REVISE_STEP_NUMBER.REVISE2
-      search['selectStatus'] = 'APPROVED'
-    } else if (value === 'APPROVED') {
-      search.revisionNumber = REVISE_STEP_NUMBER.REVISE1
-    }
-    this.setState({
+  const handleReplaceAllClick = (event) => {
+    event.preventDefault()
+    let modalProps = {
       search: search,
-      funcFindButton: true,
-    })
+    }
+    ModalsActions.showModalComponent(
+      MODAL_KEY.REPLACE_ALL,
+      modalProps,
+      'Replace text in all results',
+    )
   }
 
-  handleInputChange(name, event) {
+  const handleSubmit = () => {
+    if (funcFindButton) {
+      SearchUtils.execFind(search)
+    }
+
+    const {guess_tag: guessTag} = props.userInfo.metadata
+
+    setFuncFindButton(false)
+    if (guessTag === 1) {
+      setPreviousIsTagProjectionEnabled(true)
+    }
+    // disable tag projection
+    if (guessTag === 1) {
+      SegmentActions.changeTagProjectionStatus(false)
+    }
+  }
+
+  const handleInputChange = (name, event) => {
     //serch model
     const target = event.target
     const value = target.type === 'checkbox' ? target.checked : target.value
-    let search = this.state.search
-    search[name] = value
+    const nextSearch = {...search, [name]: value}
 
-    if (name !== 'enableReplace') {
-      this.setState({
-        search: search,
-        funcFindButton: true,
-        total: null,
-        searchReturn: false,
-        searchResults: [],
-        occurrencesList: [],
-        searchResultsDictionary: {},
-        featuredSearchResult: null,
-      })
+    // `enableReplace` and `replaceTarget` describe the replacement, not the
+    // query: neither changes which segments match, so editing them must not
+    // throw the current results away. Doing so re-armed FIND, which disabled
+    // REPLACE the moment you typed the replacement for the word you had just
+    // searched.
+    const changesTheQuery = name !== 'enableReplace' && name !== 'replaceTarget'
+
+    if (changesTheQuery) {
+      setSearch(nextSearch)
+      setFuncFindButton(true)
+      setTotal(null)
+      setSearchReturn(false)
+      setSearchResults([])
+      setOccurrencesList([])
+      setSearchResultsDictionary({})
+      setFeaturedSearchResult(null)
     } else {
-      this.setState({
-        search: search,
-      })
+      setSearch(nextSearch)
     }
   }
 
-  replaceTargetOnFocus() {
-    let search = this.state.search
-    search.enableReplace = true
-    this.setState({
-      search: search,
+  // dead code, preserved verbatim from the class component: never wired to
+  // any JSX handler there either
+  // eslint-disable-next-line no-unused-vars
+  const replaceTargetOnFocus = () => {
+    setSearch({...search, enableReplace: true})
+  }
+
+  const handleKeyDown = (e, name) => {
+    if (e.code == 'Space' && e.ctrlKey && e.shiftKey) {
+      let textToInsert = tagSignatures.nbsp.placeholder
+      let cursorPosition = e.target.selectionStart
+      let textBeforeCursorPosition = e.target.value.substring(0, cursorPosition)
+      let textAfterCursorPosition = e.target.value.substring(
+        cursorPosition,
+        e.target.value.length,
+      )
+      e.target.value =
+        textBeforeCursorPosition + textToInsert + textAfterCursorPosition
+      handleInputChange(name, e)
+    }
+  }
+
+  const setResults = useCallback((data) => {
+    setTotal(data.total)
+    setSearchResults(data.searchResults)
+    setOccurrencesList(data.occurrencesList)
+    setSearchResultsDictionary(data.searchResultsDictionary)
+    setFeaturedSearchResult(data.featuredSearchResult)
+    setSearchReturn(true)
+    setTimeout(() => {
+      !isUndefined(data.occurrencesList[data.featuredSearchResult]) &&
+        SegmentActions.openSegment(
+          data.occurrencesList[data.featuredSearchResult],
+        )
     })
-  }
+  }, [])
 
-  componentDidUpdate(prevProps) {
-    if (this.props.active) {
-      this.jobIsSplitted = CommonUtils.checkJobIsSplitted()
-      if (!prevProps.active) {
-        if (this.sourceEl && this.state.focus) {
-          this.sourceEl.focus()
-          this.setState({
-            focus: false,
-          })
-        }
-      }
-    } else {
-      if (!this.state.focus) {
-        this.setState({
-          focus: true,
-        })
-      }
-    }
-
-    // reset tag projection
-    if (!this.props.active && prevProps.active) {
-      this.setState({
-        previousIsTagProjectionEnabled: false,
+  const updateSearch = useCallback(() => {
+    if (latestRef.current.active) {
+      setTimeout(() => {
+        const searchObject = SearchUtils.updateSearchObject()
+        setSearchResults(searchObject.searchResults)
+        setOccurrencesList(searchObject.occurrencesList)
+        setSearchResultsDictionary(searchObject.searchResultsDictionary)
+        setFeaturedSearchResult(searchObject.featuredSearchResult)
+        setTimeout(() =>
+          SegmentActions.addSearchResultToSegments(
+            searchObject.occurrencesList,
+            searchObject.searchResultsDictionary,
+            searchObject.featuredSearchResult,
+            searchObject.searchParams,
+          ),
+        )
       })
     }
-    if (
-      !this.props.active &&
-      this.props.active !== prevProps.active &&
-      this.state.previousIsTagProjectionEnabled
-    ) {
-      SegmentActions.changeTagProjectionStatus(true)
+  }, [])
+
+  const handelKeydownFunction = useCallback((event) => {
+    const {
+      active,
+      search,
+      handleCancelClick,
+      handleSubmit,
+      goToPrev,
+      goToNext,
+    } = latestRef.current
+    if (active) {
+      if (event.keyCode === 27) {
+        handleCancelClick()
+      } else if (
+        event.keyCode === 13 &&
+        $(event.target).closest('.find-container').length > 0
+      ) {
+        if (search.searchTarget !== '' || search.searchSource !== '') {
+          event.preventDefault()
+          handleSubmit()
+        }
+      } else if (event.key === 'F3' && event.shiftKey) {
+        event.preventDefault()
+        goToPrev()
+      } else if (event.key === 'F3') {
+        event.preventDefault()
+        goToNext()
+      }
     }
-  }
-  getResultsHtml() {
+  }, [])
+
+  const getResultsHtml = () => {
     var html = ''
-    const {featuredSearchResult, searchReturn, occurrencesList, searchResults} =
-      this.state
     const segmentIndex = findIndex(
       searchResults,
       (item) => item.id === occurrencesList[featuredSearchResult],
     )
     //Waiting for results
-    if (!this.state.funcFindButton && !searchReturn) {
+    if (!funcFindButton && !searchReturn) {
       html = (
         <div className="search-display">
           <p className="searching">Searching ...</p>
         </div>
       )
-    } else if (!this.state.funcFindButton && searchReturn) {
+    } else if (!funcFindButton && searchReturn) {
       let query = []
-      if (this.state.search.exactMatch) query.push(' exactly')
-      if (this.state.search.searchSource)
+      if (search.exactMatch) query.push(' exactly')
+      if (search.searchSource)
         query.push(
           <span key="source" className="query">
-            <span className="param">{this.state.search.searchSource}</span>in
-            source{' '}
+            <span className="param">{search.searchSource}</span>in source{' '}
           </span>,
         )
-      if (this.state.search.searchTarget)
+      if (search.searchTarget)
         query.push(
           <span key="target" className="query">
-            <span className="param">{this.state.search.searchTarget}</span>in
-            target{' '}
+            <span className="param">{search.searchTarget}</span>in target{' '}
           </span>,
         )
-      if (this.state.search.selectStatus !== 'all') {
+      if (search.selectStatus !== 'all') {
         let statusLabel = (
           <span key="status">
             {' '}
-            and status{' '}
-            <span className="param">{this.state.search.selectStatus}</span>
+            and status <span className="param">{search.selectStatus}</span>
           </span>
         )
         query.push(statusLabel)
       }
       let caseLabel =
-        ' (' +
-        (this.state.search.matchCase ? 'case sensitive' : 'case insensitive') +
-        ')'
+        ' (' + (search.matchCase ? 'case sensitive' : 'case insensitive') + ')'
       query.push(caseLabel)
       let searchMode =
-        this.state.search.searchSource !== '' &&
-        this.state.search.searchTarget !== ''
+        search.searchSource !== '' && search.searchTarget !== ''
           ? 'source&target'
           : 'normal'
       let numbers = ''
-      let totalResults = this.state.searchResults.length
+      let totalResults = searchResults.length
       if (searchMode === 'source&target') {
-        let total = this.state.searchResults.length
-          ? this.state.searchResults.length
-          : 0
+        let total = searchResults.length ? searchResults.length : 0
         let label = total === 1 ? 'segment' : 'segments'
         numbers =
           total > 0 ? (
             <span key="numbers" className="numbers">
-              Found{' '}
-              <span className="segments">
-                {this.state.searchResults.length}
-              </span>{' '}
+              Found <span className="segments">{searchResults.length}</span>{' '}
               {label}
             </span>
           ) : (
@@ -432,17 +423,17 @@ class Search extends React.Component {
             </span>
           )
       } else {
-        let total = this.state.total ? parseInt(this.state.total) : 0
-        let label = total === 1 ? 'result' : 'results'
-        let label2 = total === 1 ? 'segment' : 'segments'
+        let total2 = total ? parseInt(total) : 0
+        let label = total2 === 1 ? 'result' : 'results'
+        let label2 = total2 === 1 ? 'segment' : 'segments'
         numbers =
-          total > 0 ? (
+          total2 > 0 ? (
             <span key="numbers" className="numbers">
               Found
-              <span className="results">{' ' + this.state.total}</span>{' '}
+              <span className="results">{' ' + total}</span>{' '}
               <span>{label}</span> in
               <span className="segments">
-                {' ' + this.state.searchResults.length}
+                {' ' + searchResults.length}
               </span>{' '}
               <span>{label2}</span>
             </span>
@@ -458,19 +449,19 @@ class Search extends React.Component {
             {numbers} having
             {query}
           </p>
-          {this.state.searchResults.length > 0 ? (
+          {searchResults.length > 0 ? (
             <div className="search-result-buttons">
               <p>{segmentIndex + 1 + ' of ' + totalResults + ' segments'}</p>
               <Button
                 size={BUTTON_SIZE.ICON_STANDARD}
                 mode={BUTTON_MODE.OUTLINE}
-                onClick={this.goToPrev.bind(this)}
+                onClick={goToPrev}
                 tooltip={'Find Previous (Shift + F3)'}
               >
                 <ChevronLeft />
               </Button>
               <Button
-                onClick={this.goToNext.bind(this)}
+                onClick={goToNext}
                 mode={BUTTON_MODE.OUTLINE}
                 size={BUTTON_SIZE.ICON_STANDARD}
                 tooltip={'Find Next (F3)'}
@@ -484,343 +475,319 @@ class Search extends React.Component {
     }
     return html
   }
-  handelKeydownFunction(event) {
-    if (this.props.active) {
-      if (event.keyCode === 27) {
-        this.handleCancelClick()
-      } else if (
-        event.keyCode === 13 &&
-        $(event.target).closest('.find-container').length > 0
-      ) {
-        if (
-          this.state.search.searchTarget !== '' ||
-          this.state.search.searchSource !== ''
-        ) {
-          event.preventDefault()
-          this.handleSubmit()
+
+  latestRef.current = {
+    active: props.active,
+    search,
+    handleSubmit,
+    goToPrev,
+    goToNext,
+    handleCancelClick,
+    handleClearClick,
+    resetStatusFilter,
+  }
+
+  // mirrors componentDidUpdate: runs after every update (not on mount).
+  // Deliberately no dependency array: this must run after every render,
+  // exactly like componentDidUpdate does, not just when specific values
+  // change (see jobIsSplittedRef, which is recomputed on every update).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      prevActiveRef.current = props.active
+      return
+    }
+
+    const prevActive = prevActiveRef.current
+
+    if (props.active) {
+      jobIsSplittedRef.current = CommonUtils.checkJobIsSplitted()
+      if (!prevActive) {
+        if (sourceElRef.current && focus) {
+          sourceElRef.current.focus()
+          setFocus(false)
         }
-      } else if (event.key === 'F3' && event.shiftKey) {
-        event.preventDefault()
-        this.goToPrev()
-      } else if (event.key === 'F3') {
-        event.preventDefault()
-        this.goToNext()
+      }
+    } else {
+      if (!focus) {
+        setFocus(true)
       }
     }
-  }
-  setStateReplaceButton = ({value}) => {
-    setTimeout(() => {
-      this.setState({
-        isSelectedTag: value,
-      })
-    })
-  }
 
-  componentDidMount() {
-    document.addEventListener('keydown', this.handelKeydownFunction, true)
-    CatToolStore.addListener(
-      CattolConstants.STORE_SEARCH_RESULT,
-      this.setResults.bind(this),
-    )
-    CatToolStore.addListener(
-      CattolConstants.CLOSE_SEARCH,
-      this.handleCancelClick,
-    )
-    SegmentStore.addListener(SegmentConstants.UPDATE_SEARCH, this.updateSearch)
-    SegmentStore.addListener(
-      SegmentConstants.SET_IS_CURRENT_SEARCH_OCCURRENCE_TAG,
-      this.setStateReplaceButton,
-    )
-  }
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.handelKeydownFunction)
-    CatToolStore.removeListener(
-      CattolConstants.STORE_SEARCH_RESULT,
-      this.setResults,
-    )
-    CatToolStore.removeListener(
-      CattolConstants.CLOSE_SEARCH,
-      this.handleCancelClick,
-    )
-    SegmentStore.removeListener(
-      SegmentConstants.UPDATE_SEARCH,
-      this.updateSearch,
-    )
-    SegmentStore.removeListener(
-      SegmentConstants.SET_IS_CURRENT_SEARCH_OCCURRENCE_TAG,
-      this.setStateReplaceButton,
-    )
-  }
-
-  render() {
-    let statusOptions = config.searchable_statuses.map((item) => {
-      return {
-        name: (
-          <>
-            <div
-              className={
-                'status-dot ' + item.label.toLowerCase() + '-color'
-              }
-            />
-            {item.label}
-          </>
-        ),
-        id: item.value,
-      }
-    })
-    if (config.secondRevisionsCount) {
-      statusOptions.push({
-        name: (
-          <>
-            <div
-              className={'status-dot approved-2ndpass-color'}
-            />
-            APPROVED
-          </>
-        ),
-        id: 'APPROVED-2',
-      })
+    // reset tag projection
+    if (!props.active && prevActive) {
+      setPreviousIsTagProjectionEnabled(false)
     }
-    let findIsDisabled = true
     if (
-      this.state.search.searchTarget !== '' ||
-      this.state.search.searchSource !== ''
+      !props.active &&
+      props.active !== prevActive &&
+      previousIsTagProjectionEnabled
     ) {
-      findIsDisabled = false
+      SegmentActions.changeTagProjectionStatus(true)
     }
-    let findButtonDisabled = !this.state.funcFindButton || findIsDisabled
-    let statusDropdownClass =
-      this.state.search.selectStatus !== '' &&
-      this.state.search.selectStatus !== 'all'
-        ? 'filtered'
-        : 'not-filtered'
-    let statusDropdownDisabled =
-      this.state.search.searchTarget !== '' ||
-      this.state.search.searchSource !== ''
-        ? ''
-        : 'disabled'
-    let replaceCheckboxClass = this.state.search.searchTarget ? '' : 'disabled'
-    let replaceDisabled = !(
-      this.state.search.enableReplace &&
-      this.state.search.searchTarget &&
-      !this.state.funcFindButton &&
-      !this.state.isSelectedTag
-    )
-    let replaceAllDisabled = !(
-      this.state.search.enableReplace && this.state.search.searchTarget
-    )
-    let clearVisible =
-      this.state.search.searchTarget !== '' ||
-      this.state.search.searchSource !== '' ||
-      (this.state.search.selectStatus !== '' &&
-        this.state.search.selectStatus !== 'all')
-    return this.props.active ? (
-      <div className="search-form">
-        <div className="find-wrapper">
-          <div className="find-container">
-            <div className="find-container-inside">
-              <div className="find-list">
-                <div className="find-element">
-                  <div className="find-in-source">
-                    <input
-                      type="text"
-                      tabIndex={1}
-                      value={this.state.search.searchSource}
-                      placeholder="Find in source"
-                      onKeyDown={(e) => this.handleKeyDown(e, 'searchSource')}
-                      onChange={this.handleInputChange.bind(
-                        this,
-                        'searchSource',
-                      )}
-                      ref={(input) => (this.sourceEl = input)}
-                    />
-                  </div>
-                  <div className="find-exact-match">
-                    <div className="exact-match">
-                      <input
-                        type="checkbox"
-                        tabIndex={3}
-                        checked={this.state.search.matchCase}
-                        onChange={this.handleInputChange.bind(
-                          this,
-                          'matchCase',
-                        )}
-                        ref={(checkbox) => (this.matchCaseCheck = checkbox)}
-                      />
-                      <label> Match Case</label>
-                    </div>
-                    <div className="exact-match">
-                      <input
-                        ref={(ref) => (this.sourceInput = ref)}
-                        type="checkbox"
-                        tabIndex={4}
-                        checked={this.state.search.exactMatch}
-                        onChange={this.handleInputChange.bind(
-                          this,
-                          'exactMatch',
-                        )}
-                      />
-                      <label> Whole word</label>
-                    </div>
-                  </div>
-                </div>
-                <div className="find-element-container">
-                  <div className="find-element">
-                    <div className="find-in-target">
-                      <input
-                        ref={(ref) => (this.targetInput = ref)}
-                        type="text"
-                        tabIndex={2}
-                        placeholder="Find in target"
-                        value={this.state.search.searchTarget}
-                        onChange={this.handleInputChange.bind(
-                          this,
-                          'searchTarget',
-                        )}
-                        onKeyDown={(e) => this.handleKeyDown(e, 'searchTarget')}
-                        className={
-                          !this.state.search.searchTarget &&
-                          this.state.search.enableReplace
-                            ? 'warn'
-                            : null
-                        }
-                      />
-                    </div>
-                    {this.state.showReplaceOptionsInSearch ? (
-                      <div
-                        className={
-                          'enable-replace-check ' + replaceCheckboxClass
-                        }
-                      >
-                        <input
-                          type="checkbox"
-                          tabIndex={5}
-                          checked={this.state.search.enableReplace}
-                          onChange={this.handleInputChange.bind(
-                            this,
-                            'enableReplace',
-                          )}
-                        />
-                        <label> Replace with</label>
-                      </div>
-                    ) : null}
-                  </div>
-                  {this.state.showReplaceOptionsInSearch &&
-                  this.state.search.enableReplace ? (
-                    <div className="find-element">
-                      <div className="find-in-replace">
-                        <input
-                          type="text"
-                          placeholder="Replace in target"
-                          value={this.state.search.replaceTarget}
-                          onChange={this.handleInputChange.bind(
-                            this,
-                            'replaceTarget',
-                          )}
-                        />
-                      </div>
-                    </div>
-                  ) : null}
-                </div>
-                <div className="find-element find-dropdown-status">
-                  <Select
-                    options={statusOptions}
-                    className={
-                      'find-dropdown ' +
-                      statusDropdownClass +
-                      ' ' +
-                      statusDropdownDisabled
-                    }
-                    isDisabled={
-                      this.state.search.searchTarget === '' &&
-                      this.state.search.searchSource === ''
-                    }
-                    onSelect={(value) => {
-                      this.handleStatusChange(value.id)
-                    }}
-                    activeOption={
-                      statusOptions.find(
-                        (item) => item.id === this.state.search.selectStatus,
-                      ) || undefined
-                    }
-                    placeholder={'Status segment'}
-                    checkSpaceToReverse={false}
-                    showResetButton={true}
-                    resetFunction={() => this.handleStatusChange('all')}
+
+    prevActiveRef.current = props.active
+  })
+
+  useEffect(() => {
+    document.addEventListener('keydown', handelKeydownFunction, true)
+    CatToolStore.addListener(CattolConstants.STORE_SEARCH_RESULT, setResults)
+    CatToolStore.addListener(CattolConstants.CLOSE_SEARCH, handleCancelClick)
+    SegmentStore.addListener(SegmentConstants.UPDATE_SEARCH, updateSearch)
+
+    return () => {
+      document.removeEventListener('keydown', handelKeydownFunction)
+      CatToolStore.removeListener(
+        CattolConstants.STORE_SEARCH_RESULT,
+        setResults,
+      )
+      CatToolStore.removeListener(
+        CattolConstants.CLOSE_SEARCH,
+        handleCancelClick,
+      )
+      SegmentStore.removeListener(SegmentConstants.UPDATE_SEARCH, updateSearch)
+    }
+  }, [
+    handelKeydownFunction,
+    setResults,
+    handleCancelClick,
+    updateSearch,
+  ])
+
+  let statusOptions = config.searchable_statuses.map((item) => {
+    return {
+      name: (
+        <>
+          <div
+            className={'status-dot ' + item.label.toLowerCase() + '-color'}
+          />
+          {item.label}
+        </>
+      ),
+      id: item.value,
+    }
+  })
+  if (config.secondRevisionsCount) {
+    statusOptions.push({
+      name: (
+        <>
+          <div className={'status-dot approved-2ndpass-color'} />
+          APPROVED
+        </>
+      ),
+      id: 'APPROVED-2',
+    })
+  }
+  let findIsDisabled = true
+  if (search.searchTarget !== '' || search.searchSource !== '') {
+    findIsDisabled = false
+  }
+  let findButtonDisabled = !funcFindButton || findIsDisabled
+  let statusDropdownClass =
+    search.selectStatus !== '' && search.selectStatus !== 'all'
+      ? 'filtered'
+      : 'not-filtered'
+  let statusDropdownDisabled =
+    search.searchTarget !== '' || search.searchSource !== '' ? '' : 'disabled'
+  let replaceCheckboxClass = search.searchTarget ? '' : 'disabled'
+  // REPLACE needs what REPLACE ALL needs: a replacement to apply, and hits to
+  // apply it to. It used to additionally require `funcFindButton` to be spent
+  // and `isSelectedTag` to be false. The latter is a latch — the only thing that
+  // ever sets it is a tag decorator deciding the current hit falls inside its
+  // range, and nothing ever sets it back — so one false positive left REPLACE
+  // dead until the next search or navigation, with REPLACE ALL still enabled.
+  let replaceDisabled = !(
+    search.enableReplace &&
+    search.searchTarget &&
+    searchReturn &&
+    total > 0
+  )
+  let replaceAllDisabled = !(search.enableReplace && search.searchTarget)
+  let clearVisible =
+    search.searchTarget !== '' ||
+    search.searchSource !== '' ||
+    (search.selectStatus !== '' && search.selectStatus !== 'all')
+  return props.active ? (
+    <div className="search-form">
+      <div className="find-wrapper">
+        <div className="find-container">
+          <div className="find-container-inside">
+            <div className="find-list">
+              <div className="find-element">
+                <div className="find-in-source">
+                  <input
+                    type="text"
+                    tabIndex={1}
+                    value={search.searchSource}
+                    placeholder="Find in source"
+                    onKeyDown={(e) => handleKeyDown(e, 'searchSource')}
+                    onChange={(e) => handleInputChange('searchSource', e)}
+                    ref={sourceElRef}
                   />
                 </div>
-                <div className="find-element find-clear-all">
-                  {clearVisible ? (
-                    <div className="find-clear">
-                      <button
-                        type="button"
-                        className=""
-                        onClick={this.handleClearClick.bind(this)}
-                      >
-                        Clear
-                      </button>
-                    </div>
-                  ) : null}
+                <div className="find-exact-match">
+                  <div className="exact-match">
+                    <input
+                      type="checkbox"
+                      tabIndex={3}
+                      checked={search.matchCase}
+                      onChange={(e) => handleInputChange('matchCase', e)}
+                      ref={matchCaseCheckRef}
+                    />
+                    <label> Match Case</label>
+                  </div>
+                  <div className="exact-match">
+                    <input
+                      ref={sourceInputRef}
+                      type="checkbox"
+                      tabIndex={4}
+                      checked={search.exactMatch}
+                      onChange={(e) => handleInputChange('exactMatch', e)}
+                    />
+                    <label> Whole word</label>
+                  </div>
                 </div>
               </div>
-              {this.state.showReplaceOptionsInSearch ? (
-                <div>
-                  <div className="find-actions">
-                    <Button
-                      mode={BUTTON_MODE.OUTLINE}
-                      onClick={this.handleSubmit.bind(this)}
-                      disabled={findButtonDisabled}
-                    >
-                      FIND
-                    </Button>
-                    <Button
-                      mode={BUTTON_MODE.OUTLINE}
-                      onClick={this.handleReplaceClick.bind(this)}
-                      disabled={replaceDisabled}
-                    >
-                      REPLACE
-                    </Button>
-                    <Button
-                      mode={BUTTON_MODE.OUTLINE}
-                      onClick={this.handleReplaceAllClick.bind(this)}
-                      disabled={replaceAllDisabled}
-                    >
-                      REPLACE ALL
-                    </Button>
+              <div className="find-element-container">
+                <div className="find-element">
+                  <div className="find-in-target">
+                    <input
+                      ref={targetInputRef}
+                      type="text"
+                      tabIndex={2}
+                      placeholder="Find in target"
+                      value={search.searchTarget}
+                      onChange={(e) => handleInputChange('searchTarget', e)}
+                      onKeyDown={(e) => handleKeyDown(e, 'searchTarget')}
+                      className={
+                        !search.searchTarget && search.enableReplace
+                          ? 'warn'
+                          : null
+                      }
+                    />
                   </div>
-                  {this.jobIsSplitted && (
-                    <div className="find-option">
+                  {showReplaceOptionsInSearch ? (
+                    <div
+                      className={'enable-replace-check ' + replaceCheckboxClass}
+                    >
                       <input
                         type="checkbox"
                         tabIndex={5}
-                        checked={this.state.search.entireJob}
-                        onChange={this.handleInputChange.bind(
-                          this,
-                          'entireJob',
-                        )}
+                        checked={search.enableReplace}
+                        onChange={(e) => handleInputChange('enableReplace', e)}
                       />
-                      <label> Search all chunks</label>
+                      <label> Replace with</label>
                     </div>
-                  )}
+                  ) : null}
                 </div>
-              ) : (
+                {showReplaceOptionsInSearch && search.enableReplace ? (
+                  <div className="find-element">
+                    <div className="find-in-replace">
+                      <input
+                        type="text"
+                        placeholder="Replace in target"
+                        value={search.replaceTarget}
+                        onChange={(e) => handleInputChange('replaceTarget', e)}
+                      />
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+              <div className="find-element find-dropdown-status">
+                <Select
+                  options={statusOptions}
+                  className={
+                    'find-dropdown ' +
+                    statusDropdownClass +
+                    ' ' +
+                    statusDropdownDisabled
+                  }
+                  isDisabled={
+                    search.searchTarget === '' && search.searchSource === ''
+                  }
+                  onSelect={(value) => {
+                    handleStatusChange(value.id)
+                  }}
+                  activeOption={
+                    statusOptions.find(
+                      (item) => item.id === search.selectStatus,
+                    ) || undefined
+                  }
+                  placeholder={'Status segment'}
+                  checkSpaceToReverse={false}
+                  showResetButton={true}
+                  resetFunction={() => handleStatusChange('all')}
+                />
+              </div>
+              <div className="find-element find-clear-all">
+                {clearVisible ? (
+                  <div className="find-clear">
+                    <button
+                      type="button"
+                      className=""
+                      onClick={handleClearClick}
+                    >
+                      Clear
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+            {showReplaceOptionsInSearch ? (
+              <div>
                 <div className="find-actions">
                   <Button
                     mode={BUTTON_MODE.OUTLINE}
-                    onClick={this.handleSubmit.bind(this)}
+                    onClick={handleSubmit}
                     disabled={findButtonDisabled}
                   >
                     FIND
                   </Button>
+                  <Button
+                    mode={BUTTON_MODE.OUTLINE}
+                    onClick={handleReplaceClick}
+                    disabled={replaceDisabled}
+                  >
+                    REPLACE
+                  </Button>
+                  <Button
+                    mode={BUTTON_MODE.OUTLINE}
+                    onClick={handleReplaceAllClick}
+                    disabled={replaceAllDisabled}
+                  >
+                    REPLACE ALL
+                  </Button>
                 </div>
-              )}
-            </div>
-            {this.getResultsHtml()}
+                {jobIsSplittedRef.current && (
+                  <div className="find-option">
+                    <input
+                      type="checkbox"
+                      tabIndex={5}
+                      checked={search.entireJob}
+                      onChange={(e) => handleInputChange('entireJob', e)}
+                    />
+                    <label> Search all chunks</label>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="find-actions">
+                <Button
+                  mode={BUTTON_MODE.OUTLINE}
+                  onClick={handleSubmit}
+                  disabled={findButtonDisabled}
+                >
+                  FIND
+                </Button>
+              </div>
+            )}
           </div>
+          {getResultsHtml()}
         </div>
       </div>
-    ) : null
-  }
+    </div>
+  ) : null
 }
 
 export default Search


### PR DESCRIPTION
## Summary

Step 05 of the PR #4768 split plan (wave 1, independent, largest of the
wave): migrates the cattool header — `SubHeaderContainer`, `Search`,
`QAComponent` and `BulkSelectionBar` — to function components with hooks,
porting the final state from the `react-class-to-functional-migration`
branch. Bundled as one PR because `SubHeaderContainer` imports all three of
the others, making this one component tree with one owner rather than four
separate reviews. Extends the per-directory eslint ratchet started in
#4814 to `public/js/components/header/cattol`.

Two things worth a reviewer's attention, verified against the actual diff
(not just taken from the split proposal's write-up, after finding one of
its claims inaccurate in an earlier step):

- **`Search`: a real, documented behaviour fix.** `handleInputChange`'s
  "does this edit invalidate the current search results" check previously
  excluded only `enableReplace` from resetting the funcFindButton search
  state; it now also excludes `replaceTarget`. Old behaviour: typing into
  the "replace with" field re-armed Find mode, which disabled Replace the
  moment you typed the replacement text for the word you'd just searched.
  The ported code documents this inline. Worth a reviewer's attention
  specifically *because* it's a genuine (if small) behaviour change bundled
  into an otherwise mechanical port, not because anything about it looks
  risky.
- **`QAComponent.allowHTML`: not a behaviour change.** I checked — this
  method has no call sites in either `develop` or the migration branch (`git
  log -p` on the whole file shows only the definition, never an
  invocation). It's pre-existing dead code, carried over verbatim with an
  `eslint-disable-next-line no-unused-vars` rather than removed, consistent
  with this migration's "preserve behaviour exactly" approach elsewhere.
  Flagging so a reviewer doesn't go looking for a change that isn't there.

## Type

- [x] `refactor` — restructure without behavior change
- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/header/cattol/SubHeaderContainer.js` | Convert to function component with hooks |
| `public/js/components/header/cattol/search/Search.js` | Convert to function component with hooks; fixes Replace being disabled by editing the replacement text |
| `public/js/components/header/cattol/QAComponent.js` | Convert to function component with hooks |
| `public/js/components/header/cattol/bulk_selection_bar/BulkSelectionBar.js` | Convert to function component with hooks |
| `.eslintrc.js` | Extend the class-component-ban override's `files` list to `public/js/components/header/cattol/**/*.js` |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [x] Manual testing performed (describe below)
- [ ] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

No new tests were added — existing tests are unchanged (they exercise the
public interface and already covered the converted components) and still
pass: `yarn test --watchAll=false public/js/components/header/cattol/` —
17 suites, 244 tests, all passing. Full suite `yarn test --watchAll=false`
— 427 suites, 4388 tests, all passing, no regressions. Scoped `npx eslint
public/js/components/header/cattol/` diffed against the pre-change
ruleset: the ratchet extension introduces zero new errors (150
pre-existing errors, unchanged, all in files outside this PR's scope).
Verified no other file under this directory is still a class component
before scoping the eslint glob broadly.

The "manual testing" box above reflects that automated verification, not
an interactive browser session — background job, no browser available.
This is the largest and highest-risk wave-1 PR; recommend an actual
click-through (search, find/replace including typing a replacement before
confirming Replace still works, QA warnings navigation, bulk selection bar)
before merge.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (Sonnet 5)

## Notes

Part of the split of #4768 (wave 1, step 05 of 14, last of wave 1) — see
#4814 for the first step in this series and the full merge-order plan.
Independent of the other wave-1 PRs; can merge in any order. Wave 1 is
complete after this PR.
