### PR TITLE
♻️ refactor(segments): convert highlight and tooltip leaves to function components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,6 +93,9 @@ module.exports = {
         'public/js/components/review_extended/**/*.js',
         'public/js/components/common/WrapperLoader.js',
         'public/js/components/header/cattol/**/*.js',
+        'public/js/components/segments/GlossaryComponents/**/*.js',
+        'public/js/components/segments/LexiqaHighlight/**/*.js',
+        'public/js/components/segments/TooltipInfo/**/*.js',
       ],
       rules: {
         'no-restricted-syntax': [

--- a/public/js/components/segments/GlossaryComponents/GlossaryHighlight.component.js
+++ b/public/js/components/segments/GlossaryComponents/GlossaryHighlight.component.js
@@ -1,16 +1,14 @@
-import React, {Component, createRef} from 'react'
+import React, {useRef} from 'react'
 import {highlightGlossaryTerm} from '../../../actions/segmentDispatchActions'
 import Tooltip from '../../common/Tooltip'
 import TEXT_UTILS from '../../../utils/textUtils'
 import {tagSignatures} from '../utils/DraftMatecatUtils/tagModel'
 
-class GlossaryHighlight extends Component {
-  constructor(props) {
-    super(props)
-    this.contentRef = createRef()
-  }
-  getTermDetails = () => {
-    const {contentState, glossary, start, end, blockKey, children} = this.props
+const GlossaryHighlight = (props) => {
+  const contentRef = useRef(null)
+
+  const getTermDetails = () => {
+    const {contentState, glossary, start, end, blockKey, children} = props
     if (tagSignatures.space) {
       const getBlocksBefore = (key) => {
         const blocks = []
@@ -97,9 +95,10 @@ class GlossaryHighlight extends Component {
       return result
     }
   }
-  onClickTerm = () => {
-    const {sid} = this.props
-    const glossaryTerm = this.getTermDetails()
+
+  const onClickTerm = () => {
+    const {sid} = props
+    const glossaryTerm = getTermDetails()
     //Call Segment footer Action
     highlightGlossaryTerm({
       sid,
@@ -107,20 +106,19 @@ class GlossaryHighlight extends Component {
       type: 'glossary',
     })
   }
-  render() {
-    const {children} = this.props
 
-    return (
-      <Tooltip
-        stylePointerElement={{display: 'inline-block', position: 'relative'}}
-        content="Termbase entry"
-      >
-        <div ref={this.contentRef} className="glossaryItem">
-          <span onClick={() => this.onClickTerm()}>{children}</span>
-        </div>
-      </Tooltip>
-    )
-  }
+  const {children} = props
+
+  return (
+    <Tooltip
+      stylePointerElement={{display: 'inline-block', position: 'relative'}}
+      content="Termbase entry"
+    >
+      <div ref={contentRef} className="glossaryItem">
+        <span onClick={() => onClickTerm()}>{children}</span>
+      </div>
+    </Tooltip>
+  )
 }
 
 export default GlossaryHighlight

--- a/public/js/components/segments/GlossaryComponents/GlossaryHighlight.component.js
+++ b/public/js/components/segments/GlossaryComponents/GlossaryHighlight.component.js
@@ -4,11 +4,18 @@ import Tooltip from '../../common/Tooltip'
 import TEXT_UTILS from '../../../utils/textUtils'
 import {tagSignatures} from '../utils/DraftMatecatUtils/tagModel'
 
-const GlossaryHighlight = (props) => {
+const GlossaryHighlight = ({
+  contentState,
+  glossary,
+  start,
+  end,
+  blockKey,
+  children,
+  sid,
+}) => {
   const contentRef = useRef(null)
 
   const getTermDetails = () => {
-    const {contentState, glossary, start, end, blockKey, children} = props
     if (tagSignatures.space) {
       const getBlocksBefore = (key) => {
         const blocks = []
@@ -97,7 +104,6 @@ const GlossaryHighlight = (props) => {
   }
 
   const onClickTerm = () => {
-    const {sid} = props
     const glossaryTerm = getTermDetails()
     //Call Segment footer Action
     highlightGlossaryTerm({
@@ -106,8 +112,6 @@ const GlossaryHighlight = (props) => {
       type: 'glossary',
     })
   }
-
-  const {children} = props
 
   return (
     <Tooltip

--- a/public/js/components/segments/GlossaryComponents/GlossaryHighlight.component.test.js
+++ b/public/js/components/segments/GlossaryComponents/GlossaryHighlight.component.test.js
@@ -29,6 +29,10 @@ jest.mock('../../common/Tooltip', () => ({
   ),
 }))
 
+// Renders `props.text` as its own visible text node so tests can shape
+// `children[0].props.text` the same way the space-disabled branch reads it.
+const FakeDecoratedText = ({text}) => <span>{text}</span>
+
 const makeContentState = (plainText) => ({
   getBlockBefore: jest.fn(() => null),
   getPlainText: () => plainText,
@@ -41,122 +45,31 @@ const baseProps = {
   sid: 42,
 }
 
+// onClickTerm() reads `glossaryTerm.term_id` on whatever getTermDetails()
+// returns, so a "no match" outcome throws when clicked — pre-existing
+// behavior this migration must not "fix". The exception is thrown inside a
+// native DOM event listener, so per the DOM spec it never reaches the code
+// that called fireEvent.click (neither try/catch nor expect(fn).toThrow()
+// observes it — verified empirically); it only surfaces as a `window` error
+// event, which is what these tests listen for instead.
+const clickAndCaptureThrow = (element) => {
+  let caught = null
+  const onError = (event) => {
+    caught = event.error
+    event.preventDefault()
+  }
+  window.addEventListener('error', onError)
+  fireEvent.click(element)
+  window.removeEventListener('error', onError)
+  return caught
+}
+
 afterEach(() => {
   jest.clearAllMocks()
 })
 
-describe('GlossaryHighlight.getTermDetails — space signature enabled (default)', () => {
-  test('finds the matching glossary term through the regex callback', () => {
-    TEXT_UTILS.getGlossaryMatchRegex.mockReturnValue({
-      regex: /hello/i,
-      regexCallback: (regex, block, callback) => callback(0, 5),
-    })
-
-    const glossary = [
-      {matching_words: ['hello'], term_id: 7, source: {term: 'ciao'}, target: {term: 'hello'}},
-    ]
-
-    const instance = new GlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('hello world'),
-      glossary,
-      children: [],
-    })
-
-    expect(instance.getTermDetails()).toEqual(glossary[0])
-  })
-
-  test('returns undefined when the callback offsets do not overlap the highlight', () => {
-    TEXT_UTILS.getGlossaryMatchRegex.mockReturnValue({
-      regex: /hello/i,
-      regexCallback: (regex, block, callback) => callback(20, 25),
-    })
-
-    const glossary = [{matching_words: ['hello'], term_id: 7}]
-
-    const instance = new GlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('hello world, unrelated text'),
-      glossary,
-      children: [],
-    })
-
-    expect(instance.getTermDetails()).toBeUndefined()
-  })
-
-  test('skips regex matching entirely when every term is a missingTerm', () => {
-    const glossary = [{matching_words: ['hello'], missingTerm: true}]
-
-    const instance = new GlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('hello world'),
-      glossary,
-      children: [],
-    })
-
-    expect(instance.getTermDetails()).toBeUndefined()
-    expect(TEXT_UTILS.getGlossaryMatchRegex).not.toHaveBeenCalled()
-  })
-})
-
-describe('GlossaryHighlight.getTermDetails — space signature disabled', () => {
-  const originalSpace = tagSignatures.space
-
-  beforeEach(() => {
-    tagSignatures.space = null
-  })
-
-  afterEach(() => {
-    tagSignatures.space = originalSpace
-  })
-
-  test('matches using the decorated text of the first child', () => {
-    const glossary = [{matching_words: ['hello'], term_id: 3}]
-    const instance = new GlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('unused'),
-      glossary,
-      children: [{props: {text: '  Hello  '}}],
-    })
-
-    expect(instance.getTermDetails()).toEqual(glossary[0])
-  })
-
-  test('returns undefined when no term matches the decorated text', () => {
-    const glossary = [{matching_words: ['other'], term_id: 3}]
-    const instance = new GlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('unused'),
-      glossary,
-      children: [{props: {text: 'hello'}}],
-    })
-
-    expect(instance.getTermDetails()).toBeUndefined()
-  })
-})
-
-describe('GlossaryHighlight.onClickTerm', () => {
-  test('dispatches highlightGlossaryTerm with the matched term id', () => {
-    const instance = new GlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('unused'),
-      glossary: [],
-      children: [],
-    })
-    jest.spyOn(instance, 'getTermDetails').mockReturnValue({term_id: 99})
-
-    instance.onClickTerm()
-
-    expect(highlightGlossaryTerm).toHaveBeenCalledWith({
-      sid: 42,
-      termId: 99,
-      type: 'glossary',
-    })
-  })
-})
-
-describe('GlossaryHighlight render', () => {
-  test('renders the tooltip content and forwards clicks to onClickTerm', () => {
+describe('GlossaryHighlight — space signature enabled (default)', () => {
+  test('renders the tooltip content and dispatches highlightGlossaryTerm on click when the callback offsets overlap the highlight', () => {
     TEXT_UTILS.getGlossaryMatchRegex.mockReturnValue({
       regex: /hello/i,
       regexCallback: (regex, block, callback) => callback(0, 5),
@@ -173,7 +86,7 @@ describe('GlossaryHighlight render', () => {
       </GlossaryHighlight>,
     )
 
-    expect(screen.getByTestId('tooltip-content').textContent).toBe(
+    expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
       'Termbase entry',
     )
 
@@ -184,5 +97,107 @@ describe('GlossaryHighlight render', () => {
       termId: 11,
       type: 'glossary',
     })
+  })
+
+  test('does not dispatch when the callback offsets do not overlap the highlight (pre-existing throw on click)', () => {
+    TEXT_UTILS.getGlossaryMatchRegex.mockReturnValue({
+      regex: /hello/i,
+      regexCallback: (regex, block, callback) => callback(20, 25),
+    })
+
+    const glossary = [{matching_words: ['hello'], term_id: 7}]
+
+    render(
+      <GlossaryHighlight
+        {...baseProps}
+        contentState={makeContentState('hello world, unrelated text')}
+        glossary={glossary}
+      >
+        hello
+      </GlossaryHighlight>,
+    )
+
+    const thrown = clickAndCaptureThrow(screen.getByText('hello'))
+
+    expect(thrown).toBeInstanceOf(TypeError)
+    expect(thrown.message).toMatch(/term_id/)
+    expect(highlightGlossaryTerm).not.toHaveBeenCalled()
+  })
+
+  test('skips regex matching entirely when every glossary entry is a missingTerm', () => {
+    const glossary = [{matching_words: ['hello'], missingTerm: true}]
+
+    render(
+      <GlossaryHighlight
+        {...baseProps}
+        contentState={makeContentState('hello world')}
+        glossary={glossary}
+      >
+        hello
+      </GlossaryHighlight>,
+    )
+
+    // getTermDetails() returns undefined here too, so the click still throws —
+    // what this test asserts is that getGlossaryMatchRegex was never reached.
+    const thrown = clickAndCaptureThrow(screen.getByText('hello'))
+
+    expect(thrown).toBeInstanceOf(TypeError)
+    expect(thrown.message).toMatch(/term_id/)
+    expect(TEXT_UTILS.getGlossaryMatchRegex).not.toHaveBeenCalled()
+    expect(highlightGlossaryTerm).not.toHaveBeenCalled()
+  })
+})
+
+describe('GlossaryHighlight — space signature disabled', () => {
+  const originalSpace = tagSignatures.space
+
+  beforeEach(() => {
+    tagSignatures.space = null
+  })
+
+  afterEach(() => {
+    tagSignatures.space = originalSpace
+  })
+
+  test('matches using the decorated text of the first child and dispatches on click', () => {
+    const glossary = [{matching_words: ['hello'], term_id: 3}]
+
+    render(
+      <GlossaryHighlight
+        {...baseProps}
+        contentState={makeContentState('unused')}
+        glossary={glossary}
+      >
+        {[<FakeDecoratedText text="  Hello  " key="child" />]}
+      </GlossaryHighlight>,
+    )
+
+    fireEvent.click(screen.getByText('Hello'))
+
+    expect(highlightGlossaryTerm).toHaveBeenCalledWith({
+      sid: 42,
+      termId: 3,
+      type: 'glossary',
+    })
+  })
+
+  test('does not dispatch when no term matches the decorated text (pre-existing throw on click)', () => {
+    const glossary = [{matching_words: ['other'], term_id: 3}]
+
+    render(
+      <GlossaryHighlight
+        {...baseProps}
+        contentState={makeContentState('unused')}
+        glossary={glossary}
+      >
+        {[<FakeDecoratedText text="hello" key="child" />]}
+      </GlossaryHighlight>,
+    )
+
+    const thrown = clickAndCaptureThrow(screen.getByText('hello'))
+
+    expect(thrown).toBeInstanceOf(TypeError)
+    expect(thrown.message).toMatch(/term_id/)
+    expect(highlightGlossaryTerm).not.toHaveBeenCalled()
   })
 })

--- a/public/js/components/segments/GlossaryComponents/QaCheckBlacklistHighlight.component.js
+++ b/public/js/components/segments/GlossaryComponents/QaCheckBlacklistHighlight.component.js
@@ -1,16 +1,14 @@
-import React, {Component, createRef} from 'react'
+import React, {useRef} from 'react'
 import Tooltip from '../../common/Tooltip'
 import {tagSignatures} from '../utils/DraftMatecatUtils/tagModel'
 import TEXT_UTILS from '../../../utils/textUtils'
 
-class QaCheckBlacklistHighlight extends Component {
-  constructor(props) {
-    super(props)
-    this.contentRef = createRef()
-  }
-  getTermDetails = () => {
+const QaCheckBlacklistHighlight = (props) => {
+  const contentRef = useRef(null)
+
+  const getTermDetails = () => {
     const {contentState, blackListedTerms, start, end, blockKey, children} =
-      this.props
+      props
     if (tagSignatures.space) {
       const getBlocksBefore = (key) => {
         const blocks = []
@@ -94,28 +92,27 @@ class QaCheckBlacklistHighlight extends Component {
       return result
     }
   }
-  render() {
-    const {children} = this.props
 
-    const term = this.getTermDetails()
+  const {children} = props
 
-    const {source, target} = term || {}
+  const term = getTermDetails()
 
-    return term ? (
-      <Tooltip
-        stylePointerElement={{display: 'inline-block', position: 'relative'}}
-        content={
-          source.term
-            ? `${target.term} is flagged as a forbidden translation for ${source.term}`
-            : `${target.term} is flagged as a forbidden word`
-        }
-      >
-        <div ref={this.contentRef} className="blacklistItem">
-          <span>{children}</span>
-        </div>
-      </Tooltip>
-    ) : null
-  }
+  const {source, target} = term || {}
+
+  return term ? (
+    <Tooltip
+      stylePointerElement={{display: 'inline-block', position: 'relative'}}
+      content={
+        source.term
+          ? `${target.term} is flagged as a forbidden translation for ${source.term}`
+          : `${target.term} is flagged as a forbidden word`
+      }
+    >
+      <div ref={contentRef} className="blacklistItem">
+        <span>{children}</span>
+      </div>
+    </Tooltip>
+  ) : null
 }
 
 export default QaCheckBlacklistHighlight

--- a/public/js/components/segments/GlossaryComponents/QaCheckBlacklistHighlight.component.js
+++ b/public/js/components/segments/GlossaryComponents/QaCheckBlacklistHighlight.component.js
@@ -3,12 +3,17 @@ import Tooltip from '../../common/Tooltip'
 import {tagSignatures} from '../utils/DraftMatecatUtils/tagModel'
 import TEXT_UTILS from '../../../utils/textUtils'
 
-const QaCheckBlacklistHighlight = (props) => {
+const QaCheckBlacklistHighlight = ({
+  contentState,
+  blackListedTerms,
+  start,
+  end,
+  blockKey,
+  children,
+}) => {
   const contentRef = useRef(null)
 
   const getTermDetails = () => {
-    const {contentState, blackListedTerms, start, end, blockKey, children} =
-      props
     if (tagSignatures.space) {
       const getBlocksBefore = (key) => {
         const blocks = []
@@ -92,8 +97,6 @@ const QaCheckBlacklistHighlight = (props) => {
       return result
     }
   }
-
-  const {children} = props
 
   const term = getTermDetails()
 

--- a/public/js/components/segments/GlossaryComponents/QaCheckBlacklistHighlight.component.test.js
+++ b/public/js/components/segments/GlossaryComponents/QaCheckBlacklistHighlight.component.test.js
@@ -39,44 +39,6 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-describe('QaCheckBlacklistHighlight.getTermDetails — space signature enabled (default)', () => {
-  test('finds the matching blacklisted term through the regex callback', () => {
-    TEXT_UTILS.getGlossaryMatchRegex.mockReturnValue({
-      regex: /hello/i,
-      regexCallback: (regex, block, callback) => callback(0, 5),
-    })
-
-    const blackListedTerms = [
-      {matching_words: ['hello'], source: {term: 'ciao'}, target: {term: 'hello'}},
-    ]
-
-    const instance = new QaCheckBlacklistHighlight({
-      ...baseProps,
-      contentState: makeContentState('hello world'),
-      blackListedTerms,
-      children: [],
-    })
-
-    expect(instance.getTermDetails()).toEqual(blackListedTerms[0])
-  })
-
-  test('returns undefined when no term overlaps the highlighted range', () => {
-    TEXT_UTILS.getGlossaryMatchRegex.mockReturnValue({
-      regex: /hello/i,
-      regexCallback: (regex, block, callback) => callback(20, 25),
-    })
-
-    const instance = new QaCheckBlacklistHighlight({
-      ...baseProps,
-      contentState: makeContentState('hello world, unrelated'),
-      blackListedTerms: [{matching_words: ['hello']}],
-      children: [],
-    })
-
-    expect(instance.getTermDetails()).toBeUndefined()
-  })
-})
-
 describe('QaCheckBlacklistHighlight.getTermDetails — space signature disabled', () => {
   const originalSpace = tagSignatures.space
 
@@ -88,16 +50,26 @@ describe('QaCheckBlacklistHighlight.getTermDetails — space signature disabled'
     tagSignatures.space = originalSpace
   })
 
-  test('matches using the decorated text of the first child', () => {
-    const blackListedTerms = [{matching_words: ['hello'], source: {}, target: {term: 'hello'}}]
-    const instance = new QaCheckBlacklistHighlight({
-      ...baseProps,
-      contentState: makeContentState('unused'),
-      blackListedTerms,
-      children: [{props: {text: '  Hello  '}}],
-    })
+  const FakeDecoratedText = ({text}) => <span>{text}</span>
 
-    expect(instance.getTermDetails()).toEqual(blackListedTerms[0])
+  test('matches using the decorated text of the first child', () => {
+    const blackListedTerms = [
+      {matching_words: ['hello'], source: {}, target: {term: 'hello'}},
+    ]
+
+    render(
+      <QaCheckBlacklistHighlight
+        {...baseProps}
+        contentState={makeContentState('unused')}
+        blackListedTerms={blackListedTerms}
+        // eslint-disable-next-line react/no-children-prop -- explicit array needed to mirror children[0] access
+        children={[<FakeDecoratedText text="  Hello  " key="0" />]}
+      />,
+    )
+
+    expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+      'hello is flagged as a forbidden word',
+    )
   })
 })
 
@@ -132,7 +104,11 @@ describe('QaCheckBlacklistHighlight render', () => {
         {...baseProps}
         contentState={makeContentState('hello world')}
         blackListedTerms={[
-          {matching_words: ['hello'], source: {term: 'ciao'}, target: {term: 'hello'}},
+          {
+            matching_words: ['hello'],
+            source: {term: 'ciao'},
+            target: {term: 'hello'},
+          },
         ]}
       >
         hello

--- a/public/js/components/segments/GlossaryComponents/QaCheckGlossaryHighlight.component.js
+++ b/public/js/components/segments/GlossaryComponents/QaCheckGlossaryHighlight.component.js
@@ -1,17 +1,14 @@
-import React, {Component, createRef} from 'react'
+import React, {useRef} from 'react'
 import {highlightGlossaryTerm} from '../../../actions/segmentDispatchActions'
 import Tooltip from '../../common/Tooltip'
 import {tagSignatures} from '../utils/DraftMatecatUtils/tagModel'
 import TEXT_UTILS from '../../../utils/textUtils'
 
-class QaCheckGlossaryHighlight extends Component {
-  constructor(props) {
-    super(props)
-    this.contentRef = createRef()
-  }
-  getTermDetails = () => {
-    const {contentState, missingTerms, start, end, blockKey, children} =
-      this.props
+const QaCheckGlossaryHighlight = (props) => {
+  const contentRef = useRef(null)
+
+  const getTermDetails = () => {
+    const {contentState, missingTerms, start, end, blockKey, children} = props
     if (tagSignatures.space) {
       const getBlocksBefore = (key) => {
         const blocks = []
@@ -95,9 +92,9 @@ class QaCheckGlossaryHighlight extends Component {
       return result
     }
   }
-  onClickTerm = () => {
-    const {sid} = this.props
-    const glossaryTerm = this.getTermDetails()
+  const onClickTerm = () => {
+    const {sid} = props
+    const glossaryTerm = getTermDetails()
     //Call Segment footer Action
     if (glossaryTerm) {
       highlightGlossaryTerm({
@@ -107,20 +104,19 @@ class QaCheckGlossaryHighlight extends Component {
       })
     }
   }
-  render() {
-    const {children} = this.props
 
-    return (
-      <Tooltip
-        stylePointerElement={{display: 'inline-block', position: 'relative'}}
-        content="Termbase translation not found in target"
-      >
-        <div ref={this.contentRef} className="qaCheckGlossaryItem">
-          <span onClick={() => this.onClickTerm()}>{children}</span>
-        </div>
-      </Tooltip>
-    )
-  }
+  const {children} = props
+
+  return (
+    <Tooltip
+      stylePointerElement={{display: 'inline-block', position: 'relative'}}
+      content="Termbase translation not found in target"
+    >
+      <div ref={contentRef} className="qaCheckGlossaryItem">
+        <span onClick={() => onClickTerm()}>{children}</span>
+      </div>
+    </Tooltip>
+  )
 }
 
 export default QaCheckGlossaryHighlight

--- a/public/js/components/segments/GlossaryComponents/QaCheckGlossaryHighlight.component.js
+++ b/public/js/components/segments/GlossaryComponents/QaCheckGlossaryHighlight.component.js
@@ -4,11 +4,18 @@ import Tooltip from '../../common/Tooltip'
 import {tagSignatures} from '../utils/DraftMatecatUtils/tagModel'
 import TEXT_UTILS from '../../../utils/textUtils'
 
-const QaCheckGlossaryHighlight = (props) => {
+const QaCheckGlossaryHighlight = ({
+  contentState,
+  missingTerms,
+  start,
+  end,
+  blockKey,
+  children,
+  sid,
+}) => {
   const contentRef = useRef(null)
 
   const getTermDetails = () => {
-    const {contentState, missingTerms, start, end, blockKey, children} = props
     if (tagSignatures.space) {
       const getBlocksBefore = (key) => {
         const blocks = []
@@ -93,7 +100,6 @@ const QaCheckGlossaryHighlight = (props) => {
     }
   }
   const onClickTerm = () => {
-    const {sid} = props
     const glossaryTerm = getTermDetails()
     //Call Segment footer Action
     if (glossaryTerm) {
@@ -104,8 +110,6 @@ const QaCheckGlossaryHighlight = (props) => {
       })
     }
   }
-
-  const {children} = props
 
   return (
     <Tooltip

--- a/public/js/components/segments/GlossaryComponents/QaCheckGlossaryHighlight.component.test.js
+++ b/public/js/components/segments/GlossaryComponents/QaCheckGlossaryHighlight.component.test.js
@@ -41,54 +41,49 @@ const baseProps = {
   sid: 42,
 }
 
+const FakeDecoratedText = ({text}) => <span>{text}</span>
+
 afterEach(() => {
   jest.clearAllMocks()
 })
 
 describe('QaCheckGlossaryHighlight.getTermDetails — space signature enabled (default)', () => {
-  test('finds the matching missing term through the regex callback', () => {
-    TEXT_UTILS.getGlossaryMatchRegex.mockReturnValue({
-      regex: /hello/i,
-      regexCallback: (regex, block, callback) => callback(0, 5),
-    })
-
-    const missingTerms = [{matching_words: ['hello'], term_id: 7}]
-
-    const instance = new QaCheckGlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('hello world'),
-      missingTerms,
-      children: [],
-    })
-
-    expect(instance.getTermDetails()).toEqual(missingTerms[0])
-  })
-
   test('returns undefined when the callback offsets do not overlap the highlight', () => {
     TEXT_UTILS.getGlossaryMatchRegex.mockReturnValue({
       regex: /hello/i,
       regexCallback: (regex, block, callback) => callback(20, 25),
     })
 
-    const instance = new QaCheckGlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('hello world, unrelated text'),
-      missingTerms: [{matching_words: ['hello']}],
-      children: [],
-    })
+    render(
+      <QaCheckGlossaryHighlight
+        {...baseProps}
+        contentState={makeContentState('hello world, unrelated text')}
+        missingTerms={[{matching_words: ['hello']}]}
+      >
+        hello
+      </QaCheckGlossaryHighlight>,
+    )
 
-    expect(instance.getTermDetails()).toBeUndefined()
+    fireEvent.click(screen.getByText('hello'))
+
+    expect(highlightGlossaryTerm).not.toHaveBeenCalled()
   })
 
   test('skips regex matching entirely when there are no missing terms', () => {
-    const instance = new QaCheckGlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('hello world'),
-      missingTerms: [],
-      children: [],
-    })
+    render(
+      <QaCheckGlossaryHighlight
+        {...baseProps}
+        contentState={makeContentState('hello world')}
+        missingTerms={[]}
+      >
+        hello
+      </QaCheckGlossaryHighlight>,
+    )
+
+    fireEvent.click(screen.getByText('hello'))
 
     expect(TEXT_UTILS.getGlossaryMatchRegex).not.toHaveBeenCalled()
+    expect(highlightGlossaryTerm).not.toHaveBeenCalled()
   })
 })
 
@@ -105,48 +100,24 @@ describe('QaCheckGlossaryHighlight.getTermDetails — space signature disabled',
 
   test('matches using the decorated text of the first child', () => {
     const missingTerms = [{matching_words: ['hello'], term_id: 3}]
-    const instance = new QaCheckGlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('unused'),
-      missingTerms,
-      children: [{props: {text: '  Hello  '}}],
-    })
 
-    expect(instance.getTermDetails()).toEqual(missingTerms[0])
-  })
-})
+    render(
+      <QaCheckGlossaryHighlight
+        {...baseProps}
+        contentState={makeContentState('unused')}
+        missingTerms={missingTerms}
+        // eslint-disable-next-line react/no-children-prop -- explicit array needed to mirror children[0] access
+        children={[<FakeDecoratedText text="  Hello  " key="0" />]}
+      />,
+    )
 
-describe('QaCheckGlossaryHighlight.onClickTerm', () => {
-  test('dispatches highlightGlossaryTerm with the matched term id', () => {
-    const instance = new QaCheckGlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('unused'),
-      missingTerms: [],
-      children: [],
-    })
-    jest.spyOn(instance, 'getTermDetails').mockReturnValue({term_id: 99})
-
-    instance.onClickTerm()
+    fireEvent.click(screen.getByText('Hello'))
 
     expect(highlightGlossaryTerm).toHaveBeenCalledWith({
       sid: 42,
-      termId: 99,
+      termId: 3,
       type: 'check',
     })
-  })
-
-  test('does nothing when there is no matched term', () => {
-    const instance = new QaCheckGlossaryHighlight({
-      ...baseProps,
-      contentState: makeContentState('unused'),
-      missingTerms: [],
-      children: [],
-    })
-    jest.spyOn(instance, 'getTermDetails').mockReturnValue(undefined)
-
-    instance.onClickTerm()
-
-    expect(highlightGlossaryTerm).not.toHaveBeenCalled()
   })
 })
 

--- a/public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.js
+++ b/public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.js
@@ -1,18 +1,15 @@
-import React, {Component, createRef} from 'react'
+import React, {useRef} from 'react'
 import {find} from 'lodash'
 
 import LexiqaTooltipInfo from '../TooltipInfo/LexiqaTooltipInfo.component'
 import LexiqaUtils from '../../../utils/lxq.main'
 import Tooltip from '../../common/Tooltip'
 
-class LexiqaHighlight extends Component {
-  constructor(props) {
-    super(props)
-    this.contentRef = createRef()
-  }
+const LexiqaHighlight = (props) => {
+  const contentRef = useRef(null)
 
-  getWarning = () => {
-    let {blockKey, start, end, warnings, isSource, sid} = this.props
+  const getWarning = () => {
+    let {blockKey, start, end, warnings, isSource, sid} = props
     // Every block starts from offset 0, so we have to check warnings's blockKey
     let warning = find(
       warnings,
@@ -29,38 +26,36 @@ class LexiqaHighlight extends Component {
     return warning
   }
 
-  render() {
-    const {children, getUpdatedSegmentInfo} = this.props
-    const {segmentOpened} = getUpdatedSegmentInfo()
-    const warning = this.getWarning()
+  const {children, getUpdatedSegmentInfo} = props
+  const {segmentOpened} = getUpdatedSegmentInfo()
+  const warning = getWarning()
 
-    return (
-      warning && (
-        <Tooltip
-          stylePointerElement={{display: 'inline-block', position: 'relative'}}
-          content={
-            segmentOpened &&
-            warning &&
-            warning.messages && (
-              <LexiqaTooltipInfo
-                messages={warning.messages}
-                onReplaceWord={this.props.replaceWordAt}
-              />
-            )
-          }
-          isInteractiveContent={true}
-        >
-          <div ref={this.contentRef} className="lexiqahighlight">
-            <span
-              style={{backgroundColor: warning.messages ? warning.color : ''}}
-            >
-              {children}
-            </span>
-          </div>
-        </Tooltip>
-      )
+  return (
+    warning && (
+      <Tooltip
+        stylePointerElement={{display: 'inline-block', position: 'relative'}}
+        content={
+          segmentOpened &&
+          warning &&
+          warning.messages && (
+            <LexiqaTooltipInfo
+              messages={warning.messages}
+              onReplaceWord={props.replaceWordAt}
+            />
+          )
+        }
+        isInteractiveContent={true}
+      >
+        <div ref={contentRef} className="lexiqahighlight">
+          <span
+            style={{backgroundColor: warning.messages ? warning.color : ''}}
+          >
+            {children}
+          </span>
+        </div>
+      </Tooltip>
     )
-  }
+  )
 }
 
 export default LexiqaHighlight

--- a/public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.js
+++ b/public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.js
@@ -5,11 +5,20 @@ import LexiqaTooltipInfo from '../TooltipInfo/LexiqaTooltipInfo.component'
 import LexiqaUtils from '../../../utils/lxq.main'
 import Tooltip from '../../common/Tooltip'
 
-const LexiqaHighlight = (props) => {
+const LexiqaHighlight = ({
+  blockKey,
+  start,
+  end,
+  warnings,
+  isSource,
+  sid,
+  children,
+  getUpdatedSegmentInfo,
+  replaceWordAt,
+}) => {
   const contentRef = useRef(null)
 
   const getWarning = () => {
-    let {blockKey, start, end, warnings, isSource, sid} = props
     // Every block starts from offset 0, so we have to check warnings's blockKey
     let warning = find(
       warnings,
@@ -26,7 +35,6 @@ const LexiqaHighlight = (props) => {
     return warning
   }
 
-  const {children, getUpdatedSegmentInfo} = props
   const {segmentOpened} = getUpdatedSegmentInfo()
   const warning = getWarning()
 
@@ -40,7 +48,7 @@ const LexiqaHighlight = (props) => {
           warning.messages && (
             <LexiqaTooltipInfo
               messages={warning.messages}
-              onReplaceWord={props.replaceWordAt}
+              onReplaceWord={replaceWordAt}
             />
           )
         }

--- a/public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.js
+++ b/public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.js
@@ -1,17 +1,22 @@
-import React, {Component} from 'react'
+import React from 'react'
 
 import LXQ from '../../../utils/lxq.main'
 import IconCloseCircle from '../../../../img/icons/IconCloseCircle'
 
-class LexiqaTooltipInfo extends Component {
-  ignoreError(message) {
+const LexiqaTooltipInfo = (props) => {
+  const ignoreError = (message) => {
     if (message.error) {
       LXQ.ignoreError(message.error)
     }
   }
 
-  buildTooltipError = () => {
-    const {messages} = this.props
+  const replaceWord = ({newWord, start, end}) => {
+    props.onReplaceWord({newWord, start, end})
+    //LXQ.redoHighlighting(segmentId, false)
+  }
+
+  const buildTooltipError = () => {
+    const {messages} = props
     const suggestions = messages.filter((item) => item.type === 'suggestion')
     const errors = messages.filter((item) => item.type !== 'suggestion')
 
@@ -20,7 +25,7 @@ class LexiqaTooltipInfo extends Component {
         <span className="tooltip-error-category">{error.msg}</span>
         <div
           className="tooltip-error-ignore"
-          onClick={() => this.ignoreError(error)}
+          onClick={() => ignoreError(error)}
         >
           <IconCloseCircle />
           <span className="tooltip-error-ignore-text">Ignore</span>
@@ -32,7 +37,7 @@ class LexiqaTooltipInfo extends Component {
       <li
         key={i}
         onClick={() =>
-          this.replaceWord({
+          replaceWord({
             newWord: suggestion.msg,
             start: suggestion.start,
             end: suggestion.end,
@@ -57,19 +62,12 @@ class LexiqaTooltipInfo extends Component {
     )
   }
 
-  replaceWord = ({newWord, start, end}) => {
-    this.props.onReplaceWord({newWord, start, end})
-    //LXQ.redoHighlighting(segmentId, false)
-  }
-
-  render() {
-    const html = this.buildTooltipError()
-    return (
-      <div className="lexiqa-tooltip">
-        <div className="tooltip-error-wrapper">{html}</div>
-      </div>
-    )
-  }
+  const html = buildTooltipError()
+  return (
+    <div className="lexiqa-tooltip">
+      <div className="tooltip-error-wrapper">{html}</div>
+    </div>
+  )
 }
 
 export default LexiqaTooltipInfo

--- a/public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.js
+++ b/public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.js
@@ -3,7 +3,7 @@ import React from 'react'
 import LXQ from '../../../utils/lxq.main'
 import IconCloseCircle from '../../../../img/icons/IconCloseCircle'
 
-const LexiqaTooltipInfo = (props) => {
+const LexiqaTooltipInfo = ({onReplaceWord, messages}) => {
   const ignoreError = (message) => {
     if (message.error) {
       LXQ.ignoreError(message.error)
@@ -11,12 +11,11 @@ const LexiqaTooltipInfo = (props) => {
   }
 
   const replaceWord = ({newWord, start, end}) => {
-    props.onReplaceWord({newWord, start, end})
+    onReplaceWord({newWord, start, end})
     //LXQ.redoHighlighting(segmentId, false)
   }
 
   const buildTooltipError = () => {
-    const {messages} = props
     const suggestions = messages.filter((item) => item.type === 'suggestion')
     const errors = messages.filter((item) => item.type !== 'suggestion')
 

--- a/public/js/components/segments/TooltipInfo/TooltipInfo.component.js
+++ b/public/js/components/segments/TooltipInfo/TooltipInfo.component.js
@@ -1,7 +1,7 @@
-import React, {Component} from 'react'
+import React from 'react'
 
-class TooltipInfo extends Component {
-  state = {}
+const TooltipInfo = (props) => {
+  const {text, isTag, tagStyle} = props
 
   /*render() {
         return <div className="tag-tooltip">
@@ -11,24 +11,21 @@ class TooltipInfo extends Component {
         </div>
     }*/
 
-  render() {
-    const {text, isTag, tagStyle} = this.props
-    return (
-      <div className="common-tooltip">
-        <div className="tooltip-error-wrapper">
-          <div className="tooltip-error-container">
-            {isTag ? (
-              <span className={`tag ${tagStyle}`}>
-                <span>{text}</span>
-              </span>
-            ) : (
-              <span className="tooltip-error-category">{text}</span>
-            )}
-          </div>
+  return (
+    <div className="common-tooltip">
+      <div className="tooltip-error-wrapper">
+        <div className="tooltip-error-container">
+          {isTag ? (
+            <span className={`tag ${tagStyle}`}>
+              <span>{text}</span>
+            </span>
+          ) : (
+            <span className="tooltip-error-category">{text}</span>
+          )}
         </div>
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 //common-tooltip

--- a/public/js/components/segments/TooltipInfo/TooltipInfo.component.js
+++ b/public/js/components/segments/TooltipInfo/TooltipInfo.component.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
-const TooltipInfo = (props) => {
-  const {text, isTag, tagStyle} = props
+const TooltipInfo = ({text, isTag, tagStyle}) => {
 
   /*render() {
         return <div className="tag-tooltip">


### PR DESCRIPTION
## Summary

Step 06 of the PR #4768 split plan (wave 2, first step, independent):
migrates the Glossary/QA-check/Lexiqa highlight components and the two
tooltips to function components with hooks, porting the final state from
the `react-class-to-functional-migration` branch. These are reached only
through the unchanged `DraftMatecatUtils/activate*.js` decorator factories,
so they're a free-standing leaf — nothing in the editor core needs to move
first. Extends the per-directory eslint ratchet started in #4814 to
`segments/GlossaryComponents`, `segments/LexiqaHighlight` and
`segments/TooltipInfo`.

## Type

- [x] `refactor` — restructure without behavior change
- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/segments/GlossaryComponents/GlossaryHighlight.component.js` (+test) | Convert to function component with hooks |
| `public/js/components/segments/GlossaryComponents/QaCheckGlossaryHighlight.component.js` (+test) | Convert to function component with hooks |
| `public/js/components/segments/GlossaryComponents/QaCheckBlacklistHighlight.component.js` (+test) | Convert to function component with hooks |
| `public/js/components/segments/LexiqaHighlight/LexiqaHighlight.component.js` | Convert to function component with hooks |
| `public/js/components/segments/TooltipInfo/TooltipInfo.component.js` | Convert to function component with hooks |
| `public/js/components/segments/TooltipInfo/LexiqaTooltipInfo.component.js` | Convert to function component with hooks |
| `.eslintrc.js` | Extend the class-component-ban override's `files` list to the three directories above |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

The three `.test.js` files change (not new files) — old tests instantiated
the class directly and called internal methods (e.g. `instance.getTermDetails()`),
which no longer exist on a function component; the migrated tests verify
the same behaviour through React Testing Library (`render` + `fireEvent` +
assertions on the `highlightGlossaryTerm`/`onClickTerm` side effects
instead of internals). This drops the raw test-case count by 7 (20 → 13
across the three files) — checked this is consolidation, not lost
coverage, by diffing each old/new test file pair and confirming the
positive- and negative-match paths are both still asserted, just through
the public interface. `yarn test --watchAll=false
public/js/components/segments/GlossaryComponents/
public/js/components/segments/LexiqaHighlight/
public/js/components/segments/TooltipInfo/` — 6 suites, 25 tests, all
passing. Full suite `yarn test --watchAll=false` — 427 suites, 4381 tests,
all passing (4388 → 4381 is exactly this 7-test consolidation, no other
change). Scoped `npx eslint` on the three directories diffed against the
pre-change ruleset: the ratchet extension introduces zero new errors (9
pre-existing errors, unchanged, all in files outside this PR's scope).
Verified no other file under these three directories is still a class
component before scoping the eslint globs.

No browser-based manual verification was performed in this session
(background job, no interactive browser available) — recommend a manual
pass over glossary/QA/Lexiqa highlighting and their tooltips before merge.

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (Sonnet 5)

## Notes

Part of the split of #4768 (wave 2, step 06 of 14, first of wave 2) — see
#4814 for the full merge-order plan. Independent of the rest of wave 2;
unlike steps 07-09 it has no dependency on `TagEntity`.
