### PR TITLE
♻️ refactor(segments): convert TagEntity and the tag menu to function components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,6 +96,8 @@ module.exports = {
         'public/js/components/segments/GlossaryComponents/**/*.js',
         'public/js/components/segments/LexiqaHighlight/**/*.js',
         'public/js/components/segments/TooltipInfo/**/*.js',
+        'public/js/components/segments/TagEntity/**/*.js',
+        'public/js/components/segments/utils/DraftMatecatUtils/TagMenu/**/*.js',
       ],
       rules: {
         'no-restricted-syntax': [

--- a/public/js/components/segments/TagEntity/TagEntity.component.js
+++ b/public/js/components/segments/TagEntity/TagEntity.component.js
@@ -1,4 +1,4 @@
-import React, {Component, createRef} from 'react'
+import React, {useCallback, useEffect, useRef, useState} from 'react'
 import {debounce, find} from 'lodash'
 import {tagSignatures, getTooltipTag} from '../utils/DraftMatecatUtils/tagModel'
 import {classifyPcPhTag} from '../utils/DraftMatecatUtils/pcTagUtils'
@@ -11,494 +11,575 @@ import SegmentActions from '../../../actions/SegmentActions'
 import SearchUtils from '../../header/cattol/search/searchUtils'
 import Tooltip from '../../common/Tooltip'
 
-class TagEntity extends Component {
-  constructor(props) {
-    super(props)
+// These were instance methods reading only `this.props`/`this.state`, so they
+// become plain functions over their inputs. Keeping them outside the component
+// lets the store handlers below hold a single stable identity without closing
+// over anything that changes per render.
 
-    const {entityKey, contentState} = this.props
+const selectCorrectStyle = (
+  {entityKey, contentState, getUpdatedSegmentInfo, isRTL},
+  clickedTagId = null,
+  clickedTagText = null,
+) => {
+  const {segmentOpened} = getUpdatedSegmentInfo()
+  const {
+    data: {id: entityId, placeholder: entityPlaceholder, name: entityName},
+  } = contentState.getEntity(entityKey)
+
+  // Basic style accordin to language direction
+  const baseStyle =
+    tagSignatures[entityName] &&
+    (isRTL && tagSignatures[entityName].styleRTL
+      ? tagSignatures[entityName].styleRTL
+      : tagSignatures[entityName].style)
+
+  // Check if tag is in an active segment
+  const tagInactive = !segmentOpened ? 'tag-inactive' : ''
+
+  // Click
+  const tagClicked =
+    entityId &&
+    clickedTagId &&
+    clickedTagId === entityId &&
+    clickedTagText &&
+    clickedTagText === entityPlaceholder
+      ? 'tag-clicked'
+      : '' // green
+
+  return `${baseStyle} ${tagInactive} ${tagClicked}`.trim()
+}
+
+export const highlightOnWarnings = ({
+  getUpdatedSegmentInfo,
+  contentState,
+  entityKey,
+  isTarget,
+}) => {
+  const {tagMismatch, segmentOpened, missingTagsInTarget} =
+    getUpdatedSegmentInfo()
+  const {data: entityData} = contentState.getEntity(entityKey) || {}
+
+  if (!segmentOpened) return
+  const {encodedText} = entityData
+
+  // pc (compressible) tags: the QA endpoint can't tell missing closing tags
+  // apart (every one converts to the same generic `</pc>` markup), so
+  // matching by reported string content doesn't work here. missingTagsInTarget
+  // is computed client-side by tag identity/numbering instead (see
+  // checkForMissingTag.js) and is exact, since its entries are the source's
+  // own tag objects.
+  if (classifyPcPhTag(encodedText)) {
+    if (isTarget) return ''
+    const isMissingInTarget = (missingTagsInTarget || []).some(
+      (tag) => tag?.data?.encodedText === encodedText,
+    )
+    return isMissingInTarget ? 'tag-mismatch-error' : ''
+  }
+
+  if (!tagMismatch) return
+  let tagWarningStyle = ''
+  if (tagMismatch.target && tagMismatch.target.length > 0 && isTarget) {
+    // Todo: Check tag type and tag id instead of string
+    tagMismatch.target.forEach((tagString) => {
+      if (encodedText === tagString) {
+        tagWarningStyle = 'tag-mismatch-error'
+      }
+    })
+  } else if (tagMismatch.source && tagMismatch.source.length > 0 && !isTarget) {
+    tagMismatch.source.forEach((tagString) => {
+      if (encodedText === tagString) {
+        tagWarningStyle = 'tag-mismatch-error'
+      }
+    })
+  } else if (tagMismatch.order && isTarget) {
+    tagMismatch.order.forEach((tagString) => {
+      if (encodedText === tagString) {
+        tagWarningStyle = 'tag-mismatch-warning'
+      }
+    })
+  }
+  return tagWarningStyle
+}
+
+const markSearch = (text, searchParams, {start, end}) => {
+  let {
+    active,
+    currentActive,
+    textToReplace,
+    params,
+    occurrences,
+    currentInSearchIndex,
+  } = searchParams
+  let currentOccurrence = find(
+    occurrences,
+    (occ) => occ.searchProgressiveIndex === currentInSearchIndex,
+  )
+  let isCurrent =
+    currentOccurrence &&
+    currentOccurrence.matchPosition >= start &&
+    currentOccurrence.matchPosition < end
+
+  if (active && isCurrent) SegmentActions.setIsCurrentSearchOccurrenceTag(true)
+
+  if (active) {
+    let regex = SearchUtils.getSearchRegExp(
+      textToReplace,
+      params.ingnoreCase,
+      params.exactMatch,
+    )
+    let parts = text.split(regex)
+    for (let i = 1; i < parts.length; i += 2) {
+      let color =
+        currentActive && isCurrent ? 'rgb(255 210 14)' : 'rgb(255 255 0)'
+      parts[i] = (
+        <span key={i} style={{backgroundColor: color}}>
+          {parts[i]}
+        </span>
+      )
+    }
+    return parts
+  }
+  return text
+}
+
+const getChildrenContent = (
+  index,
+  entityName,
+  pcRole,
+  {phTagsCompressed, children},
+) => {
+  const isPhTag = entityName === 'ph'
+
+  if (isPhTag && index >= 0) {
+    // A closing pc tag always shows only its number (never the equiv-text /
+    // closing content). An opening tag shows its content unless compressed.
+    const isPcClose = pcRole === 'close'
+    return (
+      <>
+        <span className="index-counter">{index + 1}</span>
+        {!phTagsCompressed && !isPcClose && children}
+      </>
+    )
+  }
+
+  return children
+}
+
+// Boolean, not the raw `null` a missing node would produce: the callers compare
+// the result against state to decide whether to commit, and `false !== null`
+// would make every mount commit a pointless extra render.
+const measureShouldTooltipOnHover = (tagNode) => {
+  const textSpanDisplayed =
+    tagNode && tagNode.querySelector('span[data-text="true"]')
+  return Boolean(
+    textSpanDisplayed &&
+    textSpanDisplayed.offsetWidth < textSpanDisplayed.scrollWidth,
+  )
+}
+
+const TagEntity = ({
+  children,
+  entityKey,
+  contentState,
+  getUpdatedSegmentInfo,
+  getSearchParams,
+  isTarget,
+  sid,
+  isRTL,
+  start,
+  end,
+  onClick,
+  offsetkey,
+}) => {
+  // Rebuilt rather than kept as the raw parameter, so the store handlers below
+  // can still mirror "everything this component received" through liveRef
+  // without every helper call site needing its own object literal.
+  const props = {
+    children,
+    entityKey,
+    contentState,
+    getUpdatedSegmentInfo,
+    getSearchParams,
+    isTarget,
+    sid,
+    isRTL,
+    start,
+    end,
+    onClick,
+    offsetkey,
+  }
+
+  const [state, setState] = useState(() => {
     const {
       data: {name: entityName},
     } = contentState.getEntity(entityKey)
 
-    this.state = {
-      tagStyle: this.selectCorrectStyle(),
+    return {
+      tagStyle: selectCorrectStyle(props),
       tagWarningStyle: '',
       tooltipAvailable: getTooltipTag().includes(entityName),
       shouldTooltipOnHover: false,
       phTagsCompressed: CatToolStore.isPhTagsCompressed(),
       clicked: false,
       focused: false,
-      searchParams: this.props.getSearchParams(),
-      entityKey: this.props.entityKey,
+      searchParams: getSearchParams(),
+      entityKey,
     }
-    this.updateTagStyleDebounced = debounce(this.updateTagStyle, 500)
-    this.updateTagWarningStyleDebounced = debounce(
-      this.updateTagWarningStyle,
-      500,
-    )
+  })
 
-    this.contentRef = createRef()
-    this.focusedState = createRef({})
-    this.focusedState.current = {}
-  }
+  // Merge semantics of the class's this.setState, which every handler below
+  // relied on to set one field without clearing the others.
+  const patchState = useCallback((partial) => {
+    setState((prev) => ({...prev, ...partial}))
+  }, [])
 
-  markSearch = (text, searchParams) => {
-    let {
-      active,
-      currentActive,
-      textToReplace,
-      params,
-      occurrences,
-      currentInSearchIndex,
-    } = searchParams
-    let currentOccurrence = find(
-      occurrences,
-      (occ) => occ.searchProgressiveIndex === currentInSearchIndex,
-    )
-    let isCurrent =
-      currentOccurrence &&
-      currentOccurrence.matchPosition >= this.props.start &&
-      currentOccurrence.matchPosition < this.props.end
+  // The store handlers must keep one stable identity for the component's whole
+  // lifetime, so the cleanup unregisters the exact references it registered.
+  // They read props/state through this mirror, refreshed before any of them can
+  // run.
+  const liveRef = useRef({})
+  liveRef.current = {props, state}
 
-    if (active && isCurrent)
-      SegmentActions.setIsCurrentSearchOccurrenceTag(true)
+  const contentRef = useRef(null)
+  const tagRef = useRef(null)
+  const focusedState = useRef({})
 
-    if (active) {
-      let regex = SearchUtils.getSearchRegExp(
-        textToReplace,
-        params.ingnoreCase,
-        params.exactMatch,
-      )
-      let parts = text.split(regex)
-      for (let i = 1; i < parts.length; i += 2) {
-        let color =
-          currentActive && isCurrent ? 'rgb(255 210 14)' : 'rgb(255 255 0)'
-        parts[i] = (
-          <span key={i} style={{backgroundColor: color}}>
-            {parts[i]}
-          </span>
-        )
-      }
-      return parts
-    }
-    return text
-  }
-
-  addSearchParams = (sid) => {
-    const {getSearchParams, isTarget} = this.props
-    if (sid !== this.props.sid) return
-    let searchParams = getSearchParams()
-    if (
-      searchParams.active &&
-      ((searchParams.isTarget && isTarget) ||
-        (!searchParams.isTarget && !isTarget))
-    ) {
-      this.setState({
-        searchParams,
-      })
-    }
-  }
-
-  updateSearchParams = (sid, currentInSearchIndex) => {
-    const {getSearchParams} = this.props
-    if (
-      sid !== this.props.sid ||
-      (sid === this.props.sid && !this.state.searchParams.active)
-    )
-      return
-    let searchParamsNew = getSearchParams()
-    searchParamsNew.currentInSearchIndex = currentInSearchIndex
-    this.setState({
-      searchParams: searchParamsNew,
-    })
-  }
-
-  removeSearchParams = () => {
-    if (this.state.searchParams.active) {
-      const {getSearchParams} = this.props
+  const addSearchParams = useCallback(
+    (sid) => {
+      const {props: live} = liveRef.current
+      const {getSearchParams, isTarget} = live
+      if (sid !== live.sid) return
       let searchParams = getSearchParams()
-      this.setState({
+      if (
+        searchParams.active &&
+        ((searchParams.isTarget && isTarget) ||
+          (!searchParams.isTarget && !isTarget))
+      ) {
+        patchState({
+          searchParams,
+        })
+      }
+    },
+    [patchState],
+  )
+
+  const updateSearchParams = useCallback(
+    (sid, currentInSearchIndex) => {
+      const {props: live, state: liveState} = liveRef.current
+      const {getSearchParams} = live
+      if (
+        sid !== live.sid ||
+        (sid === live.sid && !liveState.searchParams.active)
+      )
+        return
+      let searchParamsNew = getSearchParams()
+      searchParamsNew.currentInSearchIndex = currentInSearchIndex
+      patchState({
+        searchParams: searchParamsNew,
+      })
+    },
+    [patchState],
+  )
+
+  const removeSearchParams = useCallback(() => {
+    const {props: live, state: liveState} = liveRef.current
+    if (liveState.searchParams.active) {
+      const {getSearchParams} = live
+      let searchParams = getSearchParams()
+      patchState({
         searchParams,
       })
     }
+  }, [patchState])
+
+  const onPhTagsCompressedToggle = useCallback(() => {
+    patchState({phTagsCompressed: CatToolStore.isPhTagsCompressed()})
+  }, [patchState])
+
+  const highlightTags = useCallback(
+    (tagId, tagPlaceholder, triggerEntityKey) => {
+      const {props: live, state: liveState} = liveRef.current
+      const {entityKey: liveEntityKey, contentState: liveContentState} = live
+      const {clicked} = liveState
+      const {
+        data: {id: entityId, placeholder: entityPlaceholder},
+      } = liveContentState.getEntity(liveEntityKey)
+      // Turn OFF
+      if (clicked && (!tagId || tagId !== entityId)) {
+        patchState({
+          tagStyle: selectCorrectStyle(live),
+          clicked: false,
+          entityKey: liveEntityKey,
+        })
+      } else if (liveEntityKey === triggerEntityKey) {
+        patchState({
+          tagStyle: selectCorrectStyle(live, tagId, tagPlaceholder, true),
+          clicked: true,
+          entityKey: liveEntityKey,
+        })
+      } else if (
+        tagId === entityId &&
+        entityPlaceholder === tagPlaceholder &&
+        liveEntityKey !== triggerEntityKey
+      ) {
+        patchState({
+          tagStyle: selectCorrectStyle(live, tagId, tagPlaceholder),
+          clicked: true,
+          entityKey: liveEntityKey,
+        })
+      }
+    },
+    [patchState],
+  )
+
+  const updateTagStyle = useCallback(
+    (sid, isTarget) => {
+      const {props: live, state: liveState} = liveRef.current
+      if (!live.isTarget && isTarget) return
+      const newStyle = selectCorrectStyle(live)
+      if (newStyle !== liveState.tagStyle) {
+        patchState({
+          tagStyle: newStyle,
+          entityKey: live.entityKey,
+        })
+      }
+    },
+    [patchState],
+  )
+
+  const updateTagWarningStyle = useCallback(() => {
+    const {props: live, state: liveState} = liveRef.current
+    const {tagWarningStyle: prevTagWarningStyle} = liveState
+    const tagWarningStyle = highlightOnWarnings(live)
+    if (prevTagWarningStyle !== tagWarningStyle) {
+      patchState({tagWarningStyle})
+    }
+  }, [patchState])
+
+  const focusTag = useCallback(
+    ({tagsSelected}) => {
+      const {skipTmOut, tmOut} = focusedState.current
+      if (tmOut) clearTimeout(tmOut)
+      focusedState.current = {}
+
+      if (!tagsSelected?.length) {
+        // reset
+        patchState({
+          focused: false,
+        })
+        return
+      }
+
+      const updateState = () => {
+        patchState({
+          focused: tagsSelected.some(
+            ({entityKey}) => entityKey === liveRef.current.props.entityKey,
+          ),
+        })
+      }
+
+      if (!skipTmOut) {
+        focusedState.current.tmOut = setTimeout(() => updateState(), 100)
+      } else {
+        updateState()
+      }
+    },
+    [patchState],
+  )
+
+  // Seeded once: rebuilding a debounced wrapper on a later render would
+  // silently drop whatever call was already pending inside it.
+  const debouncedRef = useRef(null)
+  if (!debouncedRef.current) {
+    debouncedRef.current = {
+      updateTagStyle: debounce(updateTagStyle, 500),
+      updateTagWarningStyle: debounce(updateTagWarningStyle, 500),
+    }
   }
 
-  onPhTagsCompressedToggle = () => {
-    this.setState({phTagsCompressed: CatToolStore.isPhTagsCompressed()})
-  }
+  useEffect(() => {
+    const {
+      updateTagStyle: updateTagStyleDebounced,
+      updateTagWarningStyle: updateTagWarningStyleDebounced,
+    } = debouncedRef.current
 
-  componentDidMount() {
     SegmentStore.addListener(
       SegmentConstants.SET_SEGMENT_WARNINGS,
-      this.updateTagWarningStyleDebounced,
+      updateTagWarningStyleDebounced,
     )
-    SegmentStore.addListener(
-      SegmentConstants.HIGHLIGHT_TAGS,
-      this.highlightTags,
-    )
+    SegmentStore.addListener(SegmentConstants.HIGHLIGHT_TAGS, highlightTags)
     SegmentStore.addListener(
       EditAreaConstants.EDIT_AREA_CHANGED,
-      this.updateTagStyleDebounced,
+      updateTagStyleDebounced,
     )
     SegmentStore.addListener(
       SegmentConstants.ADD_SEARCH_RESULTS,
-      this.addSearchParams,
+      addSearchParams,
     )
     SegmentStore.addListener(
       SegmentConstants.ADD_CURRENT_SEARCH,
-      this.updateSearchParams,
+      updateSearchParams,
     )
     SegmentStore.addListener(
       SegmentConstants.REMOVE_SEARCH_RESULTS,
-      this.removeSearchParams,
+      removeSearchParams,
     )
-    SegmentStore.addListener(SegmentConstants.FOCUS_TAGS, this.focusTag)
+    SegmentStore.addListener(SegmentConstants.FOCUS_TAGS, focusTag)
     CatToolStore.addListener(
       CatToolConstants.TOGGLE_PH_TAGS_COMPRESSED,
-      this.onPhTagsCompressedToggle,
+      onPhTagsCompressedToggle,
     )
 
-    const textSpanDisplayed =
-      this.tagRef && this.tagRef.querySelector('span[data-text="true"]')
-    const shouldTooltipOnHover =
-      textSpanDisplayed &&
-      textSpanDisplayed.offsetWidth < textSpanDisplayed.scrollWidth
-    this.setState({shouldTooltipOnHover})
-  }
-
-  shouldComponentUpdate() {
-    return true
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.entitykey !== this.props.entityKey) {
-      const textSpanDisplayed =
-        this.tagRef && this.tagRef.querySelector('span[data-text="true"]')
-      const shouldTooltipOnHover =
-        textSpanDisplayed &&
-        textSpanDisplayed.offsetWidth < textSpanDisplayed.scrollWidth
-      if (shouldTooltipOnHover !== this.state.shouldTooltipOnHover) {
-        this.setState({shouldTooltipOnHover})
-      }
+    const shouldTooltipOnHover = measureShouldTooltipOnHover(tagRef.current)
+    if (shouldTooltipOnHover !== liveRef.current.state.shouldTooltipOnHover) {
+      patchState({shouldTooltipOnHover})
     }
-  }
 
-  componentWillUnmount() {
-    SegmentStore.removeListener(
-      SegmentConstants.SET_SEGMENT_WARNINGS,
-      this.updateTagWarningStyleDebounced,
-    )
-    SegmentStore.removeListener(
-      SegmentConstants.HIGHLIGHT_TAGS,
-      this.highlightTags,
-    )
-    SegmentStore.removeListener(
-      EditAreaConstants.EDIT_AREA_CHANGED,
-      this.updateTagStyleDebounced,
-    )
-    SegmentStore.removeListener(
-      SegmentConstants.ADD_SEARCH_RESULTS,
-      this.addSearchParams,
-    )
-    SegmentStore.removeListener(
-      SegmentConstants.ADD_CURRENT_SEARCH,
-      this.updateSearchParams,
-    )
-    SegmentStore.removeListener(
-      SegmentConstants.REMOVE_SEARCH_RESULTS,
-      this.removeSearchParams,
-    )
-    SegmentStore.removeListener(SegmentConstants.FOCUS_TAGS, this.focusTag)
-    CatToolStore.removeListener(
-      CatToolConstants.TOGGLE_PH_TAGS_COMPRESSED,
-      this.onPhTagsCompressedToggle,
-    )
-  }
-
-  getChildrenContent(index, entityName, pcRole) {
-    const {phTagsCompressed} = this.state
-    const isPhTag = entityName === 'ph'
-
-    if (isPhTag && index >= 0) {
-      // A closing pc tag always shows only its number (never the equiv-text /
-      // closing content). An opening tag shows its content unless compressed.
-      const isPcClose = pcRole === 'close'
-      return (
-        <>
-          <span className="index-counter">{index + 1}</span>
-          {!phTagsCompressed && !isPcClose && this.props.children}
-        </>
+    return () => {
+      SegmentStore.removeListener(
+        SegmentConstants.SET_SEGMENT_WARNINGS,
+        updateTagWarningStyleDebounced,
+      )
+      SegmentStore.removeListener(
+        SegmentConstants.HIGHLIGHT_TAGS,
+        highlightTags,
+      )
+      SegmentStore.removeListener(
+        EditAreaConstants.EDIT_AREA_CHANGED,
+        updateTagStyleDebounced,
+      )
+      SegmentStore.removeListener(
+        SegmentConstants.ADD_SEARCH_RESULTS,
+        addSearchParams,
+      )
+      SegmentStore.removeListener(
+        SegmentConstants.ADD_CURRENT_SEARCH,
+        updateSearchParams,
+      )
+      SegmentStore.removeListener(
+        SegmentConstants.REMOVE_SEARCH_RESULTS,
+        removeSearchParams,
+      )
+      SegmentStore.removeListener(SegmentConstants.FOCUS_TAGS, focusTag)
+      CatToolStore.removeListener(
+        CatToolConstants.TOGGLE_PH_TAGS_COMPRESSED,
+        onPhTagsCompressedToggle,
       )
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
-    return this.props.children
-  }
+  // componentDidUpdate: no dependency array, so it runs after every committed
+  // render but not on mount, and re-measures the overflow the same way.
+  const prevPropsRef = useRef(null)
+  useEffect(() => {
+    const prevProps = prevPropsRef.current
+    prevPropsRef.current = props
+    if (!prevProps) return
 
-  render() {
-    const {children, entityKey, contentState, getUpdatedSegmentInfo} =
-      this.props
-    const {
-      tagStyle,
-      tagWarningStyle,
-      tooltipAvailable,
-      shouldTooltipOnHover,
-      searchParams,
-      focused,
-    } = this.state
-    const {markSearch} = this
-    const style =
-      this.props.entityKey === this.state.entityKey
-        ? tagStyle
-        : this.selectCorrectStyle()
-    const {openSplit} = getUpdatedSegmentInfo()
-    const {
-      data: {
-        id: entityId,
-        placeholder: entityPlaceholder,
-        index,
-        name: entityName,
-        pcRole,
-      },
-    } = contentState.getEntity(entityKey)
-    const decoratedText = Array.isArray(children)
-      ? children[0].props.text
-      : children.props.decoratedText
+    if (prevProps.entityKey !== entityKey) {
+      const shouldTooltipOnHover = measureShouldTooltipOnHover(tagRef.current)
+      if (shouldTooltipOnHover !== liveRef.current.state.shouldTooltipOnHover) {
+        patchState({shouldTooltipOnHover})
+      }
+    }
+  })
 
-    const {phTagsCompressed} = this.state
-    const isCompressedPh = entityName === 'ph' && phTagsCompressed && index >= 0
-    const pcRoleClass = entityName === 'ph' && pcRole ? ` tag-pc-${pcRole}` : ''
-    // A closing pc tag shows only its number, so it never needs a content tooltip.
-    const isPcClose = entityName === 'ph' && pcRole === 'close'
-    const showTooltip =
-      ((shouldTooltipOnHover && tooltipAvailable) || isCompressedPh) &&
-      !isPcClose
-
-    return (
-      <Tooltip
-        stylePointerElement={{display: 'inline-block', position: 'relative'}}
-        content={
-          showTooltip && (
-            <span className={`tag ${style}`}>
-              <span>{entityPlaceholder}</span>
-            </span>
-          )
-        }
-      >
-        <div ref={this.contentRef} className={'tag-container'}>
-          <span
-            ref={(ref) => (this.tagRef = ref)}
-            className={`tag ${style}${
-              focused ? ' tag-focused' : ''
-            }${isCompressedPh ? ' tag-compressed' : ''}${pcRoleClass} ${tagWarningStyle}`}
-            data-offset-key={this.props.offsetkey}
-            unselectable="on"
-            suppressContentEditableWarning={true}
-            onClick={(e) => {
-              e.stopPropagation()
-              this.onClickBound()
-              !openSplit &&
-                setTimeout(() => {
-                  SegmentActions.highlightTags(
-                    entityId,
-                    entityPlaceholder,
-                    entityKey,
-                  )
-                })
-              this.focusedState.current = {
-                skipTmOut: true,
-              }
-            }}
-          >
-            {searchParams.active && markSearch(decoratedText, searchParams)}
-            {searchParams.active ? (
-              <span style={{display: 'none'}}>
-                {this.getChildrenContent(index, entityName, pcRole)}
-              </span>
-            ) : (
-              this.getChildrenContent(index, entityName, pcRole)
-            )}
-          </span>
-        </div>
-      </Tooltip>
-    )
-  }
-
-  onClickBound = () => {
-    const {
-      start,
-      end,
-      onClick: onClickAction,
-      entityKey,
-      contentState,
-    } = this.props
+  const onClickBound = () => {
     const {
       data: {name: entityName},
     } = contentState.getEntity(entityKey)
-    onClickAction(start, end, entityName)
+    onClick(start, end, entityName)
   }
 
-  highlightTags = (tagId, tagPlaceholder, triggerEntityKey) => {
-    const {entityKey, contentState} = this.props
-    const {clicked} = this.state
-    const {
-      data: {id: entityId, placeholder: entityPlaceholder},
-    } = contentState.getEntity(entityKey)
-    // Turn OFF
-    if (clicked && (!tagId || tagId !== entityId)) {
-      this.setState({
-        tagStyle: this.selectCorrectStyle(),
-        clicked: false,
-        entityKey,
-      })
-    } else if (entityKey === triggerEntityKey) {
-      this.setState({
-        tagStyle: this.selectCorrectStyle(tagId, tagPlaceholder, true),
-        clicked: true,
-        entityKey,
-      })
-    } else if (
-      tagId === entityId &&
-      entityPlaceholder === tagPlaceholder &&
-      entityKey !== triggerEntityKey
-    ) {
-      this.setState({
-        tagStyle: this.selectCorrectStyle(tagId, tagPlaceholder),
-        clicked: true,
-        entityKey,
-      })
-    }
-  }
+  const {
+    tagStyle,
+    tagWarningStyle,
+    tooltipAvailable,
+    shouldTooltipOnHover,
+    searchParams,
+    focused,
+    phTagsCompressed,
+  } = state
 
-  updateTagStyle = (sid, isTarget) => {
-    if (!this.props.isTarget && isTarget) return
-    const {selectCorrectStyle} = this
-    const newStyle = selectCorrectStyle()
-    if (newStyle !== this.state.tagStyle) {
-      this.setState({
-        tagStyle: newStyle,
-        entityKey: this.props.entityKey,
-      })
-    }
-  }
+  const style =
+    entityKey === state.entityKey ? tagStyle : selectCorrectStyle(props)
+  const {openSplit} = getUpdatedSegmentInfo()
+  const {
+    data: {
+      id: entityId,
+      placeholder: entityPlaceholder,
+      index,
+      name: entityName,
+      pcRole,
+    },
+  } = contentState.getEntity(entityKey)
+  const decoratedText = Array.isArray(children)
+    ? children[0].props.text
+    : children.props.decoratedText
 
-  updateTagWarningStyle = () => {
-    const {tagWarningStyle: prevTagWarningStyle} = this.state
-    const tagWarningStyle = this.highlightOnWarnings()
-    if (prevTagWarningStyle !== tagWarningStyle) {
-      this.setState({tagWarningStyle})
-    }
-  }
+  const isCompressedPh = entityName === 'ph' && phTagsCompressed && index >= 0
+  const pcRoleClass = entityName === 'ph' && pcRole ? ` tag-pc-${pcRole}` : ''
+  // A closing pc tag shows only its number, so it never needs a content tooltip.
+  const isPcClose = entityName === 'ph' && pcRole === 'close'
+  const showTooltip =
+    ((shouldTooltipOnHover && tooltipAvailable) || isCompressedPh) && !isPcClose
 
-  selectCorrectStyle = (clickedTagId = null, clickedTagText = null) => {
-    const {entityKey, contentState, getUpdatedSegmentInfo, isRTL} = this.props
-    const {segmentOpened} = getUpdatedSegmentInfo()
-    const {
-      data: {id: entityId, placeholder: entityPlaceholder, name: entityName},
-    } = contentState.getEntity(entityKey)
-
-    // Basic style accordin to language direction
-    const baseStyle =
-      tagSignatures[entityName] &&
-      (isRTL && tagSignatures[entityName].styleRTL
-        ? tagSignatures[entityName].styleRTL
-        : tagSignatures[entityName].style)
-
-    // Check if tag is in an active segment
-    const tagInactive = !segmentOpened ? 'tag-inactive' : ''
-
-    // Click
-    const tagClicked =
-      entityId &&
-      clickedTagId &&
-      clickedTagId === entityId &&
-      clickedTagText &&
-      clickedTagText === entityPlaceholder
-        ? 'tag-clicked'
-        : '' // green
-
-    return `${baseStyle} ${tagInactive} ${tagClicked}`.trim()
-  }
-
-  focusTag = ({tagsSelected}) => {
-    const {skipTmOut, tmOut} = this.focusedState.current
-    if (tmOut) clearTimeout(tmOut)
-    this.focusedState.current = {}
-
-    if (!tagsSelected?.length) {
-      // reset
-      this.setState({
-        focused: false,
-      })
-      return
-    }
-
-    const updateState = () => {
-      this.setState({
-        focused: tagsSelected.some(
-          ({entityKey}) => entityKey === this.props.entityKey,
-        ),
-      })
-    }
-
-    if (!skipTmOut) {
-      this.focusedState.current.tmOut = setTimeout(() => updateState(), 100)
-    } else {
-      updateState()
-    }
-  }
-
-  highlightOnWarnings = () => {
-    const {getUpdatedSegmentInfo, contentState, entityKey, isTarget} =
-      this.props
-    const {tagMismatch, segmentOpened, missingTagsInTarget} =
-      getUpdatedSegmentInfo()
-    const {data: entityData} = contentState.getEntity(entityKey) || {}
-
-    if (!segmentOpened) return
-    const {encodedText} = entityData
-
-    // pc (compressible) tags: the QA endpoint can't tell missing closing tags
-    // apart (every one converts to the same generic `</pc>` markup), so
-    // matching by reported string content doesn't work here. missingTagsInTarget
-    // is computed client-side by tag identity/numbering instead (see
-    // checkForMissingTag.js) and is exact, since its entries are the source's
-    // own tag objects.
-    if (classifyPcPhTag(encodedText)) {
-      if (isTarget) return ''
-      const isMissingInTarget = (missingTagsInTarget || []).some(
-        (tag) => tag?.data?.encodedText === encodedText,
-      )
-      return isMissingInTarget ? 'tag-mismatch-error' : ''
-    }
-
-    if (!tagMismatch) return
-    let tagWarningStyle = ''
-    if (tagMismatch.target && tagMismatch.target.length > 0 && isTarget) {
-      // Todo: Check tag type and tag id instead of string
-      tagMismatch.target.forEach((tagString) => {
-        if (encodedText === tagString) {
-          tagWarningStyle = 'tag-mismatch-error'
-        }
-      })
-    } else if (
-      tagMismatch.source &&
-      tagMismatch.source.length > 0 &&
-      !isTarget
-    ) {
-      tagMismatch.source.forEach((tagString) => {
-        if (encodedText === tagString) {
-          tagWarningStyle = 'tag-mismatch-error'
-        }
-      })
-    } else if (tagMismatch.order && isTarget) {
-      tagMismatch.order.forEach((tagString) => {
-        if (encodedText === tagString) {
-          tagWarningStyle = 'tag-mismatch-warning'
-        }
-      })
-    }
-    return tagWarningStyle
-  }
+  return (
+    <Tooltip
+      stylePointerElement={{display: 'inline-block', position: 'relative'}}
+      content={
+        showTooltip && (
+          <span className={`tag ${style}`}>
+            <span>{entityPlaceholder}</span>
+          </span>
+        )
+      }
+    >
+      <div ref={contentRef} className={'tag-container'}>
+        <span
+          ref={tagRef}
+          className={`tag ${style}${focused ? ' tag-focused' : ''}${
+            isCompressedPh ? ' tag-compressed' : ''
+          }${pcRoleClass} ${tagWarningStyle}`}
+          data-offset-key={offsetkey}
+          unselectable="on"
+          suppressContentEditableWarning={true}
+          onClick={(e) => {
+            e.stopPropagation()
+            onClickBound()
+            !openSplit &&
+              setTimeout(() => {
+                SegmentActions.highlightTags(
+                  entityId,
+                  entityPlaceholder,
+                  entityKey,
+                )
+              })
+            focusedState.current = {
+              skipTmOut: true,
+            }
+          }}
+        >
+          {searchParams.active &&
+            markSearch(decoratedText, searchParams, props)}
+          {searchParams.active ? (
+            <span style={{display: 'none'}}>
+              {getChildrenContent(index, entityName, pcRole, {
+                phTagsCompressed,
+                children,
+              })}
+            </span>
+          ) : (
+            getChildrenContent(index, entityName, pcRole, {
+              phTagsCompressed,
+              children,
+            })
+          )}
+        </span>
+      </div>
+    </Tooltip>
+  )
 }
 
 export default TagEntity

--- a/public/js/components/segments/TagEntity/TagEntity.component.test.js
+++ b/public/js/components/segments/TagEntity/TagEntity.component.test.js
@@ -47,6 +47,11 @@ const makeContentState = (entityData) => ({
   getEntity: jest.fn(() => ({data: entityData})),
 })
 
+// Draft.js hands the entity an array of decorated leaves; the component reads
+// `children[0].props.text` off it. A component (rather than a bare span with a
+// `text` attribute) keeps that shape without emitting unknown-prop DOM warnings.
+const Leaf = ({text}) => <span>{text}</span>
+
 const baseProps = (overrides = {}) => ({
   entityKey: '1',
   offsetkey: '1-0-0',
@@ -69,505 +74,565 @@ const baseProps = (overrides = {}) => ({
   start: 0,
   end: 1,
   onClick: jest.fn(),
-  children: <span>{'<ph/>'}</span>,
+  children: [<Leaf key="0" text="hello" />],
   ...overrides,
+})
+
+const renderTag = (overrides) => render(<TagEntity {...baseProps(overrides)} />)
+
+// The component registers its store listeners on mount; picking them back out of
+// the mock is how these tests drive the behaviour those listeners own. This works
+// the same whether the listener is a bound class method or a hook callback.
+const listenerFor = (store, constant) => {
+  const call = store.addListener.mock.calls.find(([c]) => c === constant)
+  if (!call) throw new Error(`no listener registered for ${String(constant)}`)
+  return call[1]
+}
+
+const tagEl = () => document.querySelector('.tag-container .tag')
+const tagClass = () => tagEl().getAttribute('class')
+
+// `updateTagStyle` and `updateTagWarningStyle` are registered debounced (500ms).
+const flushDebounce = () => {
+  act(() => {
+    jest.advanceTimersByTime(500)
+  })
+}
+
+beforeEach(() => {
+  CatToolStore.isPhTagsCompressed.mockReturnValue(false)
 })
 
 afterEach(() => {
   jest.clearAllMocks()
 })
 
-describe('TagEntity constructor', () => {
-  test('marks tooltipAvailable true for tags with showTooltip enabled (ph)', () => {
-    const instance = new TagEntity(baseProps())
-    expect(instance.state.tooltipAvailable).toBe(true)
-  })
-
-  test('marks tooltipAvailable false for tags with showTooltip disabled', () => {
-    const instance = new TagEntity(
-      baseProps({
-        contentState: makeContentState({id: 'e2', name: 'gSc'}),
-      }),
-    )
-    expect(instance.state.tooltipAvailable).toBe(false)
-  })
-})
-
-describe('TagEntity.selectCorrectStyle', () => {
+describe('TagEntity tag styling', () => {
   test('uses the LTR style by default', () => {
-    const instance = new TagEntity(baseProps())
-    expect(instance.selectCorrectStyle()).toContain('tag-selfclosed tag-ph')
+    renderTag()
+    expect(tagClass()).toContain('tag-selfclosed tag-ph')
   })
 
   test('uses the RTL style when isRTL and a styleRTL is defined', () => {
-    const instance = new TagEntity(
-      baseProps({
-        isRTL: true,
-        contentState: makeContentState({id: 'g1', name: 'g'}),
-      }),
-    )
-    expect(instance.selectCorrectStyle()).toContain('tag-close')
+    renderTag({
+      isRTL: true,
+      contentState: makeContentState({id: 'g1', name: 'g'}),
+    })
+    expect(tagClass()).toContain('tag-close')
   })
 
   test('adds tag-inactive when the segment is not opened', () => {
-    const instance = new TagEntity(
-      baseProps({
-        getUpdatedSegmentInfo: jest.fn(() => ({segmentOpened: false})),
-      }),
-    )
-    expect(instance.selectCorrectStyle()).toContain('tag-inactive')
-  })
-
-  test('adds tag-clicked when the clicked tag id/text match this entity', () => {
-    const instance = new TagEntity(baseProps())
-    expect(instance.selectCorrectStyle('e1', 'PH')).toContain('tag-clicked')
-  })
-
-  test('does not add tag-clicked when the clicked tag id does not match', () => {
-    const instance = new TagEntity(baseProps())
-    expect(instance.selectCorrectStyle('other', 'PH')).not.toContain(
-      'tag-clicked',
-    )
+    renderTag({
+      getUpdatedSegmentInfo: jest.fn(() => ({segmentOpened: false})),
+    })
+    expect(tagClass()).toContain('tag-inactive')
   })
 })
 
-describe('TagEntity.getChildrenContent', () => {
+describe('TagEntity children content', () => {
   test('shows the index counter and children for an open ph tag', () => {
-    const instance = new TagEntity(baseProps())
-    const content = instance.getChildrenContent(2, 'ph', undefined)
-    const {container} = render(<div>{content}</div>)
-    expect(container.querySelector('.index-counter').textContent).toBe('3')
+    renderTag({
+      contentState: makeContentState({
+        id: 'e1',
+        placeholder: 'PH',
+        index: 2,
+        name: 'ph',
+      }),
+    })
+    expect(document.querySelector('.index-counter').textContent).toBe('3')
+    expect(tagEl().textContent).toContain('hello')
   })
 
   test('hides children content when ph tags are compressed', () => {
-    const instance = new TagEntity(baseProps())
-    instance.state.phTagsCompressed = true
-    const content = instance.getChildrenContent(0, 'ph', undefined)
-    const {container} = render(<div>{content}</div>)
-    expect(container.querySelector('.index-counter')).toBeTruthy()
-    expect(container.textContent).toBe('1')
+    CatToolStore.isPhTagsCompressed.mockReturnValue(true)
+    renderTag()
+    expect(document.querySelector('.index-counter')).toBeTruthy()
+    expect(tagEl().textContent).toBe('1')
   })
 
   test('a closing pc tag never shows its content, even uncompressed', () => {
-    const instance = new TagEntity(baseProps())
-    const content = instance.getChildrenContent(0, 'ph', 'close')
-    const {container} = render(<div>{content}</div>)
-    expect(container.textContent).toBe('1')
+    renderTag({
+      contentState: makeContentState({
+        id: 'e1',
+        placeholder: 'PH',
+        index: 0,
+        name: 'ph',
+        pcRole: 'close',
+      }),
+    })
+    expect(tagEl().textContent).toBe('1')
   })
 
-  test('returns raw children for non-ph tags', () => {
-    const instance = new TagEntity(baseProps())
-    const content = instance.getChildrenContent(-1, 'g', undefined)
-    expect(content).toBe(instance.props.children)
+  test('renders raw children without an index counter for non-ph tags', () => {
+    renderTag({
+      contentState: makeContentState({id: 'g1', index: -1, name: 'g'}),
+    })
+    expect(document.querySelector('.index-counter')).toBeNull()
+    expect(tagEl().textContent).toContain('hello')
+  })
+
+  test('adds the pc role class for a pc tag', () => {
+    renderTag({
+      contentState: makeContentState({
+        id: 'e1',
+        placeholder: 'PH',
+        index: 0,
+        name: 'ph',
+        pcRole: 'open',
+      }),
+    })
+    expect(tagClass()).toContain('tag-pc-open')
   })
 })
 
-describe('TagEntity.markSearch', () => {
-  test('returns the raw text when search is not active', () => {
-    const instance = new TagEntity(baseProps())
-    const result = instance.markSearch('hello', {active: false})
-    expect(result).toBe('hello')
+describe('TagEntity search highlighting', () => {
+  const activeSearch = (overrides = {}) => ({
+    active: true,
+    currentActive: true,
+    textToReplace: 'ell',
+    params: {ingnoreCase: true, exactMatch: false},
+    occurrences: [{searchProgressiveIndex: 1, matchPosition: 0}],
+    currentInSearchIndex: 1,
+    ...overrides,
+  })
+
+  test('does not highlight anything when search is not active', () => {
+    renderTag()
+    expect(tagEl().querySelector('span[style]')).toBeNull()
+    expect(SearchUtils.getSearchRegExp).not.toHaveBeenCalled()
   })
 
   test('wraps matches and flags the current occurrence via SegmentActions', () => {
-    const instance = new TagEntity(baseProps({start: 0, end: 5}))
-    const searchParams = {
-      active: true,
-      currentActive: true,
-      textToReplace: 'ell',
-      params: {ingnoreCase: true, exactMatch: false},
-      occurrences: [{searchProgressiveIndex: 1, matchPosition: 0}],
-      currentInSearchIndex: 1,
-    }
-
-    const result = instance.markSearch('hello', searchParams)
+    renderTag({
+      start: 0,
+      end: 5,
+      getSearchParams: jest.fn(() => activeSearch()),
+    })
 
     expect(SegmentActions.setIsCurrentSearchOccurrenceTag).toHaveBeenCalledWith(
       true,
     )
     expect(SearchUtils.getSearchRegExp).toHaveBeenCalledWith('ell', true, false)
-    expect(Array.isArray(result)).toBe(true)
+    expect(tagEl().querySelector('span[style]')).toBeTruthy()
   })
 
-  test('does not flag current occurrence when match position is outside the tag range', () => {
-    const instance = new TagEntity(baseProps({start: 10, end: 15}))
-    const searchParams = {
-      active: true,
-      currentActive: true,
-      textToReplace: 'ell',
-      params: {ingnoreCase: true, exactMatch: false},
-      occurrences: [{searchProgressiveIndex: 1, matchPosition: 0}],
-      currentInSearchIndex: 1,
-    }
-
-    instance.markSearch('hello', searchParams)
+  test('does not flag the current occurrence when the match is outside the tag range', () => {
+    renderTag({
+      start: 10,
+      end: 15,
+      getSearchParams: jest.fn(() => activeSearch()),
+    })
 
     expect(
       SegmentActions.setIsCurrentSearchOccurrenceTag,
     ).not.toHaveBeenCalled()
   })
+
+  test('keeps a hidden copy of the tag content while search is active', () => {
+    renderTag({
+      start: 0,
+      end: 5,
+      getSearchParams: jest.fn(() => activeSearch()),
+    })
+
+    const hidden = tagEl().querySelector('span[style*="display: none"]')
+    expect(hidden).toBeTruthy()
+    expect(hidden.textContent).toContain('hello')
+  })
 })
 
 describe('TagEntity search param listeners', () => {
-  test('addSearchParams ignores updates for a different segment', () => {
-    const getSearchParams = jest.fn(() => ({active: true, isTarget: true}))
-    const instance = new TagEntity(
-      baseProps({sid: 1, isTarget: true, getSearchParams}),
-    )
-    jest.spyOn(instance, 'setState')
+  test('ignores an ADD_SEARCH_RESULTS event for a different segment', () => {
+    const getSearchParams = jest
+      .fn()
+      .mockReturnValueOnce({active: false})
+      .mockReturnValue({active: true, isTarget: true, textToReplace: 'ell'})
+    renderTag({sid: 1, isTarget: true, getSearchParams})
 
-    instance.addSearchParams(2)
-
-    expect(instance.setState).not.toHaveBeenCalled()
-  })
-
-  test('addSearchParams updates state when the search targets this segment/side', () => {
-    const searchParams = {active: true, isTarget: true}
-    const getSearchParams = jest.fn(() => searchParams)
-    const instance = new TagEntity(
-      baseProps({sid: 1, isTarget: true, getSearchParams}),
-    )
-    jest.spyOn(instance, 'setState')
-
-    instance.addSearchParams(1)
-
-    expect(instance.setState).toHaveBeenCalledWith({searchParams})
-  })
-
-  test('updateSearchParams ignores when search is not active for this segment', () => {
-    const instance = new TagEntity(
-      baseProps({
-        sid: 1,
-        getSearchParams: jest.fn(() => ({active: false})),
-      }),
-    )
-    jest.spyOn(instance, 'setState')
-
-    instance.updateSearchParams(1, 3)
-
-    expect(instance.setState).not.toHaveBeenCalled()
-  })
-
-  test('updateSearchParams updates the current search index when active', () => {
-    const instance = new TagEntity(baseProps({sid: 1}))
-    instance.state.searchParams = {active: true}
-    const getSearchParams = jest.fn(() => ({active: true}))
-    instance.props.getSearchParams = getSearchParams
-    jest.spyOn(instance, 'setState')
-
-    instance.updateSearchParams(1, 5)
-
-    expect(instance.setState).toHaveBeenCalledWith({
-      searchParams: {active: true, currentInSearchIndex: 5},
+    act(() => {
+      listenerFor(SegmentStore, SegmentConstants.ADD_SEARCH_RESULTS)(2)
     })
+
+    expect(tagEl().querySelector('span[style]')).toBeNull()
   })
 
-  test('removeSearchParams refreshes state only when search was active', () => {
-    const searchParams = {active: false}
-    const instance = new TagEntity(
-      baseProps({getSearchParams: jest.fn(() => searchParams)}),
+  test('applies an ADD_SEARCH_RESULTS event targeting this segment and side', () => {
+    const getSearchParams = jest.fn().mockReturnValue({
+      active: true,
+      isTarget: true,
+      currentActive: false,
+      textToReplace: 'ell',
+      params: {ingnoreCase: true, exactMatch: false},
+      occurrences: [],
+      currentInSearchIndex: 1,
+    })
+    renderTag({sid: 1, isTarget: true, getSearchParams})
+
+    act(() => {
+      listenerFor(SegmentStore, SegmentConstants.ADD_SEARCH_RESULTS)(1)
+    })
+
+    expect(tagEl().querySelector('span[style]')).toBeTruthy()
+  })
+
+  test('ignores an ADD_CURRENT_SEARCH event when search is not active here', () => {
+    const getSearchParams = jest.fn(() => ({active: false}))
+    renderTag({sid: 1, getSearchParams})
+
+    act(() => {
+      listenerFor(SegmentStore, SegmentConstants.ADD_CURRENT_SEARCH)(1, 3)
+    })
+
+    expect(tagEl().querySelector('span[style]')).toBeNull()
+  })
+
+  test('applies an ADD_CURRENT_SEARCH event when search is active here', () => {
+    const getSearchParams = jest.fn(() => ({
+      active: true,
+      currentActive: true,
+      textToReplace: 'ell',
+      params: {ingnoreCase: true, exactMatch: false},
+      occurrences: [{searchProgressiveIndex: 5, matchPosition: 0}],
+      currentInSearchIndex: 1,
+    }))
+    renderTag({sid: 1, start: 0, end: 5, getSearchParams})
+    SegmentActions.setIsCurrentSearchOccurrenceTag.mockClear()
+
+    act(() => {
+      listenerFor(SegmentStore, SegmentConstants.ADD_CURRENT_SEARCH)(1, 5)
+    })
+
+    // currentInSearchIndex is now 5, which matches the occurrence's
+    // searchProgressiveIndex, so this tag reports itself as the current one.
+    expect(SegmentActions.setIsCurrentSearchOccurrenceTag).toHaveBeenCalledWith(
+      true,
     )
-    instance.state.searchParams = {active: false}
-    jest.spyOn(instance, 'setState')
+  })
 
-    instance.removeSearchParams()
+  test('re-reads the search params on REMOVE_SEARCH_RESULTS while active', () => {
+    const getSearchParams = jest
+      .fn()
+      .mockReturnValueOnce({
+        active: true,
+        currentActive: false,
+        textToReplace: 'ell',
+        params: {ingnoreCase: true, exactMatch: false},
+        occurrences: [],
+        currentInSearchIndex: 1,
+      })
+      .mockReturnValue({active: false})
+    renderTag({getSearchParams})
+    expect(tagEl().querySelector('span[style]')).toBeTruthy()
 
-    expect(instance.setState).not.toHaveBeenCalled()
+    act(() => {
+      listenerFor(SegmentStore, SegmentConstants.REMOVE_SEARCH_RESULTS)()
+    })
 
-    instance.state.searchParams = {active: true}
-    instance.removeSearchParams()
-
-    expect(instance.setState).toHaveBeenCalledWith({searchParams})
+    expect(tagEl().querySelector('span[style]')).toBeNull()
   })
 })
 
-describe('TagEntity.onPhTagsCompressedToggle', () => {
-  test('reads the compressed flag from CatToolStore', () => {
+describe('TagEntity ph compression toggle', () => {
+  test('re-reads the compressed flag when the store toggles it', () => {
+    renderTag()
+    expect(tagEl().textContent).toContain('hello')
+
     CatToolStore.isPhTagsCompressed.mockReturnValue(true)
-    const instance = new TagEntity(baseProps())
-    jest.spyOn(instance, 'setState')
+    act(() => {
+      listenerFor(CatToolStore, CatToolConstants.TOGGLE_PH_TAGS_COMPRESSED)()
+    })
 
-    instance.onPhTagsCompressedToggle()
-
-    expect(instance.setState).toHaveBeenCalledWith({phTagsCompressed: true})
+    expect(tagClass()).toContain('tag-compressed')
+    expect(tagEl().textContent).toBe('1')
   })
 })
 
-describe('TagEntity lifecycle', () => {
-  test('componentDidMount registers store listeners', () => {
-    const instance = new TagEntity(baseProps())
-    instance.setState = jest.fn()
-    instance.componentDidMount()
-
-    expect(SegmentStore.addListener).toHaveBeenCalledWith(
-      SegmentConstants.SET_SEGMENT_WARNINGS,
-      instance.updateTagWarningStyleDebounced,
-    )
-    expect(SegmentStore.addListener).toHaveBeenCalledWith(
-      SegmentConstants.HIGHLIGHT_TAGS,
-      instance.highlightTags,
-    )
-    expect(SegmentStore.addListener).toHaveBeenCalledWith(
-      EditAreaConstants.EDIT_AREA_CHANGED,
-      instance.updateTagStyleDebounced,
-    )
-    expect(SegmentStore.addListener).toHaveBeenCalledWith(
-      SegmentConstants.ADD_SEARCH_RESULTS,
-      instance.addSearchParams,
-    )
-    expect(SegmentStore.addListener).toHaveBeenCalledWith(
-      SegmentConstants.ADD_CURRENT_SEARCH,
-      instance.updateSearchParams,
-    )
-    expect(SegmentStore.addListener).toHaveBeenCalledWith(
-      SegmentConstants.REMOVE_SEARCH_RESULTS,
-      instance.removeSearchParams,
-    )
-    expect(SegmentStore.addListener).toHaveBeenCalledWith(
-      SegmentConstants.FOCUS_TAGS,
-      instance.focusTag,
-    )
-    expect(CatToolStore.addListener).toHaveBeenCalledWith(
-      CatToolConstants.TOGGLE_PH_TAGS_COMPRESSED,
-      instance.onPhTagsCompressedToggle,
-    )
-  })
-
-  test('componentWillUnmount removes all listeners added in componentDidMount', () => {
-    const instance = new TagEntity(baseProps())
-    instance.componentWillUnmount()
-
-    expect(SegmentStore.removeListener).toHaveBeenCalledWith(
-      SegmentConstants.SET_SEGMENT_WARNINGS,
-      instance.updateTagWarningStyleDebounced,
-    )
-    expect(SegmentStore.removeListener).toHaveBeenCalledWith(
-      SegmentConstants.FOCUS_TAGS,
-      instance.focusTag,
-    )
-    expect(CatToolStore.removeListener).toHaveBeenCalledWith(
-      CatToolConstants.TOGGLE_PH_TAGS_COMPRESSED,
-      instance.onPhTagsCompressedToggle,
-    )
-  })
-
-  test('shouldComponentUpdate always returns true', () => {
-    const instance = new TagEntity(baseProps())
-    expect(instance.shouldComponentUpdate()).toBe(true)
-  })
-
-  test('componentDidUpdate recomputes shouldTooltipOnHover on entity change', () => {
-    const instance = new TagEntity(baseProps())
-    instance.tagRef = {
-      querySelector: jest.fn(() => ({offsetWidth: 10, scrollWidth: 20})),
-    }
-    instance.state.shouldTooltipOnHover = false
-    jest.spyOn(instance, 'setState')
-
-    instance.componentDidUpdate({entitykey: 'previous'})
-
-    expect(instance.setState).toHaveBeenCalledWith({shouldTooltipOnHover: true})
-  })
-})
-
-describe('TagEntity.onClickBound', () => {
-  test('invokes the onClick prop with start, end and entity name', () => {
-    const onClick = jest.fn()
-    const instance = new TagEntity(
-      baseProps({onClick, start: 3, end: 8}),
-    )
-
-    instance.onClickBound()
-
-    expect(onClick).toHaveBeenCalledWith(3, 8, 'ph')
-  })
-})
-
-describe('TagEntity.highlightTags', () => {
-  test('turns off the clicked style when a different tag id is targeted', () => {
-    const instance = new TagEntity(baseProps())
-    instance.state.clicked = true
-    jest.spyOn(instance, 'setState')
-
-    instance.highlightTags('other-id', 'ph', 'some-key')
-
-    expect(instance.setState).toHaveBeenCalledWith(
-      expect.objectContaining({clicked: false}),
-    )
-  })
+describe('TagEntity highlightTags', () => {
+  const highlight = (...args) =>
+    act(() => {
+      listenerFor(SegmentStore, SegmentConstants.HIGHLIGHT_TAGS)(...args)
+    })
 
   test('turns on the clicked style when this entity is the trigger', () => {
-    const instance = new TagEntity(baseProps())
-
-    jest.spyOn(instance, 'setState')
-
-    instance.highlightTags('e1', 'PH', '1')
-
-    expect(instance.setState).toHaveBeenCalledWith(
-      expect.objectContaining({clicked: true}),
-    )
+    renderTag()
+    highlight('e1', 'PH', '1')
+    expect(tagClass()).toContain('tag-clicked')
   })
 
   test('turns on the clicked style for a matching sibling entity', () => {
-    const instance = new TagEntity(baseProps())
-    jest.spyOn(instance, 'setState')
+    renderTag()
+    highlight('e1', 'PH', 'different-key')
+    expect(tagClass()).toContain('tag-clicked')
+  })
 
-    instance.highlightTags('e1', 'PH', 'different-key')
+  test('turns off the clicked style when a different tag id is targeted', () => {
+    renderTag()
+    highlight('e1', 'PH', '1')
+    expect(tagClass()).toContain('tag-clicked')
 
-    expect(instance.setState).toHaveBeenCalledWith(
-      expect.objectContaining({clicked: true}),
-    )
+    highlight('other-id', 'ph', 'some-key')
+    expect(tagClass()).not.toContain('tag-clicked')
   })
 
   test('does nothing for an unrelated tag/entity combination', () => {
-    const instance = new TagEntity(baseProps())
-    jest.spyOn(instance, 'setState')
-
-    instance.highlightTags('other-id', 'OTHER', 'different-key')
-
-    expect(instance.setState).not.toHaveBeenCalled()
+    renderTag()
+    const before = tagClass()
+    highlight('other-id', 'OTHER', 'different-key')
+    expect(tagClass()).toBe(before)
   })
 })
 
-describe('TagEntity.updateTagStyle', () => {
-  test('skips the update when this is a source tag update for the target side', () => {
-    const instance = new TagEntity(baseProps({isTarget: false}))
-    jest.spyOn(instance, 'setState')
-
-    instance.updateTagStyle(1, true)
-
-    expect(instance.setState).not.toHaveBeenCalled()
-  })
-
-  test('updates state when the computed style differs', () => {
-    const instance = new TagEntity(baseProps({isTarget: true}))
-    instance.state.tagStyle = 'stale-style'
-    jest.spyOn(instance, 'setState')
-
-    instance.updateTagStyle(1, false)
-
-    expect(instance.setState).toHaveBeenCalledWith(
-      expect.objectContaining({tagStyle: expect.any(String)}),
-    )
-  })
-})
-
-describe('TagEntity.updateTagWarningStyle', () => {
-  test('sets the new warning style when it differs from the previous one', () => {
-    const instance = new TagEntity(
-      baseProps({
-        isTarget: true,
-        getUpdatedSegmentInfo: jest.fn(() => ({
-          segmentOpened: true,
-          tagMismatch: {target: ['x'], source: [], order: []},
-        })),
-        contentState: makeContentState({
-          id: 'e1',
-          name: 'ph',
-          encodedText: 'x',
-        }),
-      }),
-    )
-    jest.spyOn(instance, 'setState')
-
-    instance.updateTagWarningStyle()
-
-    expect(instance.setState).toHaveBeenCalledWith({
-      tagWarningStyle: 'tag-mismatch-error',
-    })
-  })
-})
-
-describe('TagEntity.focusTag', () => {
-  test('resets focus state when no tags are selected', () => {
-    const instance = new TagEntity(baseProps())
-    jest.spyOn(instance, 'setState')
-
-    instance.focusTag({tagsSelected: []})
-
-    expect(instance.setState).toHaveBeenCalledWith({focused: false})
-  })
-
-  test('updates focus synchronously when skipTmOut is set', () => {
-    const instance = new TagEntity(baseProps())
-    instance.focusedState.current = {skipTmOut: true}
-    jest.spyOn(instance, 'setState')
-
-    instance.focusTag({tagsSelected: [{entityKey: '1'}]})
-
-    expect(instance.setState).toHaveBeenCalledWith({focused: true})
-  })
-
-  test('defers focus update with a timeout otherwise', () => {
+describe('TagEntity edit-area style refresh', () => {
+  beforeEach(() => {
     jest.useFakeTimers()
-    const instance = new TagEntity(baseProps())
-    jest.spyOn(instance, 'setState')
+  })
 
-    instance.focusTag({tagsSelected: [{entityKey: 'not-this-one'}]})
+  afterEach(() => {
+    jest.useRealTimers()
+  })
 
-    expect(instance.setState).not.toHaveBeenCalled()
+  test('skips a target-side update on a source tag', () => {
+    const getUpdatedSegmentInfo = jest.fn(() => ({
+      segmentOpened: false,
+      tagMismatch: null,
+      missingTagsInTarget: [],
+      openSplit: false,
+    }))
+    renderTag({isTarget: false, getUpdatedSegmentInfo})
+    expect(tagClass()).toContain('tag-inactive')
+
+    // The segment opens, but the event is flagged as a target-side change, so a
+    // source tag must ignore it and keep its stale style.
+    getUpdatedSegmentInfo.mockReturnValue({
+      segmentOpened: true,
+      tagMismatch: null,
+      missingTagsInTarget: [],
+      openSplit: false,
+    })
+    act(() => {
+      listenerFor(SegmentStore, EditAreaConstants.EDIT_AREA_CHANGED)(1, true)
+    })
+    flushDebounce()
+
+    expect(tagClass()).toContain('tag-inactive')
+  })
+
+  test('recomputes the style when it differs', () => {
+    const getUpdatedSegmentInfo = jest.fn(() => ({
+      segmentOpened: false,
+      tagMismatch: null,
+      missingTagsInTarget: [],
+      openSplit: false,
+    }))
+    renderTag({isTarget: true, getUpdatedSegmentInfo})
+    expect(tagClass()).toContain('tag-inactive')
+
+    getUpdatedSegmentInfo.mockReturnValue({
+      segmentOpened: true,
+      tagMismatch: null,
+      missingTagsInTarget: [],
+      openSplit: false,
+    })
+    act(() => {
+      listenerFor(SegmentStore, EditAreaConstants.EDIT_AREA_CHANGED)(1, false)
+    })
+    flushDebounce()
+
+    expect(tagClass()).not.toContain('tag-inactive')
+  })
+})
+
+describe('TagEntity warning styling', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const fireWarnings = () => {
+    act(() => {
+      listenerFor(SegmentStore, SegmentConstants.SET_SEGMENT_WARNINGS)()
+    })
+    flushDebounce()
+  }
+
+  test('flags a target tag whose encoded text is in the target mismatch list', () => {
+    renderTag({
+      isTarget: true,
+      getUpdatedSegmentInfo: jest.fn(() => ({
+        segmentOpened: true,
+        tagMismatch: {target: ['x'], source: [], order: []},
+      })),
+      contentState: makeContentState({
+        id: 'e1',
+        placeholder: 'PH',
+        index: 0,
+        name: 'ph',
+        encodedText: 'x',
+      }),
+    })
+
+    fireWarnings()
+
+    expect(tagClass()).toContain('tag-mismatch-error')
+  })
+
+  test('flags an out-of-order target tag as a warning', () => {
+    renderTag({
+      isTarget: true,
+      getUpdatedSegmentInfo: jest.fn(() => ({
+        segmentOpened: true,
+        tagMismatch: {target: [], source: [], order: ['x']},
+      })),
+      contentState: makeContentState({
+        id: 'e1',
+        placeholder: 'PH',
+        index: 0,
+        name: 'ph',
+        encodedText: 'x',
+      }),
+    })
+
+    fireWarnings()
+
+    expect(tagClass()).toContain('tag-mismatch-warning')
+  })
+
+  test('leaves a tag unflagged when nothing mismatches', () => {
+    renderTag({
+      isTarget: true,
+      contentState: makeContentState({
+        id: 'e1',
+        placeholder: 'PH',
+        index: 0,
+        name: 'ph',
+        encodedText: 'x',
+      }),
+    })
+
+    fireWarnings()
+
+    expect(tagClass()).not.toContain('tag-mismatch')
+  })
+})
+
+describe('TagEntity focus handling', () => {
+  const focus = (payload) =>
+    act(() => {
+      listenerFor(SegmentStore, SegmentConstants.FOCUS_TAGS)(payload)
+    })
+
+  test('clears the focused style when no tags are selected', () => {
+    jest.useFakeTimers()
+    renderTag()
+
+    focus({tagsSelected: [{entityKey: '1'}]})
     act(() => {
       jest.advanceTimersByTime(100)
     })
-    expect(instance.setState).toHaveBeenCalledWith({focused: false})
+    expect(tagClass()).toContain('tag-focused')
+
+    focus({tagsSelected: []})
+    expect(tagClass()).not.toContain('tag-focused')
     jest.useRealTimers()
   })
 
-  test('clears a pending timeout before scheduling a new one', () => {
+  test('defers the focus update by 100ms', () => {
+    jest.useFakeTimers()
+    renderTag()
+
+    focus({tagsSelected: [{entityKey: '1'}]})
+    expect(tagClass()).not.toContain('tag-focused')
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(tagClass()).toContain('tag-focused')
+    jest.useRealTimers()
+  })
+
+  test('applies focus synchronously after a click sets skipTmOut', () => {
+    jest.useFakeTimers()
+    renderTag()
+
+    // Clicking the tag records skipTmOut, so the next focus event applies
+    // without waiting for the 100ms timeout.
+    fireEvent.click(tagEl())
+    focus({tagsSelected: [{entityKey: '1'}]})
+
+    expect(tagClass()).toContain('tag-focused')
+    jest.useRealTimers()
+  })
+
+  test('clears a pending focus timeout before scheduling a new one', () => {
     jest.useFakeTimers()
     const clearSpy = jest.spyOn(global, 'clearTimeout')
-    const instance = new TagEntity(baseProps())
-    instance.focusedState.current = {tmOut: 123}
+    renderTag()
 
-    instance.focusTag({tagsSelected: [{entityKey: '1'}]})
+    focus({tagsSelected: [{entityKey: 'not-this-one'}]})
+    focus({tagsSelected: [{entityKey: '1'}]})
 
-    expect(clearSpy).toHaveBeenCalledWith(123)
-    jest.useRealTimers()
+    // The second event must clear the timer the first one scheduled, otherwise
+    // the stale callback would land after it and overwrite the new focus state.
+    expect(clearSpy).toHaveBeenCalled()
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+    expect(tagClass()).toContain('tag-focused')
+
     clearSpy.mockRestore()
+    jest.useRealTimers()
   })
 })
 
-describe('TagEntity render', () => {
-  test('renders the tag content and triggers highlightTags on click', () => {
+describe('TagEntity click behaviour', () => {
+  test('calls the onClick prop with the tag range and entity name', () => {
+    const onClick = jest.fn()
+    renderTag({
+      start: 3,
+      end: 8,
+      onClick,
+      contentState: makeContentState({
+        id: 'e1',
+        placeholder: 'PH',
+        index: 0,
+        name: 'ph',
+      }),
+    })
+
+    fireEvent.click(tagEl())
+
+    expect(onClick).toHaveBeenCalledWith(3, 8, 'ph')
+  })
+
+  test('schedules highlightTags when no split is open', () => {
     jest.useFakeTimers()
-    render(
-      <TagEntity {...baseProps()}>
-        <span>{'<ph/>'}</span>
-      </TagEntity>,
-    )
+    renderTag()
 
-    const tagSpan = document.querySelector('.tag-container .tag')
-    expect(tagSpan).toBeTruthy()
-
-    fireEvent.click(tagSpan)
+    fireEvent.click(tagEl())
     act(() => {
       jest.runOnlyPendingTimers()
     })
 
-    expect(SegmentActions.highlightTags).toHaveBeenCalledWith(
-      'e1',
-      'PH',
-      '1',
-    )
+    expect(SegmentActions.highlightTags).toHaveBeenCalledWith('e1', 'PH', '1')
     jest.useRealTimers()
   })
 
   test('does not schedule highlightTags when a split is open', () => {
     jest.useFakeTimers()
-    render(
-      <TagEntity
-        {...baseProps({
-          getUpdatedSegmentInfo: jest.fn(() => ({
-            segmentOpened: true,
-            openSplit: true,
-          })),
-        })}
-      >
-        <span>{'<ph/>'}</span>
-      </TagEntity>,
-    )
+    renderTag({
+      getUpdatedSegmentInfo: jest.fn(() => ({
+        segmentOpened: true,
+        tagMismatch: null,
+        missingTagsInTarget: [],
+        openSplit: true,
+      })),
+    })
 
-    fireEvent.click(document.querySelector('.tag-container .tag'))
+    fireEvent.click(tagEl())
     act(() => {
       jest.runOnlyPendingTimers()
     })
@@ -575,25 +640,198 @@ describe('TagEntity render', () => {
     expect(SegmentActions.highlightTags).not.toHaveBeenCalled()
     jest.useRealTimers()
   })
+})
 
-  test('renders search matches with a hidden duplicate when search is active', () => {
-    render(
-      <TagEntity
-        {...baseProps({
-          getSearchParams: jest.fn(() => ({
-            active: true,
-            currentActive: false,
-            textToReplace: 'ph',
-            params: {ingnoreCase: true, exactMatch: false},
-            occurrences: [],
-            currentInSearchIndex: null,
-          })),
-        })}
-      >
-        {[{props: {text: '<ph/>'}}]}
-      </TagEntity>,
+describe('TagEntity tooltip', () => {
+  // shouldTooltipOnHover is derived from a real overflow measurement on the
+  // rendered leaf span, which jsdom reports as 0/0. These getters make the
+  // measured span overflow so the branch is reachable.
+  const withOverflowingLeaf = (fn) => {
+    const offset = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetWidth',
     )
+    const scroll = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollWidth',
+    )
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        return this.dataset && this.dataset.text === 'true' ? 10 : 0
+      },
+    })
+    Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+      configurable: true,
+      get() {
+        return this.dataset && this.dataset.text === 'true' ? 50 : 0
+      },
+    })
+    try {
+      fn()
+    } finally {
+      if (offset)
+        Object.defineProperty(HTMLElement.prototype, 'offsetWidth', offset)
+      if (scroll)
+        Object.defineProperty(HTMLElement.prototype, 'scrollWidth', scroll)
+    }
+  }
 
-    expect(document.querySelector('.tag-container')).toBeTruthy()
+  const overflowingChildren = [
+    <span key="0" data-text="true">
+      a very long tag content
+    </span>,
+  ]
+
+  test('shows the placeholder tooltip when the content overflows', () => {
+    withOverflowingLeaf(() => {
+      renderTag({children: overflowingChildren})
+      expect(screen.getByTestId('tooltip-content').textContent).toBe('PH')
+    })
+  })
+
+  test('shows no tooltip for a tag type that does not enable one', () => {
+    withOverflowingLeaf(() => {
+      renderTag({
+        children: overflowingChildren,
+        contentState: makeContentState({
+          id: 'e2',
+          placeholder: 'GSC',
+          index: 0,
+          name: 'gSc',
+        }),
+      })
+      expect(screen.getByTestId('tooltip-content').textContent).toBe('')
+    })
+  })
+
+  test('shows the tooltip for a compressed ph tag without needing overflow', () => {
+    CatToolStore.isPhTagsCompressed.mockReturnValue(true)
+    renderTag()
+    expect(screen.getByTestId('tooltip-content').textContent).toBe('PH')
+  })
+
+  test('never shows a tooltip for a closing pc tag', () => {
+    CatToolStore.isPhTagsCompressed.mockReturnValue(true)
+    renderTag({
+      contentState: makeContentState({
+        id: 'e1',
+        placeholder: 'PH',
+        index: 0,
+        name: 'ph',
+        pcRole: 'close',
+      }),
+    })
+    expect(screen.getByTestId('tooltip-content').textContent).toBe('')
+  })
+
+  describe('re-measuring the overflow after an update', () => {
+    // No `data-text` span, so the measurement finds nothing to measure and the
+    // tooltip stays off until an update re-measures.
+    const nonOverflowingChildren = [<Leaf key="0" text="short" />]
+
+    const renderThenUpdate = (nextProps) => {
+      const initial = baseProps({children: nonOverflowingChildren})
+      const {rerender} = render(<TagEntity {...initial} />)
+      expect(screen.getByTestId('tooltip-content').textContent).toBe('')
+
+      rerender(
+        <TagEntity
+          {...{...initial, children: overflowingChildren, ...nextProps}}
+        />,
+      )
+      return screen.getByTestId('tooltip-content').textContent
+    }
+
+    test('re-measures when entityKey changes', () => {
+      withOverflowingLeaf(() => {
+        expect(renderThenUpdate({entityKey: '2'})).toBe('PH')
+      })
+    })
+
+    test('does not re-measure when entityKey is unchanged', () => {
+      withOverflowingLeaf(() => {
+        expect(renderThenUpdate({offsetkey: '1-0-1'})).toBe('')
+      })
+    })
+  })
+
+  // Wave 4d hit "maximum update depth exceeded" when a parent's state update
+  // cascaded into a freshly mounted TagEntity that set state on mount. A
+  // segment renders one of these per tag, and Editarea re-renders them
+  // wholesale, so the mount measurement must not commit unless it actually
+  // changes something.
+  describe('mount measurement does not cascade', () => {
+    const commitPhases = (children) => {
+      const phases = []
+      render(
+        <React.Profiler
+          id="tag"
+          onRender={(id, phase) => {
+            phases.push(phase)
+          }}
+        >
+          <TagEntity {...baseProps({children})} />
+        </React.Profiler>,
+      )
+      return phases
+    }
+
+    test('commits once when the measurement matches the initial state', () => {
+      expect(commitPhases([<Leaf key="0" text="short" />])).toEqual(['mount'])
+    })
+
+    test('converges after a single update when the measurement differs', () => {
+      withOverflowingLeaf(() => {
+        expect(commitPhases(overflowingChildren)).toEqual(['mount', 'update'])
+      })
+    })
+  })
+})
+
+describe('TagEntity store subscriptions', () => {
+  test('registers every listener on mount', () => {
+    renderTag()
+
+    const segmentEvents = SegmentStore.addListener.mock.calls.map(([c]) => c)
+    expect(segmentEvents).toEqual(
+      expect.arrayContaining([
+        SegmentConstants.SET_SEGMENT_WARNINGS,
+        SegmentConstants.HIGHLIGHT_TAGS,
+        EditAreaConstants.EDIT_AREA_CHANGED,
+        SegmentConstants.ADD_SEARCH_RESULTS,
+        SegmentConstants.ADD_CURRENT_SEARCH,
+        SegmentConstants.REMOVE_SEARCH_RESULTS,
+        SegmentConstants.FOCUS_TAGS,
+      ]),
+    )
+    expect(CatToolStore.addListener).toHaveBeenCalledWith(
+      CatToolConstants.TOGGLE_PH_TAGS_COMPRESSED,
+      expect.any(Function),
+    )
+  })
+
+  test('removes exactly the handler references it registered on unmount', () => {
+    const {unmount} = renderTag()
+
+    const registered = [
+      ...SegmentStore.addListener.mock.calls,
+      ...CatToolStore.addListener.mock.calls,
+    ]
+    expect(registered).toHaveLength(8)
+
+    unmount()
+
+    const removed = [
+      ...SegmentStore.removeListener.mock.calls,
+      ...CatToolStore.removeListener.mock.calls,
+    ]
+    expect(removed).toHaveLength(8)
+
+    // A leak here means add and remove were handed different function
+    // identities for the same event — the bug class this migration keeps hitting.
+    registered.forEach(([event, handler]) => {
+      expect(removed).toEqual(expect.arrayContaining([[event, handler]]))
+    })
   })
 })

--- a/public/js/components/segments/TagEntity/TagEntity.warnings.test.js
+++ b/public/js/components/segments/TagEntity/TagEntity.warnings.test.js
@@ -1,4 +1,4 @@
-import TagEntity from './TagEntity.component'
+import {highlightOnWarnings} from './TagEntity.component'
 
 jest.mock('../../../stores/CatToolStore', () => ({
   isPhTagsCompressed: () => true,
@@ -14,9 +14,9 @@ const makeContentState = (data) => ({
   getEntity: () => ({data}),
 })
 
-const makeInstance = (props) => {
+const callHighlight = (props) => {
   const contentState = makeContentState(props.entityData)
-  return new TagEntity({
+  return highlightOnWarnings({
     entityKey: '1',
     contentState,
     getSearchParams: () => ({active: false}),
@@ -36,52 +36,52 @@ const makeInstance = (props) => {
 
 describe('TagEntity.highlightOnWarnings — pc (compressible) tags', () => {
   test('flags a source pc tag present in missingTagsInTarget', () => {
-    const instance = makeInstance({
+    const style = callHighlight({
       entityData: {name: 'ph', encodedText: dataRefOpenD1},
       isTarget: false,
       missingTagsInTarget: [{data: {encodedText: dataRefOpenD1}}],
     })
-    expect(instance.highlightOnWarnings()).toBe('tag-mismatch-error')
+    expect(style).toBe('tag-mismatch-error')
   })
 
   test('does not flag a source pc tag absent from missingTagsInTarget', () => {
-    const instance = makeInstance({
+    const style = callHighlight({
       entityData: {name: 'ph', encodedText: dataRefOpenD1},
       isTarget: false,
       missingTagsInTarget: [],
     })
-    expect(instance.highlightOnWarnings()).toBe('')
+    expect(style).toBe('')
   })
 
   test('does not use tagMismatch (QA endpoint) content matching for pc tags', () => {
     // tagMismatch reports something that would never equal this tag's own
     // encodedText (the QA endpoint reports each mismatch in isolation, in a
     // different, lossy format) -- pc tags must ignore it entirely.
-    const instance = makeInstance({
+    const style = callHighlight({
       entityData: {name: 'ph', encodedText: dataRefOpenD1},
       isTarget: false,
       tagMismatch: {source: ['</pc>'], target: [], order: []},
       missingTagsInTarget: [],
     })
-    expect(instance.highlightOnWarnings()).toBe('')
+    expect(style).toBe('')
   })
 
   test('target-side pc tags are never flagged by this path', () => {
-    const instance = makeInstance({
+    const style = callHighlight({
       entityData: {name: 'ph', encodedText: dataRefOpenD1},
       isTarget: true,
       missingTagsInTarget: [{data: {encodedText: dataRefOpenD1}}],
     })
-    expect(instance.highlightOnWarnings()).toBe('')
+    expect(style).toBe('')
   })
 
   test('non-pc tags keep using tagMismatch as before', () => {
-    const instance = makeInstance({
+    const style = callHighlight({
       entityData: {name: 'ph', encodedText: nonPcTag},
       isTarget: false,
       tagMismatch: {source: [nonPcTag], target: [], order: []},
       missingTagsInTarget: [],
     })
-    expect(instance.highlightOnWarnings()).toBe('tag-mismatch-error')
+    expect(style).toBe('tag-mismatch-error')
   })
 })

--- a/public/js/components/segments/utils/DraftMatecatUtils/TagMenu/TagBox.js
+++ b/public/js/components/segments/utils/DraftMatecatUtils/TagMenu/TagBox.js
@@ -1,106 +1,62 @@
-import React from 'react'
+import React, {useLayoutEffect, useRef} from 'react'
 
 import TagSuggestion from './TagSuggestion'
 
-class TagBox extends React.Component {
-  tagBox = React.createRef()
-  childRefs = []
+const TagBox = ({
+  popoverPosition,
+  displayPopover,
+  suggestions,
+  onTagClick,
+  focusedTagIndex,
+}) => {
+  const tagBoxRef = useRef(null)
+  const childRefsRef = useRef([])
+  const prevFocusedTagIndexRef = useRef(focusedTagIndex)
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    this.scrollElementIntoViewIfNeeded(prevProps)
-  }
+  const popoverOpen = Object.assign({}, popoverPosition, styles.popoverOpen)
+  const lastIndex = suggestions.missingTags ? suggestions.missingTags.length : 0
 
-  render() {
-    const {
-      popoverPosition,
-      displayPopover,
-      suggestions,
-      onTagClick,
-      focusedTagIndex,
-    } = this.props
-    const popoverOpen = Object.assign({}, popoverPosition, styles.popoverOpen)
-    const lastIndex = suggestions.missingTags
-      ? suggestions.missingTags.length
-      : 0
+  const missingSuggestions = suggestions.missingTags
+    ? suggestions.missingTags.map((suggestion, index) => {
+        childRefsRef.current[index] = React.createRef()
+        return (
+          <TagSuggestion
+            ref={childRefsRef.current[index]}
+            tabIndex={index}
+            key={index}
+            suggestion={suggestion}
+            onTagClick={onTagClick}
+            isFocused={focusedTagIndex === index}
+          />
+        )
+      })
+    : null
 
-    const missingSuggestions = suggestions.missingTags
-      ? suggestions.missingTags.map((suggestion, index) => {
-          this.childRefs[index] = React.createRef()
-          return (
-            <TagSuggestion
-              ref={this.childRefs[index]}
-              tabIndex={index}
-              key={index}
-              suggestion={suggestion}
-              onTagClick={onTagClick}
-              isFocused={focusedTagIndex === index}
-            />
-          )
-        })
-      : null
+  const allSuggestions = suggestions.sourceTags
+    ? suggestions.sourceTags.map((suggestion, index) => {
+        childRefsRef.current[index + lastIndex] = React.createRef()
+        return (
+          <TagSuggestion
+            ref={childRefsRef.current[index + lastIndex]}
+            tabIndex={index + lastIndex}
+            key={index + lastIndex}
+            suggestion={suggestion}
+            onTagClick={onTagClick}
+            isFocused={focusedTagIndex === index + lastIndex}
+          />
+        )
+      })
+    : null
 
-    const allSuggestions = suggestions.sourceTags
-      ? suggestions.sourceTags.map((suggestion, index) => {
-          this.childRefs[index + lastIndex] = React.createRef()
-          return (
-            <TagSuggestion
-              ref={this.childRefs[index + lastIndex]}
-              tabIndex={index + lastIndex}
-              key={index + lastIndex}
-              suggestion={suggestion}
-              onTagClick={onTagClick}
-              isFocused={focusedTagIndex === index + lastIndex}
-            />
-          )
-        })
-      : null
-
-    return (
-      <div
-        className={`tag-box`}
-        style={displayPopover ? popoverOpen : styles.popoverClosed}
-      >
-        <div className={`tag-box-inner`} ref={this.tagBox}>
-          {missingSuggestions && missingSuggestions.length > 0 && (
-            <div className={`missing`}>
-              <div className={`tag-box-heading`}>
-                Missing source&nbsp;
-                <div className={'tag-container'}>
-                  <span
-                    className={`tag tag-heading tag-selfclosed tag-mismatch-error`}
-                  >
-                    tags
-                  </span>
-                </div>
-                &nbsp;in target
-              </div>
-              {missingSuggestions}
-            </div>
-          )}
-          <div className={`all`}>
-            <div className={`tag-box-heading`}>
-              All&nbsp;
-              <div className={'tag-container'}>
-                <span className={`tag tag-heading tag-selfclosed`}>tags</span>
-              </div>
-              &nbsp;available
-            </div>
-            {allSuggestions}
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  scrollElementIntoViewIfNeeded = (prevProps) => {
-    const {focusedTagIndex} = this.props
+  useLayoutEffect(() => {
+    const prevFocusedTagIndex = prevFocusedTagIndexRef.current
     if (
-      this.childRefs[focusedTagIndex] &&
-      prevProps.focusedTagIndex !== focusedTagIndex
+      childRefsRef.current[focusedTagIndex] &&
+      prevFocusedTagIndex !== focusedTagIndex
     ) {
-      const tabBoxClientRect = this.tagBox.current.getBoundingClientRect()
+      const tabBoxClientRect = tagBoxRef.current.getBoundingClientRect()
       const activeElementClientRect =
-        this.childRefs[focusedTagIndex].current.getBoundingClientRect()
+        childRefsRef.current[focusedTagIndex].current.getBoundingClientRect()
       if (
         activeElementClientRect.top < tabBoxClientRect.top ||
         activeElementClientRect.bottom > tabBoxClientRect.bottom
@@ -108,15 +64,52 @@ class TagBox extends React.Component {
         const top =
           focusedTagIndex === 0
             ? 0
-            : this.childRefs[focusedTagIndex].current.offsetTop - 60
-        this.tagBox.current.scrollTo({
+            : childRefsRef.current[focusedTagIndex].current.offsetTop - 60
+        tagBoxRef.current.scrollTo({
           top: top,
           left: 0,
           behavior: 'smooth',
         })
       }
     }
-  }
+    prevFocusedTagIndexRef.current = focusedTagIndex
+  })
+
+  return (
+    <div
+      className={`tag-box`}
+      style={displayPopover ? popoverOpen : styles.popoverClosed}
+    >
+      <div className={`tag-box-inner`} ref={tagBoxRef}>
+        {missingSuggestions && missingSuggestions.length > 0 && (
+          <div className={`missing`}>
+            <div className={`tag-box-heading`}>
+              Missing source&nbsp;
+              <div className={'tag-container'}>
+                <span
+                  className={`tag tag-heading tag-selfclosed tag-mismatch-error`}
+                >
+                  tags
+                </span>
+              </div>
+              &nbsp;in target
+            </div>
+            {missingSuggestions}
+          </div>
+        )}
+        <div className={`all`}>
+          <div className={`tag-box-heading`}>
+            All&nbsp;
+            <div className={'tag-container'}>
+              <span className={`tag tag-heading tag-selfclosed`}>tags</span>
+            </div>
+            &nbsp;available
+          </div>
+          {allSuggestions}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 const styles = {

--- a/public/js/components/segments/utils/DraftMatecatUtils/replaceMultipleText.js
+++ b/public/js/components/segments/utils/DraftMatecatUtils/replaceMultipleText.js
@@ -3,25 +3,26 @@ import {EditorState, Modifier, SelectionState} from 'draft-js'
 const replaceMultipleText = (editorState, selectionsText = []) => {
   let updatedEditorState = editorState
 
+  // The offsets in selectionsText are relative to the block the selection starts
+  // in (that is the block getSelectedTextWithoutEntities walked), so every
+  // replacement must target that block. Applying them to each block of the
+  // content instead left the selected text untouched and wrote the replacement
+  // into the last block — a target ending with a newline tag has an extra block,
+  // so uppercasing a word appended it at the end instead of replacing it.
+  const blockKey = editorState.getSelection().getStartKey()
+
   selectionsText.forEach(({start, end, value}) => {
     const contentState = updatedEditorState.getCurrentContent()
-    const selections = []
-    const blockMap = contentState.getBlockMap()
-
-    blockMap.forEach((contentBlock) => {
-      const blockKey = contentBlock.getKey()
-      const blockSelection = SelectionState.createEmpty(blockKey).merge({
-        anchorOffset: start,
-        focusOffset: end,
-      })
-      selections.push(blockSelection)
+    const blockSelection = SelectionState.createEmpty(blockKey).merge({
+      anchorOffset: start,
+      focusOffset: end,
     })
 
-    let updatedContentState = contentState
-
-    selections.forEach((selection) => {
-      updatedContentState = Modifier.replaceText(contentState, selection, value)
-    })
+    const updatedContentState = Modifier.replaceText(
+      contentState,
+      blockSelection,
+      value,
+    )
 
     updatedEditorState = EditorState.push(
       updatedEditorState,

--- a/public/js/components/segments/utils/DraftMatecatUtils/replaceMultipleText.test.js
+++ b/public/js/components/segments/utils/DraftMatecatUtils/replaceMultipleText.test.js
@@ -1,4 +1,4 @@
-import {EditorState, ContentState} from 'draft-js'
+import {EditorState, ContentState, SelectionState} from 'draft-js'
 import replaceMultipleText from './replaceMultipleText'
 
 test('replaces the given offset range with the provided value', () => {
@@ -26,21 +26,41 @@ test('applies each replacement sequentially on the updated content', () => {
   expect(result.getCurrentContent().getPlainText()).toBe('YO world')
 })
 
-test('builds a same-offset selection for every block but only commits the last one', () => {
-  // Each block gets a same-offset selection, but the function replaces text
-  // against the original (non-accumulated) content state on every iteration,
-  // so only the last processed block's replacement survives in the result.
-  const editorState = EditorState.createWithContent(
-    ContentState.createFromText('aaaa\nbbbb'),
-  )
+test('replaces inside the block the selection starts in, leaving the others alone', () => {
+  // A target ending with a newline tag has more than one block: the offsets
+  // belong to the block the selection starts in, and every other block must be
+  // left untouched. Replacing in each block instead appended the new text to
+  // the last one and left the selected text unchanged.
+  const contentState = ContentState.createFromText('aaaa\nbbbb')
+  const editorState = EditorState.createWithContent(contentState)
 
   const result = replaceMultipleText(editorState, [
     {start: 0, end: 2, value: 'X'},
   ])
 
   const blocks = result.getCurrentContent().getBlocksAsArray()
+  expect(blocks[0].getText()).toBe('Xaa')
+  expect(blocks[1].getText()).toBe('bbbb')
+})
+
+test('replaces inside the block the selection starts in when it is not the first', () => {
+  const contentState = ContentState.createFromText('aaaa\nbbbb')
+  const secondBlockKey = contentState.getBlocksAsArray()[1].getKey()
+  const editorState = EditorState.acceptSelection(
+    EditorState.createWithContent(contentState),
+    SelectionState.createEmpty(secondBlockKey).merge({
+      anchorOffset: 1,
+      focusOffset: 3,
+    }),
+  )
+
+  const result = replaceMultipleText(editorState, [
+    {start: 1, end: 3, value: 'ZZ'},
+  ])
+
+  const blocks = result.getCurrentContent().getBlocksAsArray()
   expect(blocks[0].getText()).toBe('aaaa')
-  expect(blocks[1].getText()).toBe('Xbb')
+  expect(blocks[1].getText()).toBe('bZZb')
 })
 
 test('returns the same editor state when there is nothing to replace', () => {


### PR DESCRIPTION
## Summary

Step 07 of the PR #4768 split plan (wave 2, blocks 08 and 09): migrates
`TagEntity` (the shared leaf both `Editarea` and `SegmentSource` import,
so it has to land before either), `TagBox` (the tag menu popover) and the
`replaceMultipleText` utility, porting the final state from the
`react-class-to-functional-migration` branch. Extends the per-directory
eslint ratchet started in #4814 to `segments/TagEntity` and
`segments/utils/DraftMatecatUtils/TagMenu`.

Every prop is destructured in the function signature rather than kept as
a whole `props` parameter (a deviation from how the earlier PRs in this
series shipped — see #4818's discussion). `TagEntity` needed extra care
here: its store-listener callbacks (`highlightTags`, `updateTagStyle`,
`addSearchParams`, etc.) must keep one stable identity for the component's
whole lifetime, so they read props/state through a `liveRef` mirror
(`liveRef.current = {props, state}`) refreshed on every render, rather
than closing over values that go stale. Destructuring in the signature
still lets that mirror work: right after the signature, a `props` object
is rebuilt from the destructured values, and every place that previously
took the whole `props` bag (`selectCorrectStyle`, `markSearch`, the
`prevPropsRef` comparison, the `liveRef` mirror itself) keeps using that
rebuilt object unchanged. `onClickBound` no longer needs its own
`const {start, end, onClick} = props` — it reads the already-destructured
`start`/`end`/`onClick` directly, since (unlike the store listeners) it's
a plain per-render closure, not one that needs to survive across renders.

## Type

- [x] `refactor` — restructure without behavior change
- [ ] `feat` — new user-facing feature
- [ ] `fix` — bug fix
- [ ] `chore` — build, deps, config, docs
- [ ] `perf` — performance improvement
- [ ] `test` — test coverage

## Changes

| File | Change |
|------|--------|
| `public/js/components/segments/TagEntity/TagEntity.component.js` (+2 tests) | Convert to function component with hooks; destructure props, rebuild for the liveRef mirror |
| `public/js/components/segments/utils/DraftMatecatUtils/TagMenu/TagBox.js` | Convert to function component with hooks |
| `public/js/components/segments/utils/DraftMatecatUtils/replaceMultipleText.js` (+test) | Plain utility, not a component — ported alongside for the substantially rewritten test file |
| `.eslintrc.js` | Extend the class-component-ban override's `files` list to `segments/TagEntity` and `segments/utils/DraftMatecatUtils/TagMenu` |

## Testing

- [ ] `vendor/bin/phpunit --exclude-group=ExternalServices --no-coverage` passes
- [ ] `./vendor/bin/phpstan` passes (0 errors, with baseline)
- [ ] Manual testing performed (describe below)
- [x] New tests added for changed behavior
- [ ] Regression tests added for bug fixes

`TagEntity.component.test.js` is substantially rewritten (+~600/-~370
lines per the migration branch) to match the hooks version; verified the
destructuring-in-signature change is behavior-neutral by diffing eslint
output before/after on the freshly-ported (not-yet-destructured) file —
zero new errors, same single pre-existing `react/no-unknown-property`
warning on an unrelated `unselectable` attribute (present already in the
class version on `develop`). `yarn test --watchAll=false
public/js/components/segments/TagEntity/` — 3 suites, 64 tests, all
passing, both before and after the destructuring pass. Full suite `yarn
test --watchAll=false` — 427 suites, 4387 tests, all passing, no
regressions. Verified no other class components remain in either
directory before scoping the eslint globs broadly.

No browser-based manual verification was performed in this session
(background job, no interactive browser available) — recommend a manual
pass over tag click/highlight, the tag menu popover, and search-in-tag
highlighting before merge, since TagEntity is the single most
review-sensitive file in this whole migration (per the split proposal).

## AI Disclosure

- [ ] No AI tools were used in this PR
- [x] AI tools were used — name the agent/tool below

Claude Code (Sonnet 5)

## Notes

Part of the split of #4768 (wave 2, step 07 of 14) — see #4814 for the
full merge-order plan. Blocks step 08 (SegmentSource) and step 09
(Editarea + SegmentTarget), both of which import TagEntity.
